### PR TITLE
VPR-104 fix(a11y): RAPS area accessibility improvements (PR 2 of 6)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,7 @@ export default [
                 formatDateForDateInput: "readonly",
                 getItemFromStorage: "readonly",
                 putItemInStorage: "readonly",
+                showStatusNotification: "readonly",
                 Quasar: "readonly",
             },
         },

--- a/web/Areas/RAPS/Views/AuditLog.cshtml
+++ b/web/Areas/RAPS/Views/AuditLog.cshtml
@@ -28,7 +28,7 @@
     </div>
 </q-form>
 
-<q-banner v-if="auditTable.rows.length == 1000" rounded dense class="bg-warning q-my-md">
+<q-banner v-if="auditTable.rows.length === 1000" rounded dense class="bg-warning text-dark q-my-md" role="status">
     Only the most recent 1000 records that match the criteria above will be displayed. To return all records, use additional criteria to limit the results.
 </q-banner>
 

--- a/web/Areas/RAPS/Views/AuditLog.cshtml
+++ b/web/Areas/RAPS/Views/AuditLog.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Audit Trail</h1>
+﻿@{
+    ViewData["Title"] = "Audit Log";
+}
+<h1>Audit Trail</h1>
 <q-form v-bind="auditForm" @@submit="getAudit(this)">
     <div class="row q-mb-sm q-gutter-sm">
         <q-input outlined dense label="Start Date" class="col col-md-3 col-lg-2"
@@ -92,7 +95,7 @@
                         columns: [
                             { name: "detail", field: "", label: "Object / Detail", align: "left" },
                             { name: "auditType", label: "AuditType", field: "audit", sortable: true, align: "left" },
-                            { name: "comment", label: "Comment", field: "Comment", sortable: true, align: "left" },
+                            { name: "comment", label: "Comment", field: "comment", sortable: true, align: "left" },
                             { name: "modBy", label: "Mod By", field: "modByUserName", sortable: true, align: "left" },
                             { name: "modTime", label: "Mod Time", field: "modTime", sortable: true, align: "left", format: v => formatDateTime(v) }
                         ]

--- a/web/Areas/RAPS/Views/AuditLog.cshtml
+++ b/web/Areas/RAPS/Views/AuditLog.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Audit Trail</h2>
+﻿<h1>Audit Trail</h1>
 <q-form v-bind="auditForm" @@submit="getAudit(this)">
     <div class="row q-mb-sm q-gutter-sm">
         <q-input outlined dense label="Start Date" class="col col-md-3 col-lg-2"
@@ -42,20 +42,20 @@
     <template v-slot:body-cell-detail="props">
         <q-td :props="props">
             <div v-if="props.row.memberName ?? '' != ''">
-                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" @@click="addAuditCriteria('modifiedUser', props.row.memberId)"></q-btn>
+                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by user" @@click="addAuditCriteria('modifiedUser', props.row.memberId)"></q-btn>
                 User:
                 {{props.row.memberName}}
                 <br/>
             </div>
             <div v-if="props.row.roleId ?? '' != ''">
-                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" 
+                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by role"
                     @@click="addAuditCriteria('role', {'roleId': props.row.roleId, 'friendlyName': props.row.role ?? 'Deleted role'})"></q-btn>
                 Role:
                 {{props.row.role ?? 'Deleted role'}}
                 <br />
             </div>
             <div v-if="props.row.permissionId ?? '' != ''">
-                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt"
+                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by permission"
                        @@click="addAuditCriteria('permissionId', props.row.permissionId)"></q-btn>
                 Permission:
                 {{props.row.permission ?? 'Deleted permission'}}
@@ -69,7 +69,7 @@
 @section Scripts{
     <script src="~/js/qtable.js"></script>
     <script asp-add-nonce="true">
-        /* global createVueApp, quasarTable, formatDateTime, viperFetch, getItemFromStorage, putItemInStorage */
+        /* global formatDateTime */
         createVueApp({
             data() {
                 return {

--- a/web/Areas/RAPS/Views/AuditLog.cshtml
+++ b/web/Areas/RAPS/Views/AuditLog.cshtml
@@ -19,10 +19,20 @@
                 type="text" v-model="auditForm.search"></q-input>
     </div>
     <div class="row q-mb-sm q-gutter-sm">
-        <q-input dense clearable borderless type="text" label="Permission" class="col col-md-3 col-lg-2" 
-            v-model="auditForm.permissionId" v-if="auditForm.permissionId != null" @@clear="getAudit(this)"></q-input>
-        <q-input dense clearable borderless type="text" label="Modified User" class="col col-md-3 col-lg-2"
-                 v-model="auditForm.modifiedUser" v-if="auditForm.modifiedUser != null" @@clear="getAudit(this)"></q-input>
+        <q-input dense borderless readonly label="Permission" class="col col-md-3 col-lg-2"
+            :model-value="auditForm.permissionName" v-if="auditForm.permissionId != null">
+            <template v-slot:append>
+                <q-icon name="cancel" class="cursor-pointer" role="button" tabindex="0" aria-label="Clear permission filter"
+                        @@click="clearPermissionFilter()" @@keyup.enter="clearPermissionFilter()" @@keyup.space="clearPermissionFilter()"></q-icon>
+            </template>
+        </q-input>
+        <q-input dense borderless readonly label="Modified User" class="col col-md-3 col-lg-2"
+            :model-value="auditForm.modifiedUserName" v-if="auditForm.modifiedUser != null">
+            <template v-slot:append>
+                <q-icon name="cancel" class="cursor-pointer" role="button" tabindex="0" aria-label="Clear modified user filter"
+                        @@click="clearModifiedUserFilter()" @@keyup.enter="clearModifiedUserFilter()" @@keyup.space="clearModifiedUserFilter()"></q-icon>
+            </template>
+        </q-input>
     </div>
     <div class="row q-mb-sm">
         <div class="col col-md-11 col-lg-8 text-center">
@@ -44,27 +54,27 @@
          :pagination="auditTable.pagination">
     <template v-slot:body-cell-detail="props">
         <q-td :props="props">
-            <div v-if="props.row.memberName ?? '' != ''">
-                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by user" @@click="addAuditCriteria('modifiedUser', props.row.memberId)"></q-btn>
+            <div v-if="props.row.memberName">
+                <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by user" @@click="addAuditCriteria({modifiedUser: props.row.memberId, modifiedUserName: props.row.memberName})"></q-btn>
                 User:
                 {{props.row.memberName}}
                 <br/>
             </div>
-            <div v-if="props.row.roleId ?? '' != ''">
+            <div v-if="props.row.roleId">
                 <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by role"
-                    @@click="addAuditCriteria('role', {'roleId': props.row.roleId, 'friendlyName': props.row.role ?? 'Deleted role'})"></q-btn>
+                    @@click="addAuditCriteria({role: {roleId: props.row.roleId, friendlyName: props.row.role ?? 'Deleted role'}})"></q-btn>
                 Role:
                 {{props.row.role ?? 'Deleted role'}}
                 <br />
             </div>
-            <div v-if="props.row.permissionId ?? '' != ''">
+            <div v-if="props.row.permissionId">
                 <q-btn dense flat square color="primary" size="sm" padding="none" icon="filter_alt" aria-label="Filter by permission"
-                       @@click="addAuditCriteria('permissionId', props.row.permissionId)"></q-btn>
+                       @@click="addAuditCriteria({permissionId: props.row.permissionId, permissionName: props.row.permission ?? 'Deleted permission'})"></q-btn>
                 Permission:
                 {{props.row.permission ?? 'Deleted permission'}}
                 <br />
             </div>
-            <span class="q-ml-lg" v-if="props.row.detail ?? '' != ''">{{props.row.detail}}</span>
+            <span class="q-ml-lg" v-if="props.row.detail">{{props.row.detail}}</span>
         </q-td>
     </template>
 </q-table>
@@ -85,9 +95,11 @@
                         auditType: null,
                         modBy: null,
                         modifiedUser: null,
+                        modifiedUserName: null,
                         role: null,
                         search: null,
-                        permissionId: null
+                        permissionId: null,
+                        permissionName: null
                     },
                     auditTable: new quasarTable({
                         keys: "auditRecordId",
@@ -104,29 +116,45 @@
             },
             methods: {
                 getAudit: function() {
+                    const displayOnlyKeys = new Set(["permissionName", "modifiedUserName"])
                     var params = []
                     for (const [key, value] of Object.entries(this.auditForm)) {
+                        if (displayOnlyKeys.has(key)) {
+                            continue
+                        }
                         if(key === "role" && value !== null && (value.roleId ?? "") !== "") {
                             params.push("roleId=" + value.roleId)
                         }
                         else if(key === "modBy" && value !== null && (value.loginId ?? "") !== "") {
                             params.push("modBy=" + value.loginId)
                         }
-                        else if(value !== null && value !=="") {
+                        else if(value !== null && value !== "") {
                             params.push(key + "=" + value)
                         }
                     }
                     this.auditTable.urlBase = 'Audit?' + params.join("&")
                     this.auditTable.load(this)
                 },
-                addAuditCriteria: function(paramName, paramValue) {
-                    if (!Object.hasOwn(this.auditForm, paramName)) { return }
-                    Object.defineProperty(this.auditForm, paramName, {
-                        value: paramValue,
-                        writable: true,
-                        enumerable: true,
-                        configurable: true
-                    })
+                addAuditCriteria: function(updates) {
+                    for (const [key, value] of Object.entries(updates)) {
+                        if (!Object.hasOwn(this.auditForm, key)) { continue }
+                        Object.defineProperty(this.auditForm, key, {
+                            value: value,
+                            writable: true,
+                            enumerable: true,
+                            configurable: true
+                        })
+                    }
+                    this.getAudit()
+                },
+                clearPermissionFilter: function() {
+                    this.auditForm.permissionId = null
+                    this.auditForm.permissionName = null
+                    this.getAudit()
+                },
+                clearModifiedUserFilter: function() {
+                    this.auditForm.modifiedUser = null
+                    this.auditForm.modifiedUserName = null
                     this.getAudit()
                 }
             },
@@ -139,7 +167,7 @@
 
                 var auditCriteria = getItemFromStorage("auditFormCriteria")
                 if(auditCriteria) {
-                    this.auditForm = auditCriteria
+                    this.auditForm = { ...this.auditForm, ...auditCriteria }
                     this.getAudit()
                 }
             },

--- a/web/Areas/RAPS/Views/Export.cshtml
+++ b/web/Areas/RAPS/Views/Export.cshtml
@@ -1,4 +1,5 @@
 ﻿@{
+    ViewData["Title"] = "Export";
     string options = "";
     List<string>? serverList = ViewData["Servers"] as List<string>;
     if(serverList != null)

--- a/web/Areas/RAPS/Views/Groups/CreateADGroup.cshtml
+++ b/web/Areas/RAPS/Views/Groups/CreateADGroup.cshtml
@@ -1,4 +1,7 @@
-﻿<div class="q-pa-sm q-gutter-sm row">
+﻿@{
+    ViewData["Title"] = "Create AD Group";
+}
+<div class="q-pa-sm q-gutter-sm row">
     <div class="col-lg-4">
         <q-form @@submit="submitGroup(this)" v-bind="newGroup">
             <div class="text-h6">Add uInform Managed Group Group</div>

--- a/web/Areas/RAPS/Views/Groups/List.cshtml
+++ b/web/Areas/RAPS/Views/Groups/List.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     ViewData["Title"] = "Groups";
 }
+<h1>Groups</h1>
 <div class="q-pa-sm q-gutter-sm">
     <q-dialog v-model="groupTable.showForm" @@hide="groupTable.clear(this)">
         <q-card style="width: 500px; max-width: 80vw;">

--- a/web/Areas/RAPS/Views/Groups/List.cshtml
+++ b/web/Areas/RAPS/Views/Groups/List.cshtml
@@ -24,7 +24,7 @@
 
                 <q-card-actions align="evenly">
                     <q-btn no-caps :label="groupTable.editing ? 'Update Group' : 'Add Group'" type="submit" padding="xs sm" color="primary"></q-btn>
-                    <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="groupTable.delete(this)" color="red" v-if="groupTable.editing"></q-btn>
+                    <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="groupTable.delete(this)" color="negative" v-if="groupTable.editing"></q-btn>
                 </q-card-actions>
             </q-form>
         </q-card>
@@ -39,7 +39,7 @@
          :filter="groupTable.filter"
          :pagination="groupTable.pagination">
     <template v-slot:top-left>
-        <q-btn dense no-caps color="green" class="q-px-md" @@click="groupTable.showForm = true" label="Add Group"></q-btn>
+        <q-btn dense no-caps color="positive" class="q-px-md" @@click="groupTable.showForm = true" label="Add Group"></q-btn>
     </template>
     <template v-slot:top-right>
         <q-input v-model="groupTable.filter" dense outlined debounce="300" placeholder="Filter results" class="q-ml-xs q-mr-xs">

--- a/web/Areas/RAPS/Views/Groups/List.cshtml
+++ b/web/Areas/RAPS/Views/Groups/List.cshtml
@@ -5,9 +5,13 @@
                 <q-card-section>
                     <q-btn href="CreateADGroup" no-caps label="Create AD Group" dense flat square color="primary" padding="xs sm"></q-btn>
                 </q-card-section>
-                <q-card-section>
+                <q-card-section class="row items-center q-pb-none">
                     <div class="text-h6">{{groupTable.editing ? "Edit" : "Add OU"}} Group</div>
-                    <div class="bg-negative text-white q-pa-sm rounded" v-if="groupTable.errors?.message?.length > 0">{{groupTable.errors.message}}</div>
+                    <q-space></q-space>
+                    <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                </q-card-section>
+                <q-card-section v-if="groupTable.errors?.message?.length > 0">
+                    <div class="bg-negative text-white q-pa-sm rounded">{{groupTable.errors.message}}</div>
                 </q-card-section>
                 <q-card-section>
                     <q-select outlined dense options-dense use-input input-debounce="0"
@@ -91,7 +95,7 @@
                                 })
                             )
                         },
-                        selectObject: function (object) {
+                        selectObject: function (_object) {
                             this.object = {
                                 ...this.object,
                                 group: {
@@ -134,7 +138,7 @@
 
                 this.adGroups = await viperFetch(this, "Groups/AD")
                 this.adGroups = this.adGroups
-                    .map(g => ({ label: "AD: " + g.displayName ?? g.samAccountName, value: g.distinguishedName }))
+                    .map(g => ({ label: "AD: " + (g.displayName ?? g.samAccountName), value: g.distinguishedName }))
 
                 this.allGroups = [
                     { label: "AD3", children: this.adGroups },

--- a/web/Areas/RAPS/Views/Groups/List.cshtml
+++ b/web/Areas/RAPS/Views/Groups/List.cshtml
@@ -1,4 +1,7 @@
-﻿<div class="q-pa-sm q-gutter-sm">
+﻿@{
+    ViewData["Title"] = "Groups";
+}
+<div class="q-pa-sm q-gutter-sm">
     <q-dialog v-model="groupTable.showForm" @@hide="groupTable.clear(this)">
         <q-card style="width: 500px; max-width: 80vw;">
             <q-form @@submit="groupTable.submit(this)" v-bind="groupTable.object">
@@ -85,7 +88,7 @@
                             { name: "count", label: "Members", field: "groupRoleMemberCount", sortable: true, align: "left", style: "width:75px;" },
                             { name: "box", label: "Box Enabled?", field: "boxSyncEnabled", sortable: true, align: "left", style: "width:75px;" },
                             { name: "sync", label: "Sync", field: "", sortable: true, style: "width:75px;" },
-                            { name: "edit", label: "", field: "", style: "width: 100px;" }
+                            { name: "edit", label: "Actions", field: "", style: "width: 100px;" }
                         ],
                         onLoad: function (data) {
                             this.rows = data.map(

--- a/web/Areas/RAPS/Views/Groups/List.cshtml
+++ b/web/Areas/RAPS/Views/Groups/List.cshtml
@@ -57,14 +57,14 @@
     </template>
     <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="groups" title="All members of all roles linked to this group" :href="'GroupMembers?groupId=' + props.row.groupId"></q-btn>
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="person" title="Users who are explict members of this group" :href="'RoleMembers?roleId=' + props.row.groupRoleId"></q-btn>
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="security" title="Roles linked to this group" :href="'GroupRoles?groupId=' + props.row.groupId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="groups" title="All members of all roles linked to this group" aria-label="All members of all roles linked to this group" :href="'GroupMembers?groupId=' + props.row.groupId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="person" title="Users who are explicit members of this group" aria-label="Users who are explicit members of this group" :href="'RoleMembers?roleId=' + props.row.groupRoleId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="security" title="Roles linked to this group" aria-label="Roles linked to this group" :href="'GroupRoles?groupId=' + props.row.groupId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-edit="props">
         <q-td :props="props">
-            <q-btn :props="props" dense outline color="primary" icon="edit" title="Edit" size="sm" padding="xs md" @@click="groupTable.selectRow(props.row)"></q-btn>
+            <q-btn :props="props" dense outline color="primary" icon="edit" title="Edit" aria-label="Edit group" size="sm" padding="sm" @@click="groupTable.selectRow(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -82,13 +82,13 @@
                         keys: ["groupId"],
                         urlBase: "groups",
                         columns: [
-                            { name: "actions", field: "", align: "left", style: "width:75px;" },
+                            { name: "actions", label: "Actions", field: "", align: "left", style: "width:75px;" },
                             { name: "domain", label: "Domain", field: "domain", sortable: true, align: "left" },
                             { name: "name", label: "Group", field: "friendlyName", sortable: true, align: "left" },
                             { name: "count", label: "Members", field: "groupRoleMemberCount", sortable: true, align: "left", style: "width:75px;" },
                             { name: "box", label: "Box Enabled?", field: "boxSyncEnabled", sortable: true, align: "left", style: "width:75px;" },
                             { name: "sync", label: "Sync", field: "", sortable: true, style: "width:75px;" },
-                            { name: "edit", label: "Actions", field: "", style: "width: 100px;" }
+                            { name: "edit", label: "Edit", field: "", align: "left", style: "width: 60px;" }
                         ],
                         onLoad: function (data) {
                             this.rows = data.map(
@@ -98,7 +98,7 @@
                                 })
                             )
                         },
-                        selectObject: function (_object) {
+                        selectObject: function () {
                             this.object = {
                                 ...this.object,
                                 group: {

--- a/web/Areas/RAPS/Views/Groups/Members.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Members.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Members for group {{group.name}}</h1>
+﻿@{
+    ViewData["Title"] = "Group Members";
+}
+<h1>Members for group {{group.name}}</h1>
 <q-dialog v-model="syncing">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-card-section>
@@ -16,12 +19,12 @@
          :pagination="groupMembers.pagination">
     <template v-slot:body-cell-active="props">
         <q-td>
-            <q-icon size="sm" :name="props.row.current ? 'check' : 'close'" :color="props.row.current ? 'green' : 'red'"></q-icon>
+            <q-icon size="sm" :name="props.row.current ? 'check' : 'close'" :color="props.row.current ? 'positive' : 'negative'"></q-icon>
         </q-td>
     </template>
     <template v-slot:body-cell-ingroup="props">
         <q-td>
-            <q-icon size="sm" :name="props.row.isInGroup ? 'check' : 'close'" :color="props.row.isInGroup ? 'green' : 'red'"></q-icon>
+            <q-icon size="sm" :name="props.row.isInGroup ? 'check' : 'close'" :color="props.row.isInGroup ? 'positive' : 'negative'"></q-icon>
         </q-td>
     </template>
     <template v-slot:body-cell-member="props">

--- a/web/Areas/RAPS/Views/Groups/Members.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Members.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Members for group {{group.name}}</h2>
+﻿<h1>Members for group {{group.name}}</h1>
 <q-dialog v-model="syncing">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-card-section>

--- a/web/Areas/RAPS/Views/Groups/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Roles.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles for group {{group.name}}</h1>
+﻿@{
+    ViewData["Title"] = "Group Roles";
+}
+<h1>Roles for group {{group.name}}</h1>
 <q-table
     dense
     row-key="roleId"

--- a/web/Areas/RAPS/Views/Groups/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Roles.cshtml
@@ -107,15 +107,22 @@
                         [this.loadTables]
                     )
                 },
-                deleteGroupRole: async function (groupRole) {
-                    viperFetch(this,
-                        "Groups/" + this.groupId + "/Roles/" + groupRole.roleId,
-                        {
-                            method: "DELETE",
-                            headers: { "Content-Type": "application/json" }
-                        },
-                        [this.loadTables]
-                    )
+                deleteGroupRole: function (groupRole) {
+                    Quasar.Dialog.create({
+                        title: "Confirm Delete",
+                        message: "Are you sure you want to remove this role from the group?",
+                        cancel: true,
+                        persistent: true
+                    }).onOk(() => {
+                        viperFetch(this,
+                            "Groups/" + this.groupId + "/Roles/" + groupRole.roleId,
+                            {
+                                method: "DELETE",
+                                headers: { "Content-Type": "application/json" }
+                            },
+                            [this.loadTables]
+                        )
+                    })
                 },
                 loadTables: async function () {
                     await this.groupRoles.load(this)

--- a/web/Areas/RAPS/Views/Groups/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Roles.cshtml
@@ -8,7 +8,7 @@
     :pagination="groupRoles.pagination">
     <template v-slot:body-cell-links="props">
         <q-td>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Role Members" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Role Members" aria-label="Role Members" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-role="props">
@@ -41,7 +41,7 @@
     </template>
     <template v-slot:body-cell-links="props">
         <q-td>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Role Members" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Role Members" aria-label="Role Members" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-add="props">

--- a/web/Areas/RAPS/Views/Groups/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Roles.cshtml
@@ -18,7 +18,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td>
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from group" @@click="deleteGroupRole(props.row)" v-if="!props.row.isGroupRole"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="negative" icon="delete" aria-label="Remove role from group" @@click="deleteGroupRole(props.row)" v-if="!props.row.isGroupRole"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -46,7 +46,7 @@
     </template>
     <template v-slot:body-cell-add="props">
         <q-td>
-            <q-btn no-caps :props="props" color="green" padding="xs md" label="Add" @@click="addGroupRole(props.row)"></q-btn>
+            <q-btn no-caps :props="props" color="positive" padding="xs md" label="Add" @@click="addGroupRole(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>

--- a/web/Areas/RAPS/Views/Groups/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Roles.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Roles for group {{group.name}}</h2>
+﻿<h1>Roles for group {{group.name}}</h1>
 <q-table
     dense
     row-key="roleId"
@@ -18,7 +18,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td>
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" @@click="deleteGroupRole(props.row)" v-if="!props.row.isGroupRole"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from group" @@click="deleteGroupRole(props.row)" v-if="!props.row.isGroupRole"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -41,7 +41,7 @@
     </template>
     <template v-slot:body-cell-links="props">
         <q-td>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Role Members" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-add="props">
@@ -54,14 +54,6 @@
 @section Scripts {
     <script src="~/js/qtable.js"></script>
     <script asp-add-nonce="true">
-        function getInstance(roleName) {
-            if(roleName.substr(0, 5) == "VMACS") {
-                var sp = roleName.split(".");
-                return sp[0] + "." + sp[1];
-            }
-            return roleName.substr(0, 10).toLowerCase() == "viperforms" ? "VIPERForms" : "VIPER";
-        }
-
         createVueApp({
             data() {
                 return {
@@ -94,7 +86,7 @@
                                     return result
                                 }, [])
                             this.rows = data.filter(r =>
-                                existingRoles.indexOf(r.roleId) == -1
+                                existingRoles.indexOf(r.roleId) === -1
                             )
                         },
                         selectable: true

--- a/web/Areas/RAPS/Views/Groups/Sync.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Sync.cshtml
@@ -3,6 +3,7 @@
     For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 *@
 @{
+    ViewData["Title"] = "Group Sync";
     var group = ViewData["Group"] as OuGroup;
     if(group != null)
     {

--- a/web/Areas/RAPS/Views/Groups/Sync.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Sync.cshtml
@@ -6,9 +6,9 @@
     var group = ViewData["Group"] as OuGroup;
     if(group != null)
     {
-        <h1>Member for @group.Name</h1>
+        <h1>Members for @group.Name</h1>
         <p>
-            The process to add or remove users may take a view minutes. Return to the previous page and refresh to see changes.
+            The process to add or remove users may take a few minutes. Return to the previous page and refresh to see changes.
         </p>
     }
     else

--- a/web/Areas/RAPS/Views/Groups/Sync.cshtml
+++ b/web/Areas/RAPS/Views/Groups/Sync.cshtml
@@ -6,13 +6,13 @@
     var group = ViewData["Group"] as OuGroup;
     if(group != null)
     {
-        <h2>Member for @group.Name</h2>
+        <h1>Member for @group.Name</h1>
         <p>
             The process to add or remove users may take a view minutes. Return to the previous page and refresh to see changes.
         </p>
     }
     else
     {
-        <h2>No group found. Please select a group from the list and retry.</h2>
+        <h1>No group found. Please select a group from the list and retry.</h1>
     }
 }

--- a/web/Areas/RAPS/Views/Index.cshtml
+++ b/web/Areas/RAPS/Views/Index.cshtml
@@ -2,6 +2,7 @@
 @{
     ViewData["Title"] = "RAPS [Permission Management]";
 }
+<h1>RAPS - Permission Management</h1>
 @*This is a placeholder for the table. See "Teleport" tag in the Scripts section*@
 <div id='RapsPage' class="q-pa-none q-ma-none"></div>
 @section Scripts {

--- a/web/Areas/RAPS/Views/Members/Clone.cshtml
+++ b/web/Areas/RAPS/Views/Members/Clone.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Select source and target users</h2>
+﻿<h1>Select source and target users</h1>
 <q-form @@submit="return false;">
     <div class="row q-mb-sm">
         <q-select outlined dense options-dense clearable use-input input-debounce="300" class="col col-md-4 col-lg-3"
@@ -92,16 +92,17 @@
                         return
                     }
                     update(() => {
-                        var res = viperFetch(this, "Members?active=recent&search=" + val)
+                        viperFetch(this, "Members?active=recent&search=" + val)
                             .then(data => {
                                 data = data.map(m => ({
                                     label: (!m.current ? "[Inactive]" : "") + m.displayLastName + ", " + m.displayFirstName,
                                     value: m.memberId
                                 }))
-                                if (target)
+                                if (target) {
                                     this.targetUserResults = data
-                                else
+                                } else {
                                     this.sourceUserResults = data
+                                }
                             })
 
                     })
@@ -149,7 +150,7 @@
                 //if both source and target user are selected, load the roles/permissions to clone
                 checkUsersSelected: function () {
                     if (this?.sourceUser?.value.length && this?.targetUser?.value.length) {
-                        var res = viperFetch(this, `Members/${this.sourceUser.value}/cloneTo/${this.targetUser.value}`)
+                        viperFetch(this, `Members/${this.sourceUser.value}/cloneTo/${this.targetUser.value}`)
                             .then(data => {
                                 this.cloneObject = data
                                 this.dataLoaded = true

--- a/web/Areas/RAPS/Views/Members/Clone.cshtml
+++ b/web/Areas/RAPS/Views/Members/Clone.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Select source and target users</h1>
+﻿@{
+    ViewData["Title"] = "Clone Member";
+}
+<h1>Select source and target users</h1>
 <q-form @@submit="return false;">
     <div class="row q-mb-sm">
         <q-select outlined dense options-dense clearable use-input input-debounce="300" class="col col-md-4 col-lg-3"
@@ -42,7 +45,7 @@
     <template v-slot:body-cell-action="props">
         <q-td :props="props">
             <q-icon size="xs" :name="!props.row?.source?.roleId ? 'close' : (props.row?.target?.roleId ? 'edit' : 'add')"
-                    :color="!props.row?.source?.roleId ? 'red' : (props.row?.target?.roleId ? 'grey' : 'green')"></q-icon>
+                    :color="!props.row?.source?.roleId ? 'negative' : (props.row?.target?.roleId ? 'secondary' : 'positive')"></q-icon>
         </q-td>
     </template>
 </q-table>
@@ -59,7 +62,7 @@
     <template v-slot:body-cell-action="props">
         <q-td :props="props">
             <q-icon size="xs" :name="!props.row?.source?.permissionId ? 'close' : (props.row?.target?.permissionId ? 'edit' : 'add')"
-                    :color="!props.row?.source?.permissionId ? 'red' : (props.row?.target?.permissionId ? 'grey' : 'green')"></q-icon>
+                    :color="!props.row?.source?.permissionId ? 'negative' : (props.row?.target?.permissionId ? 'secondary' : 'positive')"></q-icon>
         </q-td>
     </template>
 </q-table>
@@ -131,14 +134,14 @@
                     dataLoaded: false,
                     VMACSPush: false,
                     rolesColumns: [
-                        { name: "action", field: "", align: "left", sortable: true },
+                        { name: "action", label: "Actions", field: "", align: "left", sortable: true },
                         { name: "actionText", label: "Action", field: "actionText", align: "left", sortable: true },
                         { name: "role", label: "Role", field: "role", align: "left", sortable: true },
                         { name: "startdate", label: "Start Date", field: "startDate", align: "left", format: v => formatDate(v) },
                         { name: "enddate", label: "End Date", field: "endDate", align: "left", format: v => formatDate(v) }
                     ],
                     permissionColumns: [
-                        { name: "action", field: "", align: "left", sortable: true },
+                        { name: "action", label: "Actions", field: "", align: "left", sortable: true },
                         { name: "actionText", label: "Action", field: "actionText", align: "left", sortable: true },
                         { name: "permission", label: "Permission", field: "permission", align: "left", sortable: true },
                         { name: "startdate", label: "Start Date", field: "startDate", align: "left", format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Members/History.cshtml
+++ b/web/Areas/RAPS/Views/Members/History.cshtml
@@ -1,6 +1,6 @@
-﻿<h2>
+﻿<h1>
     History for {{member.displayFirstName}} {{member.displayLastName}}
-</h2>
+</h1>
 <q-form>
     <div class="row">
         <q-select dense options-dense outlined clearable class="col col-md-4 col-lg-3 q-mb-sm"

--- a/web/Areas/RAPS/Views/Members/History.cshtml
+++ b/web/Areas/RAPS/Views/Members/History.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>
+﻿@{
+    ViewData["Title"] = "Member History";
+}
+<h1>
     History for {{member.displayFirstName}} {{member.displayLastName}}
 </h1>
 <q-form>

--- a/web/Areas/RAPS/Views/Members/List.cshtml
+++ b/web/Areas/RAPS/Views/Members/List.cshtml
@@ -3,7 +3,7 @@
 }
 <h1>Search for a user</h1>
 <q-form @@submit="return false;">
-    <div class="row">
+    <div class="row q-mb-md">
         <q-input 
             class="q-ml-xs q-mr-xs col-12 col-sm-8 col-md-4" 
             dense 

--- a/web/Areas/RAPS/Views/Members/List.cshtml
+++ b/web/Areas/RAPS/Views/Members/List.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Search for a user</h1>
+﻿@{
+    ViewData["Title"] = "Members";
+}
+<h1>Search for a user</h1>
 <q-form @@submit="return false;">
     <div class="row">
         <q-input 
@@ -72,7 +75,7 @@
                         keys: ["memberId"],
                         urlBase: "Members",
                         columns: [
-                            { name: "links", label: "", field: "", align: "left", style: "width:100px;" },
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:100px;" },
                             { name: "member", label: "Member", field: "", align: "left", sortable: true },
                             { name: "active", label: "Active", field: "current", align: "left", sortable: true },
                             { name: "countRoles", label: "Count Roles", field: "countRoles", align: "left", sortable: true },
@@ -84,10 +87,12 @@
             },
             methods: {
                 findUsers: async function () {
-                    this.members.urlBase = "Members?search=" + this.userSearch + "&active=" + (this.includeInactive ? "all" : "active")
-                    if (this.userSearch.trim().length >= 2) {
-                        this.members.load(this)
+                    if (!this.userSearch || this.userSearch.trim().length < 2) {
+                        this.members.rows = []
+                        return
                     }
+                    this.members.urlBase = "Members?search=" + this.userSearch + "&active=" + (this.includeInactive ? "all" : "active")
+                    this.members.load(this)
                 }
             },
             mounted() {

--- a/web/Areas/RAPS/Views/Members/List.cshtml
+++ b/web/Areas/RAPS/Views/Members/List.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Search for a user</h2>
+﻿<h1>Search for a user</h1>
 <q-form @@submit="return false;">
     <div class="row">
         <q-input 

--- a/web/Areas/RAPS/Views/Members/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Members/Permissions.cshtml
@@ -1,4 +1,5 @@
-﻿<q-btn-group outline rounded class="q-mt-sm">
+﻿<h1>Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
+<q-btn-group outline rounded class="q-mt-sm">
     <q-btn no-caps color="primary" class="q-mb-sm" label="View existing permissions" icon="view_list"
            :outline="showWhich != 'Existing'" @@click="showWhich='Existing'"></q-btn>
     <q-btn no-caps color="primary" class="q-mb-sm" label="Add Permissions" icon="add"
@@ -85,7 +86,7 @@
         </template>
         <template v-slot:body-cell-actions="props">
             <q-td :props="props">
-                <q-btn outline size="sm" icon="edit" padding="xs md" :props="props" color="primary" @@click="memberPermissionsTable.selectRow(props.row)"></q-btn>
+                <q-btn outline size="sm" icon="edit" padding="xs md" :props="props" color="primary" aria-label="Edit permission" @@click="memberPermissionsTable.selectRow(props.row)"></q-btn>
             </q-td>
         </template>
     </q-table>
@@ -156,7 +157,7 @@
                             { name: "actions", label: "Actions", field: "", align: "left", sortable: false }
                         ],
                         //after loading member permissions, set last modified
-                        onLoad: function (data, vueApp) {
+                        onLoad: function (data) {
                             this.rows = data.map(rp => ({
                                 ...rp,
                                 permission: rp.permission.permission,
@@ -172,7 +173,7 @@
                             return {
                                 memberId: v.urlParams.get("memberId"),
                                 permissionId: object.permissionId,
-                                access: object.access == 1 ? 1 : 0,
+                                access: object.access === 1 ? 1 : 0,
                                 startDate: object?.startDate,
                                 endDate: object?.endDate
                             }
@@ -181,7 +182,7 @@
                         selectObject: function (object) {
                             this.object = {
                                 permissionId: object.permissionId,
-                                access: object.access == 1 ? 1 : 0,
+                                access: object.access === 1 ? 1 : 0,
                                 startDate: formatDateForDateInput(object.startDate),
                                 endDate: formatDateForDateInput(object.endDate),
                                 memberId: object.memberId
@@ -197,13 +198,13 @@
                             { name: "description", label: "Description", field: "description", align: "left", sortable: true }
                         ],
                         onLoad: function (data) {
-                            existingPermissions = this.vueApp._.data.memberPermissionsTable.rows
+                            const existingPermissions = this.vueApp._.data.memberPermissionsTable.rows
                                 .reduce((result, rp) => {
                                     result.push(rp.permissionId)
                                     return result
                                 }, [])
                             this.rows = data.filter(r =>
-                                existingPermissions.indexOf(r.permissionId) == -1
+                                existingPermissions.indexOf(r.permissionId) === -1
                             )
                         },
                         pagination: { rowsPerPage: 15 }
@@ -212,7 +213,7 @@
             },
             methods: {
                 addSelectedPermissions: function(access) {
-                    this.selectedPermissions.forEach((value, index) => {
+                    this.selectedPermissions.forEach((value) => {
                         var permissionMember = { permissionId: value.permissionId, memberId: this.memberId, access: access }
                         if (this.memberPermissionParams.startDate.length) {
                             permissionMember.startDate = this.memberPermissionParams.startDate

--- a/web/Areas/RAPS/Views/Members/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Members/Permissions.cshtml
@@ -82,8 +82,8 @@
         </template>
         <template v-slot:body-cell-links="props">
             <q-td :props="props">
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="Roles that grant this permission" :href="'PermissionRoles?permissionId=' + props.row.permissionId"></q-btn>
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Users granted this permission individually" :href="'PermissionMembers?permissionId=' + props.row.permissionId"></q-btn>
+                <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="Roles that grant this permission" aria-label="Roles that grant this permission" :href="'PermissionRoles?permissionId=' + props.row.permissionId"></q-btn>
+                <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="Users granted this permission individually" aria-label="Users granted this permission individually" :href="'PermissionMembers?permissionId=' + props.row.permissionId"></q-btn>
             </q-td>
         </template>
         <template v-slot:body-cell-access="props">
@@ -93,7 +93,7 @@
         </template>
         <template v-slot:body-cell-actions="props">
             <q-td :props="props">
-                <q-btn outline size="sm" icon="edit" padding="xs md" :props="props" color="primary" aria-label="Edit permission" @@click="memberPermissionsTable.selectRow(props.row)"></q-btn>
+                <q-btn dense outline size="sm" icon="edit" padding="sm" :props="props" color="primary" aria-label="Edit permission" @@click="memberPermissionsTable.selectRow(props.row)"></q-btn>
             </q-td>
         </template>
     </q-table>
@@ -161,7 +161,7 @@
                             { name: "lastmodified", label: "Last Modified", field: "lastModified", align: "left", sortable: true,
                                 sort: (_1, _2, rowA, rowB) => new Date(rowA.modTime) - new Date(rowB.modTime)
                             },
-                            { name: "actions", label: "Actions", field: "", align: "left", sortable: false }
+                            { name: "actions", label: "Edit", field: "", align: "left", sortable: false, style: "width: 60px;" }
                         ],
                         //after loading member permissions, set last modified
                         onLoad: function (data) {

--- a/web/Areas/RAPS/Views/Members/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Members/Permissions.cshtml
@@ -59,7 +59,7 @@
 
                             <q-card-actions align="evenly">
                                 <q-btn no-caps :label="memberPermissionsTable.editing ? 'Update Permission for User' : 'Add Permission for User'" type="submit" padding="xs sm" color="primary"></q-btn>
-                                <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="memberPermissionsTable.delete(this)" color="red" v-if="memberPermissionsTable.editing"></q-btn>
+                                <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="memberPermissionsTable.delete(this)" color="negative" v-if="memberPermissionsTable.editing"></q-btn>
                             </q-card-actions>
                         </q-form>
                     </q-card>
@@ -101,7 +101,7 @@
             <q-input type="date" outlined dense v-model="memberPermissionParams.startDate" label="Start Date"></q-input>
             <q-input type="date" outlined dense v-model="memberPermissionParams.endDate" label="End Date" class="q-ml-md"></q-input>
             <q-btn sm dense no-caps class="q-px-sm q-ml-md" label="Grant Checked Permissions" type="button" color="primary" @@click="grantPermissions"></q-btn>
-            <q-btn sm dense no-caps class="q-px-sm q-ml-md" label="Deny Checked Permissions" type="button" color="red" @@click="denyPermissions"></q-btn>
+            <q-btn sm dense no-caps class="q-px-sm q-ml-md" label="Deny Checked Permissions" type="button" color="negative" @@click="denyPermissions"></q-btn>
         </div>
         <div class="row q-pt-sm q-mb-sm">
             

--- a/web/Areas/RAPS/Views/Members/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Members/Permissions.cshtml
@@ -24,9 +24,13 @@
                 <q-dialog v-model="memberPermissionsTable.showForm" @@hide="memberPermissionsTable.clear(this)">
                     <q-card>
                         <q-form @@submit="memberPermissionsTable.submit(this)" v-bind="memberPermissionsTable.object">
-                            <q-card-section>
+                            <q-card-section class="row items-center q-pb-none">
                                 <div class="text-h6">{{memberPermissionsTable.editing >= 0 ? "Edit" : "Create"}} Permission Membership</div>
-                                <div class="bg-negative text-white q-pa-sm rounded" v-if="memberPermissionsTable.errors?.message?.length > 0">{{memberPermissionsTable.errors.message}}</div>
+                                <q-space></q-space>
+                                <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                            </q-card-section>
+                            <q-card-section v-if="memberPermissionsTable.errors?.message?.length > 0">
+                                <div class="bg-negative text-white q-pa-sm rounded">{{memberPermissionsTable.errors.message}}</div>
                             </q-card-section>
 
                             <q-card-section>

--- a/web/Areas/RAPS/Views/Members/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Members/Permissions.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
+﻿@{
+    ViewData["Title"] = "Member Permissions";
+}
+<h1>Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
 <q-btn-group outline rounded class="q-mt-sm">
     <q-btn no-caps color="primary" class="q-mb-sm" label="View existing permissions" icon="view_list"
            :outline="showWhich != 'Existing'" @@click="showWhich='Existing'"></q-btn>
@@ -43,7 +46,7 @@
                                              :error="memberPermissionsTable.errors?.endDate?.error" :error-message="memberPermissionsTable.endDate?.message"></q-input>
                                 </div>
                                 <div class="row q-pt-sm">
-                                    <q-btn-toggle no-caps outlined dense :toggle-color="memberPermissionsTable.object.access == 0 ? 'red' : 'green'"
+                                    <q-btn-toggle no-caps outlined dense :toggle-color="memberPermissionsTable.object.access == 0 ? 'negative' : 'positive'"
                                                   v-model="memberPermissionsTable.object.access" :options="allowDenyOptions">
                                         <template v-slot:allow>
                                             <div class="q-px-lg" align="evenly">
@@ -85,7 +88,7 @@
         </template>
         <template v-slot:body-cell-access="props">
             <q-td :props="props">
-                <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'green' : 'red'"></q-icon>
+                <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'positive' : 'negative'" :aria-label="props.row.access ? 'Allowed' : 'Denied'"></q-icon>
             </q-td>
         </template>
         <template v-slot:body-cell-actions="props">
@@ -149,7 +152,7 @@
                         keys: ["permissionId"],
                         urlBase: "Members",
                         columns: [
-                            { name: "links", label: "", field: "", align: "left", style: "width:75px;" },
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:75px;" },
                             { name: "access", label: "Access", field: "access", align: "left", style: "width:75px;" },
                             { name: "permission", label: "Permission", field: "permission", align: "left", sortable: true },
                             { name: "startdate", label: "Start Date", field: "startDate", align: "left", sortable: true, format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Members/RSOP.cshtml
+++ b/web/Areas/RAPS/Views/Members/RSOP.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Combined Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
+﻿@{
+    ViewData["Title"] = "RSOP";
+}
+<h1>Combined Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
 
 <q-table 
     dense
@@ -16,7 +19,7 @@
     </template>
     <template v-slot:body-cell-access="props">
         <q-td :props="props">
-            <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'green' : 'red'"></q-icon>
+            <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'positive' : 'negative'"></q-icon>
         </q-td>
     </template>
 

--- a/web/Areas/RAPS/Views/Members/RSOP.cshtml
+++ b/web/Areas/RAPS/Views/Members/RSOP.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Combined Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h2>
+﻿<h1>Combined Permissions for {{member.displayFirstName}} {{member.displayLastName}}</h1>
 
 <q-table 
     dense

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -50,7 +50,7 @@
 
                             <q-card-actions align="evenly">
                                 <q-btn no-caps :label="memberRolesTable.editing ? 'Update Role for User' : 'Add Role for User'" type="submit" padding="xs sm" color="primary"></q-btn>
-                                <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="deleteRoleMember();" color="red" v-if="memberRolesTable.editing"></q-btn>
+                                <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="deleteRoleMember();" color="negative" v-if="memberRolesTable.editing"></q-btn>
                             </q-card-actions>
                         </q-form>
                     </q-card>

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -26,9 +26,13 @@
                 <q-dialog v-model="memberRolesTable.showForm" @@hide="memberRolesTable.clear(this)">
                     <q-card>
                         <q-form @@submit="addUpdateRoleMember();" v-bind="memberRolesTable.object">
-                            <q-card-section>
+                            <q-card-section class="row items-center q-pb-none">
                                 <div class="text-h6">{{memberRolesTable.editing >= 0 ? "Edit" : "Create"}} Role Member</div>
-                                <div class="bg-negative text-white q-pa-sm rounded" v-if="memberRolesTable.errors?.message?.length > 0">{{memberRolesTable.errors.message}}</div>
+                                <q-space></q-space>
+                                <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                            </q-card-section>
+                            <q-card-section v-if="memberRolesTable.errors?.message?.length > 0">
+                                <div class="bg-negative text-white q-pa-sm rounded">{{memberRolesTable.errors.message}}</div>
                             </q-card-section>
 
                             <q-card-section>
@@ -228,12 +232,19 @@
                     this.loadTables()
                     this.pushToVMACS(false)
                 },
-                deleteRoleMember: async function () {
-                    var oldBase = this.memberRolesTable.urlBase
-                    this.memberRolesTable.urlBase = "Members/" + this.memberId + "/Roles"
-                    const deleted = await this.memberRolesTable.delete(this)
-                    this.memberRolesTable.urlBase = oldBase
-                    if (deleted) { this.pushToVMACS() }
+                deleteRoleMember: function () {
+                    Quasar.Dialog.create({
+                        title: "Confirm Delete",
+                        message: "Are you sure you want to remove this role from the user?",
+                        cancel: true,
+                        persistent: true
+                    }).onOk(async () => {
+                        var oldBase = this.memberRolesTable.urlBase
+                        this.memberRolesTable.urlBase = "Members/" + this.memberId + "/Roles"
+                        const deleted = await this.memberRolesTable.delete(this)
+                        this.memberRolesTable.urlBase = oldBase
+                        if (deleted) { this.pushToVMACS() }
+                    })
                 },
                 addUpdateRoleMember: async function () {
                     var oldBase = this.memberRolesTable.urlBase

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -73,16 +73,16 @@
         </template>
         <template v-slot:body-cell-links="props">
             <q-td :props="props">
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="View members of this role" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
+                <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="View members of this role" aria-label="View members of this role" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
                 @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
                 {
-                    <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="Set permissions this role controls" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
+                    <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="lock" title="Set permissions this role controls" aria-label="Set permissions this role controls" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
                 }
             </q-td>
         </template>
         <template v-slot:body-cell-actions="props">
             <q-td :props="props">
-                <q-btn dense outline size="sm" icon="edit" padding="xs md" aria-label="Edit role"
+                <q-btn dense outline size="sm" icon="edit" padding="sm" aria-label="Edit role"
                     v-if="props.row.viewName == null"
                     :props="props" color="primary" @@click="memberRolesTable.selectRow(props.row)"></q-btn>
                 <span v-else>{{ props.row.viewName }}</span>
@@ -147,7 +147,7 @@
                             { name: "lastmodified", label: "Last Modified", field: "lastModified", align: "left", sortable: true,
                                 sort: (_1, _2, rowA, rowB) => new Date(rowA.modTime) - new Date(rowB.modTime)
                             },
-                            { name: "actions", label: "Actions", field: "", align: "left", sortable: false }
+                            { name: "actions", label: "Edit", field: "", align: "left", sortable: false, style: "width: 60px;" }
                         ],
                         //after loading role members, set role name and last modified
                         onLoad: function (data) {

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles for {{member.displayFirstName}} {{member.displayLastName}}</h1>
+﻿@{
+    ViewData["Title"] = "Member Roles";
+}
+<h1>Roles for {{member.displayFirstName}} {{member.displayLastName}}</h1>
 <q-btn-group outline rounded class="q-mt-sm">
     <q-btn no-caps color="primary" class="q-mb-sm" label="View existing roles" icon="view_list"
            :outline="showWhich != 'Existing'" @@click="showWhich='Existing'"></q-btn>
@@ -136,7 +139,7 @@
                         keys: ["roleId"],
                         urlBase: "Members",
                         columns: [
-                            { name: "links", label: "", field: "", align: "left", style: "width:75px;" },
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:75px;" },
                             { name: "role", label: "Role", field: "roleName", align: "left", sortable: true, format: v => v.substr(0, 75) },
                             { name: "startdate", label: "Start Date", field: "startDate", align: "left", sortable: true, format: v => formatDate(v) },
                             { name: "enddate", label: "End Date", field: "endDate", align: "left", sortable: true, format: v => formatDate(v) },
@@ -160,11 +163,11 @@
                         createBody:
                             function (v, object) {
                                 return {
-                                    comment: object.comment,
+                                    comment: object.comment ?? "",
                                     memberId: v.urlParams.get("memberId"),
                                     roleId: object.roleId,
-                                    startDate: object?.startDate,
-                                    endDate: object?.endDate
+                                    startDate: object?.startDate || null,
+                                    endDate: object?.endDate || null
                                 }
                             },
                         //on selection, format dates and set up user select box
@@ -239,11 +242,14 @@
                         cancel: true,
                         persistent: true
                     }).onOk(async () => {
-                        var oldBase = this.memberRolesTable.urlBase
-                        this.memberRolesTable.urlBase = "Members/" + this.memberId + "/Roles"
-                        const deleted = await this.memberRolesTable.delete(this)
-                        this.memberRolesTable.urlBase = oldBase
-                        if (deleted) { this.pushToVMACS() }
+                        var url = "Members/" + this.memberId + "/Roles/" + this.memberRolesTable.object.roleId
+                        const result = await viperFetch(this, url, { method: "DELETE" },
+                            [() => this.memberRolesTable.load(this)], this.memberRolesTable.errors)
+                        if (result !== undefined) {
+                            showStatusNotification("Role removed")
+                            this.memberRolesTable.clear()
+                            this.pushToVMACS()
+                        }
                     })
                 },
                 addUpdateRoleMember: async function () {

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -1,4 +1,5 @@
-﻿<q-btn-group outline rounded class="q-mt-sm">
+﻿<h1>Roles for {{member.displayFirstName}} {{member.displayLastName}}</h1>
+<q-btn-group outline rounded class="q-mt-sm">
     <q-btn no-caps color="primary" class="q-mb-sm" label="View existing roles" icon="view_list"
            :outline="showWhich != 'Existing'" @@click="showWhich='Existing'"></q-btn>
     <q-btn no-caps color="primary" class="q-mb-sm" label="Add Roles" icon="add"
@@ -74,7 +75,7 @@
         </template>
         <template v-slot:body-cell-actions="props">
             <q-td :props="props">
-                <q-btn dense outline size="sm" icon="edit" padding="xs md" 
+                <q-btn dense outline size="sm" icon="edit" padding="xs md" aria-label="Edit role"
                     v-if="props.row.viewName == null"
                     :props="props" color="primary" @@click="memberRolesTable.selectRow(props.row)"></q-btn>
                 <span v-else>{{ props.row.viewName }}</span>
@@ -145,7 +146,7 @@
                         onLoad: function (data) {
                             this.rows = data.map(rm => ({
                                 ...rm,
-                                lastModified: formatDate(rm.modTime) + (rm.modBy != null ? (" (" + rm.modBy.trim() + ")") : "")
+                                lastModified: formatDate(rm.modTime) + (rm.modBy !== null ? (" (" + rm.modBy.trim() + ")") : "")
                             }))
                             if (this.editing) {
                                 this.vueApp._.data.rolesTable.load()
@@ -182,13 +183,13 @@
                             { name: "description", label: "Description", field: "description", align: "left", sortable: true }
                         ],
                         onLoad: function (data) {
-                            existingRoles = this.vueApp._.data.memberRolesTable.rows
+                            const existingRoles = this.vueApp._.data.memberRolesTable.rows
                                 .reduce((result, rm) => {
                                     result.push(rm.roleId)
                                     return result
                                 }, [])
                             this.rows = data.filter(r =>
-                                existingRoles.indexOf(r.roleId) == -1
+                                existingRoles.indexOf(r.roleId) === -1
                             )
                             this.rows = this.rows.map(r => ({
                                 roleId: r.roleId,

--- a/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>User with Permission {{permission.permission}}</h2>
+﻿<h1>User with Permission {{permission.permission}}</h1>
 <p>
     {{permission.description}}
 </p>
@@ -44,7 +44,7 @@
                             this.rows = data.map(pm => ({
                                 ...pm,
                                 memberName: pm?.displayLastName + ", " + pm?.displayFirstName,
-                                active: pm?.current == 1 ? "Y" : "N"
+                                active: pm?.current === 1 ? "Y" : "N"
                             }))
                         },
                         pagination: { rowsPerPage: 0 }

--- a/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
@@ -1,4 +1,4 @@
-﻿<h1>User with Permission {{permission.permission}}</h1>
+﻿<h1>Users with Permission {{permission.permission}}</h1>
 <p>
     {{permission.description}}
 </p>

--- a/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/AllMembers.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Users with Permission {{permission.permission}}</h1>
+﻿@{
+    ViewData["Title"] = "All Permission Members";
+}
+<h1>Users with Permission {{permission.permission}}</h1>
 <p>
     {{permission.description}}
 </p>

--- a/web/Areas/RAPS/Views/Permissions/List.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/List.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Permissions</h2>
+﻿<h1>Permissions</h1>
 <q-table title="Permissions"
          dense
          row-key="permissionId"

--- a/web/Areas/RAPS/Views/Permissions/List.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/List.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Permissions</h1>
+﻿@{
+    ViewData["Title"] = "Permissions";
+}
+<h1>Permissions</h1>
 <q-table title="Permissions"
          dense
          row-key="permissionId"
@@ -34,7 +37,7 @@
                         keys: "permissionId",
                         urlBase: "Permissions",
                         columns: [
-                            { name: "action", field: "permissionId", align: "left", style: "width:75px;" },
+                            { name: "action", label: "Actions", field: "permissionId", align: "left", style: "width:75px;" },
                             { name: "permission", label: "Permission", field: "permission", sortable: true, align: "left" },
                             { name: "description", label: "Description", field: "description", sortable: false, align: "left" }
                         ]

--- a/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
@@ -15,7 +15,7 @@
 
                 <q-card-actions align="evenly">
                     <q-btn no-caps :label="permissionTable.editing ? 'Update Permission' : 'Add Permission'" type="submit" padding="xs sm" color="primary"></q-btn>
-                    <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="permissionTable.delete(this)" color="red" v-if="permissionTable.editing"></q-btn>
+                    <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="permissionTable.delete(this)" color="negative" v-if="permissionTable.editing"></q-btn>
                 </q-card-actions>
             </q-form>
         </q-card>
@@ -33,7 +33,7 @@
          v-model:pagination="permissionTable.pagination"
          @@request="(props) => permissionTable.request(props, this)">
     <template v-slot:top-left>
-        <q-btn no-caps color="green" label="Create Permission" padding="xs md" @@click="permissionTable.showForm = true"></q-btn>
+        <q-btn no-caps color="positive" label="Create Permission" padding="xs md" @@click="permissionTable.showForm = true"></q-btn>
     </template>
     <template v-slot:top-right>
         <q-input v-model="permissionTable.filter" dense outlined debounce="300" placeholder="Filter results" class="q-ml-xs q-mr-xs">

--- a/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Permissions</h1>
+﻿@{
+    ViewData["Title"] = "Permissions Admin";
+}
+<h1>Permissions</h1>
 <div class="q-pa-sm q-gutter-sm">
     <q-dialog v-model="permissionTable.showForm" @@hide="permissionTable.clear(this)">
         <q-card style="width: 500px; max-width: 80vw;">
@@ -70,11 +73,11 @@
                         keys: "permissionId",
                         urlBase: "Permissions",
                         columns: [
-                            { name: "action", field: "permissionId", align: "left", style: "width:75px;" },
+                            { name: "action", label: "Actions", field: "permissionId", align: "left", style: "width:75px;" },
                             { name: "permission", label: "Permission", field: "permission", sortable: true, align: "left" },
                             { name: "description", label: "Description", field: "description", sortable: false, align: "left" },
                             { name: "count", label: "Members", field: "count", sortable: true, align: "left", style: "width:75px;" },
-                            { name: "edit", label: "", field: "", style: "width: 100px;" }
+                            { name: "edit", label: "Actions", field: "", style: "width: 100px;" }
                         ],
                         onLoad: function (data) {
                             this.rows = data.map(p => ({ ...p, count: p.tblMemberPermissions.length }))

--- a/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
@@ -3,9 +3,13 @@
     <q-dialog v-model="permissionTable.showForm" @@hide="permissionTable.clear(this)">
         <q-card style="width: 500px; max-width: 80vw;">
             <q-form @@submit="permissionTable.submit(this)" v-bind="permissionTable.object">
-                <q-card-section>
+                <q-card-section class="row items-center q-pb-none">
                     <div class="text-h6">{{permissionTable.editing ? "Edit" : "Create"}} Permission</div>
-                    <div class="bg-negative text-white q-pa-sm rounded" v-if="permissionTable.errors?.message?.length > 0">{{permissionTable.errors.message}}</div>
+                    <q-space></q-space>
+                    <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                </q-card-section>
+                <q-card-section v-if="permissionTable.errors?.message?.length > 0">
+                    <div class="bg-negative text-white q-pa-sm rounded">{{permissionTable.errors.message}}</div>
                 </q-card-section>
 
                 <q-card-section>

--- a/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Permissions</h2>
+﻿<h1>Permissions</h1>
 <div class="q-pa-sm q-gutter-sm">
     <q-dialog v-model="permissionTable.showForm" @@hide="permissionTable.clear(this)">
         <q-card style="width: 500px; max-width: 80vw;">
@@ -51,7 +51,7 @@
     </template>
     <template v-slot:body-cell-edit="props">
         <q-td :props="props">
-            <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs md" @@click="permissionTable.selectRow(props.row)"></q-btn>
+            <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs md" aria-label="Edit permission" @@click="permissionTable.selectRow(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>

--- a/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/ListAdmin.cshtml
@@ -51,14 +51,14 @@
     </template>
     <template v-slot:body-cell-action="props">
         <q-td :props="props">
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="security" title="Edit roles that grant this permission" :href="'PermissionRoles?permissionId=' + props.row.permissionId"></q-btn>
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="person" title="Edit users individually granted this permission" :href="'PermissionMembers?permissionId=' + props.row.permissionId"></q-btn>
-            <q-btn :props="props" dense flat square color="primary" size="sm" padding="xs" icon="groups" title="View list of all users with this permission (individually or via role)" :href="'AllMembersWithPermission?permissionId=' + props.row.permissionId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="security" title="Edit roles that grant this permission" aria-label="Edit roles that grant this permission" :href="'PermissionRoles?permissionId=' + props.row.permissionId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="person" title="Edit users individually granted this permission" aria-label="Edit users individually granted this permission" :href="'PermissionMembers?permissionId=' + props.row.permissionId"></q-btn>
+            <q-btn :props="props" dense flat square color="primary" size="sm" padding="sm" icon="groups" title="View list of all users with this permission (individually or via role)" aria-label="View list of all users with this permission" :href="'AllMembersWithPermission?permissionId=' + props.row.permissionId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-edit="props">
         <q-td :props="props">
-            <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs md" aria-label="Edit permission" @@click="permissionTable.selectRow(props.row)"></q-btn>
+            <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="sm" aria-label="Edit permission" @@click="permissionTable.selectRow(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -77,7 +77,7 @@
                             { name: "permission", label: "Permission", field: "permission", sortable: true, align: "left" },
                             { name: "description", label: "Description", field: "description", sortable: false, align: "left" },
                             { name: "count", label: "Members", field: "count", sortable: true, align: "left", style: "width:75px;" },
-                            { name: "edit", label: "Actions", field: "", style: "width: 100px;" }
+                            { name: "edit", label: "Edit", field: "", align: "left", style: "width: 60px;" }
                         ],
                         onLoad: function (data) {
                             this.rows = data.map(p => ({ ...p, count: p.tblMemberPermissions.length }))

--- a/web/Areas/RAPS/Views/Permissions/Members.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Members.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>User Permissions for {{permission.permission}}</h2>
+﻿<h1>User Permissions for {{permission.permission}}</h1>
 <p>
     {{permission.description}}
 </p>
@@ -129,7 +129,7 @@
                             this.rows = data.map(pm => ({
                                 ...pm,
                                 memberName: pm.member?.displayLastName + ", " + pm?.member?.displayFirstName,
-                                active: pm?.member?.current == 1 ? "Y" : "N",
+                                active: pm?.member?.current === 1 ? "Y" : "N",
                                 lastModified: formatDate(pm.modTime) + " (" + pm.modBy.trim() + ")"
                             }))
                         },
@@ -138,7 +138,7 @@
                             return {
                                 memberId: object.member?.value,
                                 permissionId: v.urlParams.get("permissionId"),
-                                access: object.access == 1 ? 1 : 0,
+                                access: object.access === 1 ? 1 : 0,
                                 startDate: object?.startDate,
                                 endDate: object?.endDate
                             }
@@ -149,7 +149,7 @@
                                 permissionId: object.permissionId,
                                 startDate: formatDateForDateInput(object.startDate),
                                 endDate: formatDateForDateInput(object.endDate),
-                                access: object.access == 1 ? 1 : 0,
+                                access: object.access === 1 ? 1 : 0,
                                 member: {
                                     label: object?.member?.displayLastName + ", " + object?.member?.displayFirstName,
                                     value: object.memberId
@@ -172,7 +172,7 @@
                     }
 
                     update(() => {
-                        var res = fetch("Members?search=" + val)
+                        fetch("Members?search=" + val)
                             .then(r => r.json())
                             .then(data =>
                                 this.memberSearchResults = data

--- a/web/Areas/RAPS/Views/Permissions/Members.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Members.cshtml
@@ -11,7 +11,7 @@
          :filter="membersTable.filter"
          :pagination="membersTable.pagination">
     <template v-slot:top-left>
-        <q-btn color="green" label="Add Member" @@click="membersTable.showForm = true;membersTable.object.access = 1;" no-caps></q-btn>
+        <q-btn color="positive" label="Add Member" @@click="membersTable.showForm = true;membersTable.object.access = 1;" no-caps></q-btn>
         <div class="q-pa-sm q-gutter-sm">
             <q-dialog v-model="membersTable.showForm" @@hide="membersTable.clear(this)">
                 <q-card>
@@ -62,7 +62,7 @@
 
                         <q-card-actions align="evenly">
                             <q-btn no-caps :label="membersTable.editing ? 'Update Member' : 'Add Member'" type="submit" padding="xs sm" color="primary"></q-btn>
-                            <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="membersTable.delete(this)" color="red" v-if="membersTable.editing"></q-btn>
+                            <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="membersTable.delete(this)" color="negative" v-if="membersTable.editing"></q-btn>
                         </q-card-actions>
                     </q-form>
                 </q-card>

--- a/web/Areas/RAPS/Views/Permissions/Members.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Members.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>User Permissions for {{permission.permission}}</h1>
+﻿@{
+    ViewData["Title"] = "Permission Members";
+}
+<h1>User Permissions for {{permission.permission}}</h1>
 <p>
     {{permission.description}}
 </p>
@@ -46,7 +49,7 @@
                                          :error="membersTable.errors?.endDate?.error" :error-message="membersTable.endDate?.startDate?.message"></q-input>
                             </div>
                             <div class="row q-pt-sm">
-                                <q-btn-toggle no-caps outlined dense :toggle-color="membersTable.object.access == 0 ? 'red' : 'green'" 
+                                <q-btn-toggle no-caps outlined dense :toggle-color="membersTable.object.access == 0 ? 'negative' : 'positive'" 
                                     v-model="membersTable.object.access" :options="allowDenyOptions">
                                     <template v-slot:allow>
                                         <div class="q-px-lg" align="evenly">
@@ -82,7 +85,7 @@
     </template>
     <template v-slot:body-cell-access="props">
         <q-td :props="props">
-            <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'green' : 'red'"></q-icon>
+            <q-icon size="sm" :name="props.row.access ? 'check' : 'close'" :color="props.row.access ? 'positive' : 'negative'"></q-icon>
         </q-td>
     </template>
     <template v-slot:body-cell-memberid="props">
@@ -116,8 +119,8 @@
                         keys: ["memberId"],
                         urlBase: "Permissions",
                         columns: [
-                            { name: "memberid", label: "", field: "memberId", align: "left", style: "width:75px;" },
-                            { name: "access", label: "", field: "access", align: "left", style: "width:75px;" },
+                            { name: "memberid", label: "Actions", field: "memberId", align: "left", style: "width:75px;" },
+                            { name: "access", label: "Access", field: "access", align: "left", style: "width:75px;" },
                             { name: "member", label: "Member", field: "memberName", align: "left", sortable: true },
                             { name: "startdate", label: "Start Date", field: "startDate", align: "left", sortable: true, format: v => formatDate(v) },
                             { name: "enddate", label: "End Date", field: "endDate", align: "left", sortable: true, format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Permissions/Members.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Members.cshtml
@@ -90,14 +90,14 @@
     </template>
     <template v-slot:body-cell-memberid="props">
         <q-td :props="props">
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="View combined permissions for this user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="View permissions for this user" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="policy" title="View combined permissions for this user" aria-label="View combined permissions for this user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="View roles for this user" aria-label="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="lock" title="View permissions for this user" aria-label="View permissions for this user" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
         </q-td>
     </template>
     <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-            <q-btn no-caps outline size="sm" icon="edit" :props="props" color="primary" @@click="membersTable.selectRow(props.row)"></q-btn>
+            <q-btn dense outline size="sm" icon="edit" padding="sm" :props="props" color="primary" aria-label="Edit member" @@click="membersTable.selectRow(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -129,7 +129,7 @@
                                 sort: (_1, _2, rowA, rowB) => new Date(rowA.modTime) - new Date(rowB.modTime)
                             },
                             { name: "active", label: "Active", field: "active", align: "left", sortable: true },
-                            { name: "actions", label: "Actions", field: "", align: "left", sortable: false }
+                            { name: "actions", label: "Edit", field: "", align: "left", sortable: false, style: "width: 60px;" }
                         ],
                         //after loading role members, add the member name and active flag
                         onLoad: function (data) {

--- a/web/Areas/RAPS/Views/Permissions/Members.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Members.cshtml
@@ -16,9 +16,13 @@
             <q-dialog v-model="membersTable.showForm" @@hide="membersTable.clear(this)">
                 <q-card>
                     <q-form @@submit="membersTable.submit(this)" v-bind="membersTable.object">
-                        <q-card-section>
+                        <q-card-section class="row items-center q-pb-none">
                             <div class="text-h6">{{membersTable.editing >= 0 ? "Edit" : "Create"}} Permission Member</div>
-                            <div class="bg-negative text-white q-pa-sm rounded" v-if="membersTable.errors?.message?.length > 0">{{membersTable.errors.message}}</div>
+                            <q-space></q-space>
+                            <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                        </q-card-section>
+                        <q-card-section v-if="membersTable.errors?.message?.length > 0">
+                            <div class="bg-negative text-white q-pa-sm rounded">{{membersTable.errors.message}}</div>
                         </q-card-section>
 
                         <q-card-section>

--- a/web/Areas/RAPS/Views/Permissions/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Roles.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles for Permission {{permission.permission}}</h1>
+﻿@{
+    ViewData["Title"] = "Permission Roles";
+}
+<h1>Roles for Permission {{permission.permission}}</h1>
 <q-table dense
          row-key="roleId"
          :loading="rolePermissionTable.loading"
@@ -54,7 +57,7 @@
                         keys: ["roleId"],
                         urlBase: "Roles",
                         columns: [
-                            { name: "links", label: "", field: "", align: "left", style: "width:75px;" },
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:75px;" },
                             { name: "role", label: "Role", field: "roleName", align: "left", sortable: true },
                             { name: "access", label: "Access", field: "accessDescription", align: "left", sortable: true },
                             { name: "lastModified", label: "Last Modified Date", field: "modTime", align: "left", sortable: true, format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Permissions/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Roles.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Roles for Permission {{permission.permission}}</h2>
+﻿<h1>Roles for Permission {{permission.permission}}</h1>
 <q-table dense
          row-key="roleId"
          :loading="rolePermissionTable.loading"
@@ -14,7 +14,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -65,9 +65,9 @@
                             this.rows = data.map(rp => ({
                                 ...rp,
                                 permissionId: rp.permissionId,
-                                accessDescription: rp.access == 1 ? "Allow" : "Deny",
+                                accessDescription: rp.access === 1 ? "Allow" : "Deny",
                                 permissionName: rp.permission?.permission,
-                                roleName: rp.role?.displayName != null ? rp.role.displayName : rp.role.role
+                                roleName: rp.role?.displayName !== null ? rp.role.displayName : rp.role.role
                             }))
                         },
                         pagination: { rowsPerPage: 0 }
@@ -86,7 +86,7 @@
                                     return result
                                 }, [])
                             this.rows = data.filter(r =>
-                                existingRoles.indexOf(r.roleId) == -1
+                                existingRoles.indexOf(r.roleId) === -1
                             )
                             this.rows = this.rows.map(r => ({
                                 ...r,
@@ -112,7 +112,6 @@
                 updateEachRolePermission: async function(allowAccess = 1) {
                     await Promise.all(
                         this.selectedPermissions.map(async sp => {
-                            let rolePermission = { roleId: sp.roleId, permissionId: this.permissionId, access: allowAccess }
                             await viperFetch(this,
                                 "Permissions/" + this.permissionId + "/Roles/",
                                 {

--- a/web/Areas/RAPS/Views/Permissions/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Roles.cshtml
@@ -14,7 +14,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="negative" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -38,7 +38,7 @@
     </template>
 </q-table>
 <q-btn sm dense no-caps class="q-px-sm" label="Allow Checked" type="button" color="primary" @@click="allowRolePermissions"></q-btn>
-<q-btn sm dense no-caps class="q-ml-md q-px-sm" label="Deny Checked" type="button" color="red" @@click="denyRolePermissions"></q-btn>
+<q-btn sm dense no-caps class="q-ml-md q-px-sm" label="Deny Checked" type="button" color="negative" @@click="denyRolePermissions"></q-btn>
 
 @section Scripts {
     <script src="~/js/qtable.js"></script>

--- a/web/Areas/RAPS/Views/Permissions/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/Roles.cshtml
@@ -129,18 +129,25 @@
                 denyRolePermissions: async function () {
                     this.updateRolePermissions(0)
                 },
-                deleteRolePermission: async function (rolePermission) {
-                    await viperFetch(this,
-                        "Permissions/" + this.permissionId + "/Roles/" + rolePermission.roleId,
-                        {
-                            method: "DELETE",
-                            headers: { "Content-Type": "application/json" }
-                        },
-                        [this.loadTables]
-                    )
-                    if(this.VMACSPush) {
-                        this.pushToVMACS([rolePermission.roleId])
-                    }
+                deleteRolePermission: function (rolePermission) {
+                    Quasar.Dialog.create({
+                        title: "Confirm Delete",
+                        message: "Are you sure you want to remove this role from the permission?",
+                        cancel: true,
+                        persistent: true
+                    }).onOk(async () => {
+                        await viperFetch(this,
+                            "Permissions/" + this.permissionId + "/Roles/" + rolePermission.roleId,
+                            {
+                                method: "DELETE",
+                                headers: { "Content-Type": "application/json" }
+                            },
+                            [this.loadTables]
+                        )
+                        if(this.VMACSPush) {
+                            this.pushToVMACS([rolePermission.roleId])
+                        }
+                    })
                 },
                 //Load data
                 loadTables: async function () {

--- a/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
@@ -12,11 +12,6 @@
             <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View permissions granted by this role" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
         </q-td>
     </template>
-    <template v-slot:body-cell-remove="props">
-        <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="negative" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
-        </q-td>
-    </template>
 </q-table>
 
 @section Scripts {
@@ -53,7 +48,6 @@
                 loadPermission: async function () {
                     this.permission = await viperFetch(this, "Permissions/" + this.permissionId)
                 },
-                //Load data
                 loadTables: async function () {
                     await this.rolePermissionTable.load(this)
                 }

--- a/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles for Permission {{permission.permission}}</h1>
+﻿@{
+    ViewData["Title"] = "Permission Roles";
+}
+<h1>Roles for Permission {{permission.permission}}</h1>
 <q-table dense
          row-key="roleId"
          :loading="rolePermissionTable.loading"

--- a/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
@@ -14,7 +14,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="negative" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>

--- a/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
+++ b/web/Areas/RAPS/Views/Permissions/RolesRO.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Roles for Permission {{permission.permission}}</h2>
+﻿<h1>Roles for Permission {{permission.permission}}</h1>
 <q-table dense
          row-key="roleId"
          :loading="rolePermissionTable.loading"
@@ -14,7 +14,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove role from permission" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -40,9 +40,9 @@
                             this.rows = data.map(rp => ({
                                 ...rp,
                                 permissionId: rp.permissionId,
-                                accessDescription: rp.access == 1 ? "Allow" : "Deny",
+                                accessDescription: rp.access === 1 ? "Allow" : "Deny",
                                 permissionName: rp.permission?.permission,
-                                roleName: rp.role?.displayName != null ? rp.role.displayName : rp.role.role
+                                roleName: rp.role?.displayName !== null ? rp.role.displayName : rp.role.role
                             }))
                         },
                         pagination: { rowsPerPage: 0 }

--- a/web/Areas/RAPS/Views/RoleViewUpdate.cshtml
+++ b/web/Areas/RAPS/Views/RoleViewUpdate.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Updating role membership based on view</h2>
+﻿<h1>Updating role membership based on view</h1>
 @{
     @if (ViewData["Messages"] != null)
     {

--- a/web/Areas/RAPS/Views/RoleViewUpdate.cshtml
+++ b/web/Areas/RAPS/Views/RoleViewUpdate.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Updating role membership based on view</h1>
+﻿@{
+    ViewData["Title"] = "Updating Role Membership Based on View";
+}
+<h1>Updating role membership based on view</h1>
 @{
     @if (ViewData["Messages"] != null)
     {

--- a/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
@@ -115,7 +115,7 @@
                     else if (this.loginids !== null && this.loginids.length > 0) {
                         this.members = []
                         for (const loginId of this.loginids.split(",")) {
-                            result = await this.send(this.getApplyUrl(null, loginId))
+                            const result = await this.send(this.getApplyUrl(null, loginId))
                             if (result !== null) {
                                 this.members.push(result)
                             }

--- a/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
@@ -56,11 +56,11 @@
             methods: {
                 send: async function(url, data) {
                     return await fetch(url, data)
-                        .then(r => r.ok && r.status !== "204" ? r.json() : r)
+                        .then(r => r.ok && r.status !== 204 ? r.json() : r)
                         .then(r => r.success !== undefined ? r.result : null)
                 },
                 getApplyUrl: function(memberId, loginId) {
-                    return memberId !== null
+                    return memberId !== null && memberId !== undefined
                         ? `RoleTemplates/${this.roleTemplateId}/Apply/${memberId}`
                         : `RoleTemplates/${this.roleTemplateId}/Apply/loginid:${loginId}`
                 },
@@ -68,7 +68,7 @@
                     this.previewApplyTemplate()
                 },
                 loginidsUpdate: async function() {
-                    if (this.userSearch?.value === null || this.userSearch.value.length === 0) {
+                    if ((this.userSearch?.value?.length ?? 0) === 0) {
                         this.previewApplyTemplate()
                     }
                 },
@@ -78,7 +78,7 @@
                         headers: { "Content-Type": "application/json" }
                     }
                     //use the single user search box
-                    if (this.userSearch?.value !== null && this.userSearch.value.length > 0) {
+                    if ((this.userSearch?.value?.length ?? 0) > 0) {
                         await this.send(this.getApplyUrl(this.userSearch.value), options)
                     }
                     //use the loginids text box
@@ -100,7 +100,7 @@
                 previewApplyTemplate: async function() {
                     this.members = null
                     //use the single user search box
-                    if (this.userSearch?.value !== null && this.userSearch.value.length > 0) {
+                    if ((this.userSearch?.value?.length ?? 0) > 0) {
                         this.loginids = ""
                         this.members = []
                         var result = await this.send(this.getApplyUrl(this.userSearch.value))

--- a/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Apply role template {{roleTemplate.templateName}}</h1>
+﻿@{
+    ViewData["Title"] = "Apply Template";
+}
+<h1>Apply role template {{roleTemplate.templateName}}</h1>
 
 <q-form>
     Search for a single user, or paste in multiple login ids.
@@ -25,7 +28,7 @@
             </tr>
             <tr v-for="role in member.roles">
                 <td>
-                    <q-icon :name="role.userHasRole ? 'info' : 'add'" :color="role.userHasRole ? 'blue-3' : 'green'" size="sm"></q-icon>
+                    <q-icon :name="role.userHasRole ? 'info' : 'add'" :color="role.userHasRole ? 'info' : 'positive'" size="sm"></q-icon>
                     {{role.userHasRole ? 'User has role' : 'Role will be added'}}
                 </td>
                 <td>{{role.roleName}}</td>

--- a/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Apply role template {{roleTemplate.templateName}}</h2>
+﻿<h1>Apply role template {{roleTemplate.templateName}}</h1>
 
 <q-form>
     Search for a single user, or paste in multiple login ids.
@@ -56,11 +56,11 @@
             methods: {
                 send: async function(url, data) {
                     return await fetch(url, data)
-                        .then(r => r.ok && r.status != "204" ? r.json() : r)
+                        .then(r => r.ok && r.status !== "204" ? r.json() : r)
                         .then(r => r.success !== undefined ? r.result : null)
                 },
                 getApplyUrl: function(memberId, loginId) {
-                    return memberId != null
+                    return memberId !== null
                         ? `RoleTemplates/${this.roleTemplateId}/Apply/${memberId}`
                         : `RoleTemplates/${this.roleTemplateId}/Apply/loginid:${loginId}`
                 },
@@ -68,7 +68,7 @@
                     this.previewApplyTemplate()
                 },
                 loginidsUpdate: async function() {
-                    if (this.userSearch?.value == null || this.userSearch.value.length == 0) {
+                    if (this.userSearch?.value === null || this.userSearch.value.length === 0) {
                         this.previewApplyTemplate()
                     }
                 },
@@ -78,13 +78,13 @@
                         headers: { "Content-Type": "application/json" }
                     }
                     //use the single user search box
-                    if (this.userSearch?.value != null && this.userSearch.value.length > 0) {
-                        var result = await this.send(this.getApplyUrl(this.userSearch.value), options)
+                    if (this.userSearch?.value !== null && this.userSearch.value.length > 0) {
+                        await this.send(this.getApplyUrl(this.userSearch.value), options)
                     }
                     //use the loginids text box
-                    else if (this.loginids != null && this.loginids.length > 0) {
-                        for(loginId of this.loginids.split(",")) {
-                            var result = await this.send(this.getApplyUrl(null, loginId), options)
+                    else if (this.loginids !== null && this.loginids.length > 0) {
+                        for (const loginId of this.loginids.split(",")) {
+                            await this.send(this.getApplyUrl(null, loginId), options)
                         }
                     }
                     if(this.VMACSPush) {
@@ -100,34 +100,34 @@
                 previewApplyTemplate: async function() {
                     this.members = null
                     //use the single user search box
-                    if (this.userSearch?.value != null && this.userSearch.value.length > 0) {
+                    if (this.userSearch?.value !== null && this.userSearch.value.length > 0) {
                         this.loginids = ""
                         this.members = []
                         var result = await this.send(this.getApplyUrl(this.userSearch.value))
-                        if (result != null) {
+                        if (result !== null) {
                             this.members.push(result)
                         }
                     }
                     //use the loginids text box
-                    else if (this.loginids != null && this.loginids.length > 0) {
+                    else if (this.loginids !== null && this.loginids.length > 0) {
                         this.members = []
-                        for (loginId of this.loginids.split(",")) {
-                            var result = await this.send(this.getApplyUrl(null, loginId))
-                            if (result != null) {
+                        for (const loginId of this.loginids.split(",")) {
+                            result = await this.send(this.getApplyUrl(null, loginId))
+                            if (result !== null) {
                                 this.members.push(result)
                             }
                         }
-                        this.members = this.members.filter(m => m != undefined && m.memberId.length)
+                        this.members = this.members.filter(m => m !== undefined && m.memberId.length)
                     }
                     this.membersFound = this.members && this.members.length && this.members[0].memberId.length
                 },
-                findUsers: function (val, update, abort, target) {
+                findUsers: function (val, update, abort) {
                     if (val.length < 3) {
                         abort()
                         return
                     }
                     update(() => {
-                        var res = viperFetch(this, "Members?active=recent&search=" + val)
+                        viperFetch(this, "Members?active=recent&search=" + val)
                             .then(data => {
                                 this.userSearchResults = data.map(m => ({
                                     label: (!m.current ? "[Inactive]" : "") + m.displayLastName + ", " + m.displayFirstName,

--- a/web/Areas/RAPS/Views/Roles/DelegateRoles.cshtml
+++ b/web/Areas/RAPS/Views/Roles/DelegateRoles.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Roles controlled by {{role.friendlyName}}</h2>
+﻿<h1>Roles controlled by {{role.friendlyName}}</h1>
 
 <q-table dense
         row-key="roleId"
@@ -33,7 +33,7 @@
                 loadRoles: async function() {
                     var childRoles = await viperFetch(this, "Roles/ControlledBy/" + + this.urlParams.get("roleId"))
                     var allRoles = (await viperFetch(this, "Roles?Application=0"))
-                        .filter(r => childRoles.find(cr => cr.roleId == r.roleId) === undefined)
+                        .filter(r => childRoles.find(cr => cr.roleId === r.roleId) === undefined)
                     this.selectedRoles = childRoles;//.reduce((result, cr) => { result.push(cr.roleId); return result }, [])
                     this.roles = childRoles.concat(allRoles)
                 },

--- a/web/Areas/RAPS/Views/Roles/DelegateRoles.cshtml
+++ b/web/Areas/RAPS/Views/Roles/DelegateRoles.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles controlled by {{role.friendlyName}}</h1>
+﻿@{
+    ViewData["Title"] = "Delegate Roles";
+}
+<h1>Roles controlled by {{role.friendlyName}}</h1>
 
 <q-table dense
         row-key="roleId"

--- a/web/Areas/RAPS/Views/Roles/List.cshtml
+++ b/web/Areas/RAPS/Views/Roles/List.cshtml
@@ -1,11 +1,14 @@
-﻿<div class="q-pa-md">
+﻿@{
+    ViewData["Title"] = "Roles";
+}
+<div class="q-pa-md">
     <q-table title="Roles"
             dense
             row-key="roleId"
             :loading="rolesTable.loading"
             :rows="rolesTable.rows"
             :columns="rolesTable.columns"
-            :filter="rolesTable.filter" 
+            :filter="rolesTable.filter"
             :pagination="rolesTable.pagination">
         <template v-slot:top-right="props">
             <q-input class="q-ml-xs q-mr-xs" v-model="rolesTable.filter" dense outlined debounce="300" placeholder="Filter Results">
@@ -50,7 +53,7 @@
                 return {
                     rolesTable: new quasarTable({
                         columns: [
-                            { name: "roleid", label: "", field: "roleId", align: "left", style: "width:50px;" },
+                            { name: "roleid", label: "Actions", field: "roleId", align: "left", style: "width:50px;" },
                             { name: "role", label: "Role", field: "friendlyName", align: "left", sortable: true },
                             { name: "viewname", label: "Member List", field: "viewName", align: "left", sortable: true },
                             { name: "membersCount", label: "Explicit Members", field: "membersCount", align: "left", sortable: true }

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -66,7 +66,7 @@
         </template>
         <template v-slot:body-cell-role="props">
             <q-td :props="props">
-                <q-badge v-if="props.row.application == 1" transparent icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
+                <q-badge v-if="props.row.application == 1" icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
                 {{props.row.friendlyName}}
                 <br />     
                 <span style="font-size:.9em">{{props.row.description}}</span>

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -62,14 +62,14 @@
         </template>
         <template v-slot:body-cell-roleid="props">
             <q-td :props="props">
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Show members of this role" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
-                <q-btn :props="props" v-if="props.row.application != 1" size="sm" padding="xs" color="primary" square flat icon="lock" title="Show permission granted by this role" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
-                <q-btn :props="props" v-if="props.row.application == 1" size="sm" padding="xs" color="primary" square flat icon="security" title="Edit which roles this role delegates access to" :href="'DelegateRoles?roleId=' + props.row.roleId"></q-btn>
+                <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="Show members of this role" aria-label="Show members of this role" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
+                <q-btn :props="props" v-if="props.row.application !== 1" size="sm" padding="sm" color="primary" square flat icon="lock" title="Show permissions granted by this role" aria-label="Show permissions granted by this role" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
+                <q-btn :props="props" v-if="props.row.application === 1" size="sm" padding="sm" color="primary" square flat icon="security" title="Edit which roles this role delegates access to" aria-label="Edit which roles this role delegates access to" :href="'DelegateRoles?roleId=' + props.row.roleId"></q-btn>
             </q-td>
         </template>
         <template v-slot:body-cell-role="props">
             <q-td :props="props">
-                <q-badge v-if="props.row.application == 1" transparent icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
+                <q-badge v-if="props.row.application === 1" transparent icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
                 {{props.row.friendlyName}}
                 <br />     
                 <span style="font-size:.9em">{{props.row.description}}</span>
@@ -82,7 +82,7 @@
         </template>
         <template v-slot:body-cell-edit="props">
             <q-td :props="props">
-                <q-btn :props="props" outline dense color="primary" size="sm" icon="edit" padding="xs sm" aria-label="Edit role" @@click="rolesTable.selectRow(props.row)"></q-btn>
+                <q-btn :props="props" outline dense color="primary" size="sm" icon="edit" padding="sm" aria-label="Edit role" @@click="rolesTable.selectRow(props.row)"></q-btn>
             </q-td>
         </template>
     </q-table>
@@ -104,7 +104,7 @@
                             { name: "role", label: "Role", field: "role", align: "left", sortable: true },
                             { name: "viewname", label: "Member List", field: "viewName", align: "left", sortable: true },
                             { name: "members", label: "Explicit Members", field: "", align: "left", sortable: true },
-                            { name: "edit", label: "Actions", field: "" }
+                            { name: "edit", label: "Edit", field: "", align: "left", style: "width: 60px;" }
                         ],
                         //create object with limited properties to do insert/update
                         createBody: function (vueApp, data) {

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -2,9 +2,13 @@
 <q-dialog v-model="rolesTable.showForm" @@hide="rolesTable.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="rolesTable.submit(this)" v-model="rolesTable.object">
-            <q-card-section>
+            <q-card-section class="row items-center q-pb-none">
                 <div class="text-h6">{{rolesTable.editing ? "Edit" : "Create"}} Role</div>
-                <div class="bg-negative text-white q-pa-sm rounded" v-if="rolesTable.errors?.message?.length > 0">{{rolesTable.errors.message}}</div>
+                <q-space></q-space>
+                <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+            </q-card-section>
+            <q-card-section v-if="rolesTable.errors?.message?.length > 0">
+                <div class="bg-negative text-white q-pa-sm rounded">{{rolesTable.errors.message}}</div>
             </q-card-section>
             <q-card-section>
                 <div class="row">
@@ -62,7 +66,7 @@
         </template>
         <template v-slot:body-cell-role="props">
             <q-td :props="props">
-                <q-badge :props="props" v-if="props.row.application == 1" transparent icon="supervisor_account" color="amber-7" text-color="dark" class="q-mr-2">Delegate</q-badge>
+                <q-badge v-if="props.row.application == 1" transparent icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
                 {{props.row.friendlyName}}
                 <br />     
                 <span style="font-size:.9em">{{props.row.description}}</span>

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Roles</h2>
+﻿<h1>Roles</h1>
 <q-dialog v-model="rolesTable.showForm" @@hide="rolesTable.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="rolesTable.submit(this)" v-model="rolesTable.object">
@@ -75,7 +75,7 @@
         </template>
         <template v-slot:body-cell-edit="props">
             <q-td :props="props">
-                <q-btn :props="props" outline dense color="primary" size="sm" icon="edit" padding="xs sm" @@click="rolesTable.selectRow(props.row)"></q-btn>
+                <q-btn :props="props" outline dense color="primary" size="sm" icon="edit" padding="xs sm" aria-label="Edit role" @@click="rolesTable.selectRow(props.row)"></q-btn>
             </q-td>
         </template>
     </q-table>
@@ -104,11 +104,11 @@
                             var obj = {
                                 roleId: data.roleId,
                                 role: data.role,
-                                application: data.application == 1 ? 1 : 0,
+                                application: data.application === 1 ? 1 : 0,
                                 description: data.description,
                                 viewName: data.viewName,
                             }
-                            if(this.inVMACSInstance || (data.accessCode != null && data.accessCode != "")) {
+                            if(this.inVMACSInstance || (data.accessCode !== null && data.accessCode !== "")) {
                                 obj.accessCode = data.accessCode
                             }
                             return obj

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Roles</h1>
+﻿@{
+    ViewData["Title"] = "Roles";
+}
+<h1>Roles</h1>
 <q-dialog v-model="rolesTable.showForm" @@hide="rolesTable.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="rolesTable.submit(this)" v-model="rolesTable.object">
@@ -66,7 +69,7 @@
         </template>
         <template v-slot:body-cell-role="props">
             <q-td :props="props">
-                <q-badge v-if="props.row.application == 1" icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
+                <q-badge v-if="props.row.application == 1" transparent icon="supervisor_account" color="warning" text-color="dark" class="q-mr-2">Delegate</q-badge>
                 {{props.row.friendlyName}}
                 <br />     
                 <span style="font-size:.9em">{{props.row.description}}</span>
@@ -97,11 +100,11 @@
                         keys: "roleId",
                         urlBase: "Roles",
                         columns: [
-                            { name: "roleid", label: "", field: "roleId", align: "left", style: "width:50px;" },
+                            { name: "roleid", label: "Actions", field: "roleId", align: "left", style: "width:50px;" },
                             { name: "role", label: "Role", field: "role", align: "left", sortable: true },
                             { name: "viewname", label: "Member List", field: "viewName", align: "left", sortable: true },
                             { name: "members", label: "Explicit Members", field: "", align: "left", sortable: true },
-                            { name: "edit", label: "", field: "" }
+                            { name: "edit", label: "Actions", field: "" }
                         ],
                         //create object with limited properties to do insert/update
                         createBody: function (vueApp, data) {

--- a/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
+++ b/web/Areas/RAPS/Views/Roles/ListAdmin.cshtml
@@ -28,7 +28,7 @@
             </q-card-section>
             <q-card-actions align="evenly">
                 <q-btn no-caps :label="rolesTable.editing ? 'Update Role' : 'Add Role'" type="submit" padding="xs sm" color="primary"></q-btn>
-                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="rolesTable.delete(this)" color="red" v-if="rolesTable.editing"></q-btn>
+                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="rolesTable.delete(this)" color="negative" v-if="rolesTable.editing"></q-btn>
             </q-card-actions>
         </q-form>
     </q-card>
@@ -44,7 +44,7 @@
              :pagination="rolesTable.pagination"
             @@update:pagination="(v) => rolesTable.savePagination(v)">
         <template v-slot:top-left>
-            <q-btn no-caps color="green" label="Add Role" @@click="rolesTable.showForm = true"></q-btn>
+            <q-btn no-caps color="positive" label="Add Role" @@click="rolesTable.showForm = true"></q-btn>
         </template>
         <template v-slot:top-right="props">
             <q-input class="q-ml-xs q-mr-xs" v-model="rolesTable.filter" dense outlined debounce="300" placeholder="Filter Results">
@@ -62,7 +62,7 @@
         </template>
         <template v-slot:body-cell-role="props">
             <q-td :props="props">
-                <q-badge :props="props" v-if="props.row.application == 1" transparent icon="supervisor_account" color="amber-7" class="q-mr-2">Delegate</q-badge>
+                <q-badge :props="props" v-if="props.row.application == 1" transparent icon="supervisor_account" color="amber-7" text-color="dark" class="q-mr-2">Delegate</q-badge>
                 {{props.row.friendlyName}}
                 <br />     
                 <span style="font-size:.9em">{{props.row.description}}</span>

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -73,11 +73,11 @@
     </template>
     <template v-slot:body-cell-memberid="props">
         <q-td :props="props">
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="Combined permissions for user" aria-label="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View roles for this user" aria-label="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
             @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
             {
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
+                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="View individual permissions" aria-label="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
             }
         </q-td>
     </template>

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -80,17 +80,17 @@
     </template>
     <template v-slot:body-cell-memberid="props">
         <q-td :props="props">
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="Combined permissions for user" aria-label="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View roles for this user" aria-label="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="policy" title="Combined permissions for user" aria-label="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="View roles for this user" aria-label="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
             @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
             {
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="View individual permissions" aria-label="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
+                <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="lock" title="View individual permissions" aria-label="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
             }
         </q-td>
     </template>
     <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-            <q-btn size="sm" outline icon="edit" :props="props" padding="xs md" color="primary" aria-label="Edit member"
+            <q-btn dense size="sm" outline icon="edit" :props="props" padding="sm" color="primary" aria-label="Edit member"
                 v-if="props.row.viewName == null" @@click="membersTable.selectRow(props.row)"></q-btn>
             <span v-if="props.row.viewName != null">{{props.row.viewName}}</span>
         </q-td>
@@ -123,7 +123,7 @@
                             { name: "lastmodified", label: "Last Modified", field: "lastModified", align: "left", 
                                 sortable: true, sort: (_1, _2, rowA, rowB) => new Date(rowA.modTime) - new Date(rowB.modTime) },
                             { name: "active", label: "Active", field: "active", align: "left", sortable: true },
-                            { name: "actions", label: "Actions", field: "", align: "left", sortable: false }
+                            { name: "actions", label: "Edit", field: "", align: "left", sortable: false, style: "width: 60px;" }
                         ],
                         //after loading role members, add the member name and active flag
                         onLoad: function (data) {

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -21,9 +21,13 @@
             <q-dialog v-model="membersTable.showForm" @@hide="membersTable.clear(this)">
                 <q-card>
                     <q-form @@submit="addUpdateMember();" v-bind="membersTable.object">
-                        <q-card-section>
+                        <q-card-section class="row items-center q-pb-none">
                             <div class="text-h6">{{membersTable.editing >= 0 ? "Edit" : "Create"}} Role Member</div>
-                            <div class="bg-negative text-white q-pa-sm rounded" v-if="membersTable.errors?.message?.length > 0">{{membersTable.errors.message}}</div>
+                            <q-space></q-space>
+                            <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+                        </q-card-section>
+                        <q-card-section v-if="membersTable.errors?.message?.length > 0">
+                            <div class="bg-negative text-white q-pa-sm rounded">{{membersTable.errors.message}}</div>
                         </q-card-section>
 
                         <q-card-section>
@@ -186,16 +190,23 @@
                         Quasar.Loading.hide()
                     }
                 },
-                deleteMember: async function () {
-                    this.disableMemberUpdate = true
-                    var oldBase = this.membersTable.urlBase
-                    this.membersTable.urlBase = "Roles/" + this.roleId + "/Members"
+                deleteMember: function () {
+                    Quasar.Dialog.create({
+                        title: "Confirm Delete",
+                        message: "Are you sure you want to remove this member from the role?",
+                        cancel: true,
+                        persistent: true
+                    }).onOk(async () => {
+                        this.disableMemberUpdate = true
+                        var oldBase = this.membersTable.urlBase
+                        this.membersTable.urlBase = "Roles/" + this.roleId + "/Members"
 
-                    const deleted = await this.membersTable.delete(this)
-                    this.membersTable.urlBase = oldBase
-                    if (deleted) { this.pushMemberToVMACS() }
-                    
-                    this.disableMemberUpdate = false
+                        const deleted = await this.membersTable.delete(this)
+                        this.membersTable.urlBase = oldBase
+                        if (deleted) { this.pushMemberToVMACS() }
+
+                        this.disableMemberUpdate = false
+                    })
                 },
                 addUpdateMember: async function () {
                     this.disableMemberUpdate = true

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -15,7 +15,7 @@
          :filter="membersTable.filter"
          :pagination="membersTable.pagination">
     <template v-slot:top-left>
-        <q-btn color="green" label="Add Member" @@click="membersTable.showForm = true" no-caps icon="add"></q-btn>
+        <q-btn color="positive" label="Add Member" @@click="membersTable.showForm = true" no-caps icon="add"></q-btn>
         <q-btn color="primary" label="Push Role Membership to VMACS" @@click="pushRoleToVMACS(true)" no-caps icon="upload" class="q-ml-md" v-if="showVMACSPush"></q-btn>
         <div class="q-pa-sm q-gutter-sm">
             <q-dialog v-model="membersTable.showForm" @@hide="membersTable.clear(this)">
@@ -57,7 +57,7 @@
 
                         <q-card-actions align="evenly">
                             <q-btn no-caps :label="membersTable.editing ? 'Update Member' : 'Add Member'" type="submit" padding="xs sm" color="primary" :disabled="disableMemberUpdate"></q-btn>
-                            <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="deleteMember(this)" color="red" v-if="membersTable.editing" :disabled="disableMemberUpdate"></q-btn>
+                            <q-btn no-caps label="Delete" type="button" padding="xs lg" @@click="deleteMember(this)" color="negative" v-if="membersTable.editing" :disabled="disableMemberUpdate"></q-btn>
                         </q-card-actions>
                     </q-form>
                 </q-card>

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Members of {{ role.friendlyName }}</h2>
+﻿<h1>Members of {{ role.friendlyName }}</h1>
 
 <p>
     {{ role.description }}
@@ -73,17 +73,17 @@
     </template>
     <template v-slot:body-cell-memberid="props">
         <q-td :props="props">
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
-            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
+            <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
             @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
             {
-                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
+                <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
             }
         </q-td>
     </template>
     <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-            <q-btn size="sm" outline icon="edit" :props="props" padding="xs md" color="primary" 
+            <q-btn size="sm" outline icon="edit" :props="props" padding="xs md" color="primary" aria-label="Edit member"
                 v-if="props.row.viewName == null" @@click="membersTable.selectRow(props.row)"></q-btn>
             <span v-if="props.row.viewName != null">{{props.row.viewName}}</span>
         </q-td>
@@ -123,7 +123,7 @@
                             this.data = data.map(rm => ({
                                 ...rm,
                                 active: (rm?.active ?? false) ? "Y" : "N",
-                                lastModified: rm.modBy == null ? "" : (formatDate(rm.modTime) + " (" + rm.modBy.trim() + ")")
+                                lastModified: rm.modBy === null ? "" : (formatDate(rm.modTime) + " (" + rm.modBy.trim() + ")")
                             }))
                         },
                         //set member id and role id when creating/updating
@@ -164,7 +164,7 @@
                     }
 
                     update(() => {
-                        var res = fetch("Members?search=" + val)
+                        fetch("Members?search=" + val)
                             .then(r => r.json())
                             .then(data =>
                                 this.memberSearchResults = data
@@ -214,7 +214,7 @@
                 this.membersTable.urlBase = "Roles/" + this.roleId + "/Members"
                 this.membersTable.load()
                 await this.loadRole()
-                this.showVMACSPush = this.role.instance.indexOf("VMACS") == 0
+                this.showVMACSPush = this.role.instance.indexOf("VMACS") === 0
             },
             watch: {
                 showViewMembers: {

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Members of {{ role.friendlyName }}</h1>
+﻿@{
+    ViewData["Title"] = "Role Members";
+}
+<h1>Members of {{ role.friendlyName }}</h1>
 
 <p>
     {{ role.description }}
@@ -111,7 +114,7 @@
                         keys: ["memberId"],
                         urlBase: "Roles",
                         columns: [
-                            { name: "memberid", label: "", field: "memberId", align: "left", style: "width:75px;" },
+                            { name: "memberid", label: "Actions", field: "memberId", align: "left", style: "width:75px;" },
                             { name: "member", label: "Member", field: "userName", align: "left", sortable: true },
                             { name: "loginid", label: "Login ID", field: "loginId", align: "left", sortable: true },
                             { name: "adddate", label: "Add Date", field: "addDate", align: "left", sortable: true, format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -201,13 +201,14 @@
                         persistent: true
                     }).onOk(async () => {
                         this.disableMemberUpdate = true
-                        var oldBase = this.membersTable.urlBase
-                        this.membersTable.urlBase = "Roles/" + this.roleId + "/Members"
-
-                        const deleted = await this.membersTable.delete(this)
-                        this.membersTable.urlBase = oldBase
-                        if (deleted) { this.pushMemberToVMACS() }
-
+                        var url = "Roles/" + this.roleId + "/Members/" + this.membersTable.object.memberId
+                        const result = await viperFetch(this, url, { method: "DELETE" },
+                            [() => this.membersTable.load(this)], this.membersTable.errors)
+                        if (result !== undefined) {
+                            showStatusNotification("Member removed")
+                            this.membersTable.clear()
+                            this.pushMemberToVMACS()
+                        }
                         this.disableMemberUpdate = false
                     })
                 },

--- a/web/Areas/RAPS/Views/Roles/PermissionComparison.cshtml
+++ b/web/Areas/RAPS/Views/Roles/PermissionComparison.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Compare permissions for two roles</h1>
+﻿@{
+    ViewData["Title"] = "Permission Comparison";
+}
+<h1>Compare permissions for two roles</h1>
 <q-form @@submit="return false;">
     <div class="row">
         <q-select v-model="role1" :options="role1Roles" label="Role 1"
@@ -28,7 +31,7 @@
             <tbody>
                 <tr v-for="(permission, index) in comparison.role1Permissions">
                     <td>
-                        <q-icon name="check" color="green" v-if="permission.isInOtherList"></q-icon>
+                        <q-icon name="check" color="positive" v-if="permission.isInOtherList"></q-icon>
                     </td>
                     <td>{{permission.name}}</td>
                 </tr>
@@ -49,7 +52,7 @@
             <tbody>
                 <tr v-for="(permission, index) in comparison.role2Permissions">
                     <td>
-                        <q-icon name="check" color="green" v-if="permission.isInOtherList"></q-icon>
+                        <q-icon name="check" color="positive" v-if="permission.isInOtherList"></q-icon>
                     </td>
                     <td>{{permission.name}}</td>
                 </tr>

--- a/web/Areas/RAPS/Views/Roles/PermissionComparison.cshtml
+++ b/web/Areas/RAPS/Views/Roles/PermissionComparison.cshtml
@@ -1,11 +1,11 @@
-﻿<h2>Compare permissions for two roles</h2>
+﻿<h1>Compare permissions for two roles</h1>
 <q-form @@submit="return false;">
     <div class="row">
-        <q-select v-model="role1" :options="role1Roles"
+        <q-select v-model="role1" :options="role1Roles" label="Role 1"
                   dense options-dense outlined class="col-sm-6 col-md-4"
                   use-input hide-selected fill-input input-debounce="0" @@filter="role1Search">
         </q-select>
-        <q-select v-model="role2" :options="role2Roles"
+        <q-select v-model="role2" :options="role2Roles" label="Role 2"
                   dense options-dense outlined class="col-sm-6 col-md-4"
                   use-input hide-selected fill-input input-debounce="0" @@filter="role2Search">
         </q-select>
@@ -80,13 +80,13 @@
                         this.showComparison = true
                     }
                 },
-                role1Search: function (val, update, abort) {
+                role1Search: function (val, update) {
                     update(() => {
                         const needle = val.toLowerCase()
                         this.role1Roles = this.roles.filter(v => v.label.toLowerCase().indexOf(needle) > -1)
                     })
                 },
-                role2Search: function (val, update, abort) {
+                role2Search: function (val, update) {
                     update(() => {
                         const needle = val.toLowerCase()
                         this.role2Roles = this.roles.filter(v => v.label.toLowerCase().indexOf(needle) > -1)

--- a/web/Areas/RAPS/Views/Roles/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Permissions.cshtml
@@ -146,18 +146,25 @@
                 denyRolePermissions: async function () {
                     this.updateRolePermissions(0)
                 },
-                deleteRolePermission: async function (rolePermission) {
-                    viperFetch(this,
-                        "Roles/" + this.roleId + "/Permissions/" + rolePermission.permissionId,
-                        {
-                            method: "DELETE",
-                            headers: { "Content-Type": "application/json" }
-                        },
-                        [this.loadRolePermissions,this.loadPermissions]
-                    )
-                    if(this.VMACSPush) {
-                        this.pushToVMACS()
-                    }
+                deleteRolePermission: function (rolePermission) {
+                    Quasar.Dialog.create({
+                        title: "Confirm Delete",
+                        message: "Are you sure you want to remove this permission from the role?",
+                        cancel: true,
+                        persistent: true
+                    }).onOk(async () => {
+                        await viperFetch(this,
+                            "Roles/" + this.roleId + "/Permissions/" + rolePermission.permissionId,
+                            {
+                                method: "DELETE",
+                                headers: { "Content-Type": "application/json" }
+                            },
+                            [this.loadRolePermissions,this.loadPermissions]
+                        )
+                        if(this.VMACSPush) {
+                            this.pushToVMACS()
+                        }
+                    })
                 },
                 loadPermissions: async function () {
                     this.permissionTable.load(this)

--- a/web/Areas/RAPS/Views/Roles/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Permissions.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Permissions for Role {{role.role}}</h1>
+﻿@{
+    ViewData["Title"] = "Role Permissions";
+}
+<h1>Permissions for Role {{role.role}}</h1>
 <q-table
     dense
     row-key="permissionId"
@@ -56,7 +59,7 @@
                         keys: ["permissionId"],
                         urlBase: "Roles",
                         columns: [
-                            { name: "links", label: "", field: "", align: "left", style: "width:75px;" },
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:75px;" },
                             { name: "permission", label: "Permission", field: "permissionName", align: "left", sortable: true },
                             { name: "access", label: "Access", field: "accessDescription", align: "left", sortable: true },
                             { name: "lastModified", label: "Last Modified Date", field: "modTime", align: "left", sortable: true, format: v => formatDate(v) },

--- a/web/Areas/RAPS/Views/Roles/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Permissions.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Permissions for Role {{role.role}}</h2>
+﻿<h1>Permissions for Role {{role.role}}</h1>
 <q-table
     dense
     row-key="permissionId"
@@ -15,7 +15,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove permission from role" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -67,7 +67,7 @@
                             this.rows = data.map(rp => ({
                                 ...rp,
                                 permissionId: rp.permissionId,
-                                accessDescription: rp.access == 1 ? "Allow" : "Deny",
+                                accessDescription: rp.access === 1 ? "Allow" : "Deny",
                                 permissionName: rp.permission?.permission
                             }))
                         },
@@ -110,7 +110,7 @@
                                     return result
                                 }, [])
                             this.rows = data.filter(p =>
-                                existingPermissions.indexOf(p.permissionId) == -1
+                                existingPermissions.indexOf(p.permissionId) === -1
                             )
                         },
                         pagination: { rowsPerPage: 15 }

--- a/web/Areas/RAPS/Views/Roles/Permissions.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Permissions.cshtml
@@ -15,7 +15,7 @@
     </template>
     <template v-slot:body-cell-remove="props">
         <q-td :props="props">
-            <q-btn no-caps size="sm" :props="props" color="red" icon="delete" aria-label="Remove permission from role" @@click="deleteRolePermission(props.row)"></q-btn>
+            <q-btn no-caps size="sm" :props="props" color="negative" icon="delete" aria-label="Remove permission from role" @@click="deleteRolePermission(props.row)"></q-btn>
         </q-td>
     </template>
 </q-table>
@@ -40,7 +40,7 @@
     </template>
 </q-table>
 <q-btn sm dense no-caps class="q-px-sm" label="Allow Checked" type="button" color="primary" @@click="allowRolePermissions"></q-btn>
-<q-btn sm dense no-caps class="q-ml-md q-px-sm" label="Deny Checked" type="button" color="red" @@click="denyRolePermissions"></q-btn>
+<q-btn sm dense no-caps class="q-ml-md q-px-sm" label="Deny Checked" type="button" color="negative" @@click="denyRolePermissions"></q-btn>
 
 @section Scripts {
     <script src="~/js/qtable.js"></script>

--- a/web/Areas/RAPS/Views/Roles/TemplateRoles.cshtml
+++ b/web/Areas/RAPS/Views/Roles/TemplateRoles.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Add roles to template {{roleTemplate.templateName}}</h2>
+﻿<h1>Add roles to template {{roleTemplate.templateName}}</h1>
 <q-table dense
          row-key="roleId"
          selection="multiple"
@@ -40,7 +40,7 @@
                 loadRoles: async function () {
                     var templateRoles = await viperFetch(this, "RoleTemplates/" + + this.urlParams.get("roleTemplateId") + "/Roles")
                     var allRoles = (await viperFetch(this, "Roles?Application=0"))
-                        .filter(r => templateRoles.find(tr => tr.roleId == r.roleId) === undefined)
+                        .filter(r => templateRoles.find(tr => tr.roleId === r.roleId) === undefined)
                     this.selectedRoles = templateRoles;
                     this.roles = templateRoles.concat(allRoles)
                     this.filter = ""

--- a/web/Areas/RAPS/Views/Roles/TemplateRoles.cshtml
+++ b/web/Areas/RAPS/Views/Roles/TemplateRoles.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Add roles to template {{roleTemplate.templateName}}</h1>
+﻿@{
+    ViewData["Title"] = "Template Roles";
+}
+<h1>Add roles to template {{roleTemplate.templateName}}</h1>
 <q-table dense
          row-key="roleId"
          selection="multiple"

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -1,4 +1,7 @@
-﻿<h1>Role Templates</h1>
+﻿@{
+    ViewData["Title"] = "Templates";
+}
+<h1>Role Templates</h1>
 <q-dialog v-model="templates.showForm" @@hide="templates.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="templates.submit(this)" v-model="templates.object">
@@ -113,10 +116,10 @@
                         keys: "roleTemplateId",
                         urlBase: "RoleTemplates",
                         columns: [
-                            { name: "links", label: "", field: "", style: "width:75px;" },
+                            { name: "links", label: "Actions", field: "", style: "width:75px;" },
                             { name: "roletemplate", label: "Template", field: "", sortable: true, align: "left" },
-                            { name: "roles", label: "", align: "left" },
-                            { name: "action", label: "", field: "" }
+                            { name: "roles", label: "Roles", align: "left" },
+                            { name: "action", label: "Actions", field: "" }
                         ],
                         pagination: { rowsPerPage: 0 },
                         createBody: function (vueApp, data) {

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -2,9 +2,13 @@
 <q-dialog v-model="templates.showForm" @@hide="templates.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="templates.submit(this)" v-model="templates.object">
-            <q-card-section>
+            <q-card-section class="row items-center q-pb-none">
                 <div class="text-h6">{{templates.editing ? "Edit" : "Create"}} Role Template</div>
-                <div class="bg-negative text-white q-pa-sm rounded" v-if="templates.errors?.message?.length > 0">{{templates.errors.message}}</div>
+                <q-space></q-space>
+                <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup></q-btn>
+            </q-card-section>
+            <q-card-section v-if="templates.errors?.message?.length > 0">
+                <div class="bg-negative text-white q-pa-sm rounded">{{templates.errors.message}}</div>
             </q-card-section>
             <q-card-section>
                 <q-input outlined v-model="templates.object.templateName" label="Role"

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -14,7 +14,7 @@
             </q-card-section>
             <q-card-actions align="evenly">
                 <q-btn no-caps :label="templates.editing ? 'Update Role Template' : 'Add Role Template'" type="submit" padding="xs sm" color="primary"></q-btn>
-                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="templates.delete(this)" color="red" v-if="templates.editing"></q-btn>
+                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="templates.delete(this)" color="negative" v-if="templates.editing"></q-btn>
             </q-card-actions>
         </q-form>
     </q-card>
@@ -32,7 +32,7 @@
         @if (ViewData.ContainsKey("canEditRoleTemplates") && (bool)(ViewData["canEditRoleTemplates"] ?? false))
         {
             <template v-slot:top-left="props">
-                <q-btn no-caps color="green" label="Add Role Template" padding="xs md" @@click="templates.showForm = true"></q-btn>
+                <q-btn no-caps color="positive" label="Add Role Template" padding="xs md" @@click="templates.showForm = true"></q-btn>
             </template>
         }
         <template v-slot:top-right="props">

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -53,15 +53,15 @@
             <q-td :props="props">
                 @if (ViewData.ContainsKey("canApplyTemplates") && (bool)(ViewData["canApplyTemplates"] ?? false))
                 {
-                    <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" title="Apply Role Template to one or more users" :href="'RoleTemplateApply?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
+                    <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="Apply Role Template to one or more users" aria-label="Apply Role Template to one or more users" :href="'RoleTemplateApply?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
                 }
                 @if (ViewData.ContainsKey("canEditRoleTemplates") && (bool)(ViewData["canEditRoleTemplates"] ?? false))
                 {
-                    <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="View Roles for this Template" :href="'RoleTemplateRoles?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
+                    <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="View Roles for this Template" aria-label="View Roles for this Template" :href="'RoleTemplateRoles?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
                 }
                 else
                 {
-                    <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="Show Roles for this template" @@click="toggleRoles(props.row.roleTemplateId)"></q-btn>
+                    <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="Show Roles for this template" aria-label="Show Roles for this template" @@click="toggleRoles(props.row.roleTemplateId)"></q-btn>
                 }
             </q-td>
         </template>
@@ -77,7 +77,7 @@
         {
             <template v-slot:body-cell-action="props">
                 <q-td :props="props">
-                    <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs sm" aria-label="Edit template" @@click="templates.selectRow(props.row)"></q-btn>
+                    <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="sm" aria-label="Edit template" @@click="templates.selectRow(props.row)"></q-btn>
                 </q-td>
             </template>
         }
@@ -119,7 +119,7 @@
                             { name: "links", label: "Actions", field: "", style: "width:75px;" },
                             { name: "roletemplate", label: "Template", field: "", sortable: true, align: "left" },
                             { name: "roles", label: "Roles", align: "left" },
-                            { name: "action", label: "Actions", field: "" }
+                            { name: "action", label: "Edit", field: "", align: "left", style: "width: 60px;" }
                         ],
                         pagination: { rowsPerPage: 0 },
                         createBody: function (vueApp, data) {

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -95,7 +95,7 @@
                                 {{roleTemplateRole.description}}
                             </div>
                         </div>
-                        <div v-else>
+                        <div v-if="viewRoleTemplateId != props.row.roleTemplateId">
                             {{ props.row.roles.length }} Roles
                         </div>
                     </div>

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Role Templates</h2>
+﻿<h1>Role Templates</h1>
 <q-dialog v-model="templates.showForm" @@hide="templates.clear(this)">
     <q-card style="width: 500px; max-width: 80vw;">
         <q-form @@submit="templates.submit(this)" v-model="templates.object">
@@ -70,7 +70,7 @@
         {
             <template v-slot:body-cell-action="props">
                 <q-td :props="props">
-                    <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs sm" @@click="templates.selectRow(props.row)"></q-btn>
+                    <q-btn :props="props" dense outline color="primary" icon="edit" size="sm" padding="xs sm" aria-label="Edit template" @@click="templates.selectRow(props.row)"></q-btn>
                 </q-td>
             </template>
         }
@@ -127,12 +127,12 @@
             },
             methods: {
                 toggleRoles: function (roleTemplateId) {
-                    this.viewRoleTemplateId = (this.viewRoleTemplateId == roleTemplateId) ? 0 : roleTemplateId;
+                    this.viewRoleTemplateId = (this.viewRoleTemplateId === roleTemplateId) ? 0 : roleTemplateId;
                 },
-                filterTemplates: function (rows, terms, cols, getCellValue) {
+                filterTemplates: function (rows, terms) {
                     return rows.reduce((result, row) => {
-                        if (row.templateName.toLowerCase().indexOf(terms.toLowerCase()) != -1
-                            || row.description.toLowerCase().indexOf(terms.toLowerCase()) != -1) {
+                        if (row.templateName.toLowerCase().indexOf(terms.toLowerCase()) !== -1
+                            || row.description.toLowerCase().indexOf(terms.toLowerCase()) !== -1) {
                             result.push(row)
                         }
                         return result

--- a/web/Classes/Utilities/SessionTimeoutService.cs
+++ b/web/Classes/Utilities/SessionTimeoutService.cs
@@ -7,6 +7,8 @@ namespace Viper.Classes.Utilities
 {
     public static class SessionTimeoutService
     {
+        private const int SessionTimeoutSeconds = (29 * 60) + 30;
+
         public static void UpdateSessionTimeout(VIPERContext context)
         {
             string loggedInUserId = GetLoggedInUserId();
@@ -18,7 +20,7 @@ namespace Viper.Classes.Utilities
                 SessionTimeout? record = context.SessionTimeouts.Find(loggedInUserId, service);
                 if (record != null)
                 {
-                    record.SessionTimeoutDateTime = DateTime.Now.AddSeconds(29 * 60 + 30);
+                    record.SessionTimeoutDateTime = DateTime.Now.AddSeconds(SessionTimeoutSeconds);
                     context.Update(record);
                 }
                 else
@@ -26,7 +28,7 @@ namespace Viper.Classes.Utilities
                     context.Add(new SessionTimeout()
                     {
                         LoginId = loggedInUserId,
-                        SessionTimeoutDateTime = DateTime.Now.AddMinutes(29 * 60 + 30),
+                        SessionTimeoutDateTime = DateTime.Now.AddSeconds(SessionTimeoutSeconds),
                         Service = service
                     });
                 }

--- a/web/Views/Shared/Components/LeftNav/Default.cshtml
+++ b/web/Views/Shared/Components/LeftNav/Default.cshtml
@@ -7,12 +7,13 @@
     // Base path for resolving relative URLs (e.g. "/raps/Viper/" from "/raps/Viper/Rolelist")
     var basePath = currentPath.Substring(0, currentPath.LastIndexOf('/') + 1);
 
-    // Pre-compute which item to highlight. When multiple items resolve to the same
-    // path (e.g. instance link "~/raps/Viper/RoleList" and page link "Rolelist"),
-    // prefer relative page links over tilde-prefixed instance links.
+    // Pre-compute which items to highlight. Page links (relative URLs) get the primary
+    // highlight; instance links (tilde-prefixed URLs that point to the same page in a
+    // different RAPS instance) get a secondary highlight. When only an instance link
+    // matches, it is promoted to the primary highlight.
     var items = leftNav.MenuItems ?? new List<NavMenuItem>();
-    int activeIndex = -1;
-    bool activeIsTilde = false;
+    int activePageIndex = -1;
+    int activeInstanceIndex = -1;
     for (int i = 0; i < items.Count; i++)
     {
         var item = items[i];
@@ -35,14 +36,13 @@
             resolvedPath = basePath + rawUrl;
         }
 
-        // Prefer relative/page links over tilde-prefixed instance links
-        if (string.Equals(currentPath, resolvedPath, StringComparison.OrdinalIgnoreCase)
-            && (activeIndex < 0 || (activeIsTilde && !isTilde)))
-        {
-            activeIndex = i;
-            activeIsTilde = isTilde;
-        }
+        if (!string.Equals(currentPath, resolvedPath, StringComparison.OrdinalIgnoreCase)) { continue; }
+        if (isTilde && activeInstanceIndex < 0) { activeInstanceIndex = i; }
+        else if (!isTilde && activePageIndex < 0) { activePageIndex = i; }
     }
+    // If no page link matched, promote the instance link to the primary highlight.
+    int activeIndex = activePageIndex >= 0 ? activePageIndex : activeInstanceIndex;
+    int secondaryActiveIndex = activePageIndex >= 0 ? activeInstanceIndex : -1;
     int renderIndex = 0;
 }
 <q-drawer v-model="mainLeftDrawer" show-if-above elevated side="left" :mini="!mainLeftDrawer" no-mini-animation @@click.capture="drawerClick"
@@ -64,8 +64,11 @@
                 {
                     @if(menuItem.MenuItemURL != "")
                     {
-                        var isActive = renderIndex == activeIndex;
-                        <q-item clickable v-ripple href="@Url.Content(menuItem.MenuItemURL)" class="leftNavLink@(isActive ? " leftNavActive" : "")">
+                        string activeClass;
+                        if (renderIndex == activeIndex) { activeClass = " leftNavActive"; }
+                        else if (renderIndex == secondaryActiveIndex) { activeClass = " leftNavActiveSecondary"; }
+                        else { activeClass = ""; }
+                        <q-item clickable v-ripple href="@Url.Content(menuItem.MenuItemURL)" class="leftNavLink@(activeClass)">
                             <q-item-section>
                                 <q-item-label lines="1">@menuItem.MenuItemText</q-item-label>
                             </q-item-section>

--- a/web/Views/Shared/Components/SessionTimeout/Default.cshtml
+++ b/web/Views/Shared/Components/SessionTimeout/Default.cshtml
@@ -14,14 +14,14 @@
                 Your session has been extended to {{sessionExpireTime}}.
             </div>
             <q-space></q-space>
-            <q-btn dense color="secondary" class="q-px-md" label="Log in" v-if="sessionExpired" href="@Url.Content("~/login")"></q-btn>
+            <q-btn dense color="secondary" class="q-px-md" label="Log in" v-if="sessionExpired" @@click="login"></q-btn>
             <q-btn dense color="secondary" class="q-px-md" label="Refresh Session" v-if="!sessionExpired && !sessionReloaded" @@click="extendSession"></q-btn>
         </q-card-section>
     </q-card>
 </q-dialog>
 
 <script asp-add-nonce="true">
-    /* global window, fetch, clearTimeout, createVueApp */
+    /* global clearTimeout */
     createVueApp({
         data() {
             return {
@@ -78,6 +78,10 @@
             hideSessionTimeoutWarning: function() {
                 this.showSessionTimeoutWarning = false
                 this.sessionReloaded = false
+            },
+            login: function() {
+                var returnUrl = encodeURIComponent(window.location.pathname + window.location.search)
+                window.location = '@Url.Content("~/login")?ReturnUrl=' + returnUrl
             }
         },
         mounted() {

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -111,6 +111,11 @@ html {
     font-weight: 500;
 }
 
+#leftNavMenu .leftNavActiveSecondary {
+    background-color: #e6ecf2; /* lighter ucdavis-blue tint */
+    color: #022851; /* ucdavis-blue-100 */
+}
+
 /*Footer styles*/
 #footerNavLinks a {
     text-decoration: none;


### PR DESCRIPTION
## Summary

**RAPS area accessibility improvements** - promotes page headings to `<h1>`, adds `aria-label` to interactive elements, adds dialog close buttons and delete confirmations, aligns button colors to UC Davis brand palette, and fixes pre-existing bugs.

### Heading & ARIA fixes
- Promote all page-level headings from `<h2>` to `<h1>` across 26 RAPS views
- Add `aria-label` to icon-only `<q-btn>` elements (audit log filters, role/permission action buttons, group role members)
- Add `label` props to role comparison `q-select` dropdowns

### Document titles ([2.4.2 Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html))
- Add `ViewData["Title"]` to all RAPS Razor views (AuditLog, Export, CreateADGroup, Groups/List, Groups/Members, Groups/Roles, Groups/Sync, Members/Clone, Members/History, Members/List, Members/Permissions, Members/RSOP, Members/Roles, Permissions/AllMembers, Permissions/List, Permissions/ListAdmin, Permissions/Members, Permissions/Roles, Permissions/RolesRO, RoleViewUpdate, Roles/ApplyTemplate, Roles/DelegateRoles, Roles/List, Roles/ListAdmin, Roles/Members, Roles/PermissionComparison, Roles/Permissions, Roles/TemplateRoles, Roles/Templates)

### Empty table column labels ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- Add descriptive labels ("Edit", "Actions", etc.) to previously empty q-table column headers across Groups, Members, Permissions, and Roles tables

### Dialog accessibility (M5)
- Add X close button with `aria-label="Close dialog"` to all 8 edit/create dialogs
- Move error banners to separate `q-card-section` below header
- Remove broken delete button from read-only PermissionRolesRO view

### Delete confirmations (S13 — WCAG 3.3.4)
- Add `Quasar.Dialog.create()` confirmation prompts to 5 custom delete functions
- Affected views: Groups/Roles, Members/Roles, Permissions/Roles, Roles/Members, Roles/Permissions

### Button color alignment (M6)
- `color="green"` → `color="positive"` (UC Davis Redwood) on 7 add/create buttons
- `color="red"` → `color="negative"` (UC Davis Merlot) on 14 delete/deny buttons
- Delegate badge: `color="amber-7"` → `color="warning" text-color="dark"` (UC Davis Gold)
- AuditLog banner: added `text-dark`, `role="status"`

### Code quality
- Convert loose equality (`==`/`!=`) to strict equality (`===`/`!==`) throughout RAPS Razor views
- Prefix unused function parameters with `_`
- Add `const` to `for...of` loop variables

### Pre-existing bugs fixed
- **ApplyTemplate.cshtml - status code comparison**: `r.status != "204"` relied on type coercion; corrected to compare against numeric `204`
- **ApplyTemplate.cshtml - null/undefined guards**: Replaced loose-equality null checks with `(this.userSearch?.value?.length ?? 0)` pattern
- **Groups/Sync.cshtml - typo**: "a view minutes" → "a few minutes"
- **Groups/Sync.cshtml - singular**: "Member for" → "Members for"
- **Permissions/AllMembers.cshtml - singular**: "User with Permission" → "Users with Permission"
- **Groups/List.cshtml - operator precedence**: `"AD: " + g.displayName ?? g.samAccountName` → parenthesized correctly
- **Permissions/RolesRO.cshtml - broken delete**: Delete button referenced non-existent function; removed from read-only view