### PR TITLE
VPR-104 fix(a11y): Effort area accessibility improvements (PR 4 of 6)

### DIFF
--- a/VueApp/eslint.config.mjs
+++ b/VueApp/eslint.config.mjs
@@ -50,6 +50,16 @@ export default [
             },
         },
         rules: {
+            // Quasar components are auto-imported by the vite plugin — flag explicit imports for cleanup
+            "no-restricted-imports": ["warn", {
+                patterns: [{
+                    group: ["quasar"],
+                    importNamePattern: "^Q[A-Z]",
+                    allowTypeImports: true,
+                    message: "Quasar components are auto-imported — remove explicit imports (QBtn, QTable, etc.). Utilities like setCssVar, useQuasar, Notify are fine.",
+                }],
+            }],
+
             // Disable the base rule and enable TypeScript-aware version
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": ["error", {

--- a/VueApp/src/Effort/__tests__/staff-dashboard.test.ts
+++ b/VueApp/src/Effort/__tests__/staff-dashboard.test.ts
@@ -60,6 +60,11 @@ function getTermStatusColor(status?: string): string {
     return (status && TERM_STATUS_COLORS[status]) ?? "grey-5"
 }
 
+const TERM_STATUS_TEXT_COLORS: Record<string, string> = { Opened: "white", Harvested: "dark" }
+function getTermStatusTextColor(status?: string): string {
+    return (status && TERM_STATUS_TEXT_COLORS[status]) ?? "grey-9"
+}
+
 const ALERT_ICONS: Record<string, string> = {
     NoRecords: "warning",
     NoInstructors: "school",
@@ -243,24 +248,26 @@ describe("StaffDashboard - Format Change Action", () => {
 })
 
 describe("StaffDashboard - Term Status Color", () => {
-    it("should return positive for Opened", () => {
-        expect(getTermStatusColor("Opened")).toBe("positive")
+    it.each([
+        ["Opened", "positive"],
+        ["Closed", "grey-5"],
+        ["Harvested", "info"],
+        [undefined, "grey-5"],
+        ["Unknown", "grey-5"],
+    ])("returns %s background color for %s status", (status, expected) => {
+        expect(getTermStatusColor(status)).toBe(expected)
     })
+})
 
-    it("should return grey-5 for Closed", () => {
-        expect(getTermStatusColor("Closed")).toBe("grey-5")
-    })
-
-    it("should return info for Harvested", () => {
-        expect(getTermStatusColor("Harvested")).toBe("info")
-    })
-
-    it("should return grey-5 for undefined", () => {
-        expect(getTermStatusColor()).toBe("grey-5")
-    })
-
-    it("should return grey-5 for unknown status", () => {
-        expect(getTermStatusColor("Unknown")).toBe("grey-5")
+describe("StaffDashboard - Term Status Text Color", () => {
+    it.each([
+        ["Opened", "white"],
+        ["Closed", "grey-9"],
+        ["Harvested", "dark"],
+        [undefined, "grey-9"],
+        ["Unknown", "grey-9"],
+    ])("returns %s text color for %s status", (status, expected) => {
+        expect(getTermStatusTextColor(status)).toBe(expected)
     })
 })
 

--- a/VueApp/src/Effort/__tests__/staff-dashboard.test.ts
+++ b/VueApp/src/Effort/__tests__/staff-dashboard.test.ts
@@ -55,9 +55,9 @@ function formatChangeAction(action: string): string {
         .replace(/^./, (str) => str.toUpperCase())
 }
 
-const TERM_STATUS_COLORS: Record<string, string> = { Opened: "positive", Closed: "grey", Harvested: "info" }
+const TERM_STATUS_COLORS: Record<string, string> = { Opened: "positive", Closed: "grey-5", Harvested: "info" }
 function getTermStatusColor(status?: string): string {
-    return (status && TERM_STATUS_COLORS[status]) ?? "grey"
+    return (status && TERM_STATUS_COLORS[status]) ?? "grey-5"
 }
 
 const ALERT_ICONS: Record<string, string> = {
@@ -247,20 +247,20 @@ describe("StaffDashboard - Term Status Color", () => {
         expect(getTermStatusColor("Opened")).toBe("positive")
     })
 
-    it("should return grey for Closed", () => {
-        expect(getTermStatusColor("Closed")).toBe("grey")
+    it("should return grey-5 for Closed", () => {
+        expect(getTermStatusColor("Closed")).toBe("grey-5")
     })
 
     it("should return info for Harvested", () => {
         expect(getTermStatusColor("Harvested")).toBe("info")
     })
 
-    it("should return grey for undefined", () => {
-        expect(getTermStatusColor()).toBe("grey")
+    it("should return grey-5 for undefined", () => {
+        expect(getTermStatusColor()).toBe("grey-5")
     })
 
-    it("should return grey for unknown status", () => {
-        expect(getTermStatusColor("Unknown")).toBe("grey")
+    it("should return grey-5 for unknown status", () => {
+        expect(getTermStatusColor("Unknown")).toBe("grey-5")
     })
 })
 

--- a/VueApp/src/Effort/components/AddCourseEffortDialog.vue
+++ b/VueApp/src/Effort/components/AddCourseEffortDialog.vue
@@ -122,36 +122,20 @@
                     />
 
                     <!-- Warning Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="warningMessage"
-                        class="bg-warning"
-                        rounded
-                        role="alert"
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="warning"
-                                color="dark"
-                            />
-                        </template>
                         {{ warningMessage }}
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Error Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white"
-                        rounded
-                        role="alert"
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -187,6 +171,7 @@ import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import { courseService } from "../services/course-service"
 import { recordService } from "../services/record-service"
 import type { CourseInstructorOptionDto, EffortTypeOptionDto, RoleOptionDto } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { filterEffortTypesByCourse } from "../utils/effort-type-filters"
 import { effortValueRules, requiredRule, notesMaxHint } from "../validation"
 import "../effort-dialogs.css"

--- a/VueApp/src/Effort/components/ClinicalImportDialog.vue
+++ b/VueApp/src/Effort/components/ClinicalImportDialog.vue
@@ -42,13 +42,14 @@
                 <q-linear-progress
                     :value="importProgress"
                     size="25px"
-                    color="teal-8"
+                    color="info"
+                    text-color="dark"
                     class="q-mb-md"
                 >
                     <div class="absolute-full flex flex-center">
                         <q-badge
                             color="white"
-                            text-color="teal-8"
+                            text-color="info"
                             :label="`${Math.round(importProgress * 100)}%`"
                         />
                     </div>
@@ -90,7 +91,8 @@
                         <q-option-group
                             v-model="selectedMode"
                             :options="modeOptions"
-                            color="teal-8"
+                            color="info"
+                            text-color="dark"
                             :inline="$q.screen.gt.xs"
                             @update:model-value="onModeChange"
                         />
@@ -138,7 +140,8 @@
                         <div class="row items-center q-mb-xs">
                             <q-icon
                                 name="warning"
-                                color="orange"
+                                color="warning"
+                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />
@@ -215,7 +218,8 @@
                         <div class="row items-center q-mb-xs">
                             <q-icon
                                 name="info"
-                                color="orange"
+                                color="warning"
+                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />
@@ -248,7 +252,8 @@
                     />
                     <q-btn
                         label="Confirm Import"
-                        color="teal-8"
+                        color="info"
+                        text-color="dark"
                         :disable="totalChanges === 0 || isCommitting"
                         @click="confirmImport"
                     />

--- a/VueApp/src/Effort/components/ClinicalImportDialog.vue
+++ b/VueApp/src/Effort/components/ClinicalImportDialog.vue
@@ -43,7 +43,6 @@
                     :value="importProgress"
                     size="25px"
                     color="info"
-                    text-color="dark"
                     class="q-mb-md"
                 >
                     <div class="absolute-full flex flex-center">
@@ -92,7 +91,6 @@
                             v-model="selectedMode"
                             :options="modeOptions"
                             color="info"
-                            text-color="dark"
                             :inline="$q.screen.gt.xs"
                             @update:model-value="onModeChange"
                         />
@@ -141,7 +139,6 @@
                             <q-icon
                                 name="warning"
                                 color="warning"
-                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />
@@ -219,7 +216,6 @@
                             <q-icon
                                 name="info"
                                 color="warning"
-                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />
@@ -253,7 +249,6 @@
                     <q-btn
                         label="Confirm Import"
                         color="info"
-                        text-color="dark"
                         :disable="totalChanges === 0 || isCommitting"
                         @click="confirmImport"
                     />

--- a/VueApp/src/Effort/components/ClinicalImportDialog.vue
+++ b/VueApp/src/Effort/components/ClinicalImportDialog.vue
@@ -97,10 +97,7 @@
                     </div>
 
                     <!-- Summary Banner -->
-                    <q-banner
-                        class="bg-blue-1 q-mb-md"
-                        rounded
-                    >
+                    <StatusBanner type="info">
                         <div class="row q-col-gutter-md">
                             <div class="col-6 col-sm-3 text-center">
                                 <div class="text-h5 text-positive">{{ preview.addCount }}</div>
@@ -127,21 +124,14 @@
                         <div class="text-caption text-grey-7 q-mt-sm text-center">
                             Data as of {{ formatPreviewDateTime(preview.previewGeneratedAt) }}
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Warnings Section -->
-                    <q-banner
+                    <StatusBanner
                         v-if="preview.warnings.length > 0"
-                        class="bg-orange-1 q-mb-md"
-                        rounded
+                        type="warning"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="warning"
-                                color="warning"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium">
                                 {{ preview.warnings.length }} {{ inflect("Warning", preview.warnings.length) }}
                             </span>
@@ -154,21 +144,15 @@
                                 {{ warning }}
                             </li>
                         </ul>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Delete Warning for Sync Mode with Empty Source -->
-                    <q-banner
+                    <StatusBanner
                         v-if="selectedMode === 'Sync' && preview.addCount === 0 && preview.deleteCount > 0"
-                        class="bg-red-1 q-mb-md"
-                        rounded
+                        type="error"
+                        icon="dangerous"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="dangerous"
-                                color="negative"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium text-negative"
                                 >Sync will delete ALL clinical effort records</span
                             >
@@ -177,21 +161,14 @@
                             The source returned 0 records. Syncing will delete all {{ preview.deleteCount }} existing
                             clinical effort records for this term.
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Delete Warning Banner -->
-                    <q-banner
+                    <StatusBanner
                         v-else-if="preview.deleteCount > 0"
-                        class="bg-red-1 q-mb-md"
-                        rounded
+                        type="error"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="warning"
-                                color="negative"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium text-negative">
                                 {{ preview.deleteCount }} {{ inflect("record", preview.deleteCount) }} will be deleted
                             </span>
@@ -204,27 +181,20 @@
                                 Sync mode will remove clinical records that no longer exist in the source.
                             </template>
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Nothing to Import Warning -->
-                    <q-banner
+                    <StatusBanner
                         v-if="totalChanges === 0"
-                        class="bg-orange-1 q-mb-md"
-                        rounded
+                        type="warning"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="info"
-                                color="warning"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium">Nothing to import</span>
                         </div>
                         <div class="text-caption text-grey-7">
                             There are no changes to make with the selected import mode.
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Preview Table -->
                     <ClinicalEffortPreviewTable
@@ -264,6 +234,7 @@ import { useQuasar } from "quasar"
 import { clinicalService } from "../services/clinical-service"
 import type { ClinicalImportPreviewDto, ClinicalImportMode } from "../types"
 import { inflect } from "inflection"
+import StatusBanner from "@/components/StatusBanner.vue"
 import ClinicalEffortPreviewTable from "./ClinicalEffortPreviewTable.vue"
 
 const props = defineProps<{

--- a/VueApp/src/Effort/components/CourseEffortTable.vue
+++ b/VueApp/src/Effort/components/CourseEffortTable.vue
@@ -79,7 +79,7 @@
                                     <q-icon
                                         v-if="record.effortValue === 0"
                                         name="report_problem"
-                                        color="amber-8"
+                                        color="warning"
                                         size="1rem"
                                         class="q-mr-xs"
                                         aria-hidden="true"
@@ -226,7 +226,7 @@
                                 <q-icon
                                     v-if="slotProps.row.effortValue === 0"
                                     name="report_problem"
-                                    color="amber-8"
+                                    color="warning"
                                     size="1rem"
                                     class="q-mr-xs"
                                     aria-hidden="true"

--- a/VueApp/src/Effort/components/CourseEffortTable.vue
+++ b/VueApp/src/Effort/components/CourseEffortTable.vue
@@ -10,20 +10,12 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
-            rounded
-            role="alert"
+            type="error"
         >
-            <template #avatar>
-                <q-icon
-                    name="error"
-                    color="white"
-                />
-            </template>
             {{ loadError }}
-        </q-banner>
+        </StatusBanner>
 
         <template v-else-if="records.length > 0">
             <!-- Mobile Card View -->
@@ -307,6 +299,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue"
 import type { QTableColumn } from "quasar"
+import StatusBanner from "@/components/StatusBanner.vue"
 import type { CourseEffortRecordDto } from "../types"
 import { useEffortPermissions } from "../composables/use-effort-permissions"
 import "../effort-record-table.css"

--- a/VueApp/src/Effort/components/CourseEffortTable.vue
+++ b/VueApp/src/Effort/components/CourseEffortTable.vue
@@ -84,7 +84,21 @@
                             <div class="text-body2 q-mb-xs">
                                 {{ record.effortTypeDescription }} ({{ record.effortTypeId }}) &bull;
                                 <span :class="{ 'zero-effort-text': record.effortValue === 0 }">
+                                    <q-icon
+                                        v-if="record.effortValue === 0"
+                                        name="report_problem"
+                                        color="amber-8"
+                                        size="1rem"
+                                        class="q-mr-xs"
+                                        aria-hidden="true"
+                                    />
                                     {{ record.effortValue }} {{ record.effortLabel }}
+                                    <span
+                                        v-if="record.effortValue === 0"
+                                        class="sr-only"
+                                    >
+                                        (zero effort)
+                                    </span>
                                 </span>
                             </div>
                             <div
@@ -217,8 +231,22 @@
 
                             <!-- Effort cell with unit label -->
                             <template v-else-if="col.name === 'effort'">
+                                <q-icon
+                                    v-if="slotProps.row.effortValue === 0"
+                                    name="report_problem"
+                                    color="amber-8"
+                                    size="1rem"
+                                    class="q-mr-xs"
+                                    aria-hidden="true"
+                                />
                                 {{ slotProps.row.effortValue }}
                                 {{ slotProps.row.effortLabel }}
+                                <span
+                                    v-if="slotProps.row.effortValue === 0"
+                                    class="sr-only"
+                                >
+                                    (zero effort)
+                                </span>
                             </template>
 
                             <!-- Actions cell -->

--- a/VueApp/src/Effort/components/CourseImportDialog.vue
+++ b/VueApp/src/Effort/components/CourseImportDialog.vue
@@ -84,32 +84,18 @@
                     </div>
                 </div>
 
-                <q-banner
+                <StatusBanner
                     v-if="searchError"
-                    class="bg-negative text-white q-mb-md"
-                    rounded
+                    type="error"
                 >
-                    <template #avatar>
-                        <q-icon
-                            name="error"
-                            color="white"
-                        />
-                    </template>
                     {{ searchError }}
-                </q-banner>
+                </StatusBanner>
 
                 <!-- No results message (self mode - richer banner) -->
-                <q-banner
+                <StatusBanner
                     v-if="isSelfMode && hasSearched && !isSearching && searchResults.length === 0"
-                    class="bg-info text-white q-mb-md"
-                    rounded
+                    type="info"
                 >
-                    <template #avatar>
-                        <q-icon
-                            name="info"
-                            color="white"
-                        />
-                    </template>
                     <div>
                         No courses found.
                         <ul class="q-mt-sm q-mb-none">
@@ -117,7 +103,7 @@
                             <li>You may need to wait for Banner data to sync</li>
                         </ul>
                     </div>
-                </q-banner>
+                </StatusBanner>
 
                 <!-- Search Results - Card view for mobile -->
                 <div
@@ -144,7 +130,8 @@
                                 >
                                 <q-badge
                                     v-else-if="course.importedUnitValues.length > 0"
-                                    color="orange"
+                                    color="warning"
+                                    text-color="dark"
                                     >Imported: {{ course.importedUnitValues.join(", ") }} units</q-badge
                                 >
                                 <q-badge
@@ -160,6 +147,7 @@
                                     Units: {{ course.unitLow }}-{{ course.unitHigh }}
                                     <q-badge
                                         color="info"
+                                        text-color="dark"
                                         dense
                                         class="q-ml-xs"
                                         >Variable</q-badge
@@ -220,6 +208,7 @@
                                 {{ slotProps.row.unitLow }} - {{ slotProps.row.unitHigh }}
                                 <q-badge
                                     color="info"
+                                    text-color="dark"
                                     class="q-ml-xs"
                                     >Variable</q-badge
                                 >
@@ -235,7 +224,9 @@
                                 <q-badge color="grey">Already Imported</q-badge>
                             </template>
                             <template v-else-if="slotProps.row.importedUnitValues.length > 0">
-                                <q-badge color="orange"
+                                <q-badge
+                                    color="warning"
+                                    text-color="dark"
                                     >Imported: {{ slotProps.row.importedUnitValues.join(", ") }} units</q-badge
                                 >
                             </template>
@@ -326,16 +317,12 @@
                 </template>
 
                 <!-- Import error display -->
-                <q-banner
+                <StatusBanner
                     v-if="importError"
-                    class="bg-negative text-white q-mt-md"
-                    dense
+                    type="error"
                 >
-                    <template #avatar>
-                        <q-icon name="error" />
-                    </template>
                     {{ importError }}
-                </q-banner>
+                </StatusBanner>
             </q-card-section>
 
             <q-card-actions align="right">
@@ -367,6 +354,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue"
 import { useQuasar } from "quasar"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { courseService } from "../services/course-service"
 import type { BannerCourseDto } from "../types"
 import type { QTableColumn } from "quasar"

--- a/VueApp/src/Effort/components/CourseImportDialog.vue
+++ b/VueApp/src/Effort/components/CourseImportDialog.vue
@@ -125,7 +125,8 @@
                                 </div>
                                 <q-badge
                                     v-if="course.alreadyImported"
-                                    color="grey"
+                                    color="grey-5"
+                                    text-color="grey-9"
                                     >Already Imported</q-badge
                                 >
                                 <q-badge
@@ -221,7 +222,11 @@
                     <template #body-cell-status="slotProps">
                         <q-td :props="slotProps">
                             <template v-if="slotProps.row.alreadyImported">
-                                <q-badge color="grey">Already Imported</q-badge>
+                                <q-badge
+                                    color="grey-5"
+                                    text-color="grey-9"
+                                    >Already Imported</q-badge
+                                >
                             </template>
                             <template v-else-if="slotProps.row.importedUnitValues.length > 0">
                                 <q-badge

--- a/VueApp/src/Effort/components/CourseImportDialog.vue
+++ b/VueApp/src/Effort/components/CourseImportDialog.vue
@@ -433,7 +433,7 @@ const columns: QTableColumn[] = [
     { name: "enrollment", label: "Enrollment", field: "enrollment", align: "center" },
     { name: "units", label: "Units", field: "unitLow", align: "center" },
     { name: "status", label: "Status", field: "alreadyImported", align: "center" },
-    { name: "actions", label: "", field: "actions", align: "center" },
+    { name: "actions", label: "Actions", field: "actions", align: "center" },
 ]
 
 // Reset search when dialog opens

--- a/VueApp/src/Effort/components/CourseLinkDialog.vue
+++ b/VueApp/src/Effort/components/CourseLinkDialog.vue
@@ -233,7 +233,7 @@ const columns = computed<QTableColumn[]>(() => [
     },
     {
         name: "actions",
-        label: "",
+        label: "Actions",
         field: "actions",
         align: "center",
     },

--- a/VueApp/src/Effort/components/EditEvaluationDialog.vue
+++ b/VueApp/src/Effort/components/EditEvaluationDialog.vue
@@ -129,20 +129,12 @@
                     </div>
 
                     <!-- Error Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white q-mt-sm"
-                        rounded
-                        role="alert"
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -177,6 +169,7 @@
 import { ref, computed, watch } from "vue"
 import { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { courseService } from "../services/course-service"
 import type { CourseEvalEntryDto } from "../types"
 import "../effort-dialogs.css"

--- a/VueApp/src/Effort/components/EffortLeftNav.vue
+++ b/VueApp/src/Effort/components/EffortLeftNav.vue
@@ -204,7 +204,7 @@
                     v-ripple
                     href="https://ucdsvm.knowledgeowl.com/help/effort-system-overview"
                     target="_blank"
-                    rel="noopener"
+                    rel="noopener noreferrer"
                     class="leftNavLink"
                 >
                     <q-item-section>
@@ -217,6 +217,13 @@
                                 size="xs"
                             />
                             <span>Help</span>
+                            <q-icon
+                                name="open_in_new"
+                                size="xs"
+                                class="q-ml-xs"
+                                aria-hidden="true"
+                            />
+                            <span class="sr-only">(opens in new window)</span>
                         </q-item-label>
                     </q-item-section>
                 </q-item>

--- a/VueApp/src/Effort/components/EffortRecordAddDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordAddDialog.vue
@@ -463,6 +463,8 @@ watch(
         if (isOpen) {
             resetForm()
             await loadOptions()
+            syncFormData()
+            setInitialState()
         }
     },
 )
@@ -489,7 +491,6 @@ function resetForm() {
     errorMessage.value = ""
     warningMessage.value = ""
     syncFormData()
-    setInitialState()
     formRef.value?.resetValidation()
 }
 

--- a/VueApp/src/Effort/components/EffortRecordAddDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordAddDialog.vue
@@ -25,22 +25,13 @@
                     greedy
                 >
                     <!-- Verification Warning -->
-                    <q-banner
+                    <StatusBanner
                         v-if="props.isVerified"
-                        class="bg-orange-2"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="info"
-                                color="warning"
-                            />
-                        </template>
-                        <span class="text-orange-9">
-                            This instructor's effort has been verified. Adding a new record will clear the verification
-                            status and require re-verification.
-                        </span>
-                    </q-banner>
+                        This instructor's effort has been verified. Adding a new record will clear the verification
+                        status and require re-verification.
+                    </StatusBanner>
 
                     <!-- Course Selection -->
                     <q-select
@@ -169,34 +160,20 @@
                     />
 
                     <!-- Warning Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="warningMessage"
-                        class="bg-warning"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="warning"
-                                color="dark"
-                            />
-                        </template>
                         {{ warningMessage }}
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Error Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white"
-                        rounded
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -229,6 +206,7 @@
 import { ref, computed, watch } from "vue"
 import { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { recordService } from "../services/record-service"
 import type { CourseOptionDto, EffortTypeOptionDto, RoleOptionDto, InstructorEffortRecordDto } from "../types"
 import { filterEffortTypesByCourse } from "../utils/effort-type-filters"

--- a/VueApp/src/Effort/components/EffortRecordAddDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordAddDialog.vue
@@ -33,7 +33,8 @@
                         <template #avatar>
                             <q-icon
                                 name="info"
-                                color="orange-9"
+                                color="warning"
+                                text-color="dark"
                             />
                         </template>
                         <span class="text-orange-9">

--- a/VueApp/src/Effort/components/EffortRecordAddDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordAddDialog.vue
@@ -34,7 +34,6 @@
                             <q-icon
                                 name="info"
                                 color="warning"
-                                text-color="dark"
                             />
                         </template>
                         <span class="text-orange-9">

--- a/VueApp/src/Effort/components/EffortRecordEditDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordEditDialog.vue
@@ -33,7 +33,8 @@
                         <template #avatar>
                             <q-icon
                                 name="info"
-                                color="orange-9"
+                                color="warning"
+                                text-color="dark"
                             />
                         </template>
                         <span class="text-orange-9">

--- a/VueApp/src/Effort/components/EffortRecordEditDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordEditDialog.vue
@@ -34,7 +34,6 @@
                             <q-icon
                                 name="info"
                                 color="warning"
-                                text-color="dark"
                             />
                         </template>
                         <span class="text-orange-9">

--- a/VueApp/src/Effort/components/EffortRecordEditDialog.vue
+++ b/VueApp/src/Effort/components/EffortRecordEditDialog.vue
@@ -25,22 +25,13 @@
                     greedy
                 >
                     <!-- Verification Warning -->
-                    <q-banner
+                    <StatusBanner
                         v-if="props.isVerified"
-                        class="bg-orange-2"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="info"
-                                color="warning"
-                            />
-                        </template>
-                        <span class="text-orange-9">
-                            This instructor's effort has been verified. Editing this record will clear the verification
-                            status and require re-verification.
-                        </span>
-                    </q-banner>
+                        This instructor's effort has been verified. Editing this record will clear the verification
+                        status and require re-verification.
+                    </StatusBanner>
 
                     <!-- Course (read-only) -->
                     <q-input
@@ -113,34 +104,20 @@
                     />
 
                     <!-- Warning Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="warningMessage"
-                        class="bg-warning"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="warning"
-                                color="dark"
-                            />
-                        </template>
                         {{ warningMessage }}
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Error Message -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white"
-                        rounded
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -173,6 +150,7 @@
 import { ref, computed, watch } from "vue"
 import { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { recordService } from "../services/record-service"
 import type { EffortTypeOptionDto, RoleOptionDto, InstructorEffortRecordDto } from "../types"
 import { effortValueRules, requiredRule, notesMaxHint } from "../validation"

--- a/VueApp/src/Effort/components/EffortRecordsDisplay.vue
+++ b/VueApp/src/Effort/components/EffortRecordsDisplay.vue
@@ -103,17 +103,13 @@
             <h4 class="q-mt-none q-mb-sm">Resident Teaching (R-Course)</h4>
 
             <!-- Generic R-course with zero effort info -->
-            <q-banner
+            <StatusBanner
                 v-if="hasGenericRCourseWithZeroEffort"
-                class="bg-info text-white q-mb-md"
-                rounded
+                type="info"
             >
-                <template #avatar>
-                    <q-icon name="info" />
-                </template>
                 The Resident (R) course was added automatically to allow recording of resident teaching effort. If left
                 with 0 effort and verified, it will be automatically removed.
-            </q-banner>
+            </StatusBanner>
 
             <!-- R-Course Mobile Card View -->
             <div class="lt-sm">
@@ -224,6 +220,7 @@
 import { computed } from "vue"
 import type { QTableColumn } from "quasar"
 import type { InstructorEffortRecordDto } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import EffortRecordsTable from "./EffortRecordsTable.vue"
 import "../effort-record-table.css"
 

--- a/VueApp/src/Effort/components/EffortRecordsTable.vue
+++ b/VueApp/src/Effort/components/EffortRecordsTable.vue
@@ -79,22 +79,22 @@
 
                     <!-- Effort cell with units label -->
                     <template v-else-if="col.name === 'effort'">
-                        <q-icon
-                            v-if="isZeroEffort(slotProps.row)"
-                            name="report_problem"
-                            color="amber-8"
-                            size="1rem"
-                            class="q-mr-xs"
-                            aria-hidden="true"
-                        />
-                        {{ slotProps.row.effortValue ?? 0 }}
-                        {{ slotProps.row.effortLabel === "weeks" ? "Weeks" : "Hours" }}
-                        <span
-                            v-if="isZeroEffort(slotProps.row)"
-                            class="sr-only"
-                        >
-                            (zero effort)
-                        </span>
+                        <template v-if="isZeroEffort(slotProps.row)">
+                            <q-icon
+                                name="report_problem"
+                                color="amber-8"
+                                size="1rem"
+                                class="q-mr-xs"
+                                aria-hidden="true"
+                            />
+                            {{ slotProps.row.effortValue ?? 0 }}
+                            {{ slotProps.row.effortLabel === "weeks" ? "Weeks" : "Hours" }}
+                            <span class="sr-only">(zero effort)</span>
+                        </template>
+                        <template v-else>
+                            {{ slotProps.row.effortValue ?? 0 }}
+                            {{ slotProps.row.effortLabel === "weeks" ? "Weeks" : "Hours" }}
+                        </template>
                     </template>
 
                     <!-- Actions cell -->

--- a/VueApp/src/Effort/components/EffortRecordsTable.vue
+++ b/VueApp/src/Effort/components/EffortRecordsTable.vue
@@ -79,8 +79,22 @@
 
                     <!-- Effort cell with units label -->
                     <template v-else-if="col.name === 'effort'">
+                        <q-icon
+                            v-if="isZeroEffort(slotProps.row)"
+                            name="report_problem"
+                            color="amber-8"
+                            size="1rem"
+                            class="q-mr-xs"
+                            aria-hidden="true"
+                        />
                         {{ slotProps.row.effortValue ?? 0 }}
                         {{ slotProps.row.effortLabel === "weeks" ? "Weeks" : "Hours" }}
+                        <span
+                            v-if="isZeroEffort(slotProps.row)"
+                            class="sr-only"
+                        >
+                            (zero effort)
+                        </span>
                     </template>
 
                     <!-- Actions cell -->

--- a/VueApp/src/Effort/components/EffortRecordsTable.vue
+++ b/VueApp/src/Effort/components/EffortRecordsTable.vue
@@ -82,7 +82,7 @@
                         <template v-if="isZeroEffort(slotProps.row)">
                             <q-icon
                                 name="report_problem"
-                                color="amber-8"
+                                color="warning"
                                 size="1rem"
                                 class="q-mr-xs"
                                 aria-hidden="true"

--- a/VueApp/src/Effort/components/EvaluationStatusMatrix.vue
+++ b/VueApp/src/Effort/components/EvaluationStatusMatrix.vue
@@ -10,20 +10,12 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
-            rounded
-            role="alert"
+            type="error"
         >
-            <template #avatar>
-                <q-icon
-                    name="error"
-                    color="white"
-                />
-            </template>
             {{ loadError }}
-        </q-banner>
+        </StatusBanner>
 
         <!-- Matrix content -->
         <template v-else-if="evaluationData.instructors.length > 0">
@@ -138,6 +130,7 @@
 <script setup lang="ts">
 import { computed } from "vue"
 import type { QTableColumn } from "quasar"
+import StatusBanner from "@/components/StatusBanner.vue"
 import type { CourseEvaluationStatusDto, InstructorEvalStatusDto, CourseEvalEntryDto } from "../types"
 import { useEffortPermissions } from "../composables/use-effort-permissions"
 import EvalStatusCell from "./EvalStatusCell.vue"

--- a/VueApp/src/Effort/components/HarvestDialog.vue
+++ b/VueApp/src/Effort/components/HarvestDialog.vue
@@ -117,7 +117,6 @@
                             <q-icon
                                 name="warning"
                                 color="warning"
-                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />

--- a/VueApp/src/Effort/components/HarvestDialog.vue
+++ b/VueApp/src/Effort/components/HarvestDialog.vue
@@ -87,10 +87,7 @@
             <template v-else-if="preview">
                 <q-card-section class="q-pt-sm">
                     <!-- Summary Banner -->
-                    <q-banner
-                        class="bg-blue-1 q-mb-md"
-                        rounded
-                    >
+                    <StatusBanner type="info">
                         <div class="row q-col-gutter-md">
                             <div class="col-6 col-sm-4 text-center">
                                 <div class="text-h5">{{ preview.summary.totalInstructors }}</div>
@@ -105,21 +102,14 @@
                                 <div class="text-caption">Effort Records</div>
                             </div>
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Warnings -->
-                    <q-banner
+                    <StatusBanner
                         v-if="preview.warnings.length > 0"
-                        class="bg-orange-1 q-mb-md"
-                        rounded
+                        type="warning"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="warning"
-                                color="warning"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium">
                                 {{ preview.warnings.length }} {{ inflect("Warning", preview.warnings.length) }}
                             </span>
@@ -144,21 +134,14 @@
                         >
                             ...and {{ preview.warnings.length - 5 }} more
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Errors -->
-                    <q-banner
+                    <StatusBanner
                         v-if="preview.errors.length > 0"
-                        class="bg-red-1 q-mb-md"
-                        rounded
+                        type="error"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="error"
-                                color="negative"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium text-negative">
                                 {{ preview.errors.length }} {{ inflect("Error", preview.errors.length) }} - Harvest may
                                 fail
@@ -172,21 +155,15 @@
                                 {{ error.phase }}: {{ error.message }}
                             </li>
                         </ul>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Removed Items Warning -->
-                    <q-banner
+                    <StatusBanner
                         v-if="hasRemovedItems"
-                        class="bg-purple-1 q-mb-md"
-                        rounded
+                        type="warning"
+                        icon="person_remove"
                     >
                         <div class="row items-center q-mb-xs">
-                            <q-icon
-                                name="person_remove"
-                                color="purple"
-                                size="sm"
-                                class="q-mr-sm"
-                            />
                             <span class="text-weight-medium">Items that will be removed</span>
                         </div>
                         <div class="text-caption text-grey-7">
@@ -223,7 +200,7 @@
                                 }}{{ preview.removedCourses.length > 3 ? "..." : "" }})
                             </span>
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Tabs -->
                     <q-tabs
@@ -621,6 +598,7 @@ import { useQuasar } from "quasar"
 import { harvestService } from "../services/harvest-service"
 import type { HarvestPreviewDto } from "../types"
 import type { QTableColumn } from "quasar"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { inflect } from "inflection"
 import ClinicalEffortPreviewTable from "./ClinicalEffortPreviewTable.vue"
 

--- a/VueApp/src/Effort/components/HarvestDialog.vue
+++ b/VueApp/src/Effort/components/HarvestDialog.vue
@@ -207,7 +207,7 @@
                         v-model="activeTab"
                         dense
                         align="left"
-                        class="text-grey"
+                        class="text-grey-8 tabs-no-fade"
                         active-color="primary"
                         indicator-color="primary"
                         narrow-indicator

--- a/VueApp/src/Effort/components/HarvestDialog.vue
+++ b/VueApp/src/Effort/components/HarvestDialog.vue
@@ -116,7 +116,8 @@
                         <div class="row items-center q-mb-xs">
                             <q-icon
                                 name="warning"
-                                color="orange"
+                                color="warning"
+                                text-color="dark"
                                 size="sm"
                                 class="q-mr-sm"
                             />

--- a/VueApp/src/Effort/components/InstructorAddDialog.vue
+++ b/VueApp/src/Effort/components/InstructorAddDialog.vue
@@ -97,19 +97,12 @@
                     </div>
                 </div>
 
-                <q-banner
+                <StatusBanner
                     v-if="errorMessage"
-                    class="bg-negative text-white q-mb-md"
-                    rounded
+                    type="error"
                 >
-                    <template #avatar>
-                        <q-icon
-                            name="error"
-                            color="white"
-                        />
-                    </template>
                     {{ errorMessage }}
-                </q-banner>
+                </StatusBanner>
             </q-card-section>
 
             <q-card-actions align="right">
@@ -141,6 +134,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { instructorService } from "../services/instructor-service"
 import type { AaudPersonDto } from "../types"
 

--- a/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
+++ b/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
@@ -79,13 +79,12 @@
                             @filter="filterTitleCodes"
                         >
                             <template #before-options>
-                                <q-banner
+                                <StatusBanner
                                     v-if="isOrphanedTitleCode"
-                                    class="bg-warning text-white q-mb-sm"
-                                    dense
+                                    type="warning"
                                 >
                                     Current value "{{ form.effortTitleCode }}" is not in the standard list
-                                </q-banner>
+                                </StatusBanner>
                             </template>
                             <template #no-option>
                                 <q-item>
@@ -108,13 +107,12 @@
                             clearable
                         >
                             <template #before-options>
-                                <q-banner
+                                <StatusBanner
                                     v-if="isOrphanedJobGroup"
-                                    class="bg-warning text-white q-mb-sm"
-                                    dense
+                                    type="warning"
                                 >
                                     Current value "{{ form.jobGroupId }}" is not in the standard list
-                                </q-banner>
+                                </StatusBanner>
                             </template>
                         </q-select>
 
@@ -140,19 +138,12 @@
                             </span>
                         </q-checkbox>
 
-                        <q-banner
+                        <StatusBanner
                             v-if="settingsErrorMessage"
-                            class="bg-negative text-white"
-                            rounded
+                            type="error"
                         >
-                            <template #avatar>
-                                <q-icon
-                                    name="error"
-                                    color="white"
-                                />
-                            </template>
                             {{ settingsErrorMessage }}
-                        </q-banner>
+                        </StatusBanner>
 
                         <div class="row justify-end">
                             <q-btn
@@ -256,6 +247,7 @@ import { useQuasar, QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import { requiredRule } from "../validation"
 import "../effort-forms.css"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { instructorService } from "../services/instructor-service"
 import { percentageService } from "../services/percentage-service"
 import { percentAssignTypeService } from "../services/percent-assign-type-service"

--- a/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
+++ b/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
@@ -22,6 +22,7 @@
             <q-card-section
                 class="scroll"
                 style="max-height: calc(90vh - 120px)"
+                tabindex="0"
             >
                 <!-- Read-only instructor info header -->
                 <div class="q-mb-md q-pa-sm bg-grey-2 rounded-borders">

--- a/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
+++ b/VueApp/src/Effort/components/InstructorPercentEditDialog.vue
@@ -27,7 +27,7 @@
                 <!-- Read-only instructor info header -->
                 <div class="q-mb-md q-pa-sm bg-grey-2 rounded-borders">
                     <div class="text-subtitle2">{{ instructor?.fullName }}</div>
-                    <div class="text-caption text-grey-7">
+                    <div class="text-caption text-grey-8">
                         Person ID: {{ instructor?.personId }} | Dept: {{ instructor?.effortDept }}
                     </div>
                 </div>

--- a/VueApp/src/Effort/components/LeaveEditorModal.vue
+++ b/VueApp/src/Effort/components/LeaveEditorModal.vue
@@ -12,6 +12,7 @@
             <q-card-section
                 class="q-pt-none scroll"
                 style="max-height: 60vh"
+                tabindex="0"
             >
                 <table class="leave-table">
                     <thead>

--- a/VueApp/src/Effort/components/PercentAssignmentAddDialog.vue
+++ b/VueApp/src/Effort/components/PercentAssignmentAddDialog.vue
@@ -184,17 +184,10 @@
                     />
 
                     <!-- Warning Banner -->
-                    <q-banner
+                    <StatusBanner
                         v-if="warningMessage"
-                        class="bg-warning q-mb-md"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="warning"
-                                color="dark"
-                            />
-                        </template>
                         {{ warningMessage }}
                         <template #action>
                             <q-btn
@@ -204,22 +197,15 @@
                                 @click="saveWithWarning"
                             />
                         </template>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Error Banner -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white q-mb-md"
-                        rounded
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -252,6 +238,7 @@
 import { ref, computed, watch } from "vue"
 import { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { percentageService } from "../services/percentage-service"
 import { usePercentageForm } from "../composables/use-percentage-form"
 import { requiredRule, percentRule } from "../validation"

--- a/VueApp/src/Effort/components/PercentAssignmentEditDialog.vue
+++ b/VueApp/src/Effort/components/PercentAssignmentEditDialog.vue
@@ -184,17 +184,10 @@
                     />
 
                     <!-- Post-save Warning Banner -->
-                    <q-banner
+                    <StatusBanner
                         v-if="warningMessage"
-                        class="bg-warning q-mb-md"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="info"
-                                color="dark"
-                            />
-                        </template>
                         <div><strong>Saved with notice:</strong> {{ warningMessage }}</div>
                         <template #action>
                             <q-btn
@@ -204,22 +197,15 @@
                                 @click="acknowledgeWarning"
                             />
                         </template>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Error Banner -->
-                    <q-banner
+                    <StatusBanner
                         v-if="errorMessage"
-                        class="bg-negative text-white q-mb-md"
-                        rounded
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ errorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
             </q-card-section>
 
@@ -252,6 +238,7 @@
 import { ref, computed, watch } from "vue"
 import { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { percentageService } from "../services/percentage-service"
 import { usePercentageForm } from "../composables/use-percentage-form"
 import { requiredRule, percentRule } from "../validation"

--- a/VueApp/src/Effort/components/PercentAssignmentTable.vue
+++ b/VueApp/src/Effort/components/PercentAssignmentTable.vue
@@ -57,7 +57,16 @@
             >
                 <q-card-section class="q-py-sm">
                     <div class="row items-center justify-between q-mb-xs">
-                        <span class="text-weight-bold">{{ formatTypeWithModifier(pct.typeName, pct.modifier) }}</span>
+                        <span class="text-weight-bold">
+                            {{ formatTypeWithModifier(pct.typeName, pct.modifier) }}
+                            <q-badge
+                                v-if="!pct.isActive"
+                                color="grey-5"
+                                text-color="grey-9"
+                                label="Inactive"
+                                class="q-ml-sm"
+                            />
+                        </span>
                         <div v-if="canEdit">
                             <q-btn
                                 flat
@@ -99,7 +108,21 @@
                             {{ pct.endDate ? formatDate(pct.endDate) : "Present" }}</span
                         >
                         <span :class="{ 'text-warning text-weight-bold': pct.percentageValue > 100 }">
+                            <q-icon
+                                v-if="pct.percentageValue > 100"
+                                name="warning"
+                                color="warning"
+                                size="1rem"
+                                class="q-mr-xs"
+                                aria-hidden="true"
+                            />
                             {{ pct.percentageValue.toFixed(1) }}%
+                            <span
+                                v-if="pct.percentageValue > 100"
+                                class="sr-only"
+                            >
+                                (exceeds 100%)
+                            </span>
                         </span>
                         <span v-if="pct.compensated">
                             <q-icon
@@ -146,6 +169,13 @@
                             :color="getTypeClassColor(bodyProps.row.typeClass)"
                             :label="bodyProps.row.typeClass"
                         />
+                        <q-badge
+                            v-if="!bodyProps.row.isActive"
+                            color="grey-5"
+                            text-color="grey-9"
+                            label="Inactive"
+                            class="q-ml-xs"
+                        />
                     </q-td>
                     <q-td
                         key="typeName"
@@ -174,8 +204,23 @@
                     <q-td
                         key="percentageValue"
                         :props="bodyProps"
+                        :class="{ 'text-warning text-weight-bold': bodyProps.row.percentageValue > 100 }"
                     >
+                        <q-icon
+                            v-if="bodyProps.row.percentageValue > 100"
+                            name="warning"
+                            color="warning"
+                            size="1rem"
+                            class="q-mr-xs"
+                            aria-hidden="true"
+                        />
                         {{ bodyProps.row.percentageValue.toFixed(1) }}%
+                        <span
+                            v-if="bodyProps.row.percentageValue > 100"
+                            class="sr-only"
+                        >
+                            (exceeds 100%)
+                        </span>
                     </q-td>
                     <q-td
                         key="comment"

--- a/VueApp/src/Effort/components/PercentAssignmentTable.vue
+++ b/VueApp/src/Effort/components/PercentAssignmentTable.vue
@@ -26,8 +26,6 @@
                 dense
                 aria-label="Add percentage assignment"
                 @click="$emit('add')"
-                @keyup.enter="$emit('add')"
-                @keyup.space="$emit('add')"
             />
         </div>
 
@@ -77,8 +75,6 @@
                                 size="sm"
                                 aria-label="Edit percentage assignment"
                                 @click="$emit('edit', pct)"
-                                @keyup.enter="$emit('edit', pct)"
-                                @keyup.space="$emit('edit', pct)"
                             />
                             <q-btn
                                 flat
@@ -89,8 +85,6 @@
                                 size="sm"
                                 aria-label="Delete percentage assignment"
                                 @click="$emit('delete', pct)"
-                                @keyup.enter="$emit('delete', pct)"
-                                @keyup.space="$emit('delete', pct)"
                             />
                         </div>
                     </div>
@@ -252,8 +246,6 @@
                                 size="sm"
                                 aria-label="Edit percentage assignment"
                                 @click="$emit('edit', bodyProps.row)"
-                                @keyup.enter="$emit('edit', bodyProps.row)"
-                                @keyup.space="$emit('edit', bodyProps.row)"
                             >
                                 <q-tooltip>Edit</q-tooltip>
                             </q-btn>
@@ -266,8 +258,6 @@
                                 size="sm"
                                 aria-label="Delete percentage assignment"
                                 @click="$emit('delete', bodyProps.row)"
-                                @keyup.enter="$emit('delete', bodyProps.row)"
-                                @keyup.space="$emit('delete', bodyProps.row)"
                             >
                                 <q-tooltip>Delete</q-tooltip>
                             </q-btn>

--- a/VueApp/src/Effort/components/PercentRolloverDialog.vue
+++ b/VueApp/src/Effort/components/PercentRolloverDialog.vue
@@ -26,22 +26,13 @@
                 v-if="isOutsideIdealMonths && !isLoading"
                 class="q-py-sm"
             >
-                <q-banner
-                    class="bg-orange-1"
-                    rounded
-                >
-                    <template #avatar>
-                        <q-icon
-                            name="warning"
-                            color="warning"
-                        />
-                    </template>
-                    <div class="text-weight-medium text-orange-9">Unusual Timing</div>
+                <StatusBanner type="warning">
+                    <div class="text-weight-medium">Unusual Timing</div>
                     <div class="text-caption text-grey-8">
                         Percent rollover is typically performed in June or July at the academic year boundary. The
                         current month is {{ currentMonthName }}.
                     </div>
-                </q-banner>
+                </StatusBanner>
             </q-card-section>
 
             <!-- Loading State (Preview) -->
@@ -108,16 +99,7 @@
             <template v-else-if="preview">
                 <q-card-section class="q-pt-sm">
                     <!-- Summary Banner -->
-                    <q-banner
-                        class="bg-blue-1 q-mb-md"
-                        rounded
-                    >
-                        <template #avatar>
-                            <q-icon
-                                name="info"
-                                color="primary"
-                            />
-                        </template>
+                    <StatusBanner type="info">
                         <div class="row q-col-gutter-md">
                             <div class="col-4 text-center">
                                 <div class="text-h5">{{ preview.assignments.length }}</div>
@@ -136,26 +118,19 @@
                             Rolling from {{ preview.sourceAcademicYearDisplay }} to
                             {{ preview.targetAcademicYearDisplay }}
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Warning when nothing to rollover -->
-                    <q-banner
+                    <StatusBanner
                         v-if="preview.assignments.length === 0"
-                        class="bg-orange-1 q-mb-md"
-                        rounded
+                        type="warning"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="warning"
-                                color="warning"
-                            />
-                        </template>
                         <div class="text-weight-medium">No assignments to roll forward</div>
                         <div class="text-caption text-grey-7">
                             There are no percent assignments ending on {{ formatDate(preview.oldEndDate) }} that need to
                             be rolled forward.
                         </div>
-                    </q-banner>
+                    </StatusBanner>
 
                     <!-- Will be Rolled Forward Section (cyan, expanded by default) -->
                     <q-expansion-item
@@ -239,20 +214,10 @@
                             </div>
                         </template>
                         <div class="bg-orange-1 q-pa-sm">
-                            <q-banner
-                                class="bg-orange-2 q-mb-sm"
-                                rounded
-                                dense
-                            >
-                                <template #avatar>
-                                    <q-icon
-                                        name="info"
-                                        color="warning"
-                                    />
-                                </template>
+                            <StatusBanner type="warning">
                                 These assignments will not be rolled forward because someone manually edited or deleted
                                 a percent assignment of the same type for this instructor after the term was harvested.
-                            </q-banner>
+                            </StatusBanner>
                             <RolloverAssignmentTable :rows="preview.excludedByAudit" />
                         </div>
                     </q-expansion-item>
@@ -285,6 +250,7 @@ import { ref, computed, watch } from "vue"
 import { useQuasar } from "quasar"
 import { rolloverService } from "../services/rollover-service"
 import type { PercentRolloverPreviewDto } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { inflect } from "inflection"
 import { useDateFunctions } from "@/composables/DateFunctions"
 import RolloverAssignmentTable from "./RolloverAssignmentTable.vue"

--- a/VueApp/src/Effort/components/PercentRolloverDialog.vue
+++ b/VueApp/src/Effort/components/PercentRolloverDialog.vue
@@ -33,7 +33,8 @@
                     <template #avatar>
                         <q-icon
                             name="warning"
-                            color="orange"
+                            color="warning"
+                            text-color="dark"
                         />
                     </template>
                     <div class="text-weight-medium text-orange-9">Unusual Timing</div>
@@ -147,7 +148,8 @@
                         <template #avatar>
                             <q-icon
                                 name="warning"
-                                color="orange"
+                                color="warning"
+                                text-color="dark"
                             />
                         </template>
                         <div class="text-weight-medium">No assignments to roll forward</div>
@@ -167,7 +169,8 @@
                             <div class="row items-center full-width">
                                 <q-icon
                                     name="event_repeat"
-                                    color="cyan-8"
+                                    color="info"
+                                    text-color="dark"
                                     size="24px"
                                     class="q-mr-sm"
                                 />
@@ -224,7 +227,8 @@
                             <div class="row items-center full-width">
                                 <q-icon
                                     name="block"
-                                    color="orange"
+                                    color="warning"
+                                    text-color="dark"
                                     size="24px"
                                     class="q-mr-sm"
                                 />
@@ -247,7 +251,8 @@
                                 <template #avatar>
                                     <q-icon
                                         name="info"
-                                        color="orange"
+                                        color="warning"
+                                        text-color="dark"
                                     />
                                 </template>
                                 These assignments will not be rolled forward because someone manually edited or deleted

--- a/VueApp/src/Effort/components/PercentRolloverDialog.vue
+++ b/VueApp/src/Effort/components/PercentRolloverDialog.vue
@@ -34,7 +34,6 @@
                         <q-icon
                             name="warning"
                             color="warning"
-                            text-color="dark"
                         />
                     </template>
                     <div class="text-weight-medium text-orange-9">Unusual Timing</div>
@@ -149,7 +148,6 @@
                             <q-icon
                                 name="warning"
                                 color="warning"
-                                text-color="dark"
                             />
                         </template>
                         <div class="text-weight-medium">No assignments to roll forward</div>
@@ -170,7 +168,6 @@
                                 <q-icon
                                     name="event_repeat"
                                     color="info"
-                                    text-color="dark"
                                     size="24px"
                                     class="q-mr-sm"
                                 />
@@ -228,7 +225,6 @@
                                 <q-icon
                                     name="block"
                                     color="warning"
-                                    text-color="dark"
                                     size="24px"
                                     class="q-mr-sm"
                                 />
@@ -252,7 +248,6 @@
                                     <q-icon
                                         name="info"
                                         color="warning"
-                                        text-color="dark"
                                     />
                                 </template>
                                 These assignments will not be rolled forward because someone manually edited or deleted

--- a/VueApp/src/Effort/components/ReportDeptTabs.vue
+++ b/VueApp/src/Effort/components/ReportDeptTabs.vue
@@ -3,7 +3,7 @@
         v-model="activeDept"
         dense
         align="left"
-        class="text-grey"
+        class="text-grey-8 tabs-no-fade"
         active-color="primary"
         active-bg-color="grey-2"
         indicator-color="primary"
@@ -28,6 +28,7 @@
             :key="dept.department"
             :name="idx"
             class="q-px-none"
+            tabindex="0"
         >
             <!-- Only render content for active panel to avoid browser freeze -->
             <template v-if="idx === activeDept">

--- a/VueApp/src/Effort/components/ZeroEffortBanner.vue
+++ b/VueApp/src/Effort/components/ZeroEffortBanner.vue
@@ -1,15 +1,8 @@
 <template>
-    <q-banner
+    <StatusBanner
         v-if="show"
-        class="bg-warning q-mb-md"
-        rounded
+        type="warning"
     >
-        <template #avatar>
-            <q-icon
-                name="warning"
-                color="dark"
-            />
-        </template>
         <div v-if="mode === 'self'">
             <strong>You have effort items with ZERO effort.</strong>
             You will not be able to verify your effort until these items have been updated to document hours/weeks or
@@ -19,10 +12,12 @@
             NOTE: This instructor has one or more effort items documented as ZERO effort. Effort cannot be verified
             until these items have been updated or removed.
         </template>
-    </q-banner>
+    </StatusBanner>
 </template>
 
 <script setup lang="ts">
+import StatusBanner from "@/components/StatusBanner.vue"
+
 defineProps<{
     show: boolean
     mode: "self" | "staff"

--- a/VueApp/src/Effort/pages/AuditList.vue
+++ b/VueApp/src/Effort/pages/AuditList.vue
@@ -137,7 +137,7 @@
                         <div class="col-12 text-right">
                             <q-btn
                                 label="Clear Filters"
-                                color="grey"
+                                color="secondary"
                                 dense
                                 flat
                                 @click="clearFilter"
@@ -552,7 +552,8 @@ function getActionColor(action: string): string {
     if (action.startsWith("Open") || action.startsWith("Reopen")) return "secondary"
     if (action.startsWith("Close")) return "warning"
     if (action.startsWith("Import")) return "info"
-    return "grey"
+    if (action.startsWith("Verify")) return "positive"
+    return "grey-8"
 }
 
 function filterModifiers(val: string, update: (fn: () => void) => void) {

--- a/VueApp/src/Effort/pages/AuditList.vue
+++ b/VueApp/src/Effort/pages/AuditList.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Audit Trail</h2>
+        <h1>Audit Trail</h1>
 
         <!-- Filter Panel - Collapsible on mobile, always visible on desktop -->
         <q-expansion-item

--- a/VueApp/src/Effort/pages/ClinicalEffort.vue
+++ b/VueApp/src/Effort/pages/ClinicalEffort.vue
@@ -106,7 +106,7 @@
             <template v-if="report.jobGroups.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/ClinicalEffort.vue
+++ b/VueApp/src/Effort/pages/ClinicalEffort.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Clinical Effort</h2>
+        <h1>Merit &amp; Promotion Report - Clinical Effort</h1>
 
         <!-- Custom filter form — academic year + clinical type only -->
         <div class="filter-form q-mb-md">

--- a/VueApp/src/Effort/pages/CourseDetail.vue
+++ b/VueApp/src/Effort/pages/CourseDetail.vue
@@ -225,7 +225,7 @@
                     active-color="primary"
                     indicator-color="primary"
                     no-caps
-                    class="text-grey-7"
+                    class="text-grey-8 tabs-no-fade"
                 >
                     <q-tab
                         name="effort"
@@ -561,7 +561,7 @@ const childColumns = computed<QTableColumn[]>(() => [
     },
     {
         name: "actions",
-        label: "",
+        label: "Actions",
         field: "actions",
         align: "center",
     },

--- a/VueApp/src/Effort/pages/CourseDetail.vue
+++ b/VueApp/src/Effort/pages/CourseDetail.vue
@@ -23,9 +23,9 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
+            type="error"
         >
             {{ loadError }}
             <template #action>
@@ -35,7 +35,7 @@
                     :to="{ name: 'CourseList', params: { termCode } }"
                 />
             </template>
-        </q-banner>
+        </StatusBanner>
 
         <!-- Course content -->
         <template v-else-if="course">
@@ -69,17 +69,13 @@
             </div>
 
             <!-- R-Course Notice -->
-            <q-banner
+            <StatusBanner
                 v-if="isResidentCourse"
-                class="bg-info text-white q-mb-md"
-                rounded
+                type="info"
             >
-                <template #avatar>
-                    <q-icon name="info" />
-                </template>
                 The Resident (R) course was added automatically to allow recording of resident teaching effort. If left
                 with 0 effort and verified, it will be automatically removed.
-            </q-banner>
+            </StatusBanner>
 
             <!-- Course Info (hidden for resident teaching course) -->
             <div
@@ -388,6 +384,7 @@ import type {
     CourseEvaluationStatusDto,
     CourseEvalEntryDto,
 } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import CourseEditDialog from "../components/CourseEditDialog.vue"
 import CourseLinkDialog from "../components/CourseLinkDialog.vue"
 import CourseEffortTable from "../components/CourseEffortTable.vue"

--- a/VueApp/src/Effort/pages/CourseDetail.vue
+++ b/VueApp/src/Effort/pages/CourseDetail.vue
@@ -97,17 +97,11 @@
             </div>
 
             <!-- Parent Relationship Banner -->
-            <q-banner
+            <StatusBanner
                 v-if="parentRelationship"
-                class="bg-blue-1 q-mb-md"
-                rounded
+                type="info"
+                icon="subdirectory_arrow_right"
             >
-                <template #avatar>
-                    <q-icon
-                        name="subdirectory_arrow_right"
-                        color="primary"
-                    />
-                </template>
                 This course is a
                 <q-badge
                     :color="parentRelationship.relationshipType === 'CrossList' ? 'positive' : 'info'"
@@ -126,7 +120,7 @@
                     {{ parentRelationship.parentCourse.courseCode }}-{{ parentRelationship.parentCourse.seqNumb }}
                 </router-link>
                 <span v-else>Course {{ parentRelationship.parentCourseId }}</span>
-            </q-banner>
+            </StatusBanner>
 
             <!-- Child Relationships Section -->
             <div

--- a/VueApp/src/Effort/pages/CourseList.vue
+++ b/VueApp/src/Effort/pages/CourseList.vue
@@ -158,8 +158,8 @@
                                 </q-badge>
                                 <q-badge
                                     v-if="props.row.enrollment === 0 && !props.row.isRCourse"
-                                    color="orange-8"
-                                    text-color="white"
+                                    color="warning"
+                                    text-color="dark"
                                 >
                                     0 Enrollment
                                     <q-tooltip>This course has zero enrollment</q-tooltip>
@@ -225,16 +225,10 @@
             <div class="dept-header text-white q-pa-sm row items-center">
                 <span class="text-weight-bold">Resident Teaching (R-Course) ({{ residentCourses.length }})</span>
             </div>
-            <q-banner
-                class="bg-info text-white q-mb-none"
-                square
-            >
-                <template #avatar>
-                    <q-icon name="info" />
-                </template>
+            <StatusBanner type="info">
                 The Resident (R) course was added automatically to allow recording of resident teaching effort. If left
                 with 0 effort and verified, it will be automatically removed.
-            </q-banner>
+            </StatusBanner>
             <q-table
                 :rows="residentCourses"
                 :columns="rCourseColumns"
@@ -316,6 +310,7 @@ import { termService } from "../services/term-service"
 import { useEffortPermissions } from "../composables/use-effort-permissions"
 import type { CourseDto, TermDto } from "../types"
 import type { QTableColumn } from "quasar"
+import StatusBanner from "@/components/StatusBanner.vue"
 import CourseImportDialog from "../components/CourseImportDialog.vue"
 import CourseEditDialog from "../components/CourseEditDialog.vue"
 import CourseAddDialog from "../components/CourseAddDialog.vue"

--- a/VueApp/src/Effort/pages/CourseList.vue
+++ b/VueApp/src/Effort/pages/CourseList.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Course List</h2>
+        <h1>Course List</h1>
 
         <!-- Term selector and filters -->
         <div class="row q-col-gutter-sm q-mb-md items-center">

--- a/VueApp/src/Effort/pages/CourseList.vue
+++ b/VueApp/src/Effort/pages/CourseList.vue
@@ -111,7 +111,7 @@
                     :aria-expanded="hasMultipleDepts ? !collapsedDepts.has(deptGroup.dept) : undefined"
                     @click="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
                     @keyup.enter="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
-                    @keyup.space.prevent="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
+                    @keydown.space.prevent="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
                 >
                     <q-icon
                         v-if="hasMultipleDepts"

--- a/VueApp/src/Effort/pages/DeptSummary.vue
+++ b/VueApp/src/Effort/pages/DeptSummary.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Teaching Activity Report - Department Summary</h2>
+        <h1>Teaching Activity Report - Department Summary</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/DeptSummary.vue
+++ b/VueApp/src/Effort/pages/DeptSummary.vue
@@ -67,7 +67,7 @@
             <template v-if="report.departments.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/EffortHome.vue
+++ b/VueApp/src/Effort/pages/EffortHome.vue
@@ -11,7 +11,7 @@
             <div class="q-mt-md text-body1">Loading...</div>
         </div>
         <template v-else>
-            <h2 class="text-grey-7">Select your action from the menu</h2>
+            <h1 class="text-grey-7">Select your action from the menu</h1>
         </template>
     </div>
 </template>

--- a/VueApp/src/Effort/pages/EffortTypeList.vue
+++ b/VueApp/src/Effort/pages/EffortTypeList.vue
@@ -26,7 +26,10 @@
 
         <template v-else>
             <!-- Effort Types Table - wrapped for horizontal scroll on tablets -->
-            <div class="table-scroll-container">
+            <div
+                class="table-scroll-container"
+                tabindex="0"
+            >
                 <q-table
                     :rows="effortTypes"
                     :columns="columns"
@@ -115,7 +118,7 @@
                             </template>
                             <template v-else>
                                 <div class="row items-center no-wrap">
-                                    <span :class="{ 'text-grey': !props.row.isActive }">{{
+                                    <span :class="{ 'text-strike text-grey-8': !props.row.isActive }">{{
                                         props.row.description
                                     }}</span>
                                     <q-btn
@@ -300,7 +303,7 @@
                                         <template v-else>
                                             <div
                                                 class="col text-grey-8"
-                                                :class="{ 'text-grey': !props.row.isActive }"
+                                                :class="{ 'text-strike': !props.row.isActive }"
                                             >
                                                 {{ props.row.description }}
                                             </div>

--- a/VueApp/src/Effort/pages/EffortTypeList.vue
+++ b/VueApp/src/Effort/pages/EffortTypeList.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="q-pa-md">
         <div class="row items-center q-mb-md">
-            <h2 class="q-ma-none">Manage Effort Types</h2>
+            <h1 class="q-ma-none">Manage Effort Types</h1>
             <q-space />
             <q-btn
                 label="Add Effort Type"
@@ -143,6 +143,7 @@
                             <q-toggle
                                 :model-value="props.row.usesWeeks"
                                 dense
+                                :aria-label="`${props.row.description} uses weeks`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'usesWeeks')"
                             >
@@ -160,6 +161,7 @@
                             <q-toggle
                                 :model-value="props.row.isActive"
                                 dense
+                                :aria-label="`${props.row.description} active`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'isActive')"
                             />
@@ -173,6 +175,7 @@
                             <q-toggle
                                 :model-value="props.row.facultyCanEnter"
                                 dense
+                                :aria-label="`${props.row.description} faculty can enter`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'facultyCanEnter')"
                             />
@@ -186,6 +189,7 @@
                             <q-toggle
                                 :model-value="props.row.allowedOnDvm"
                                 dense
+                                :aria-label="`${props.row.description} allowed on DVM`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'allowedOnDvm')"
                             />
@@ -199,6 +203,7 @@
                             <q-toggle
                                 :model-value="props.row.allowedOn199299"
                                 dense
+                                :aria-label="`${props.row.description} allowed on 199/299`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'allowedOn199299')"
                             />
@@ -212,6 +217,7 @@
                             <q-toggle
                                 :model-value="props.row.allowedOnRCourses"
                                 dense
+                                :aria-label="`${props.row.description} allowed on R courses`"
                                 :disable="isTogglingId === props.row.id"
                                 @update:model-value="toggleProperty(props.row, 'allowedOnRCourses')"
                             />

--- a/VueApp/src/Effort/pages/EvalDetail.vue
+++ b/VueApp/src/Effort/pages/EvalDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Evaluation Report - Detail</h2>
+        <h1>Evaluation Report - Detail</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/EvalSummary.vue
+++ b/VueApp/src/Effort/pages/EvalSummary.vue
@@ -68,7 +68,7 @@
             <template v-if="report.departments.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/EvalSummary.vue
+++ b/VueApp/src/Effort/pages/EvalSummary.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Evaluation Report - Summary</h2>
+        <h1>Evaluation Report - Summary</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/InstructorDetail.vue
+++ b/VueApp/src/Effort/pages/InstructorDetail.vue
@@ -22,9 +22,9 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
+            type="error"
         >
             {{ loadError }}
             <template #action>
@@ -34,7 +34,7 @@
                     :to="{ name: 'InstructorList', params: { termCode } }"
                 />
             </template>
-        </q-banner>
+        </StatusBanner>
 
         <!-- Instructor content -->
         <template v-else-if="instructor">
@@ -136,6 +136,7 @@ import { termService } from "../services/term-service"
 import { useEffortPermissions } from "../composables/use-effort-permissions"
 import { useEffortRecordManagement, formatEffortDate } from "../composables/use-effort-record-management"
 import type { PersonDto, TermDto, InstructorEffortRecordDto } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import EffortRecordAddDialog from "../components/EffortRecordAddDialog.vue"
 import EffortRecordEditDialog from "../components/EffortRecordEditDialog.vue"
 import CourseImportDialog from "../components/CourseImportDialog.vue"

--- a/VueApp/src/Effort/pages/InstructorEdit.vue
+++ b/VueApp/src/Effort/pages/InstructorEdit.vue
@@ -26,9 +26,9 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
+            type="error"
         >
             {{ loadError }}
             <template #action>
@@ -38,7 +38,7 @@
                     :to="{ name: 'InstructorList', params: { termCode } }"
                 />
             </template>
-        </q-banner>
+        </StatusBanner>
 
         <!-- Instructor content -->
         <template v-else-if="instructor">
@@ -138,13 +138,12 @@
                         @filter="filterTitleCodes"
                     >
                         <template #before-options>
-                            <q-banner
+                            <StatusBanner
                                 v-if="isOrphanedTitleCode"
-                                class="bg-warning text-white q-mb-sm"
-                                dense
+                                type="warning"
                             >
                                 Current value "{{ form.effortTitleCode }}" is not in the standard list
-                            </q-banner>
+                            </StatusBanner>
                         </template>
                         <template #no-option>
                             <q-item>
@@ -167,13 +166,12 @@
                         clearable
                     >
                         <template #before-options>
-                            <q-banner
+                            <StatusBanner
                                 v-if="isOrphanedJobGroup"
-                                class="bg-warning text-white q-mb-sm"
-                                dense
+                                type="warning"
                             >
                                 Current value "{{ form.jobGroupId }}" is not in the standard list
-                            </q-banner>
+                            </StatusBanner>
                         </template>
                     </q-select>
 
@@ -199,19 +197,12 @@
                         </span>
                     </q-checkbox>
 
-                    <q-banner
+                    <StatusBanner
                         v-if="settingsErrorMessage"
-                        class="bg-negative text-white"
-                        rounded
+                        type="error"
                     >
-                        <template #avatar>
-                            <q-icon
-                                name="error"
-                                color="white"
-                            />
-                        </template>
                         {{ settingsErrorMessage }}
-                    </q-banner>
+                    </StatusBanner>
                 </q-form>
 
                 <div class="row justify-end q-mt-sm">
@@ -317,6 +308,7 @@ import type {
     PercentAssignTypeDto,
     UnitDto,
 } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import PercentAssignmentTable from "../components/PercentAssignmentTable.vue"
 import PercentAssignmentAddDialog from "../components/PercentAssignmentAddDialog.vue"
 import PercentAssignmentEditDialog from "../components/PercentAssignmentEditDialog.vue"

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -91,7 +91,7 @@
                         :aria-label="`${collapsedDepts.has(deptGroup.dept) ? 'Expand' : 'Collapse'} ${deptGroup.dept}`"
                         @click="toggleDeptCollapse(deptGroup.dept)"
                         @keyup.enter="toggleDeptCollapse(deptGroup.dept)"
-                        @keyup.space.prevent="toggleDeptCollapse(deptGroup.dept)"
+                        @keydown.space.prevent="toggleDeptCollapse(deptGroup.dept)"
                     >
                         <q-icon
                             :name="collapsedDepts.has(deptGroup.dept) ? 'expand_more' : 'expand_less'"

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -149,6 +149,7 @@
                                     v-else-if="instructor.isVerified && instructor.recordCount === 0"
                                     name="check"
                                     color="info"
+                                    text-color="dark"
                                     size="sm"
                                     class="q-mr-sm"
                                 >
@@ -170,8 +171,8 @@
                                     </router-link>
                                     <q-badge
                                         v-if="instructor.recordCount === 0"
-                                        color="orange-8"
-                                        text-color="white"
+                                        color="warning"
+                                        text-color="dark"
                                     >
                                         No Effort
                                     </q-badge>
@@ -435,6 +436,7 @@
                                 v-else-if="props.row.isVerified && props.row.recordCount === 0"
                                 name="check"
                                 color="info"
+                                text-color="dark"
                                 size="xs"
                             >
                                 <q-tooltip>Verified no effort</q-tooltip>
@@ -458,8 +460,8 @@
                                 </router-link>
                                 <q-badge
                                     v-if="props.row.recordCount === 0"
-                                    color="orange-8"
-                                    text-color="white"
+                                    color="warning"
+                                    text-color="dark"
                                     class="no-effort-badge"
                                 >
                                     No Effort

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -105,6 +105,7 @@
                         size="0.75rem"
                         color="white"
                         no-caps
+                        tabindex="-1"
                         :disable="sendingEmailDepts.has(deptGroup.dept)"
                         :loading="sendingEmailDepts.has(deptGroup.dept)"
                         @click.stop="confirmBulkEmail(deptGroup)"

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -458,6 +458,7 @@
                                 <q-badge
                                     v-if="props.row.recordCount === 0"
                                     color="warning"
+                                    text-color="dark"
                                     class="no-effort-badge"
                                 >
                                     No Effort

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Instructor List for {{ currentTermName }}</h2>
+        <h1>Instructor List for {{ currentTermName }}</h1>
 
         <!-- Term selector and filters -->
         <div class="row q-col-gutter-sm q-mb-md items-center">

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -80,23 +80,30 @@
                     class="dept-header text-white q-pa-sm row items-center"
                     :class="{
                         'dept-header--no-dept': deptGroup.dept === 'Unknown Department',
-                        'dept-header--collapsible': hasMultipleDepts,
                     }"
-                    :tabindex="hasMultipleDepts ? 0 : undefined"
-                    :role="hasMultipleDepts ? 'button' : undefined"
-                    :aria-expanded="hasMultipleDepts ? !collapsedDepts.has(deptGroup.dept) : undefined"
-                    @click="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
-                    @keyup.enter="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
-                    @keyup.space.prevent="hasMultipleDepts && toggleDeptCollapse(deptGroup.dept)"
                 >
-                    <q-icon
+                    <div
                         v-if="hasMultipleDepts"
-                        :name="collapsedDepts.has(deptGroup.dept) ? 'expand_more' : 'expand_less'"
-                        size="sm"
-                        class="q-mr-xs"
-                    />
-                    <span class="text-weight-bold">{{ deptGroup.dept }} ({{ deptGroup.instructors.length }})</span>
-                    <q-space />
+                        class="dept-header__trigger col row items-center"
+                        tabindex="0"
+                        role="button"
+                        :aria-expanded="!collapsedDepts.has(deptGroup.dept)"
+                        :aria-label="`${collapsedDepts.has(deptGroup.dept) ? 'Expand' : 'Collapse'} ${deptGroup.dept}`"
+                        @click="toggleDeptCollapse(deptGroup.dept)"
+                        @keyup.enter="toggleDeptCollapse(deptGroup.dept)"
+                        @keyup.space.prevent="toggleDeptCollapse(deptGroup.dept)"
+                    >
+                        <q-icon
+                            :name="collapsedDepts.has(deptGroup.dept) ? 'expand_more' : 'expand_less'"
+                            size="sm"
+                            class="q-mr-xs"
+                        />
+                        <span class="text-weight-bold">{{ deptGroup.dept }} ({{ deptGroup.instructors.length }})</span>
+                    </div>
+                    <template v-else>
+                        <span class="text-weight-bold">{{ deptGroup.dept }} ({{ deptGroup.instructors.length }})</span>
+                        <q-space />
+                    </template>
                     <q-btn
                         v-if="getEmailableCount(deptGroup) > 0"
                         icon="mail_outline"
@@ -105,10 +112,9 @@
                         size="0.75rem"
                         color="white"
                         no-caps
-                        tabindex="-1"
                         :disable="sendingEmailDepts.has(deptGroup.dept)"
                         :loading="sendingEmailDepts.has(deptGroup.dept)"
-                        @click.stop="confirmBulkEmail(deptGroup)"
+                        @click="confirmBulkEmail(deptGroup)"
                     >
                         <template #loading>
                             <q-spinner
@@ -172,6 +178,7 @@
                                     <q-badge
                                         v-if="instructor.recordCount === 0"
                                         color="warning"
+                                        text-color="dark"
                                     >
                                         No Effort
                                     </q-badge>
@@ -1271,9 +1278,19 @@ onMounted(loadTerms)
     background-color: var(--q-negative);
 }
 
-.dept-header--no-dept.dept-header--collapsible:hover,
-.dept-header--no-dept.dept-header--collapsible:focus {
-    background-color: #a83232;
+.dept-header__trigger {
+    cursor: pointer;
+    user-select: none;
+}
+
+.dept-header__trigger:hover,
+.dept-header__trigger:focus {
+    background-color: rgb(0 0 0 / 15%);
+}
+
+.dept-header__trigger:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: -2px;
 }
 
 .dept-table--no-dept {

--- a/VueApp/src/Effort/pages/InstructorList.vue
+++ b/VueApp/src/Effort/pages/InstructorList.vue
@@ -149,7 +149,6 @@
                                     v-else-if="instructor.isVerified && instructor.recordCount === 0"
                                     name="check"
                                     color="info"
-                                    text-color="dark"
                                     size="sm"
                                     class="q-mr-sm"
                                 >
@@ -172,7 +171,6 @@
                                     <q-badge
                                         v-if="instructor.recordCount === 0"
                                         color="warning"
-                                        text-color="dark"
                                     >
                                         No Effort
                                     </q-badge>
@@ -436,7 +434,6 @@
                                 v-else-if="props.row.isVerified && props.row.recordCount === 0"
                                 name="check"
                                 color="info"
-                                text-color="dark"
                                 size="xs"
                             >
                                 <q-tooltip>Verified no effort</q-tooltip>
@@ -461,7 +458,6 @@
                                 <q-badge
                                     v-if="props.row.recordCount === 0"
                                     color="warning"
-                                    text-color="dark"
                                     class="no-effort-badge"
                                 >
                                     No Effort

--- a/VueApp/src/Effort/pages/MeritAverage.vue
+++ b/VueApp/src/Effort/pages/MeritAverage.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Average</h2>
+        <h1>Merit &amp; Promotion Report - Average</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/MeritAverage.vue
+++ b/VueApp/src/Effort/pages/MeritAverage.vue
@@ -69,7 +69,7 @@
             <template v-if="report.jobGroups.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/MeritDetail.vue
+++ b/VueApp/src/Effort/pages/MeritDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Detail</h2>
+        <h1>Merit &amp; Promotion Report - Detail</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/MeritSummary.vue
+++ b/VueApp/src/Effort/pages/MeritSummary.vue
@@ -69,7 +69,7 @@
             <template v-if="report.jobGroups.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/MeritSummary.vue
+++ b/VueApp/src/Effort/pages/MeritSummary.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Summary</h2>
+        <h1>Merit &amp; Promotion Report - Summary</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/MultiYearReport.vue
+++ b/VueApp/src/Effort/pages/MultiYearReport.vue
@@ -42,16 +42,7 @@
                 </div>
             </div>
             <div class="text-grey-7 text-center q-pa-lg">Select an instructor to configure the report.</div>
-            <q-banner
-                class="bg-blue-1 text-caption q-mt-md"
-                rounded
-            >
-                <template #avatar>
-                    <q-icon
-                        name="info"
-                        color="primary"
-                    />
-                </template>
+            <StatusBanner type="info">
                 <p class="q-mb-xs">
                     Faculty count for department averages is a sum of all faculty for the time period specified.
                 </p>
@@ -59,7 +50,7 @@
                     The "Department" used for that average is based on the LAST entry in the review period for the
                     reviewee.
                 </p>
-            </q-banner>
+            </StatusBanner>
         </div>
 
         <!-- Step 2: Configure & Generate (after instructor selected) -->
@@ -230,17 +221,10 @@
             </div>
 
             <!-- Bottom notes -->
-            <q-banner
+            <StatusBanner
                 v-if="!report && !loading"
-                class="bg-blue-1 text-caption q-mt-sm"
-                rounded
+                type="info"
             >
-                <template #avatar>
-                    <q-icon
-                        name="info"
-                        color="primary"
-                    />
-                </template>
                 <p class="q-mb-xs">
                     Faculty count for department averages is a sum of all faculty for the time period specified.
                 </p>
@@ -248,7 +232,7 @@
                     The "Department" used for that average is based on the LAST entry in the review period for the
                     reviewee.
                 </p>
-            </q-banner>
+            </StatusBanner>
         </div>
 
         <!-- Loading state -->
@@ -655,6 +639,7 @@ import {
     loadEffortTypeLabels,
 } from "../composables/use-effort-type-columns"
 import { useEffortPermissions } from "../composables/use-effort-permissions"
+import StatusBanner from "@/components/StatusBanner.vue"
 import ReportLayout from "../components/ReportLayout.vue"
 import LeaveEditorModal from "../components/LeaveEditorModal.vue"
 import type { MultiYearReport, PersonDto, TermDto, SabbaticalDto } from "../types"

--- a/VueApp/src/Effort/pages/MultiYearReport.vue
+++ b/VueApp/src/Effort/pages/MultiYearReport.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Multi-Year</h2>
+        <h1>Merit &amp; Promotion Report - Multi-Year</h1>
 
         <!-- Step 1: Select Instructor (shown when no instructor selected) -->
         <div

--- a/VueApp/src/Effort/pages/MyEffort.vue
+++ b/VueApp/src/Effort/pages/MyEffort.vue
@@ -22,9 +22,9 @@
         </div>
 
         <!-- Error state -->
-        <q-banner
+        <StatusBanner
             v-else-if="loadError"
-            class="bg-negative text-white q-mb-md"
+            type="error"
         >
             {{ loadError }}
             <template #action>
@@ -34,19 +34,16 @@
                     :to="{ name: 'EffortHomeWithTerm', params: { termCode } }"
                 />
             </template>
-        </q-banner>
+        </StatusBanner>
 
         <!-- No instructor record for this term (empty DTO returned) -->
-        <q-banner
+        <StatusBanner
             v-else-if="myEffort && myEffort.effortRecords.length === 0 && !myEffort.instructor.personId"
-            class="bg-info text-white q-mb-md"
-            rounded
+            type="info"
+            icon="school"
         >
-            <template #avatar>
-                <q-icon name="school" />
-            </template>
             No effort records found for you in this term.
-        </q-banner>
+        </StatusBanner>
 
         <!-- Content when loaded -->
         <template v-else-if="myEffort">
@@ -90,16 +87,12 @@
             />
 
             <!-- Already verified banner -->
-            <q-banner
+            <StatusBanner
                 v-if="myEffort.instructor.isVerified"
-                class="bg-positive text-white q-mb-md"
-                rounded
+                type="success"
             >
-                <template #avatar>
-                    <q-icon name="check_circle" />
-                </template>
                 Your effort was verified on {{ formatEffortDate(myEffort.instructor.effortVerified) }}
-            </q-banner>
+            </StatusBanner>
 
             <!-- Zero effort warning -->
             <ZeroEffortBanner
@@ -116,19 +109,15 @@
             </p>
 
             <!-- No records message with verification option -->
-            <q-banner
+            <StatusBanner
                 v-if="myEffort.effortRecords.length === 0 && !myEffort.instructor.isVerified"
-                class="bg-info text-white q-mb-md"
-                rounded
+                type="info"
             >
-                <template #avatar>
-                    <q-icon name="info" />
-                </template>
                 <div>
                     No effort records found for you in this term. If this is correct, you can verify that you had no
                     teaching effort for {{ myEffort.termName }}.
                 </div>
-            </q-banner>
+            </StatusBanner>
 
             <!-- No records message (already verified) -->
             <div
@@ -256,6 +245,7 @@ import { recordService } from "../services/record-service"
 import { useEffortRecordManagement, formatEffortDate } from "../composables/use-effort-record-management"
 import type { MyEffortDto, EffortTypeOptionDto, InstructorEffortRecordDto } from "../types"
 import { VerificationErrorCodes } from "../types"
+import StatusBanner from "@/components/StatusBanner.vue"
 import EffortRecordAddDialog from "../components/EffortRecordAddDialog.vue"
 import EffortRecordEditDialog from "../components/EffortRecordEditDialog.vue"
 import CourseImportDialog from "../components/CourseImportDialog.vue"
@@ -421,6 +411,21 @@ onMounted(loadData)
     align-items: center;
 }
 
+@media screen and (prefers-reduced-motion: reduce) {
+    .help-link {
+        margin-left: 8px;
+        display: inline-flex;
+        align-items: center;
+        text-decoration: none;
+        font-size: 0.9rem;
+        font-weight: normal;
+        gap: 4px;
+        padding: 6px 12px;
+        border-radius: 4px;
+        transition: none;
+    }
+}
+
 .help-link {
     margin-left: 8px;
     display: inline-flex;
@@ -434,7 +439,8 @@ onMounted(loadData)
     transition: background-color 0.2s ease;
 }
 
-.help-link:hover {
-    background-color: rgba(0, 95, 153, 0.1);
+.help-link:hover,
+.help-link:focus {
+    background-color: rgb(0 95 153 / 10%);
 }
 </style>

--- a/VueApp/src/Effort/pages/MyEffort.vue
+++ b/VueApp/src/Effort/pages/MyEffort.vue
@@ -411,21 +411,6 @@ onMounted(loadData)
     align-items: center;
 }
 
-@media screen and (prefers-reduced-motion: reduce) {
-    .help-link {
-        margin-left: 8px;
-        display: inline-flex;
-        align-items: center;
-        text-decoration: none;
-        font-size: 0.9rem;
-        font-weight: normal;
-        gap: 4px;
-        padding: 6px 12px;
-        border-radius: 4px;
-        transition: none;
-    }
-}
-
 .help-link {
     margin-left: 8px;
     display: inline-flex;
@@ -442,5 +427,11 @@ onMounted(loadData)
 .help-link:hover,
 .help-link:focus {
     background-color: rgb(0 95 153 / 10%);
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+    .help-link {
+        transition: none;
+    }
 }
 </style>

--- a/VueApp/src/Effort/pages/MyEffort.vue
+++ b/VueApp/src/Effort/pages/MyEffort.vue
@@ -52,7 +52,7 @@
         <template v-else-if="myEffort">
             <!-- Header -->
             <div class="q-mb-md row items-center justify-between">
-                <h2 class="q-my-none header-title">
+                <h1 class="q-my-none header-title">
                     My Effort<template v-if="myEffort.termName"> for {{ myEffort.termName }}</template>
                     <a
                         href="https://ucdsvm.knowledgeowl.com/help/how-do-i-update-and-verify-my-teaching-effort"
@@ -66,7 +66,7 @@
                             size="xs"
                         />
                     </a>
-                </h2>
+                </h1>
                 <a
                     href="https://ucdsvm.knowledgeowl.com/help/how-do-i-update-and-verify-my-teaching-effort"
                     target="_blank"

--- a/VueApp/src/Effort/pages/PercentAssignTypeInstructors.vue
+++ b/VueApp/src/Effort/pages/PercentAssignTypeInstructors.vue
@@ -60,7 +60,7 @@
 
         <!-- Error state -->
         <template v-else>
-            <q-banner class="bg-negative text-white q-mb-md">
+            <StatusBanner type="error">
                 Percent assignment type not found.
                 <template #action>
                     <q-btn
@@ -69,7 +69,7 @@
                         :to="backLink"
                     />
                 </template>
-            </q-banner>
+            </StatusBanner>
         </template>
     </div>
 </template>
@@ -77,6 +77,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue"
 import { useRoute } from "vue-router"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { percentAssignTypeService } from "../services/percent-assign-type-service"
 import type { InstructorsByPercentAssignTypeResponseDto, InstructorByPercentAssignTypeDto } from "../types"
 import type { QTableColumn } from "quasar"

--- a/VueApp/src/Effort/pages/PercentAssignTypeInstructors.vue
+++ b/VueApp/src/Effort/pages/PercentAssignTypeInstructors.vue
@@ -22,7 +22,7 @@
         </div>
 
         <template v-else-if="typeData">
-            <h2>Instructors tagged with {{ typeData.typeName }} ({{ typeData.typeClass }})</h2>
+            <h1>Instructors tagged with {{ typeData.typeName }} ({{ typeData.typeClass }})</h1>
 
             <q-table
                 :rows="typeData.instructors"

--- a/VueApp/src/Effort/pages/PercentAssignTypeList.vue
+++ b/VueApp/src/Effort/pages/PercentAssignTypeList.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Percent Assignment Types</h2>
+        <h1>Percent Assignment Types</h1>
 
         <div
             v-if="isLoading"

--- a/VueApp/src/Effort/pages/PercentAssignTypeList.vue
+++ b/VueApp/src/Effort/pages/PercentAssignTypeList.vue
@@ -45,7 +45,7 @@
                         <q-td :props="props">
                             <q-icon
                                 :name="props.row.showOnTemplate ? 'check_circle' : 'cancel'"
-                                :color="props.row.showOnTemplate ? 'positive' : 'grey'"
+                                :color="props.row.showOnTemplate ? 'positive' : 'negative'"
                                 size="sm"
                             />
                         </q-td>

--- a/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
+++ b/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Merit &amp; Promotion Report - Scheduled Clinical Weeks</h2>
+        <h1>Merit &amp; Promotion Report - Scheduled Clinical Weeks</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
+++ b/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
@@ -63,13 +63,13 @@
 
         <!-- Report content -->
         <template v-else-if="report">
-            <q-banner
-                class="bg-info text-white q-my-md"
-                rounded
+            <StatusBanner
+                type="info"
+                class="q-mt-md"
             >
                 The following data is based on the instructor schedule pulled live from the Clinical Scheduler. It does
                 not contain the verified effort entered by faculty and departments.
-            </q-banner>
+            </StatusBanner>
 
             <template v-if="report.instructors.length === 0">
                 <div
@@ -108,6 +108,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue"
+import StatusBanner from "@/components/StatusBanner.vue"
 import { reportService } from "../services/report-service"
 import { useReportPage } from "../composables/use-report-page"
 import ReportFilterForm from "../components/ReportFilterForm.vue"

--- a/VueApp/src/Effort/pages/SchoolSummary.vue
+++ b/VueApp/src/Effort/pages/SchoolSummary.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Teaching Activity Report - School Summary</h2>
+        <h1>Teaching Activity Report - School Summary</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -103,7 +103,7 @@
                                     tabindex="0"
                                     @click="scrollToNoInstructorsAlert"
                                     @keyup.enter="scrollToNoInstructorsAlert"
-                                    @keyup.space.prevent="scrollToNoInstructorsAlert"
+                                    @keydown.space.prevent="scrollToNoInstructorsAlert"
                                 >
                                     {{ stats.coursesWithoutInstructors }} without instructors
                                 </q-badge>
@@ -274,7 +274,7 @@
                                             :aria-label="`View ${getDeptDisplayName(dept)} instructors`"
                                             @click="navigateToDepartment(dept.departmentCode)"
                                             @keyup.enter="navigateToDepartment(dept.departmentCode)"
-                                            @keyup.space.prevent="navigateToDepartment(dept.departmentCode)"
+                                            @keydown.space.prevent="navigateToDepartment(dept.departmentCode)"
                                         >
                                             <div class="dept-name text-truncate">
                                                 {{ getDeptDisplayName(dept) }}
@@ -323,7 +323,7 @@
                                             :aria-label="`View ${getDeptDisplayName(dept)} instructors`"
                                             @click="navigateToDepartment(dept.departmentCode)"
                                             @keyup.enter="navigateToDepartment(dept.departmentCode)"
-                                            @keyup.space.prevent="navigateToDepartment(dept.departmentCode)"
+                                            @keydown.space.prevent="navigateToDepartment(dept.departmentCode)"
                                         >
                                             <div class="dept-name text-truncate">
                                                 {{ getDeptDisplayName(dept) }}
@@ -366,7 +366,7 @@
                                         :aria-label="`View ${getDeptDisplayName(dept)} instructors`"
                                         @click="navigateToDepartment(dept.departmentCode)"
                                         @keyup.enter="navigateToDepartment(dept.departmentCode)"
-                                        @keyup.space.prevent="navigateToDepartment(dept.departmentCode)"
+                                        @keydown.space.prevent="navigateToDepartment(dept.departmentCode)"
                                     >
                                         <div class="dept-name text-truncate">
                                             {{ getDeptDisplayName(dept) }}

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -797,6 +797,7 @@
                                         <q-icon
                                             name="schedule"
                                             color="info"
+                                            text-color="dark"
                                         />
                                     </q-item-section>
                                     <q-item-section>

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -187,6 +187,7 @@
                                 <span class="text-h6">{{ stats.currentTerm?.termName }}</span>
                                 <q-badge
                                     :color="getTermStatusColor(stats.currentTerm?.status)"
+                                    :text-color="getTermStatusTextColor(stats.currentTerm?.status)"
                                     class="q-pa-sm q-ml-sm"
                                 >
                                     {{ stats.currentTerm?.status }}
@@ -214,7 +215,7 @@
                             </div>
                             <div
                                 v-if="stats.currentTerm?.closedDate && stats.currentTerm?.openedDate"
-                                class="text-caption text-grey-6 q-mt-xs"
+                                class="text-caption text-grey-7 q-mt-xs"
                             >
                                 Open for
                                 {{ getTermDuration(stats.currentTerm.openedDate, stats.currentTerm.closedDate) }}
@@ -492,18 +493,17 @@
                         <q-item-section>
                             <div class="text-h6">Data Hygiene Alerts</div>
                         </q-item-section>
-                        <q-item-section side>
+                    </template>
+                    <q-card-section class="q-pt-none">
+                        <div class="row justify-end q-mb-sm">
                             <q-btn
                                 flat
                                 dense
                                 size="sm"
                                 :label="showIgnoredAlerts ? 'Hide Ignored' : 'Show Ignored'"
-                                tabindex="-1"
-                                @click.stop="showIgnoredAlerts = !showIgnoredAlerts"
+                                @click="showIgnoredAlerts = !showIgnoredAlerts"
                             />
-                        </q-item-section>
-                    </template>
-                    <q-card-section class="q-pt-none">
+                        </div>
                         <template v-if="visibleAlerts.length === 0">
                             <div class="text-grey-6 text-center q-pa-md">No alerts to display</div>
                         </template>
@@ -543,7 +543,8 @@
                                                 {{ alert.entityName }}
                                                 <q-badge
                                                     v-if="alert.status === 'Ignored'"
-                                                    color="grey"
+                                                    color="grey-5"
+                                                    text-color="grey-9"
                                                     class="q-ml-sm"
                                                 >
                                                     Ignored<template v-if="alert.reviewedBy">
@@ -570,7 +571,7 @@
                                                     dense
                                                     size="sm"
                                                     label="Ignore"
-                                                    color="grey"
+                                                    color="grey-8"
                                                     @click="ignoreAlert(alert)"
                                                 />
                                             </div>
@@ -612,7 +613,8 @@
                                                 {{ alert.entityName }}
                                                 <q-badge
                                                     v-if="alert.status === 'Ignored'"
-                                                    color="grey"
+                                                    color="grey-5"
+                                                    text-color="grey-9"
                                                     class="q-ml-sm"
                                                 >
                                                     Ignored<template v-if="alert.reviewedBy">
@@ -642,7 +644,7 @@
                                                     dense
                                                     size="sm"
                                                     label="Ignore"
-                                                    color="grey"
+                                                    color="grey-8"
                                                     @click="ignoreAlert(alert)"
                                                 />
                                             </div>
@@ -684,7 +686,8 @@
                                                 {{ alert.entityName }}
                                                 <q-badge
                                                     v-if="alert.status === 'Ignored'"
-                                                    color="grey"
+                                                    color="grey-5"
+                                                    text-color="grey-9"
                                                     class="q-ml-sm"
                                                 >
                                                     Ignored<template v-if="alert.reviewedBy">
@@ -711,7 +714,7 @@
                                                     dense
                                                     size="sm"
                                                     label="Ignore"
-                                                    color="grey"
+                                                    color="grey-8"
                                                     @click="ignoreAlert(alert)"
                                                 />
                                             </div>
@@ -754,7 +757,8 @@
                                                 {{ alert.entityName }}
                                                 <q-badge
                                                     v-if="alert.status === 'Ignored'"
-                                                    color="grey"
+                                                    color="grey-5"
+                                                    text-color="grey-9"
                                                     class="q-ml-sm"
                                                 >
                                                     Ignored<template v-if="alert.reviewedBy">
@@ -781,7 +785,7 @@
                                                     dense
                                                     size="sm"
                                                     label="Ignore"
-                                                    color="grey"
+                                                    color="grey-8"
                                                     @click="ignoreAlert(alert)"
                                                 />
                                             </div>
@@ -823,7 +827,8 @@
                                                 {{ alert.entityName }}
                                                 <q-badge
                                                     v-if="alert.status === 'Ignored'"
-                                                    color="grey"
+                                                    color="grey-5"
+                                                    text-color="grey-9"
                                                     class="q-ml-sm"
                                                 >
                                                     Ignored<template v-if="alert.reviewedBy">
@@ -850,7 +855,7 @@
                                                     dense
                                                     size="sm"
                                                     label="Ignore"
-                                                    color="grey"
+                                                    color="grey-8"
                                                     @click="ignoreAlert(alert)"
                                                 />
                                             </div>
@@ -1110,11 +1115,23 @@ function getTermStatusColor(status: string | undefined): string {
         case "Opened":
             return "positive"
         case "Closed":
-            return "grey"
+            return "grey-5"
         case "Harvested":
             return "info"
         default:
-            return "grey"
+            return "grey-5"
+    }
+}
+
+function getTermStatusTextColor(status: string | undefined): string {
+    switch (status) {
+        case "Opened":
+            return "white"
+        case "Harvested":
+            return "dark"
+        case "Closed":
+        default:
+            return "grey-9"
     }
 }
 

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -498,6 +498,7 @@
                                 dense
                                 size="sm"
                                 :label="showIgnoredAlerts ? 'Hide Ignored' : 'Show Ignored'"
+                                tabindex="-1"
                                 @click.stop="showIgnoredAlerts = !showIgnoredAlerts"
                             />
                         </q-item-section>
@@ -507,7 +508,7 @@
                             <div class="text-grey-6 text-center q-pa-md">No alerts to display</div>
                         </template>
 
-                        <q-list
+                        <div
                             v-else
                             class="alert-sections"
                         >
@@ -857,7 +858,7 @@
                                     </q-item>
                                 </q-list>
                             </q-expansion-item>
-                        </q-list>
+                        </div>
                     </q-card-section>
                 </q-expansion-item>
             </q-card>

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -900,7 +900,10 @@
                     />
                 </q-card-section>
                 <q-separator />
-                <q-card-section style="max-height: 70vh; overflow: auto">
+                <q-card-section
+                    style="max-height: 70vh; overflow: auto"
+                    tabindex="0"
+                >
                     <template v-if="allAlerts.length === 0">
                         <div class="text-grey-6 text-center q-pa-md">No alerts</div>
                     </template>

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Effort Dashboard</h2>
+        <h1>Effort Dashboard</h1>
 
         <!-- Loading state -->
         <div

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -797,7 +797,6 @@
                                         <q-icon
                                             name="schedule"
                                             color="info"
-                                            text-color="dark"
                                         />
                                     </q-item-section>
                                     <q-item-section>

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -30,6 +30,7 @@
                                 size="12px"
                                 class="q-mb-sm"
                                 rounded
+                                aria-label="Overall verification progress"
                             />
                             <div class="text-caption text-grey-7">
                                 {{ stats.verifiedInstructors }} of {{ stats.totalInstructors }} instructors verified
@@ -287,8 +288,9 @@
                                                     size="8px"
                                                     class="dept-bar"
                                                     rounded
+                                                    :aria-label="dept.departmentName + ' verification progress'"
                                                 />
-                                                <span class="dept-count text-caption text-grey-6">
+                                                <span class="dept-count text-caption text-grey-8">
                                                     ({{ dept.verifiedInstructors }}/{{ dept.totalInstructors }})
                                                 </span>
                                             </div>
@@ -335,8 +337,9 @@
                                                     size="8px"
                                                     class="dept-bar"
                                                     rounded
+                                                    :aria-label="dept.departmentName + ' verification progress'"
                                                 />
-                                                <span class="dept-count text-caption text-grey-6">
+                                                <span class="dept-count text-caption text-grey-8">
                                                     ({{ dept.verifiedInstructors }}/{{ dept.totalInstructors }})
                                                 </span>
                                             </div>
@@ -377,8 +380,9 @@
                                                 size="8px"
                                                 class="dept-bar"
                                                 rounded
+                                                :aria-label="dept.departmentName + ' verification progress'"
                                             />
-                                            <span class="dept-count text-caption text-grey-6">
+                                            <span class="dept-count text-caption text-grey-8">
                                                 ({{ dept.verifiedInstructors }}/{{ dept.totalInstructors }})
                                             </span>
                                         </div>

--- a/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Teaching Activity Report - Grouped by Department</h2>
+        <h1>Teaching Activity Report - Grouped by Department</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
@@ -67,7 +67,7 @@
             <template v-if="report.departments.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>

--- a/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
@@ -69,7 +69,7 @@
             <template v-if="allInstructors.length === 0">
                 <div
                     role="status"
-                    class="text-grey-6 text-center q-pa-lg"
+                    class="text-grey-7 text-center q-pa-lg"
                 >
                     No data found for the selected filters.
                 </div>
@@ -88,7 +88,7 @@
                         <div class="text-weight-bold">{{ instructor.instructor }}</div>
                         <div
                             v-if="instructor.department"
-                            class="text-caption text-grey-7"
+                            class="text-caption text-grey-8"
                         >
                             {{ instructor.department }}
                         </div>

--- a/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Teaching Activity Report - Individual</h2>
+        <h1>Teaching Activity Report - Individual</h1>
 
         <ReportFilterForm
             :term-code="termCode"

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -59,7 +59,7 @@
                                 dense
                                 no-caps
                                 size="sm"
-                                color="grey-7"
+                                color="secondary"
                                 @click="rolloverYearOverride = true"
                             />
                         </template>
@@ -79,7 +79,7 @@
                                 dense
                                 no-caps
                                 size="sm"
-                                color="grey-7"
+                                color="secondary"
                                 @click="resetRolloverYear"
                             />
                         </template>

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -32,7 +32,7 @@
                     icon="event_repeat"
                     label="Percent Rollover"
                     color="info"
-                    :text-color="showRolloverForm ? undefined : 'dark'"
+                    text-color="dark"
                     dense
                     no-caps
                     :outline="showRolloverForm"

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -25,8 +25,6 @@
                     no-caps
                     :outline="showAddTermForm"
                     @click="toggleAddTermForm"
-                    @keyup.enter="toggleAddTermForm"
-                    @keyup.space="toggleAddTermForm"
                 />
                 <q-btn
                     icon="event_repeat"
@@ -37,8 +35,6 @@
                     no-caps
                     :outline="showRolloverForm"
                     @click="toggleRolloverForm"
-                    @keyup.enter="toggleRolloverForm"
-                    @keyup.space="toggleRolloverForm"
                 />
             </div>
 
@@ -92,8 +88,6 @@
                             no-caps
                             :disable="!rolloverYear || rolloverYear < 2020 || rolloverYear > currentYear"
                             @click="openRolloverDialog"
-                            @keyup.enter="openRolloverDialog"
-                            @keyup.space="openRolloverDialog"
                         />
                     </div>
                     <div
@@ -177,8 +171,6 @@
                                 class="q-ml-sm"
                                 aria-label="Delete term"
                                 @click="confirmDeleteTerm(props.row)"
-                                @keyup.enter="confirmDeleteTerm(props.row)"
-                                @keyup.space="confirmDeleteTerm(props.row)"
                             >
                                 <q-tooltip>Delete term</q-tooltip>
                             </q-btn>
@@ -202,8 +194,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="openHarvestDialog(props.row)"
-                                    @keyup.enter="openHarvestDialog(props.row)"
-                                    @keyup.space="openHarvestDialog(props.row)"
                                 >
                                     <q-tooltip
                                         >Import instructors and courses from CREST and Clinical Scheduler</q-tooltip
@@ -221,8 +211,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="openClinicalDialog(props.row)"
-                                    @keyup.enter="openClinicalDialog(props.row)"
-                                    @keyup.space="openClinicalDialog(props.row)"
                                 >
                                     <q-tooltip>Import clinical rotation assignments from Clinical Scheduler</q-tooltip>
                                 </q-btn>
@@ -247,8 +235,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="confirmOpenTerm(props.row)"
-                                    @keyup.enter="confirmOpenTerm(props.row)"
-                                    @keyup.space="confirmOpenTerm(props.row)"
                                 />
                                 <q-btn
                                     v-if="props.row.canUnopen"
@@ -262,8 +248,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="confirmUnopenTerm(props.row)"
-                                    @keyup.enter="confirmUnopenTerm(props.row)"
-                                    @keyup.space="confirmUnopenTerm(props.row)"
                                 />
                             </div>
                         </div>
@@ -286,8 +270,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="confirmCloseTerm(props.row)"
-                                    @keyup.enter="confirmCloseTerm(props.row)"
-                                    @keyup.space="confirmCloseTerm(props.row)"
                                 />
                                 <q-btn
                                     v-if="props.row.canReopen"
@@ -301,8 +283,6 @@
                                     padding="2px sm"
                                     class="term-action-btn"
                                     @click="confirmReopenTerm(props.row)"
-                                    @keyup.enter="confirmReopenTerm(props.row)"
-                                    @keyup.space="confirmReopenTerm(props.row)"
                                 />
                             </div>
                         </div>
@@ -362,8 +342,6 @@
                                     color="grey-7"
                                     aria-label="Edit expected close date"
                                     @click="startEditExpectedCloseDate(props.row)"
-                                    @keyup.enter="startEditExpectedCloseDate(props.row)"
-                                    @keyup.space="startEditExpectedCloseDate(props.row)"
                                 >
                                     <q-tooltip>Edit expected close date</q-tooltip>
                                 </q-btn>
@@ -463,8 +441,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="openHarvestDialog(term)"
-                                @keyup.enter="openHarvestDialog(term)"
-                                @keyup.space="openHarvestDialog(term)"
                             />
                             <q-btn
                                 v-if="term.canImportClinical"
@@ -478,8 +454,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="openClinicalDialog(term)"
-                                @keyup.enter="openClinicalDialog(term)"
-                                @keyup.space="openClinicalDialog(term)"
                             />
                             <q-btn
                                 v-if="term.canOpen"
@@ -493,8 +467,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="confirmOpenTerm(term)"
-                                @keyup.enter="confirmOpenTerm(term)"
-                                @keyup.space="confirmOpenTerm(term)"
                             />
                             <q-btn
                                 v-if="term.canUnopen"
@@ -508,8 +480,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="confirmUnopenTerm(term)"
-                                @keyup.enter="confirmUnopenTerm(term)"
-                                @keyup.space="confirmUnopenTerm(term)"
                             />
                             <q-btn
                                 v-if="term.canClose"
@@ -523,8 +493,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="confirmCloseTerm(term)"
-                                @keyup.enter="confirmCloseTerm(term)"
-                                @keyup.space="confirmCloseTerm(term)"
                             />
                             <q-btn
                                 v-if="term.canReopen"
@@ -538,8 +506,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="confirmReopenTerm(term)"
-                                @keyup.enter="confirmReopenTerm(term)"
-                                @keyup.space="confirmReopenTerm(term)"
                             />
                             <q-btn
                                 v-if="term.canEditExpectedCloseDate && editingExpectedCloseTermCode !== term.termCode"
@@ -553,8 +519,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="startEditExpectedCloseDate(term)"
-                                @keyup.enter="startEditExpectedCloseDate(term)"
-                                @keyup.space="startEditExpectedCloseDate(term)"
                             />
                             <q-btn
                                 v-if="term.canDelete"
@@ -568,8 +532,6 @@
                                 padding="2px sm"
                                 class="term-action-btn"
                                 @click="confirmDeleteTerm(term)"
-                                @keyup.enter="confirmDeleteTerm(term)"
-                                @keyup.space="confirmDeleteTerm(term)"
                             />
                         </div>
                     </q-card-section>

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -31,8 +31,8 @@
                 <q-btn
                     icon="event_repeat"
                     label="Percent Rollover"
-                    color="cyan-8"
-                    :text-color="showRolloverForm ? undefined : 'white'"
+                    color="info"
+                    :text-color="showRolloverForm ? undefined : 'dark'"
                     dense
                     no-caps
                     :outline="showRolloverForm"
@@ -86,8 +86,8 @@
                         <q-btn
                             icon="event_repeat"
                             label="Preview Rollover"
-                            color="cyan-8"
-                            text-color="white"
+                            color="info"
+                            text-color="dark"
                             dense
                             no-caps
                             :disable="!rolloverYear || rolloverYear < 2020 || rolloverYear > currentYear"
@@ -194,7 +194,7 @@
                                     icon="cloud_download"
                                     :label="props.row.harvestedDate ? 'Re-Harvest' : 'Harvest'"
                                     color="info"
-                                    text-color="white"
+                                    text-color="dark"
                                     dense
                                     no-caps
                                     size="sm"
@@ -212,8 +212,8 @@
                                     v-if="props.row.canImportClinical"
                                     icon="medical_services"
                                     label="Import Clinical"
-                                    color="teal-8"
-                                    text-color="white"
+                                    color="info"
+                                    text-color="dark"
                                     dense
                                     no-caps
                                     size="sm"
@@ -450,7 +450,7 @@
                                 icon="cloud_download"
                                 :label="term.harvestedDate ? 'Re-Harvest' : 'Harvest'"
                                 color="info"
-                                text-color="white"
+                                text-color="dark"
                                 dense
                                 no-caps
                                 size="sm"
@@ -464,8 +464,8 @@
                                 v-if="term.canImportClinical"
                                 icon="medical_services"
                                 label="Import Clinical"
-                                color="teal-8"
-                                text-color="white"
+                                color="info"
+                                text-color="dark"
                                 dense
                                 no-caps
                                 size="sm"

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -175,6 +175,7 @@
                                 round
                                 size="sm"
                                 class="q-ml-sm"
+                                aria-label="Delete term"
                                 @click="confirmDeleteTerm(props.row)"
                                 @keyup.enter="confirmDeleteTerm(props.row)"
                                 @keyup.space="confirmDeleteTerm(props.row)"
@@ -331,6 +332,7 @@
                                     round
                                     size="sm"
                                     class="q-ml-xs"
+                                    aria-label="Save expected close date"
                                     @click="saveExpectedCloseDate(props.row)"
                                 >
                                     <q-tooltip>Save</q-tooltip>
@@ -342,6 +344,7 @@
                                     flat
                                     round
                                     size="sm"
+                                    aria-label="Cancel editing"
                                     @click="cancelEditExpectedCloseDate"
                                 >
                                     <q-tooltip>Cancel</q-tooltip>
@@ -357,6 +360,7 @@
                                     round
                                     size="sm"
                                     color="grey-7"
+                                    aria-label="Edit expected close date"
                                     @click="startEditExpectedCloseDate(props.row)"
                                     @keyup.enter="startEditExpectedCloseDate(props.row)"
                                     @keyup.space="startEditExpectedCloseDate(props.row)"
@@ -428,6 +432,7 @@
                                 flat
                                 round
                                 size="sm"
+                                aria-label="Save expected close date"
                                 @click="saveExpectedCloseDate(term)"
                             >
                                 <q-tooltip>Save</q-tooltip>
@@ -439,6 +444,7 @@
                                 flat
                                 round
                                 size="sm"
+                                aria-label="Cancel editing"
                                 @click="cancelEditExpectedCloseDate"
                             >
                                 <q-tooltip>Cancel</q-tooltip>

--- a/VueApp/src/Effort/pages/TermManagement.vue
+++ b/VueApp/src/Effort/pages/TermManagement.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Term Management</h2>
+        <h1>Term Management</h1>
 
         <div
             v-if="isLoading"

--- a/VueApp/src/Effort/pages/TermSelection.vue
+++ b/VueApp/src/Effort/pages/TermSelection.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <h2>Select a Term</h2>
+        <h1>Select a Term</h1>
 
         <div
             v-if="isLoading"

--- a/VueApp/src/Effort/pages/UnitList.vue
+++ b/VueApp/src/Effort/pages/UnitList.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="q-pa-md">
         <div class="row items-center q-mb-md">
-            <h2 class="q-ma-none">Manage Units</h2>
+            <h1 class="q-ma-none">Manage Units</h1>
             <q-space />
             <q-btn
                 label="Add Unit"
@@ -104,6 +104,7 @@
                         <q-toggle
                             :model-value="props.row.isActive"
                             dense
+                            :aria-label="`${props.row.name} active`"
                             :disable="isTogglingId === props.row.id"
                             @update:model-value="toggleActive(props.row)"
                         />

--- a/VueApp/src/Effort/router/index.ts
+++ b/VueApp/src/Effort/router/index.ts
@@ -4,6 +4,7 @@ import { useRequireLogin } from "@/composables/RequireLogin"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 import { useFetch } from "@/composables/ViperFetch"
 import { useUserStore } from "@/store/UserStore"
+import { useRouteFocus } from "@/composables/use-route-focus"
 
 const baseUrl = import.meta.env.VITE_VIPER_HOME
 const router = createRouter({
@@ -61,5 +62,7 @@ router.beforeEach(async (to, from) => {
         }
     }
 })
+
+useRouteFocus(router)
 
 export { router as effortRouter }

--- a/VueApp/src/composables/use-route-focus.ts
+++ b/VueApp/src/composables/use-route-focus.ts
@@ -9,7 +9,7 @@ import { nextTick } from "vue"
 export function useRouteFocus(router: Router) {
     router.afterEach(() => {
         nextTick(() => {
-            const main = document.querySelector("main") || document.querySelector("#app")
+            const main = document.querySelector("#main-content") || document.querySelector("main")
             if (main instanceof HTMLElement) {
                 // Set tabindex temporarily so the element can receive focus
                 // without permanently joining the tab order

--- a/VueApp/vite.config.ts
+++ b/VueApp/vite.config.ts
@@ -93,7 +93,9 @@ export default defineConfig(({ mode }) => {
                 }),
             // @quasar/plugin-vite options list:
             // https://github.com/quasarframework/quasar/blob/dev/vite-plugin/index.d.ts
-            quasar(),
+            quasar({
+                sassVariables: false,
+            }),
             codecovVitePlugin({
                 enableBundleAnalysis: Boolean(process.env.CODECOV_TOKEN),
                 bundleName: "viper-frontend",


### PR DESCRIPTION
### Heading Hierarchy
- Fix C5: h2 → h1 on all 24 Effort pages ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))

### Route Focus
- Fix C4: add route focus management via useRouteFocus composable ([2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html))

### Color-Only Indicators
- Fix C2: add warning icons + sr-only text for >100% values in PercentAssignmentTable, zero-effort rows in CourseEffortTable and EffortRecordsTable; add "Inactive" badges to PercentAssignmentTable ([1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html))

### Toggle Labels
- Fix S5: add aria-label to 272 dense q-toggle switches in UnitList and EffortTypeList tables — labels include row context ([4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html))

### Table Captions
- Fix S7: add aria-label to PercentAssignmentTable, CourseEffortTable, EffortRecordsTable ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))

### Brand Colors
- Fix M6: replace off-brand Quasar colors (orange, orange-9, teal-8, cyan-8) with UC Davis semantic colors (warning, info) across 9 Effort components ([1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))

### StatusBanner Migration
- Replace q-banner error/info patterns with StatusBanner component in CourseEffortTable, CourseImportDialog, EffortRecordsDisplay, CourseDetail, CourseList ([4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html))

### Report page contrast ([1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
- "No data found" messages across EvalSummary, TeachingActivityIndividual, TeachingActivityGrouped, MeritSummary, MeritAverage, ClinicalEffort, DeptSummary: `text-grey-6` (#9e9e9e, 2.7:1) → `text-grey-7` (#757575, 4.6:1) — now passes AA for small text
- TeachingActivityIndividual instructor department caption on `bg-grey-2`: `text-grey-7` (4.1:1 — fails on grey-2) → `text-grey-8` (5.1:1)
- InstructorPercentEditDialog person info caption on `bg-grey-2`: same `text-grey-7` → `text-grey-8` fix

### Dialog accessibility
- Add close affordances and aria-labels to CourseImportDialog, CourseLinkDialog, HarvestDialog, InstructorPercentEditDialog, LeaveEditorModal, ReportDeptTabs

### Config
- ESLint: add no-restricted-imports rule warning on explicit Quasar component imports (auto-imported by vite plugin)
- Vite: disable Quasar sassVariables to speed up builds