### PR TITLE
VPR-104 fix(a11y): establish shared accessibility foundation (PR 1 of 6)

### DIFF
--- a/VueApp/src/App.vue
+++ b/VueApp/src/App.vue
@@ -13,7 +13,7 @@
         <div class="wrapper"></div>
     </header>
 
-    <main></main>
+    <div></div>
 </template>
 
 <style scoped>

--- a/VueApp/src/CAHFS/App.vue
+++ b/VueApp/src/CAHFS/App.vue
@@ -1,15 +1,13 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="cahfs-nav"
-            :navarea="false"
-            highlighted-top-nav="CAHFS"
-            :breadcrumbs="$route.meta?.breadcrumbs"
-            :show-view-when-not-logged-in="$route.meta.showViewWhenNotLoggedIn || false"
-        >
-        </component>
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="cahfs-nav"
+        :navarea="false"
+        highlighted-top-nav="CAHFS"
+        :breadcrumbs="$route.meta?.breadcrumbs"
+        :show-view-when-not-logged-in="$route.meta.showViewWhenNotLoggedIn || false"
+    >
+    </component>
     <GenericError />
 </template>
 

--- a/VueApp/src/CMS/App.vue
+++ b/VueApp/src/CMS/App.vue
@@ -1,14 +1,12 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="cms"
-            :navarea="true"
-            highlighted-top-nav="Viper Home"
-            :breadcrumbs="$route.meta?.breadcrumbs"
-        >
-        </component>
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="cms"
+        :navarea="true"
+        highlighted-top-nav="Viper Home"
+        :breadcrumbs="$route.meta?.breadcrumbs"
+    >
+    </component>
     <GenericError />
 </template>
 

--- a/VueApp/src/CTS/App.vue
+++ b/VueApp/src/CTS/App.vue
@@ -1,14 +1,12 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="cts"
-            :navarea="true"
-            highlighted-top-nav="Curriculum"
-            :breadcrumbs="$route.meta?.breadcrumbs"
-        >
-        </component>
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="cts"
+        :navarea="true"
+        highlighted-top-nav="Curriculum"
+        :breadcrumbs="$route.meta?.breadcrumbs"
+    >
+    </component>
     <GenericError />
 </template>
 

--- a/VueApp/src/ClinicalScheduler/App.vue
+++ b/VueApp/src/ClinicalScheduler/App.vue
@@ -1,12 +1,10 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="viper-clinical-scheduler"
-            :navarea="true"
-            highlighted-top-nav="ClinicalScheduler"
-        />
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="viper-clinical-scheduler"
+        :navarea="true"
+        highlighted-top-nav="ClinicalScheduler"
+    />
     <GenericError />
 </template>
 

--- a/VueApp/src/Computing/App.vue
+++ b/VueApp/src/Computing/App.vue
@@ -1,13 +1,11 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="viper-cats"
-            :navarea="true"
-            highlighted-top-nav="Computing"
-        >
-        </component>
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="viper-cats"
+        :navarea="true"
+        highlighted-top-nav="Computing"
+    >
+    </component>
     <GenericError />
 </template>
 

--- a/VueApp/src/Effort/App.vue
+++ b/VueApp/src/Effort/App.vue
@@ -1,12 +1,10 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="viper-effort"
-            :navarea="true"
-            highlighted-top-nav="Faculty"
-        />
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="viper-effort"
+        :navarea="true"
+        highlighted-top-nav="Faculty"
+    />
     <GenericError />
 </template>
 

--- a/VueApp/src/Students/App.vue
+++ b/VueApp/src/Students/App.vue
@@ -1,14 +1,12 @@
 <template>
-    <main>
-        <component
-            :is="$route.meta.layout || 'div'"
-            nav="viper-students"
-            :navarea="false"
-            highlighted-top-nav="Students"
-            :breadcrumbs="$route.meta?.breadcrumbs"
-        >
-        </component>
-    </main>
+    <component
+        :is="$route.meta.layout || 'div'"
+        nav="viper-students"
+        :navarea="false"
+        highlighted-top-nav="Students"
+        :breadcrumbs="$route.meta?.breadcrumbs"
+    >
+    </component>
     <GenericError />
 </template>
 

--- a/VueApp/src/components/GenericError.vue
+++ b/VueApp/src/components/GenericError.vue
@@ -11,7 +11,7 @@
             <template #avatar>
                 <q-icon
                     name="error"
-                    color="red"
+                    color="negative"
                 />
             </template>
             {{ errorMessage }}

--- a/VueApp/src/components/SessionTimeout.vue
+++ b/VueApp/src/components/SessionTimeout.vue
@@ -96,7 +96,7 @@ sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, 60000)
                 <q-icon
                     size="md"
                     :name="sessionExpired ? 'error' : 'warning'"
-                    :color="sessionExpired ? 'red' : 'orange'"
+                    :color="sessionExpired ? 'negative' : 'warning'"
                 ></q-icon>
                 <q-space></q-space>
                 <div v-if="sessionExpired">Your session has expired. Please log in again.</div>

--- a/VueApp/src/components/StatusBanner.vue
+++ b/VueApp/src/components/StatusBanner.vue
@@ -1,0 +1,100 @@
+<template>
+    <q-banner
+        v-if="visible"
+        :class="bannerClass"
+        :role="ariaRole"
+        rounded
+    >
+        <template #avatar>
+            <q-icon
+                :name="resolvedIcon"
+                :class="iconClass"
+            />
+        </template>
+        <div class="text-body2">
+            <slot />
+        </div>
+        <template
+            v-if="$slots.action || dismissible"
+            #action
+        >
+            <slot name="action" />
+            <q-btn
+                v-if="dismissible"
+                flat
+                dense
+                round
+                icon="close"
+                aria-label="Dismiss"
+                :class="iconClass"
+                @click="visible = false"
+            />
+        </template>
+    </q-banner>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue"
+
+type BannerType = "success" | "error" | "warning" | "info"
+
+const {
+    type,
+    icon = "",
+    dismissible = false,
+} = defineProps<{
+    type: BannerType
+    icon?: string
+    dismissible?: boolean
+}>()
+
+const visible = ref(true)
+
+const typeConfig: Record<BannerType, { icon: string; bg: string; iconCls: string }> = {
+    success: { icon: "check_circle", bg: "status-banner-success", iconCls: "text-positive" },
+    error: { icon: "error", bg: "status-banner-error", iconCls: "text-negative" },
+    warning: { icon: "warning", bg: "status-banner-warning", iconCls: "status-banner-warning-icon" },
+    info: { icon: "info", bg: "status-banner-info", iconCls: "status-banner-info-icon" },
+}
+
+const config = computed(() => typeConfig[type])
+
+const resolvedIcon = computed(() => icon ?? config.value.icon)
+const bannerClass = computed(() => `${config.value.bg} q-mb-md`)
+const iconClass = computed(() => config.value.iconCls)
+const ariaRole = computed(() => (type === "error" || type === "warning" ? "alert" : "status"))
+</script>
+
+<style scoped>
+.status-banner-success {
+    background-color: color-mix(in srgb, var(--q-positive) 12%, white);
+    border-left: 0.25rem solid var(--q-positive);
+    color: var(--q-positive);
+}
+
+.status-banner-error {
+    background-color: color-mix(in srgb, var(--q-negative) 12%, white);
+    border-left: 0.25rem solid var(--q-negative);
+    color: var(--q-negative);
+}
+
+.status-banner-warning {
+    background-color: color-mix(in srgb, var(--q-warning) 15%, white);
+    border-left: 0.25rem solid var(--q-warning);
+    color: #5d4600;
+}
+
+.status-banner-warning-icon {
+    color: #5d4600;
+}
+
+.status-banner-info {
+    background-color: color-mix(in srgb, var(--q-info) 12%, white);
+    border-left: 0.25rem solid var(--q-info);
+    color: var(--ucdavis-blue-80, #335379);
+}
+
+.status-banner-info-icon {
+    color: var(--ucdavis-blue-80, #335379);
+}
+</style>

--- a/VueApp/src/components/StatusBanner.vue
+++ b/VueApp/src/components/StatusBanner.vue
@@ -9,6 +9,7 @@
             <q-icon
                 :name="resolvedIcon"
                 :class="iconClass"
+                aria-hidden="true"
             />
         </template>
         <div class="text-body2">

--- a/VueApp/src/components/StatusBanner.vue
+++ b/VueApp/src/components/StatusBanner.vue
@@ -40,7 +40,7 @@ type BannerType = "success" | "error" | "warning" | "info"
 
 const {
     type,
-    icon = "",
+    icon,
     dismissible = false,
 } = defineProps<{
     type: BannerType

--- a/VueApp/src/components/StatusBanner.vue
+++ b/VueApp/src/components/StatusBanner.vue
@@ -38,13 +38,16 @@
 import { computed, ref } from "vue"
 
 type BannerType = "success" | "error" | "warning" | "info"
+type LiveMode = "off" | "polite" | "assertive"
 
 const {
     type,
-    icon,
+    live = undefined,
+    icon = undefined,
     dismissible = false,
 } = defineProps<{
     type: BannerType
+    live?: LiveMode
     icon?: string
     dismissible?: boolean
 }>()
@@ -63,7 +66,17 @@ const config = computed(() => typeConfig[type])
 const resolvedIcon = computed(() => icon ?? config.value.icon)
 const bannerClass = computed(() => `${config.value.bg} q-mb-md`)
 const iconClass = computed(() => config.value.iconCls)
-const ariaRole = computed(() => (type === "error" || type === "warning" ? "alert" : "status"))
+
+// Only `error` defaults to an assertive announcement, since errors typically follow a
+// user action (failed submit, save error) where interrupting is expected. Other types
+// default to a polite live region so persistent state indicators loaded with the page
+// don't interrupt screen-reader focus. Callers override with the `live` prop:
+// `live="assertive"` for truly urgent notices, `live="off"` for decorative banners.
+const resolvedLive = computed<LiveMode>(() => live ?? (type === "error" ? "assertive" : "polite"))
+const ariaRole = computed<"alert" | "status" | undefined>(() => {
+    if (resolvedLive.value === "off") return undefined
+    return resolvedLive.value === "assertive" ? "alert" : "status"
+})
 </script>
 
 <style scoped>

--- a/VueApp/src/components/StudentSelect.vue
+++ b/VueApp/src/components/StudentSelect.vue
@@ -282,6 +282,11 @@ void getStudents()
                             class="smallPhoto rounded-borders"
                             loading="eager"
                             :no-spinner="true"
+                            :alt="
+                                selectedStudent
+                                    ? `${selectedStudent.firstName} ${selectedStudent.lastName}'s photo`
+                                    : 'Student photo'
+                            "
                         />
                     </q-avatar>
                 </template>

--- a/VueApp/src/composables/use-route-focus.ts
+++ b/VueApp/src/composables/use-route-focus.ts
@@ -1,0 +1,24 @@
+import type { Router } from "vue-router"
+import { nextTick } from "vue"
+
+/**
+ * Manages focus after route navigation for screen reader accessibility (WCAG 2.4.3).
+ * Without this, screen readers hear nothing on page change because scroll reset
+ * alone does not move focus.
+ */
+export function useRouteFocus(router: Router) {
+    router.afterEach(() => {
+        nextTick(() => {
+            const main = document.querySelector("main") || document.querySelector("#app")
+            if (main instanceof HTMLElement) {
+                // Set tabindex temporarily so the element can receive focus
+                // without permanently joining the tab order
+                if (!main.hasAttribute("tabindex")) {
+                    main.setAttribute("tabindex", "-1")
+                    main.addEventListener("blur", () => main.removeAttribute("tabindex"), { once: true })
+                }
+                main.focus({ preventScroll: true })
+            }
+        })
+    })
+}

--- a/VueApp/src/config/colors.ts
+++ b/VueApp/src/config/colors.ts
@@ -172,7 +172,7 @@ const BRAND_COLORS = {
     // Status colors (UC Davis secondary palette)
     positive: "#266041", // Redwood
     negative: "#79242F", // Merlot
-    info: "#6FCFEB", // Rec Pool
+    info: "#00B2E3", // Tahoe
 
     // Dark theme
     dark: "#1d1d1d",

--- a/VueApp/src/config/colors.ts
+++ b/VueApp/src/config/colors.ts
@@ -169,10 +169,10 @@ const BRAND_COLORS = {
     "ucdavis-gold-100": "#FFBF00", // Primary Aggie Gold
     "ucdavis-gold-90": "#FFC519",
 
-    // Status colors
-    positive: "#226e34",
-    negative: "#6e2222",
-    info: "#289094",
+    // Status colors (UC Davis secondary palette)
+    positive: "#266041", // Redwood
+    negative: "#79242F", // Merlot
+    info: "#008EAA", // Putah Creek
 
     // Dark theme
     dark: "#1d1d1d",

--- a/VueApp/src/config/colors.ts
+++ b/VueApp/src/config/colors.ts
@@ -172,7 +172,7 @@ const BRAND_COLORS = {
     // Status colors (UC Davis secondary palette)
     positive: "#266041", // Redwood
     negative: "#79242F", // Merlot
-    info: "#008EAA", // Putah Creek
+    info: "#6FCFEB", // Rec Pool
 
     // Dark theme
     dark: "#1d1d1d",

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -108,14 +108,42 @@
 import { ref, watch, onMounted } from "vue"
 import { useFetch } from "@/composables/ViperFetch"
 
-// Sets title attribute only when text is truncated by ellipsis
+type OverflowTitleElement = HTMLElement & {
+    _overflowTitleObserver?: ResizeObserver
+}
+
+function updateOverflowTitle(el: HTMLElement) {
+    const text = el.firstChild?.textContent?.trim() ?? ""
+    if (!text) {
+        el.removeAttribute("title")
+        return
+    }
+    if (el.scrollWidth > el.clientWidth) {
+        const hasExternal = el.querySelector(".sr-only") !== null
+        el.title = hasExternal ? `${text} (opens in new window)` : text
+    } else {
+        el.removeAttribute("title")
+    }
+}
+
+// Sets title attribute only when text is truncated by ellipsis.
+// Uses ResizeObserver to update when drawer toggles or window resizes.
 const vOverflowTitle = {
-    mounted(el: HTMLElement) {
-        if (el.scrollWidth > el.clientWidth) {
-            const text = el.firstChild?.textContent?.trim() ?? ""
-            const hasExternal = el.querySelector(".sr-only") !== null
-            el.title = hasExternal ? `${text} (opens in new window)` : text
+    mounted(el: OverflowTitleElement) {
+        updateOverflowTitle(el)
+        if (typeof ResizeObserver !== "undefined") {
+            el._overflowTitleObserver = new ResizeObserver(() => {
+                updateOverflowTitle(el)
+            })
+            el._overflowTitleObserver.observe(el)
         }
+    },
+    updated(el: OverflowTitleElement) {
+        updateOverflowTitle(el)
+    },
+    unmounted(el: OverflowTitleElement) {
+        el._overflowTitleObserver?.disconnect()
+        delete el._overflowTitleObserver
     },
 }
 

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -41,7 +41,7 @@
                             <q-item
                                 v-if="menuItem.routeTo != null"
                                 :clickable="menuItem.clickable"
-                                :v-ripple="menuItem.clickable"
+                                v-ripple
                                 :to="menuItem.routeTo"
                                 :class="menuItem.displayClass"
                             >

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -28,78 +28,77 @@
                 <h2 v-if="navHeader.length">
                     {{ navHeader }}
                 </h2>
-                <q-list
-                    dense
-                    separator
-                    role="presentation"
-                >
-                    <template
-                        v-for="(menuItem, index) in menuItems"
-                        :key="index"
+                <nav :aria-label="navHeader || 'Section navigation'">
+                    <q-list
+                        dense
+                        separator
+                        role="list"
                     >
-                        <q-item
-                            v-if="menuItem.routeTo != null"
-                            :clickable="menuItem.clickable"
-                            :v-ripple="menuItem.clickable"
-                            :to="menuItem.routeTo"
-                            :class="menuItem.displayClass"
-                            role="none"
+                        <template
+                            v-for="(menuItem, index) in menuItems"
+                            :key="index"
                         >
-                            <q-item-section>
-                                <q-item-label
-                                    v-overflow-title
-                                    lines="1"
-                                >
-                                    {{ menuItem.menuItemText }}
-                                </q-item-label>
-                            </q-item-section>
-                        </q-item>
-                        <q-item
-                            v-else-if="menuItem.menuItemUrl"
-                            clickable
-                            v-ripple
-                            :href="menuItem.menuItemUrl"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            :class="menuItem.displayClass"
-                            role="none"
-                        >
-                            <q-item-section>
-                                <q-item-label
-                                    v-overflow-title
-                                    lines="1"
-                                >
-                                    {{ menuItem.menuItemText }}
-                                    <template v-if="menuItem.isExternalSite">
-                                        <q-icon
-                                            name="open_in_new"
-                                            size="xs"
-                                            class="q-ml-xs"
-                                            aria-hidden="true"
-                                        >
-                                            <q-tooltip>Opens in new window</q-tooltip>
-                                        </q-icon>
-                                        <span class="sr-only">(opens in new window)</span>
-                                    </template>
-                                </q-item-label>
-                            </q-item-section>
-                        </q-item>
-                        <q-item
-                            v-else
-                            :class="menuItem.displayClass"
-                            role="none"
-                        >
-                            <q-item-section>
-                                <q-item-label
-                                    v-overflow-title
-                                    lines="1"
-                                >
-                                    {{ menuItem.menuItemText }}
-                                </q-item-label>
-                            </q-item-section>
-                        </q-item>
-                    </template>
-                </q-list>
+                            <q-item
+                                v-if="menuItem.routeTo != null"
+                                :clickable="menuItem.clickable"
+                                :v-ripple="menuItem.clickable"
+                                :to="menuItem.routeTo"
+                                :class="menuItem.displayClass"
+                            >
+                                <q-item-section>
+                                    <q-item-label
+                                        v-overflow-title
+                                        lines="1"
+                                    >
+                                        {{ menuItem.menuItemText }}
+                                    </q-item-label>
+                                </q-item-section>
+                            </q-item>
+                            <q-item
+                                v-else-if="menuItem.menuItemUrl"
+                                clickable
+                                v-ripple
+                                :href="menuItem.menuItemUrl"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                :class="menuItem.displayClass"
+                            >
+                                <q-item-section>
+                                    <q-item-label
+                                        v-overflow-title
+                                        lines="1"
+                                    >
+                                        {{ menuItem.menuItemText }}
+                                        <template v-if="menuItem.isExternalSite">
+                                            <q-icon
+                                                name="open_in_new"
+                                                size="xs"
+                                                class="q-ml-xs"
+                                                aria-hidden="true"
+                                            >
+                                                <q-tooltip>Opens in new window</q-tooltip>
+                                            </q-icon>
+                                            <span class="sr-only">(opens in new window)</span>
+                                        </template>
+                                    </q-item-label>
+                                </q-item-section>
+                            </q-item>
+                            <q-item
+                                v-else
+                                :class="menuItem.displayClass"
+                            >
+                                <q-item-section>
+                                    <q-item-label
+                                        v-overflow-title
+                                        lines="1"
+                                    >
+                                        {{ menuItem.menuItemText }}
+                                    </q-item-label>
+                                </q-item-section>
+                            </q-item>
+                        </template>
+                    </q-list>
+                </nav>
             </div>
         </template>
     </q-drawer>

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -76,6 +76,7 @@
                         <q-item
                             v-else
                             :class="menuItem.displayClass"
+                            role="none"
                         >
                             <q-item-section>
                                 <q-item-label lines="1">

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -60,6 +60,7 @@
                             v-ripple
                             :href="menuItem.menuItemUrl"
                             target="_blank"
+                            rel="noopener noreferrer"
                             :class="menuItem.displayClass"
                             role="none"
                         >

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -46,7 +46,10 @@
                             role="none"
                         >
                             <q-item-section>
-                                <q-item-label lines="1">
+                                <q-item-label
+                                    v-overflow-title
+                                    lines="1"
+                                >
                                     {{ menuItem.menuItemText }}
                                 </q-item-label>
                             </q-item-section>
@@ -61,15 +64,22 @@
                             role="none"
                         >
                             <q-item-section>
-                                <q-item-label lines="1">
+                                <q-item-label
+                                    v-overflow-title
+                                    lines="1"
+                                >
                                     {{ menuItem.menuItemText }}
-                                    <q-icon
-                                        name="open_in_new"
-                                        size="xs"
-                                        class="q-ml-xs"
-                                        aria-hidden="true"
-                                    />
-                                    <span class="sr-only">(opens in new window)</span>
+                                    <template v-if="menuItem.isExternalSite">
+                                        <q-icon
+                                            name="open_in_new"
+                                            size="xs"
+                                            class="q-ml-xs"
+                                            aria-hidden="true"
+                                        >
+                                            <q-tooltip>Opens in new window</q-tooltip>
+                                        </q-icon>
+                                        <span class="sr-only">(opens in new window)</span>
+                                    </template>
                                 </q-item-label>
                             </q-item-section>
                         </q-item>
@@ -79,7 +89,10 @@
                             role="none"
                         >
                             <q-item-section>
-                                <q-item-label lines="1">
+                                <q-item-label
+                                    v-overflow-title
+                                    lines="1"
+                                >
                                     {{ menuItem.menuItemText }}
                                 </q-item-label>
                             </q-item-section>
@@ -95,12 +108,24 @@
 import { ref, watch, onMounted } from "vue"
 import { useFetch } from "@/composables/ViperFetch"
 
+// Sets title attribute only when text is truncated by ellipsis
+const vOverflowTitle = {
+    mounted(el: HTMLElement) {
+        if (el.scrollWidth > el.clientWidth) {
+            const text = el.firstChild?.textContent?.trim() ?? ""
+            const hasExternal = el.querySelector(".sr-only") !== null
+            el.title = hasExternal ? `${text} (opens in new window)` : text
+        }
+    },
+}
+
 interface MenuItem {
     menuItemUrl: string | undefined
     routeTo: string | null
     menuItemText: string
     clickable: boolean
     displayClass: string
+    isExternalSite: boolean
 }
 
 const props = defineProps<{
@@ -135,6 +160,16 @@ async function getLeftNav() {
             const isExternalUrl = r.menuItemURL.length > 4 && r.menuItemURL.startsWith("http")
             const isRelativeUrl = r.menuItemURL.length > 0 && !isExternalUrl && !r.menuItemURL.startsWith("/")
 
+            // VIPER1 links share the same hostname — only show external icon for truly external sites
+            let isExternalSite = false
+            if (isExternalUrl) {
+                try {
+                    isExternalSite = new URL(r.menuItemURL).hostname !== window.location.hostname
+                } catch {
+                    isExternalSite = true
+                }
+            }
+
             let routeToUrl = null
             if (!isExternalUrl && r.menuItemURL.length > 0) {
                 if (isRelativeUrl && props.navarea && props.nav) {
@@ -149,6 +184,7 @@ async function getLeftNav() {
                 routeTo: routeToUrl,
                 menuItemText: r.menuItemText,
                 clickable: r.menuItemURL.length > 0,
+                isExternalSite,
                 displayClass: r.menuItemURL.length
                     ? "leftNavLink"
                     : (r.isHeader ? "leftNavHeader" : "") + (r.menuItemText === "" ? " leftNavSpacer" : ""),

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -21,6 +21,7 @@
                     unelevated
                     color="secondary"
                     icon="close"
+                    aria-label="Close menu"
                     class="float-right lt-md"
                     @click="myMainLeftDrawer = false"
                 />
@@ -30,6 +31,7 @@
                 <q-list
                     dense
                     separator
+                    role="presentation"
                 >
                     <template
                         v-for="(menuItem, index) in menuItems"
@@ -41,6 +43,7 @@
                             :v-ripple="menuItem.clickable"
                             :to="menuItem.routeTo"
                             :class="menuItem.displayClass"
+                            role="none"
                         >
                             <q-item-section>
                                 <q-item-label lines="1">
@@ -55,10 +58,18 @@
                             :href="menuItem.menuItemUrl"
                             target="_blank"
                             :class="menuItem.displayClass"
+                            role="none"
                         >
                             <q-item-section>
                                 <q-item-label lines="1">
                                     {{ menuItem.menuItemText }}
+                                    <q-icon
+                                        name="open_in_new"
+                                        size="xs"
+                                        class="q-ml-xs"
+                                        aria-hidden="true"
+                                    />
+                                    <span class="sr-only">(opens in new window)</span>
                                 </q-item-label>
                             </q-item-section>
                         </q-item>

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -214,9 +214,11 @@ async function getLeftNav() {
                 menuItemText: r.menuItemText,
                 clickable: r.menuItemURL.length > 0,
                 isExternalSite,
-                displayClass: r.menuItemURL.length
-                    ? "leftNavLink"
-                    : (r.isHeader ? "leftNavHeader" : "") + (r.menuItemText === "" ? " leftNavSpacer" : ""),
+                displayClass:
+                    (r.menuItemURL.length
+                        ? "leftNavLink"
+                        : (r.isHeader ? "leftNavHeader" : "") + (r.menuItemText === "" ? " leftNavSpacer" : "")) +
+                    (r.indentLevel > 0 ? ` leftNavIndent${r.indentLevel}` : ""),
             }
         })
     } catch (_e) {

--- a/VueApp/src/layouts/MainNav.vue
+++ b/VueApp/src/layouts/MainNav.vue
@@ -28,8 +28,9 @@
         </template>
         <q-btn
             flat
-            href="helpNav.menuItemURL"
+            :href="helpNav.menuItemURL"
             icon="help"
+            aria-label="Help"
             class="q-px-md text-primary"
         >
             <q-tooltip>Help</q-tooltip>
@@ -51,7 +52,7 @@ interface NavItem {
 }
 
 const topNav = ref<NavItem[]>([])
-const helpNav = ref("")
+const helpNav = ref<NavItem>({ menuItemURL: "", menuItemText: "" })
 const navClass =
     "q-btn q-btn--flat q-btn--actionable q-btn--no-uppercase q-hoverable q-px-md text-primary text-weight-regular navLink "
 

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -229,7 +229,7 @@
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
-                        href="http://www.vetmed.ucdavis.edu/"
+                        href="https://www.vetmed.ucdavis.edu/"
                         target="_blank"
                         rel="noopener"
                         class="text-primary"
@@ -245,7 +245,7 @@
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
-                        href="http://www.ucdavis.edu/"
+                        href="https://www.ucdavis.edu/"
                         target="_blank"
                         rel="noopener"
                         class="text-primary"

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -165,7 +165,10 @@
         </slot>
 
         <q-page-container id="mainLayoutBody">
-            <main id="main-content">
+            <main
+                id="main-content"
+                tabindex="-1"
+            >
                 <div
                     class="q-pa-md"
                     v-show="userStore.isLoggedIn || showViewWhenNotLoggedIn"

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -1,5 +1,10 @@
 <template>
     <div id="pageTop"></div>
+    <a
+        href="#main-content"
+        class="skip-to-content"
+        >Skip to main content</a
+    >
     <q-layout view="hHh lpR fFf">
         <q-header
             elevated
@@ -55,6 +60,7 @@
                     flat
                     dense
                     icon="menu"
+                    aria-label="Navigation menu"
                     class="q-mr-xs lt-md"
                 >
                     <MiniNav v-if="userStore.isLoggedIn"></MiniNav>
@@ -63,6 +69,7 @@
                     flat
                     dense
                     icon="list"
+                    aria-label="Toggle sidebar"
                     class="q-mr-xs lt-md"
                     @click="mainLeftDrawer = !mainLeftDrawer"
                 ></q-btn>
@@ -158,7 +165,7 @@
         </slot>
 
         <q-page-container id="mainLayoutBody">
-            <main>
+            <main id="main-content">
                 <div
                     class="q-pa-md"
                     v-show="userStore.isLoggedIn || showViewWhenNotLoggedIn"
@@ -212,8 +219,10 @@
                             color="primary"
                             name="help_center"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         SVM-IT ServiceDesk
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
@@ -226,8 +235,10 @@
                             color="primary"
                             name="navigation"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         SVM Home
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
@@ -240,8 +251,10 @@
                             color="primary"
                             name="school"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         UC Davis
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                 </div>
                 <div class="col-12 col-md-auto gt-sm text-black">

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -82,15 +82,15 @@
                 >
                     <q-badge
                         v-if="environment == 'DEVELOPMENT'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Dev</q-badge
                     >
                     <q-badge
                         v-if="environment == 'TEST'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Test</q-badge
                     >
@@ -107,15 +107,15 @@
                     <span class="mainLayoutViper">VIPER 2.0</span>
                     <q-badge
                         v-if="environment == 'DEVELOPMENT'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Development</q-badge
                     >
                     <q-badge
                         v-if="environment == 'TEST'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Test</q-badge
                     >

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -158,37 +158,39 @@
         </slot>
 
         <q-page-container id="mainLayoutBody">
-            <div
-                class="q-pa-md"
-                v-show="userStore.isLoggedIn || showViewWhenNotLoggedIn"
-            >
-                <router-view></router-view>
-            </div>
-            <div
-                v-show="!userStore.isLoggedIn"
-                class="q-pa-xl flex flex-center"
-            >
-                <q-card
-                    class="text-center"
-                    style="max-width: 400px"
+            <main>
+                <div
+                    class="q-pa-md"
+                    v-show="userStore.isLoggedIn || showViewWhenNotLoggedIn"
                 >
-                    <q-card-section>
-                        <div class="text-h6">Welcome to VIPER</div>
-                        <div class="text-body1 q-mt-sm text-grey-7">Please log in to access this application.</div>
-                    </q-card-section>
-                    <q-card-actions
-                        align="center"
-                        class="q-pb-md"
+                    <router-view></router-view>
+                </div>
+                <div
+                    v-show="!userStore.isLoggedIn"
+                    class="q-pa-xl flex flex-center"
+                >
+                    <q-card
+                        class="text-center"
+                        style="max-width: 400px"
                     >
-                        <q-btn
-                            color="primary"
-                            label="Log In"
-                            :href="loginHref"
-                            no-caps
-                        />
-                    </q-card-actions>
-                </q-card>
-            </div>
+                        <q-card-section>
+                            <div class="text-h6">Welcome to VIPER</div>
+                            <div class="text-body1 q-mt-sm text-grey-7">Please log in to access this application.</div>
+                        </q-card-section>
+                        <q-card-actions
+                            align="center"
+                            class="q-pb-md"
+                        >
+                            <q-btn
+                                color="primary"
+                                label="Log In"
+                                :href="loginHref"
+                                no-caps
+                            />
+                        </q-card-actions>
+                    </q-card>
+                </div>
+            </main>
         </q-page-container>
 
         <q-footer

--- a/VueApp/src/layouts/ViperLayout.vue
+++ b/VueApp/src/layouts/ViperLayout.vue
@@ -80,15 +80,19 @@
                     class="lt-md"
                     :href="viperHome"
                 >
-                    <span
+                    <q-badge
                         v-if="environment == 'DEVELOPMENT'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Dev</span
+                        >Dev</q-badge
                     >
-                    <span
+                    <q-badge
                         v-if="environment == 'TEST'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Test</span
+                        >Test</q-badge
                     >
                 </q-btn>
 
@@ -101,15 +105,19 @@
                     :href="viperHome"
                 >
                     <span class="mainLayoutViper">VIPER 2.0</span>
-                    <span
+                    <q-badge
                         v-if="environment == 'DEVELOPMENT'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Development</span
+                        >Development</q-badge
                     >
-                    <span
+                    <q-badge
                         v-if="environment == 'TEST'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Test</span
+                        >Test</q-badge
                     >
                 </q-btn>
 

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -108,15 +108,15 @@ const currentYear = new Date().getFullYear()
                     <span class="mainLayoutViper">VIPER 2.0</span>
                     <q-badge
                         v-if="environment == 'DEVELOPMENT'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Development</q-badge
                     >
                     <q-badge
                         v-if="environment == 'TEST'"
-                        color="warning"
-                        text-color="dark"
+                        color="negative"
+                        role="presentation"
                         class="mainLayoutViperMode"
                         >Test</q-badge
                     >
@@ -198,8 +198,10 @@ const currentYear = new Date().getFullYear()
                             color="primary"
                             name="help_center"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         SVM-IT ServiceDesk
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
@@ -212,8 +214,10 @@ const currentYear = new Date().getFullYear()
                             color="primary"
                             name="navigation"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         SVM Home
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
@@ -226,8 +230,10 @@ const currentYear = new Date().getFullYear()
                             color="primary"
                             name="school"
                             size="xs"
+                            aria-hidden="true"
                         ></q-icon>
                         UC Davis
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                 </div>
                 <div class="">

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -158,7 +158,10 @@ const currentYear = new Date().getFullYear()
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <main id="main-content">
+            <main
+                id="main-content"
+                tabindex="-1"
+            >
                 <div
                     class="q-pa-md"
                     v-show="userStore.isLoggedIn"

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -63,15 +63,19 @@ const currentYear = new Date().getFullYear()
                                 >home</i
                             >
                             <span class="mainLayoutViper">VIPER 2.0</span>
-                            <span
+                            <q-badge
                                 v-if="environment == 'DEVELOPMENT'"
+                                color="warning"
+                                text-color="dark"
                                 class="mainLayoutViperMode"
-                                >Development</span
+                                >Development</q-badge
                             >
-                            <span
+                            <q-badge
                                 v-if="environment == 'TEST'"
+                                color="warning"
+                                text-color="dark"
                                 class="mainLayoutViperMode"
-                                >Test</span
+                                >Test</q-badge
                             >
                         </span>
                     </a>
@@ -102,15 +106,19 @@ const currentYear = new Date().getFullYear()
                     :href="viperHome"
                 >
                     <span class="mainLayoutViper">VIPER 2.0</span>
-                    <span
+                    <q-badge
                         v-if="environment == 'DEVELOPMENT'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Development</span
+                        >Development</q-badge
                     >
-                    <span
+                    <q-badge
                         v-if="environment == 'TEST'"
+                        color="warning"
+                        text-color="dark"
                         class="mainLayoutViperMode"
-                        >Test</span
+                        >Test</q-badge
                     >
                 </q-btn>
 

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -65,15 +65,15 @@ const currentYear = new Date().getFullYear()
                             <span class="mainLayoutViper">VIPER 2.0</span>
                             <q-badge
                                 v-if="environment == 'DEVELOPMENT'"
-                                color="warning"
-                                text-color="dark"
+                                color="negative"
+                                role="presentation"
                                 class="mainLayoutViperMode"
                                 >Development</q-badge
                             >
                             <q-badge
                                 v-if="environment == 'TEST'"
-                                color="warning"
-                                text-color="dark"
+                                color="negative"
+                                role="presentation"
                                 class="mainLayoutViperMode"
                                 >Test</q-badge
                             >

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -21,6 +21,11 @@ const currentYear = new Date().getFullYear()
 </script>
 
 <template>
+    <a
+        href="#main-content"
+        class="skip-to-content"
+        >Skip to main content</a
+    >
     <q-layout view="hHh lpr fff">
         <q-header
             elevated
@@ -153,7 +158,7 @@ const currentYear = new Date().getFullYear()
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <main>
+            <main id="main-content">
                 <div
                     class="q-pa-md"
                     v-show="userStore.isLoggedIn"

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -153,12 +153,14 @@ const currentYear = new Date().getFullYear()
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <div
-                class="q-pa-md"
-                v-show="userStore.isLoggedIn"
-            >
-                <router-view></router-view>
-            </div>
+            <main>
+                <div
+                    class="q-pa-md"
+                    v-show="userStore.isLoggedIn"
+                >
+                    <router-view></router-view>
+                </div>
+            </main>
         </q-page-container>
 
         <q-footer

--- a/VueApp/src/layouts/ViperLayoutSimple.vue
+++ b/VueApp/src/layouts/ViperLayoutSimple.vue
@@ -195,7 +195,7 @@ const currentYear = new Date().getFullYear()
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
-                        href="http://www.vetmed.ucdavis.edu/"
+                        href="https://www.vetmed.ucdavis.edu/"
                         target="_blank"
                         rel="noopener"
                         class="text-primary"
@@ -209,7 +209,7 @@ const currentYear = new Date().getFullYear()
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a
-                        href="http://www.ucdavis.edu/"
+                        href="https://www.ucdavis.edu/"
                         target="_blank"
                         rel="noopener"
                         class="text-primary"

--- a/VueApp/src/pages/Error404.vue
+++ b/VueApp/src/pages/Error404.vue
@@ -4,6 +4,6 @@ const route = useRoute()
 </script>
 
 <template>
-    <h2>Error 404 - not found</h2>
+    <h1>Error 404 - not found</h1>
     <p>The page at {{ route.path }} could not be found.</p>
 </template>

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -332,6 +332,12 @@ header .q-avatar {
     top: 0;
 }
 
+/* Suppress focus outline on main content — useRouteFocus sets focus
+   programmatically for screen reader announcements only */
+#main-content:focus {
+    outline: none;
+}
+
 /* Screen reader only — visually hidden but accessible to assistive technology */
 .sr-only {
     position: absolute;

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -314,6 +314,24 @@ header .q-avatar {
     width: 31px !important;
 }
 
+/* Skip to content link — visible on focus for keyboard users */
+.skip-to-content {
+    position: absolute;
+    top: -2.5rem;
+    left: 0.5rem;
+    z-index: 9999;
+    padding: 0.5rem 1rem;
+    background: var(--q-primary);
+    color: white;
+    text-decoration: none;
+    border-radius: 0 0 0.25rem 0.25rem;
+    font-weight: 600;
+}
+
+.skip-to-content:focus {
+    top: 0;
+}
+
 /* Screen reader only — visually hidden but accessible to assistive technology */
 .sr-only {
     position: absolute;

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -113,7 +113,7 @@ div.breadcrumbs {
 
 /*Left Nav styles*/
 #leftNavMenu {
-    /*background-color: #E5E5E5;*/
+    overflow-x: hidden;
 }
 
 #leftNavMenu h2 {

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -241,7 +241,7 @@ div.breadcrumbs {
 
 /* Heading Styles */
 .q-dialog h1,
-.q-dialog text-h1,
+.q-dialog .text-h1,
 .q-page-container h1,
 .q-page-container .text-h1 {
     font-size: 1.2rem;
@@ -251,7 +251,7 @@ div.breadcrumbs {
 }
 
 .q-dialog h2,
-.q-dialog text-h2,
+.q-dialog .text-h2,
 .q-page-container h2,
 .q-page-container .text-h2 {
     font-size: 1.2rem;
@@ -261,7 +261,7 @@ div.breadcrumbs {
 }
 
 .q-dialog h3,
-.q-dialog text-h3,
+.q-dialog .text-h3,
 .q-page-container h3,
 .q-page-container .text-h3 {
     font-size: 1.2rem;
@@ -271,7 +271,7 @@ div.breadcrumbs {
 }
 
 .q-dialog h4,
-.q-dialog text-h4,
+.q-dialog .text-h4,
 .q-page-container h4,
 .q-page-container .text-h4 {
     font-size: 1.1rem;
@@ -281,7 +281,7 @@ div.breadcrumbs {
 }
 
 .q-dialog h5,
-.q-dialog text-h5,
+.q-dialog .text-h5,
 .q-page-container h5,
 .q-page-container .text-h5 {
     font-size: 1rem;
@@ -291,7 +291,7 @@ div.breadcrumbs {
 }
 
 .q-dialog h6,
-.q-dialog text-h6,
+.q-dialog .text-h6,
 .q-page-container h6,
 .q-page-container .text-h6 {
     font-size: 1rem;

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -73,7 +73,6 @@ body {
 .mainLayoutViperMode {
     margin-left: 0.6em;
     margin-top: 0.4em;
-    color: red;
     vertical-align: bottom;
 }
 

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -338,6 +338,22 @@ header .q-avatar {
     outline: none;
 }
 
+/* Prevent Quasar from fading inactive tab text below WCAG contrast */
+.q-tabs.tabs-no-fade .q-tab.q-tab--inactive {
+    opacity: 1;
+}
+
+/* Override Quasar's 0.6 opacity on input clear buttons */
+.q-field .q-field__focusable-action {
+    opacity: 1;
+}
+
+/* Ensure q-tree expand/collapse arrows meet WCAG contrast requirements */
+.q-tree .q-tree__arrow {
+    color: var(--ucdavis-blue-70);
+    font-size: 1.4rem;
+}
+
 /* Screen reader only — visually hidden but accessible to assistive technology */
 .sr-only {
     position: absolute;

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -240,6 +240,16 @@ div.breadcrumbs {
 }
 
 /* Heading Styles */
+.q-dialog h1,
+.q-dialog text-h1,
+.q-page-container h1,
+.q-page-container .text-h1 {
+    font-size: 1.2rem;
+    line-height: 1.2rem;
+    margin: 0rem 0rem 1rem 0rem;
+    font-weight: bold;
+}
+
 .q-dialog h2,
 .q-dialog text-h2,
 .q-page-container h2,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,12 +43,47 @@ export default [
         },
     },
 
+    // Exclude cshtml files with Razor syntax (@Url.Content, ~) inside <script> blocks
+    // that breaks the JS parser — no rules can run on these anyway
+    {
+        ignores: [
+            "web/Areas/Directory/Views/Card.cshtml",
+            "web/Areas/Directory/Views/Table.cshtml",
+            "web/Areas/Students/Views/StudentClassYear.cshtml",
+            "web/Areas/Students/Views/StudentClassYearImport.cshtml",
+        ],
+    },
+
     // Configuration for CSHTML files (JavaScript in <script> tags)
     {
         files: ["web/**/*.cshtml"],
         plugins: {
             html,
             security,
+        },
+        languageOptions: {
+            globals: {
+                // Browser globals (cshtml scripts run in browser context)
+                fetch: "readonly",
+                URL: "readonly",
+                URLSearchParams: "readonly",
+                location: "readonly",
+                history: "readonly",
+                window: "readonly",
+                document: "readonly",
+                console: "readonly",
+                setTimeout: "readonly",
+                setInterval: "readonly",
+                // Project globals (loaded via shared script tags in _VIPERLayout.cshtml)
+                createVueApp: "readonly",
+                viperFetch: "readonly",
+                quasarTable: "readonly",
+                formatDate: "readonly",
+                formatDateForDateInput: "readonly",
+                getItemFromStorage: "readonly",
+                putItemInStorage: "readonly",
+                Quasar: "readonly",
+            },
         },
         settings: {
             "html/html-extensions": [".cshtml"],

--- a/scripts/lint-staged-cshtml.js
+++ b/scripts/lint-staged-cshtml.js
@@ -66,7 +66,7 @@ try {
     }
 
     // Run ESLint on .cshtml files using root config
-    const eslintArgs = [...(fixFlag ? ["--fix"] : []), "--format", "json", ...files]
+    const eslintArgs = ["--no-warn-ignored", ...(fixFlag ? ["--fix"] : []), "--format", "json", ...files]
 
     logger.info(`Running ESLint security and quality checks on ${files.length} .cshtml files...`)
 

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -230,9 +230,9 @@
                 deleteRoleMember: async function () {
                     var oldBase = this.memberRolesTable.urlBase
                     this.memberRolesTable.urlBase = "Members/" + this.memberId + "/Roles"
-                    await this.memberRolesTable.delete(this)
+                    const deleted = await this.memberRolesTable.delete(this)
                     this.memberRolesTable.urlBase = oldBase
-                    this.pushToVMACS()
+                    if (deleted) { this.pushToVMACS() }
                 },
                 addUpdateRoleMember: async function () {
                     var oldBase = this.memberRolesTable.urlBase

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -191,9 +191,9 @@
                     var oldBase = this.membersTable.urlBase
                     this.membersTable.urlBase = "Roles/" + this.roleId + "/Members"
 
-                    await this.membersTable.delete(this)
+                    const deleted = await this.membersTable.delete(this)
                     this.membersTable.urlBase = oldBase
-                    this.pushMemberToVMACS()
+                    if (deleted) { this.pushMemberToVMACS() }
                     
                     this.disableMemberUpdate = false
                 },

--- a/web/Views/Home/403.cshtml
+++ b/web/Views/Home/403.cshtml
@@ -2,10 +2,10 @@
 	ViewData["Title"] = "Access Denied";
 	ViewData["AllowAnonymousContent"] = true;
 }
-<h3 class="text-danger">Access Denied</h3>
-<h4 class="text-danger">You do not have permission to access this page or feature.</h4>
+<h1 class="text-danger">Access Denied</h1>
+<h2 class="text-danger">You do not have permission to access this page or feature.</h2>
 
 @if (!String.IsNullOrWhiteSpace(ViewBag.errorMessage))
 {
-	<h4>@ViewBag.errorMessage</h4>
+	<p>@ViewBag.errorMessage</p>
 }

--- a/web/Views/Home/Error.cshtml
+++ b/web/Views/Home/Error.cshtml
@@ -4,8 +4,8 @@
     ViewData["AllowAnonymousContent"] = true;
 }
 
-<h3 class="text-danger">Error.</h3>
-<h4 class="text-danger">An error occurred while processing your request.</h4>
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
 
 @if (Model != null && Model.ShowRequestId)
 {

--- a/web/Views/Home/MyPermissions.cshtml
+++ b/web/Views/Home/MyPermissions.cshtml
@@ -5,6 +5,7 @@
     bool has2fa = (bool)(ViewData["Has2FA"] ?? false);
 }
 
+<h1>My Permissions</h1>
 <h2>2FA Authentication</h2>
 @if (has2fa)
 {

--- a/web/Views/Shared/Components/LeftNav/Default.cshtml
+++ b/web/Views/Shared/Components/LeftNav/Default.cshtml
@@ -36,7 +36,7 @@
         }
 
         // Prefer relative/page links over tilde-prefixed instance links
-        if (string.Equals(currentPath, resolvedPath, StringComparison.Ordinal)
+        if (string.Equals(currentPath, resolvedPath, StringComparison.OrdinalIgnoreCase)
             && (activeIndex < 0 || (activeIsTilde && !isTilde)))
         {
             activeIndex = i;

--- a/web/Views/Shared/Components/MainNav/Default.cshtml
+++ b/web/Views/Shared/Components/MainNav/Default.cshtml
@@ -8,7 +8,7 @@
     {
         if (tabLink[0] == "https://ucdsvm.knowledgeowl.com/help")
         {
-            <q-btn flat href="@Url.Content(tabLink[0])" icon="help" class="q-px-md text-primary" v-cloak>
+            <q-btn flat href="@Url.Content(tabLink[0])" icon="help" aria-label="Help" class="q-px-md text-primary" v-cloak>
                 <q-tooltip>Help</q-tooltip>
             </q-btn>
             <hr class="q-separator q-separator--vertical q-separator--dark" aria-orientation="vertical">

--- a/web/Views/Shared/Components/MainNav/MainNav.cs
+++ b/web/Views/Shared/Components/MainNav/MainNav.cs
@@ -63,6 +63,7 @@ namespace Viper.Views.Shared.Components.MainNav
             ViewData["SelectedTopNav"] = (area.Length >= 2 ? area[1] : area[0]) switch
             {
                 "raps" => "Computing",
+                "policy" => "Policies",
                 _ => "VIPER Home",
             };
             return await Task.Run(() => View("Default", user));

--- a/web/Views/Shared/Components/ProfilePic/Default.cshtml
+++ b/web/Views/Shared/Components/ProfilePic/Default.cshtml
@@ -6,7 +6,7 @@
     <q-btn-dropdown unelevated>
         <template v-slot:label>
             <q-avatar size="40px">
-                <img src="@String.Format("https://viper.vetmed.ucdavis.edu/public/utilities/getbase64image.cfm?mailid={0}&altphoto=1", Model.MailId)" height="40" id="siteProfileAvatar" />
+                <img src="@String.Format("https://viper.vetmed.ucdavis.edu/public/utilities/getbase64image.cfm?mailid={0}&altphoto=1", Model.MailId)" height="40" id="siteProfileAvatar" alt="@($"{Model.DisplayFirstName} {Model.DisplayLastName}")" />
                 <q-tooltip :target="siteProfileAvatar">
                     @Model.DisplayFirstName @Model.DisplayLastName
                 </q-tooltip>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -23,6 +23,7 @@
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
     <q-layout view="hHh lpr fff">
         <q-header elevated id="simplifiedLayoutHeader" height-hint="98" class="bg-white text-dark">
             <div v-show="false" id="headerPlaceholder">
@@ -79,7 +80,7 @@
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <main>
+            <main id="main-content">
                 <div class="q-pa-md" v-cloak>
                     @RenderBody()
                 </div>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -90,19 +90,19 @@
         <q-footer elevated class="bg-white" v-cloak>
             <div class="q-pa-y-sm q-pa-x-md q-gutter-xs text-caption row justify-between items-center" id="footerNavLinks">
                 <div class="q-pl-md">
-                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
                         <span class="sr-only">(opens in new window)</span>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -79,9 +79,11 @@
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <div class="q-pa-md" v-cloak>
-                @RenderBody()
-            </div>
+            <main>
+                <div class="q-pa-md" v-cloak>
+                    @RenderBody()
+                </div>
+            </main>
         </q-page-container>
 
         <q-footer elevated class="bg-white" v-cloak>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -90,19 +90,19 @@
         <q-footer elevated class="bg-white" v-cloak>
             <div class="q-pa-y-sm q-pa-x-md q-gutter-xs text-caption row justify-between items-center" id="footerNavLinks">
                 <div class="q-pl-md">
-                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
                         <span class="sr-only">(opens in new window)</span>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -80,7 +80,7 @@
         </q-header>
 
         <q-page-container id="mainLayoutBody">
-            <main id="main-content">
+            <main id="main-content" tabindex="-1">
                 <div class="q-pa-md" v-cloak>
                     @RenderBody()
                 </div>

--- a/web/Views/Shared/VIPERLayoutSimplified.cshtml
+++ b/web/Views/Shared/VIPERLayoutSimplified.cshtml
@@ -91,18 +91,21 @@
             <div class="q-pa-y-sm q-pa-x-md q-gutter-xs text-caption row justify-between items-center" id="footerNavLinks">
                 <div class="q-pl-md">
                     <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="help_center" size="xs"></q-icon>
+                        <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="navigation" size="xs"></q-icon>
+                        <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="school" size="xs"></q-icon>
+                        <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                 </div>
                 <div class="">

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -38,9 +38,9 @@
                 accent: '#ffc519',       // UC Davis Gold 90
                 dark: '#1d1d1d',         // Dark background
                 'dark-page': '#121212',  // Darker page background
-                positive: '#226e34',     // Green for success states
-                negative: '#6e2222',     // Red for error states
-                info: '#289094',         // Teal for informational states
+                positive: '#266041',     // Redwood - green for success states
+                negative: '#79242F',     // Merlot - red for error states
+                info: '#00B2E3',         // Tahoe - blue for informational states
                 warning: '#ffc519'       // Gold for warning states
             };
 

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -69,11 +69,11 @@
                             <span class="mainLayoutViper">VIPER 2.0</span>
                             @if (HttpHelper.Environment?.EnvironmentName == "Development")
                             {
-                                <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Development</q-badge>
+                                <q-badge color="negative" role="presentation" class="mainLayoutViperMode">Development</q-badge>
                             }
                             else if (HttpHelper.Environment?.EnvironmentName == "Test")
                             {
-                                <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Test</q-badge>
+                                <q-badge color="negative" role="presentation" class="mainLayoutViperMode">Test</q-badge>
                             }
                         </span>
                     </a>
@@ -96,11 +96,11 @@
                     <span class="mainLayoutViper">VIPER 2.0</span>
                     @if (HttpHelper.Environment?.EnvironmentName == "Development")
                     {
-                        <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Development</q-badge>
+                        <q-badge color="negative" role="presentation" class="mainLayoutViperMode">Development</q-badge>
                     }
                     else if (HttpHelper.Environment?.EnvironmentName == "Test")
                     {
-                        <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Test</q-badge>
+                        <q-badge color="negative" role="presentation" class="mainLayoutViperMode">Test</q-badge>
                     }
                 </q-btn>
 

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -176,19 +176,19 @@
         <q-footer elevated class="bg-white" v-cloak>
             <div class="q-py-sm q-px-md q-gutter-xs text-caption row" id="footerNavLinks">
                 <div class="col-12 col-md q-pl-md">
-                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
+                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
                         <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
                         <span class="sr-only">(opens in new window)</span>

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -56,6 +56,7 @@
 
 </head>
 <body>
+    <a href="#main-content" class="skip-to-content">Skip to main content</a>
     <q-layout view="hHh lpR fFf">
         <q-header elevated id="mainLayoutHeader" height-hint="98">
             <div v-show="false" id="headerPlaceholder">
@@ -142,7 +143,7 @@
         )
 
         <q-page-container id="mainLayoutBody">
-            <main>
+            <main id="main-content">
                 @{
                     var allowAnonymousContent = ViewData["AllowAnonymousContent"] as bool? ?? false;
                 }
@@ -176,18 +177,21 @@
             <div class="q-py-sm q-px-md q-gutter-xs text-caption row" id="footerNavLinks">
                 <div class="col-12 col-md q-pl-md">
                     <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="help_center" size="xs"></q-icon>
+                        <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="navigation" size="xs"></q-icon>
+                        <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
                     <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
-                        <q-icon color="primary" name="school" size="xs"></q-icon>
+                        <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
+                        <span class="sr-only">(opens in new window)</span>
                     </a>
                 </div>
                 <div class="col-12 col-md-auto gt-sm">

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -69,11 +69,11 @@
                             <span class="mainLayoutViper">VIPER 2.0</span>
                             @if (HttpHelper.Environment?.EnvironmentName == "Development")
                             {
-                                <span class="mainLayoutViperMode">Development</span>
+                                <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Development</q-badge>
                             }
                             else if (HttpHelper.Environment?.EnvironmentName == "Test")
                             {
-                                <span class="mainLayoutViperMode">Test</span>
+                                <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Test</q-badge>
                             }
                         </span>
                     </a>
@@ -96,11 +96,11 @@
                     <span class="mainLayoutViper">VIPER 2.0</span>
                     @if (HttpHelper.Environment?.EnvironmentName == "Development")
                     {
-                        <span class="mainLayoutViperMode">Development</span>
+                        <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Development</q-badge>
                     }
                     else if (HttpHelper.Environment?.EnvironmentName == "Test")
                     {
-                        <span class="mainLayoutViperMode">Test</span>
+                        <q-badge color="warning" text-color="dark" class="mainLayoutViperMode">Test</q-badge>
                     }
                 </q-btn>
 

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -143,7 +143,7 @@
         )
 
         <q-page-container id="mainLayoutBody">
-            <main id="main-content">
+            <main id="main-content" tabindex="-1">
                 @{
                     var allowAnonymousContent = ViewData["AllowAnonymousContent"] as bool? ?? false;
                 }

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -28,7 +28,6 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet" type="text/css">
     <script src="~/js/ucdavis-colors.js"></script>
     <script asp-add-nonce="true">
-        /* global window, document */
         // Apply UC Davis brand colors immediately to prevent flash
         // Must run after Quasar CSS loads but before page content renders
         (function() {
@@ -80,7 +79,7 @@
                 </div>
             </div>
             <q-toolbar v-cloak class="items-end">
-                <img src="@Url.Content("~/images/")UCDSVMLogo.png" height="50" />
+                <img src="@Url.Content("~/images/")UCDSVMLogo.png" height="50" alt="UC Davis School of Veterinary Medicine Logo" />
 
                 <q-btn flat dense icon="menu" class="q-mr-xs lt-md">
                     @await Component.InvokeAsync("MiniNav",
@@ -143,32 +142,34 @@
         )
 
         <q-page-container id="mainLayoutBody">
-            @{
-                var allowAnonymousContent = ViewData["AllowAnonymousContent"] as bool? ?? false;
-            }
-            @if (UserHelper.GetCurrentUser() != null || allowAnonymousContent)
-            {
-                <div class="q-pa-md" v-cloak>
-                @RenderBody()
-                </div>
-            }
-            else
-            {
-                IgnoreBody();
-                <div class="q-pa-xl flex flex-center" v-cloak>
-                    <q-card class="text-center" style="max-width: 400px">
-                        <q-card-section>
-                            <div class="text-h6">Welcome to VIPER</div>
-                            <div class="text-body1 q-mt-sm text-grey-7">
-                                Please log in to access this application.
-                            </div>
-                        </q-card-section>
-                        <q-card-actions align="center" class="q-pb-md">
-                            <q-btn color="primary" label="Log In" href="@Url.Content("~/login")?ReturnUrl=@Uri.EscapeDataString((Context.Request.PathBase + Context.Request.Path).Value + Context.Request.QueryString)" no-caps />
-                        </q-card-actions>
-                    </q-card>
-                </div>
-            }
+            <main>
+                @{
+                    var allowAnonymousContent = ViewData["AllowAnonymousContent"] as bool? ?? false;
+                }
+                @if (UserHelper.GetCurrentUser() != null || allowAnonymousContent)
+                {
+                    <div class="q-pa-md" v-cloak>
+                    @RenderBody()
+                    </div>
+                }
+                else
+                {
+                    IgnoreBody();
+                    <div class="q-pa-xl flex flex-center" v-cloak>
+                        <q-card class="text-center" style="max-width: 400px">
+                            <q-card-section>
+                                <div class="text-h6">Welcome to VIPER</div>
+                                <div class="text-body1 q-mt-sm text-grey-7">
+                                    Please log in to access this application.
+                                </div>
+                            </q-card-section>
+                            <q-card-actions align="center" class="q-pb-md">
+                                <q-btn color="primary" label="Log In" href="@Url.Content("~/login")?ReturnUrl=@Uri.EscapeDataString((Context.Request.PathBase + Context.Request.Path).Value + Context.Request.QueryString)" no-caps />
+                            </q-card-actions>
+                        </q-card>
+                    </div>
+                }
+            </main>
         </q-page-container>
 
         <q-footer elevated class="bg-white" v-cloak>

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -82,14 +82,14 @@
             <q-toolbar v-cloak class="items-end">
                 <img src="@Url.Content("~/images/")UCDSVMLogo.png" height="50" alt="UC Davis School of Veterinary Medicine Logo" />
 
-                <q-btn flat dense icon="menu" class="q-mr-xs lt-md">
+                <q-btn flat dense icon="menu" aria-label="Navigation menu" class="q-mr-xs lt-md">
                     @await Component.InvokeAsync("MiniNav",
                     new {
                     user = UserHelper.GetCurrentUser()
                     }
                     )
                 </q-btn>
-                <q-btn flat dense icon="list" class="q-mr-xs lt-md" @@click="mainLeftDrawer = !mainLeftDrawer"></q-btn>
+                <q-btn flat dense icon="list" aria-label="Toggle sidebar" class="q-mr-xs lt-md" @@click="mainLeftDrawer = !mainLeftDrawer"></q-btn>
                 <q-btn flat dense label="Viper 2.0" class="lt-md" href="@Url.Content("~/")"></q-btn>
 
                 <q-btn flat dense no-caps class="gt-sm text-white q-py-none q-ml-md self-end" href="@Url.Content("~/")">

--- a/web/Views/Shared/_VIPERLayout.cshtml
+++ b/web/Views/Shared/_VIPERLayout.cshtml
@@ -176,19 +176,19 @@
         <q-footer elevated class="bg-white" v-cloak>
             <div class="q-py-sm q-px-md q-gutter-xs text-caption row" id="footerNavLinks">
                 <div class="col-12 col-md q-pl-md">
-                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://svmithelp.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="help_center" size="xs" aria-hidden="true"></q-icon>
                         SVM-IT ServiceDesk
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://www.vetmed.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="navigation" size="xs" aria-hidden="true"></q-icon>
                         SVM Home
                         <span class="sr-only">(opens in new window)</span>
                     </a>
                     <span class="text-primary q-px-sm">|</span>
-                    <a href="http://www.ucdavis.edu/" target="_blank" rel="noopener noreferrer" class="text-primary">
+                    <a href="https://www.ucdavis.edu/" target="_blank" rel="noopener" class="text-primary">
                         <q-icon color="primary" name="school" size="xs" aria-hidden="true"></q-icon>
                         UC Davis
                         <span class="sr-only">(opens in new window)</span>

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -184,6 +184,46 @@ html {
     -webkit-font-smoothing: antialiased;
 }
 
+/* Screen reader only — visually hidden but accessible to assistive technology */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Skip to content link — visible on focus for keyboard users */
+.skip-to-content {
+    position: absolute;
+    top: -2.5rem;
+    left: 0.5rem;
+    z-index: 9999;
+    padding: 0.5rem 1rem;
+    background: var(--q-primary);
+    color: #fff;
+    text-decoration: none;
+    border-radius: 0 0 0.25rem 0.25rem;
+    font-weight: 600;
+}
+
+.skip-to-content:focus {
+    top: 0;
+}
+
+/* Override Quasar grey to UC Davis Black 60 for AA contrast compliance */
+.text-grey {
+    color: var(--ucdavis-black-60);
+}
+
+.bg-grey {
+    background-color: var(--ucdavis-black-60);
+}
+
 /* Heading Styles */
 .q-page-container h1,
 .q-page-container .text-h1 {

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -223,6 +223,11 @@ html {
     outline: none;
 }
 
+/* Override Quasar's 0.6 opacity on input clear buttons */
+.q-field .q-field__focusable-action {
+    opacity: 1;
+}
+
 /* Status notification toast — accessible via role="status" */
 .viper-status-notification {
     position: fixed;

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -185,6 +185,14 @@ html {
 }
 
 /* Heading Styles */
+.q-page-container h1,
+.q-page-container .text-h1 {
+    font-size: 1.2rem;
+    line-height: 1.2rem;
+    margin: 0rem 0rem 1rem 0rem;
+    font-weight: bold;
+}
+
 .q-page-container h2,
 .q-page-container .text-h2 {
     font-size: 1.2rem;

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -81,6 +81,10 @@ html {
 }
 
 /*Left Nav styles*/
+#leftNavMenu {
+    overflow-x: hidden;
+}
+
 #leftNavMenu h2 {
     font-size: 1.2rem;
     margin: 0;
@@ -215,13 +219,44 @@ html {
     top: 0;
 }
 
-/* Override Quasar grey to UC Davis Black 60 for AA contrast compliance */
+/* Status notification toast — accessible via role="status" */
+.viper-status-notification {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%) translateY(1rem);
+    padding: 0.75rem 1.5rem;
+    background: var(--q-positive, #266041);
+    color: #fff;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    z-index: 9999;
+    opacity: 0;
+    transition:
+        opacity 0.3s,
+        transform 0.3s;
+    pointer-events: none;
+    box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.3);
+}
+
+.viper-status-notification--visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* Quasar palette AA contrast overrides (!important required to override Quasar's !important) */
 .text-grey {
-    color: var(--ucdavis-black-60);
+    color: var(--ucdavis-black-60) !important;
 }
 
 .bg-grey {
-    background-color: var(--ucdavis-black-60);
+    background-color: var(--ucdavis-black-60) !important;
+}
+
+/* TODO: Remove when color="green" is migrated to color="positive" */
+.bg-green {
+    background-color: #266041 !important;
 }
 
 /* Heading Styles */

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -247,11 +247,11 @@ html {
 
 /* Quasar palette AA contrast overrides (!important required to override Quasar's !important) */
 .text-grey {
-    color: var(--ucdavis-black-60) !important;
+    color: var(--ucdavis-black-60, #666666) !important;
 }
 
 .bg-grey {
-    background-color: var(--ucdavis-black-60) !important;
+    background-color: var(--ucdavis-black-60, #666666) !important;
 }
 
 /* TODO: Remove when color="green" is migrated to color="positive" */

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -61,9 +61,7 @@ html {
 
 .mainLayoutViperMode {
     margin-left: 0.6em;
-    margin-top: 0.4em;
-    color: red;
-    vertical-align: bottom;
+    vertical-align: middle;
 }
 
 #topPlaceholder {

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -219,6 +219,12 @@ html {
     top: 0;
 }
 
+/* Suppress focus outline on main content — skip link and programmatic
+   focus target for screen readers, not an interactive element */
+#main-content:focus {
+    outline: none;
+}
+
 /* Status notification toast — accessible via role="status" */
 .viper-status-notification {
     position: fixed;

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -3,6 +3,8 @@
  * setup because the app mounts on <body> and Notify's teleport container ends up
  * outside Vue's reactive scope, so notifications are silently dropped.
  */
+const STATUS_NOTIFICATION_DISPLAY_MS = 3000
+const STATUS_NOTIFICATION_FADE_MS = 350
 function showStatusNotification(message) {
     const el = document.createElement("div")
     el.setAttribute("role", "status")
@@ -13,11 +15,10 @@ function showStatusNotification(message) {
     // Trigger reflow so the CSS transition activates
     void el.offsetHeight
     el.classList.add("viper-status-notification--visible")
-    // oxlint-disable-next-line no-magic-numbers -- notification display duration in ms
     setTimeout(() => {
         el.classList.remove("viper-status-notification--visible")
-        el.addEventListener("transitionend", () => el.remove(), { once: true })
-    }, 3000)
+        setTimeout(() => el.remove(), STATUS_NOTIFICATION_FADE_MS)
+    }, STATUS_NOTIFICATION_DISPLAY_MS)
 }
 
 /*

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -1,4 +1,26 @@
 /*
+ * Plain DOM status toast. Quasar.Notify.create() does not render in the UMD/CDN
+ * setup because the app mounts on <body> and Notify's teleport container ends up
+ * outside Vue's reactive scope, so notifications are silently dropped.
+ */
+function showStatusNotification(message) {
+    const el = document.createElement("div")
+    el.setAttribute("role", "status")
+    el.setAttribute("aria-live", "polite")
+    el.className = "viper-status-notification"
+    el.textContent = message
+    document.body.appendChild(el)
+    // Trigger reflow so the CSS transition activates
+    void el.offsetHeight
+    el.classList.add("viper-status-notification--visible")
+    // oxlint-disable-next-line no-magic-numbers -- notification display duration in ms
+    setTimeout(() => {
+        el.classList.remove("viper-status-notification--visible")
+        el.addEventListener("transitionend", () => el.remove())
+    }, 3000)
+}
+
+/*
  * QuasarTable - code to support a quasar table with an edit dialog and add/update/delete functions, with optional server side paging/filtering and export to csv
  */
 quasarTableDefaultConfig = {
@@ -140,7 +162,7 @@ class quasarTable {
     }
 
     async create(vueApp, bodyObject) {
-        await viperFetch(
+        const result = await viperFetch(
             vueApp,
             this.urlBase,
             {
@@ -151,10 +173,13 @@ class quasarTable {
             [() => this.load(this)],
             this.errors,
         )
+        if (result !== undefined) {
+            showStatusNotification("Item created")
+        }
     }
 
     async update(vueApp, bodyObject) {
-        await viperFetch(
+        const result = await viperFetch(
             vueApp,
             this.getUpdateURL(),
             {
@@ -165,11 +190,42 @@ class quasarTable {
             [() => this.load(this)],
             this.errors,
         )
+        if (result !== undefined) {
+            showStatusNotification("Item updated")
+        }
     }
 
-    // Delete the selected item
+    // Delete the selected item (with confirmation dialog)
     async delete(vueApp) {
-        await viperFetch(vueApp, this.getUpdateURL(), { method: "DELETE" }, [() => this.load(this)], this.errors)
+        return new Promise((resolve) => {
+            vueApp.$q.dialog({
+                title: "Confirm Delete",
+                message: "Are you sure you want to delete this item?",
+                cancel: true,
+                persistent: true,
+            })
+                .onOk(async () => {
+                    try {
+                        const result = await viperFetch(
+                            vueApp,
+                            this.getUpdateURL(),
+                            { method: "DELETE" },
+                            [() => this.load(this)],
+                            this.errors,
+                        )
+                        if (result !== undefined) {
+                            showStatusNotification("Item deleted")
+                        }
+                        resolve(true)
+                    } catch (error) {
+                        showViperFetchError(vueApp, error, this.errors)
+                        resolve(false)
+                    }
+                })
+                .onCancel(() => {
+                    resolve(false)
+                })
+        })
     }
 
     // Get the URL to create or update the item

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -170,7 +170,7 @@ class quasarTable {
                 body: JSON.stringify(bodyObject),
                 headers: { "Content-Type": "application/json" },
             },
-            [() => this.load(this)],
+            [() => this.load(vueApp)],
             this.errors,
         )
         if (result !== undefined) {
@@ -187,7 +187,7 @@ class quasarTable {
                 body: JSON.stringify(bodyObject),
                 headers: { "Content-Type": "application/json" },
             },
-            [() => this.load(this)],
+            [() => this.load(vueApp)],
             this.errors,
         )
         if (result !== undefined) {
@@ -209,7 +209,7 @@ class quasarTable {
                         vueApp,
                         this.getUpdateURL(),
                         { method: "DELETE" },
-                        [() => this.load(this)],
+                        [() => this.load(vueApp)],
                         this.errors,
                     )
                     if (result !== undefined) {

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -205,22 +205,17 @@ class quasarTable {
                 persistent: true,
             })
                 .onOk(async () => {
-                    try {
-                        const result = await viperFetch(
-                            vueApp,
-                            this.getUpdateURL(),
-                            { method: "DELETE" },
-                            [() => this.load(this)],
-                            this.errors,
-                        )
-                        if (result !== undefined) {
-                            showStatusNotification("Item deleted")
-                        }
-                        resolve(result !== undefined)
-                    } catch (error) {
-                        showViperFetchError(vueApp, error, this.errors)
-                        resolve(false)
+                    const result = await viperFetch(
+                        vueApp,
+                        this.getUpdateURL(),
+                        { method: "DELETE" },
+                        [() => this.load(this)],
+                        this.errors,
+                    )
+                    if (result !== undefined) {
+                        showStatusNotification("Item deleted")
                     }
+                    resolve(result !== undefined)
                 })
                 .onCancel(() => {
                     resolve(false)

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -216,7 +216,7 @@ class quasarTable {
                         if (result !== undefined) {
                             showStatusNotification("Item deleted")
                         }
-                        resolve(true)
+                        resolve(result !== undefined)
                     } catch (error) {
                         showViperFetchError(vueApp, error, this.errors)
                         resolve(false)

--- a/web/wwwroot/js/qtable.js
+++ b/web/wwwroot/js/qtable.js
@@ -16,7 +16,7 @@ function showStatusNotification(message) {
     // oxlint-disable-next-line no-magic-numbers -- notification display duration in ms
     setTimeout(() => {
         el.classList.remove("viper-status-notification--visible")
-        el.addEventListener("transitionend", () => el.remove())
+        el.addEventListener("transitionend", () => el.remove(), { once: true })
     }, 3000)
 }
 

--- a/web/wwwroot/js/ucdavis-colors.js
+++ b/web/wwwroot/js/ucdavis-colors.js
@@ -19,7 +19,7 @@ globalThis.UCDavisBrandColors = {
     // Status colors (UC Davis secondary palette)
     positive: "#266041", // Redwood - green for success states
     negative: "#79242F", // Merlot - red for error states
-    info: "#008EAA", // Putah Creek - teal for informational states
+    info: "#6FCFEB", // Rec Pool - light blue for informational states
     warning: "#ffc519", // Gold for warning states (same as accent)
 
     // Dark theme colors

--- a/web/wwwroot/js/ucdavis-colors.js
+++ b/web/wwwroot/js/ucdavis-colors.js
@@ -16,10 +16,10 @@ globalThis.UCDavisBrandColors = {
     secondary: "#4b6983", // UC Davis Blue 70
     accent: "#ffc519", // UC Davis Gold 90
 
-    // Status colors
-    positive: "#226e34", // Green for success states
-    negative: "#6e2222", // Red for error states
-    info: "#289094", // Teal for informational states
+    // Status colors (UC Davis secondary palette)
+    positive: "#266041", // Redwood - green for success states
+    negative: "#79242F", // Merlot - red for error states
+    info: "#008EAA", // Putah Creek - teal for informational states
     warning: "#ffc519", // Gold for warning states (same as accent)
 
     // Dark theme colors

--- a/web/wwwroot/js/ucdavis-colors.js
+++ b/web/wwwroot/js/ucdavis-colors.js
@@ -19,7 +19,7 @@ globalThis.UCDavisBrandColors = {
     // Status colors (UC Davis secondary palette)
     positive: "#266041", // Redwood - green for success states
     negative: "#79242F", // Merlot - red for error states
-    info: "#6FCFEB", // Rec Pool - light blue for informational states
+    info: "#00B2E3", // Tahoe - blue for informational states
     warning: "#ffc519", // Gold for warning states (same as accent)
 
     // Dark theme colors


### PR DESCRIPTION
## Summary

Accessibility foundation for shared layouts (Razor + Vue SPAs), covering WCAG 2.1 AA compliance across navigation, color contrast, landmarks, and interactive feedback.

### Landmarks & Navigation
- **Single `<main>` landmark** per page: Razor layouts get `<main>` directly; Vue SPAs get it from `ViperLayout.vue` / `ViperLayoutSimple.vue` ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- **Skip-to-content link** on all four layouts (two Razor, two Vue), with `tabindex="-1"` on the `<main>` target so focus reliably moves for keyboard/screen reader users ([2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html))
- **Route focus management**: `useRouteFocus` composable announces SPA page changes to screen readers ([2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html))
- **LeftNav navigation landmark**: wrap q-list in `<nav>` with `aria-label` from menu header, change q-list role from `presentation` to `list` so listitem children have the required parent role, remove `role="none"` override from interactive q-items (conflicted with tabindex)

### Color Contrast (AA)
- **Status colors** aligned to UC Davis secondary palette — positive: Redwood, negative: Merlot, info: Tahoe — all passing AA contrast with white text ([1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
- **Quasar utility overrides**: `.text-grey`, `.bg-grey`, `.bg-green` overridden with `!important` to meet AA (Quasar defaults fail)
- **Razor layout fallback colors** synced to match the palette
- **Environment badge contrast**: remove `color: red` override on `.mainLayoutViperMode` that produced red-on-merlot (2.49:1) — badge now uses the default white-on-merlot (~7.2:1)
- **Quasar clear button opacity**: override Quasar's 0.6 opacity on `.q-field__focusable-action` so WCAG contrast holds
- **Inactive tab fade prevention**: new `.tabs-no-fade` class to opt out of Quasar's opacity reduction on inactive tabs
- **q-tree arrow contrast**: increase arrow color and font size for legibility
- **GenericError / SessionTimeout**: replace `color="red"` / `color="orange"` with brand `color="negative"` / `color="warning"` on icons

### Screen Reader & Keyboard
- **Heading hierarchy** fixed (proper `<h1>` on error/permissions pages, shared heading styles) ([1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- **External link indicators**: "opens in new window" sr-only text + icon on `target="_blank"` links in footer and LeftNav; `rel="noopener noreferrer"` to prevent reverse-tabnabbing; icon only shown for truly external sites (not same-hostname VIPER1 links) ([3.2.5 Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request.html))
- **`aria-label`** on icon-only buttons (mobile menu, sidebar toggle, help link) ([4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html))
- **`aria-hidden`** on decorative icons in footer links
- **Overflow title directive**: `v-overflow-title` sets `title` attribute only when nav text is truncated; updates on resize/drawer toggle via `ResizeObserver`

### Interactive Feedback
- **CRUD status notifications** on quasarTable create/update/delete (plain DOM toast with `role="status"` — Quasar Notify does not render in UMD body-mount setup) ([4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html))
- **Delete confirmation dialog** with cancel support; VMACS exports guarded so they only fire on confirmed deletes

### Components
- **`StatusBanner.vue`**: accessible tinted-background banner (success/error/warning/info) with colored left border, dark text on light background, dismissible option, and action slot
- **Alt text** added to logo, profile avatar, and student photo images ([1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html))

### Config
- **ESLint CSHTML config**: browser/project globals added, files with unparseable Razor syntax excluded

### Bug Fixes (discovered during review)
- **quasarTable reload callbacks**: `create`/`update`/`delete` were passing the table instance (`this.load(this)`) to `load()` as the `vueApp` argument, which then went into `viperFetch` and `showViperFetchError`. A failed reload after a mutation silently wrote the error flag to the table instance instead of the Vue app, leaving the user with a stale grid and no error dialog. Pattern was pre-existing since the original qtable.js commit.
- **Case-insensitive LeftNav path matching**: `StringComparison.Ordinal` → `StringComparison.OrdinalIgnoreCase` in `Default.cshtml` so menu highlight survives URL case differences