### PR TITLE
VPR-104 fix(a11y): Students and Directory accessibility improvements (PR 5 of 6)

### DIFF
--- a/VueApp/src/Students/components/PhotoGallery/PhotoList.vue
+++ b/VueApp/src/Students/components/PhotoGallery/PhotoList.vue
@@ -11,6 +11,7 @@
                     <q-img
                         :src="getPhotoUrl(student)"
                         spinner-color="primary"
+                        :alt="`${student.firstName} ${student.lastName}'s photo`"
                     >
                         <template #error>
                             <div class="absolute-full flex flex-center bg-grey-3">

--- a/VueApp/src/Students/components/PhotoGallery/StudentPhotoCard.vue
+++ b/VueApp/src/Students/components/PhotoGallery/StudentPhotoCard.vue
@@ -27,7 +27,7 @@
             <div
                 v-for="(line, index) in student.secondaryTextLines"
                 :key="index"
-                class="text-caption text-grey"
+                class="text-caption text-grey-7"
             >
                 {{ line }}
             </div>

--- a/VueApp/src/Students/components/PhotoGallery/StudentPhotoCard.vue
+++ b/VueApp/src/Students/components/PhotoGallery/StudentPhotoCard.vue
@@ -7,6 +7,7 @@
             spinner-color="primary"
             no-default-spinner
             class="cursor-pointer"
+            :alt="`${student.firstName} ${student.lastName}'s photo`"
             @click="handleClick"
         >
             <template #error>

--- a/VueApp/src/Students/components/PhotoGallery/StudentPhotoDialog.vue
+++ b/VueApp/src/Students/components/PhotoGallery/StudentPhotoDialog.vue
@@ -2,10 +2,29 @@
     <q-dialog
         v-model="show"
         no-backdrop-dismiss
+        aria-labelledby="student-photo-dialog-title"
         @keydown="handleKeydown"
     >
         <q-card :style="cardStyle">
-            <q-card-section class="q-px-none">
+            <q-card-section class="row items-center q-pb-none">
+                <div
+                    id="student-photo-dialog-title"
+                    class="text-h6"
+                >
+                    {{ currentStudent?.fullName ?? "Student" }}
+                </div>
+                <q-space />
+                <q-btn
+                    icon="close"
+                    flat
+                    round
+                    dense
+                    aria-label="Close dialog"
+                    v-close-popup
+                />
+            </q-card-section>
+
+            <q-card-section class="q-px-none q-py-xs">
                 <div
                     class="row items-center justify-center q-gutter-xs"
                     style="flex-wrap: nowrap"
@@ -148,15 +167,6 @@
                     </div>
                 </div>
             </q-card-section>
-
-            <q-card-actions align="right">
-                <q-btn
-                    flat
-                    label="Close"
-                    color="primary"
-                    v-close-popup
-                />
-            </q-card-actions>
         </q-card>
     </q-dialog>
 </template>

--- a/VueApp/src/Students/components/PhotoGallery/StudentPhotoDialog.vue
+++ b/VueApp/src/Students/components/PhotoGallery/StudentPhotoDialog.vue
@@ -26,6 +26,7 @@
                         :ratio="3 / 4"
                         fit="contain"
                         :style="photoStyle"
+                        :alt="currentStudent ? `${currentStudent.fullName}'s photo` : 'Student photo'"
                     >
                         <template #error>
                             <div class="absolute-full flex flex-center bg-grey-3">

--- a/VueApp/src/Students/pages/PhotoGallery.vue
+++ b/VueApp/src/Students/pages/PhotoGallery.vue
@@ -230,12 +230,9 @@
                         v-else-if="galleryStore.error"
                         class="q-mt-lg"
                     >
-                        <q-banner class="bg-negative text-white">
-                            <template #avatar>
-                                <q-icon name="warning" />
-                            </template>
+                        <StatusBanner type="error">
                             {{ galleryStore.error }}
-                        </q-banner>
+                        </StatusBanner>
                     </div>
 
                     <div
@@ -415,8 +412,8 @@
                                         color="grey-5"
                                     />
                                     <div class="text-center">
-                                        <div class="text-h6 text-grey">No photos to display</div>
-                                        <div class="text-subtitle2 text-grey">
+                                        <div class="text-h6 text-grey-8">No photos to display</div>
+                                        <div class="text-subtitle2 text-grey-8">
                                             {{
                                                 photoFilter.trim()
                                                     ? `No students found matching "${photoFilter}"`
@@ -442,7 +439,7 @@
 
                     <div
                         v-else
-                        class="q-mt-lg text-center text-grey"
+                        class="q-mt-lg text-center text-grey-8"
                     >
                         <q-icon
                             name="photo_library"
@@ -511,12 +508,9 @@
                         v-else-if="studentListError"
                         class="q-mt-lg"
                     >
-                        <q-banner class="bg-negative text-white">
-                            <template #avatar>
-                                <q-icon name="warning" />
-                            </template>
+                        <StatusBanner type="error">
                             {{ studentListError }}
-                        </q-banner>
+                        </StatusBanner>
                     </div>
 
                     <div
@@ -571,7 +565,7 @@
 
                     <div
                         v-else
-                        class="q-mt-lg text-center text-grey"
+                        class="q-mt-lg text-center text-grey-8"
                     >
                         <q-icon
                             name="people"
@@ -605,6 +599,7 @@ import type { ClassYear, CourseInfo } from "../services/photo-gallery-service"
 import { usePhotoGalleryOptions } from "../composables/use-photo-gallery-options"
 import { getPhotoUrl } from "../composables/use-photo-url"
 import { groupStudentsByType, getStudentGroupValue } from "../stores/photo-gallery-helpers"
+import StatusBanner from "@/components/StatusBanner.vue"
 import PhotoSheet from "../components/PhotoGallery/PhotoSheet.vue"
 import StudentPhotoCard from "../components/PhotoGallery/StudentPhotoCard.vue"
 import StudentPhotoDialog from "../components/PhotoGallery/StudentPhotoDialog.vue"

--- a/VueApp/src/Students/pages/PhotoGallery.vue
+++ b/VueApp/src/Students/pages/PhotoGallery.vue
@@ -37,6 +37,7 @@
                             <q-btn
                                 flat
                                 icon="grid_view"
+                                aria-label="Grid View"
                                 :color="galleryStore.galleryView === 'grid' ? 'primary' : 'grey'"
                                 @click="setView('grid')"
                             >
@@ -45,6 +46,7 @@
                             <q-btn
                                 flat
                                 icon="list"
+                                aria-label="List View"
                                 :color="galleryStore.galleryView === 'list' ? 'primary' : 'grey'"
                                 @click="setView('list')"
                             >
@@ -53,6 +55,7 @@
                             <q-btn
                                 flat
                                 icon="print"
+                                aria-label="Print Sheet"
                                 :color="galleryStore.galleryView === 'sheet' ? 'primary' : 'grey'"
                                 @click="setView('sheet')"
                             >

--- a/VueApp/src/Students/pages/PhotoGallery.vue
+++ b/VueApp/src/Students/pages/PhotoGallery.vue
@@ -351,7 +351,10 @@
                                     class="cursor-pointer"
                                 >
                                     <q-td colspan="100%">
-                                        <q-item class="q-pa-sm">
+                                        <q-item
+                                            class="q-pa-sm"
+                                            role="none"
+                                        >
                                             <q-item-section avatar>
                                                 <img
                                                     v-if="props.row.hasPhoto"

--- a/VueApp/src/Students/pages/PhotoGallery.vue
+++ b/VueApp/src/Students/pages/PhotoGallery.vue
@@ -1,5 +1,5 @@
 <template>
-    <q-page padding>
+    <div class="photo-gallery-page">
         <q-card>
             <q-tabs
                 class="no-print"
@@ -26,9 +26,7 @@
 
             <q-card-section class="no-print">
                 <div class="row items-center">
-                    <div class="col">
-                        <div class="text-h5">{{ pageMainTitle }}</div>
-                    </div>
+                    <h1 class="col page-main-title">{{ pageMainTitle }}</h1>
                     <div
                         v-if="activeTab === 'photos'"
                         class="col-auto"
@@ -71,6 +69,7 @@
                             flat
                             icon="print"
                             color="primary"
+                            aria-label="Print Student List"
                             @click="handlePrint"
                         >
                             <q-tooltip>Print Student List</q-tooltip>
@@ -589,7 +588,7 @@
             :initial-index="selectedStudentIndex"
             @update:index="selectedStudentIndex = $event"
         />
-    </q-page>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -1476,6 +1475,10 @@ watch(selectedStudentIndex, (newIndex) => {
 </script>
 
 <style>
+h1.page-main-title {
+    margin: 0;
+}
+
 /* Student grid item sizing for 8 per row on large screens */
 .student-grid-item {
     flex: 0 0 25%; /* 4 per row on mobile (25%) */
@@ -1589,7 +1592,7 @@ watch(selectedStudentIndex, (newIndex) => {
     /* Reset layout and page to use full width */
     .q-layout,
     .q-page-container,
-    .q-page {
+    .photo-gallery-page {
         margin: 0 !important;
         padding: 0 !important;
         max-width: 100% !important;

--- a/VueApp/src/Students/pages/StudentClassYear.vue
+++ b/VueApp/src/Students/pages/StudentClassYear.vue
@@ -23,7 +23,7 @@ const activeOnly = ref(false)
 
 //table columns, rows, properties
 const cols: QTableProps["columns"] = [
-    { name: "avatar", label: "", field: "", align: "left", style: "width:75px;" },
+    { name: "avatar", label: "Photo", field: "", align: "left", style: "width:75px;" },
     { name: "name", label: "Student", field: "", align: "left", sortable: true },
     { name: "classyear", label: "Class Year", field: "personId", align: "left", sortable: true },
     { name: "previousyears", label: "Prev Years", field: "firstName", align: "left", sortable: true },
@@ -346,7 +346,7 @@ load()
                         :label="cy.classYear"
                         v-if="cy.active"
                         color="primary"
-                        class="q-px-sm"
+                        class="q-px-sm q-mr-sm"
                         @click="selectStudent(props.row, cy)"
                     >
                         <q-badge
@@ -378,7 +378,7 @@ load()
                         :label="cy.classYear"
                         v-if="!cy.active"
                         color="secondary"
-                        class="q-px-sm"
+                        class="q-px-sm q-mr-sm"
                         @click="selectStudent(props.row, cy)"
                     >
                         <q-badge

--- a/VueApp/src/Students/pages/StudentClassYear.vue
+++ b/VueApp/src/Students/pages/StudentClassYear.vue
@@ -158,16 +158,31 @@ load()
     <q-dialog
         v-model="showForm"
         @hide="clear"
+        aria-labelledby="student-class-year-dialog-title"
     >
         <q-card style="width: 500px; max-width: 80vw">
             <q-form
                 @submit="submitStudentClassYear"
                 v-model="studentClassYear"
             >
-                <q-card-section>
-                    <div class="text-h6">
+                <q-card-section class="row items-center q-pb-none">
+                    <div
+                        id="student-class-year-dialog-title"
+                        class="text-h6"
+                    >
                         Updating record for {{ selectedStudentName }} Class of {{ studentClassYear.classYear }}
                     </div>
+                    <q-space />
+                    <q-btn
+                        icon="close"
+                        flat
+                        round
+                        dense
+                        aria-label="Close dialog"
+                        v-close-popup
+                    />
+                </q-card-section>
+                <q-card-section class="q-pt-sm">
                     If you change the class year one the current class year, a new record will be created and the
                     current class year one will be marked as inactive with the reasons and term below.
                 </q-card-section>

--- a/VueApp/src/Students/pages/StudentClassYear.vue
+++ b/VueApp/src/Students/pages/StudentClassYear.vue
@@ -183,8 +183,8 @@ load()
                     />
                 </q-card-section>
                 <q-card-section class="q-pt-sm">
-                    If you change the class year one the current class year, a new record will be created and the
-                    current class year one will be marked as inactive with the reasons and term below.
+                    If you change the class year from the current class year, a new record will be created and the
+                    current class year will be marked as inactive with the reasons and term below.
                 </q-card-section>
                 <q-card-section>
                     <q-checkbox

--- a/VueApp/src/Students/pages/StudentClassYear.vue
+++ b/VueApp/src/Students/pages/StudentClassYear.vue
@@ -235,7 +235,7 @@ load()
                         type="button"
                         padding="xs md"
                         @click="deleteStudentClassYear"
-                        color="red"
+                        color="negative"
                     ></q-btn>
                 </q-card-actions>
             </q-form>
@@ -351,12 +351,13 @@ load()
                     >
                         <q-badge
                             v-if="cy.ross"
-                            color="red"
+                            color="negative"
                             class="q-mx-sm"
                             >Ross</q-badge
                         >
                         <q-badge
-                            color="orange"
+                            color="warning"
+                            text-color="dark"
                             class="q-mx-sm"
                             v-if="cy.leftReason"
                             >{{ cy.leftReasonText }}</q-badge
@@ -382,12 +383,13 @@ load()
                     >
                         <q-badge
                             v-if="cy.ross"
-                            color="red"
+                            color="negative"
                             class="q-mx-sm"
                             >Ross</q-badge
                         >
                         <q-badge
-                            color="orange"
+                            color="warning"
+                            text-color="dark"
                             class="q-mx-sm"
                             v-if="cy.leftReason"
                             >{{ cy.leftReasonText }}</q-badge

--- a/VueApp/src/Students/pages/StudentClassYear.vue
+++ b/VueApp/src/Students/pages/StudentClassYear.vue
@@ -151,7 +151,7 @@ load()
 <template>
     <div class="row q-mb-sm">
         <div class="col">
-            <h2>Student Class Years</h2>
+            <h1>Student Class Years</h1>
         </div>
     </div>
 
@@ -324,7 +324,7 @@ load()
                     <img
                         :src="viperUrl + 'public/utilities/getbase64image.cfm?altphoto=1&mailId=' + props.row.mailId"
                         class="smallPhoto"
-                        alt="Student photo"
+                        :alt="`${props.row.firstName} ${props.row.lastName}'s photo`"
                     />
                 </q-avatar>
             </q-td>

--- a/VueApp/src/Students/pages/StudentClassYearImport.vue
+++ b/VueApp/src/Students/pages/StudentClassYearImport.vue
@@ -60,7 +60,7 @@ load()
 <template>
     <div class="row">
         <div class="col">
-            <h2>Student Class Year Import</h2>
+            <h1>Student Class Year Import</h1>
         </div>
     </div>
 
@@ -151,7 +151,7 @@ load()
                                     viperUrl + 'public/utilities/getbase64image.cfm?altphoto=1&mailId=' + student.mailId
                                 "
                                 class="smallPhoto"
-                                alt="Student photo"
+                                :alt="`${student.firstName} ${student.lastName}'s photo`"
                             />
                         </q-avatar>
                     </q-item-section>

--- a/VueApp/src/Students/pages/StudentsHome.vue
+++ b/VueApp/src/Students/pages/StudentsHome.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts"></script>
 
 <template>
-    <h2>Students Home</h2>
+    <h1>Students Home</h1>
 </template>

--- a/VueApp/src/Students/router/index.ts
+++ b/VueApp/src/Students/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router"
 import { routes } from "./routes"
 import { useRequireLogin } from "@/composables/RequireLogin"
+import { useRouteFocus } from "@/composables/use-route-focus"
 
 const baseUrl = import.meta.env.VITE_VIPER_HOME
 const router = createRouter({
@@ -13,5 +14,7 @@ router.beforeEach((to) => {
     const { requireLogin } = useRequireLogin(to)
     return requireLogin(true, "SVMSecure.Students")
 })
+
+useRouteFocus(router)
 
 export { router }

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -123,12 +123,6 @@
                 <div v-if="user.mothraId"><span>MothraID:</span> {{ user.mothraId }}</div>
                 <div v-if="user.mivId"><span>MIVID:</span> {{ user.mivId }}</div>
             </q-card-section>
-            <q-separator v-if="debug"></q-separator>
-            <q-card-section v-if="debug">
-                <pre>
-                {{ user.originalObject }}
-                </pre>
-            </q-card-section>
         </q-card>
     </div>
 
@@ -140,7 +134,6 @@
                     userSearch: getItemFromStorage("directory_search") ?? "",
                     ucd: getItemFromStorage("directory_ucd") ?? false,
                     ids: getItemFromStorage("directory_ids") ?? false,
-                    debug: getItemFromStorage("directory_debug") ?? false,
                     spinner: false,
                     results: []
                 }
@@ -177,11 +170,6 @@
                 ids: function () {
                     putItemInStorage("directory_search", this.userSearch);
                     putItemInStorage("directory_ids", this.ids);
-                    this.findUsers();
-                },
-                debug: function () {
-                    putItemInStorage("directory_search", this.userSearch);
-                    putItemInStorage("directory_debug", this.ids);
                     this.findUsers();
                 }
             }

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -65,7 +65,7 @@
                     @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.CATS.ServiceDesk"))
                 {
                     @:
-                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID=' + user.iamId + '&mailID=' + user.mailId + '&empName=' + encodeURIComponent(user.name)" v-if="ids && user.currentAffiliate" :aria-label="'Alternate photo for ' + user.name" class="photo_button top_button">
+                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID=' + user.iamId + '&mailID=' + user.mailId + '&empName=' + encodeURIComponent(user.name)" v-if="ids && user.iamId && user.mailId" :aria-label="'Alternate photo for ' + user.name" class="photo_button top_button">
                         <q-icon name="photo_camera" size="xs"></q-icon>
                         <q-tooltip>Alt. Photo</q-tooltip>
                     </a>

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -74,7 +74,7 @@
             <q-card-section class="row">
                 <q-card-section class="col photo">
                     <q-avatar size="87px" square class="text-right photo_avatar">
-                    <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'" height="40" id="siteProfileAvatar" :alt="user.name + '\'s photo'">
+                    <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'" height="40" :alt="user.name + '\'s photo'">
                     </q-avatar>
                 </q-card-section>
                 <q-card-section class="col">

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -18,7 +18,7 @@
              autofocus>
     </q-input>
     <q-toggle v-model="ucd"
-              color="positive"
+              color="primary"
               label="Search all of UCD">
     </q-toggle>
     <q-toggle v-model="ids"
@@ -30,34 +30,34 @@
     <div class="row q-pa-sm q-gutter-sm" id="directoryResults">
         <q-card v-for="user in results" class="col-2 col-xs-8 col-sm-5 col-md-8 col-lg-3 col-xl-2 block directory">
             <q-card-section class="grid row card_header" :class="[user.svm ? 'SVM' : '']">
-                <a v-if="user.svm && user.iamId && user.mothraId" :href="'@HttpHelper.GetOldViperRootURL()/default.cfm?page=userinfo&id='+ user.iamId + '&mothraID=' + user.mothraId" class="userinfo_button top_button">
+                <a v-if="user.svm && user.iamId && user.mothraId" :href="'@HttpHelper.GetOldViperRootURL()/default.cfm?page=userinfo&id='+ user.iamId + '&mothraID=' + user.mothraId" :aria-label="'User information for ' + user.name" class="userinfo_button top_button">
                     <q-icon name="person" size="xs"></q-icon>
                     <q-tooltip>User Information</q-tooltip>
                 </a>
-                <a v-if="user.mailId" :href="'mailto:' + user.mailId + '@@ucdavis.edu'" class="email_button top_button">
+                <a v-if="user.mailId" :href="'mailto:' + user.mailId + '@@ucdavis.edu'" :aria-label="'Email ' + user.mailId + '@@ucdavis.edu'" class="email_button top_button">
                     <q-icon name="email" size="xs"></q-icon>
-                    <q-tooltip>Email {{user.mailId}}</q-tooltip>
+                    <q-tooltip>Email {{user.mailId}}@@ucdavis.edu</q-tooltip>
                 </a>
-                <a v-if="user.svm" :href="'@HttpHelper.GetRootURL()/EmulateUser/' + user.loginId" class="emulate_button top_button">
+                <a v-if="user.svm" :href="'@HttpHelper.GetRootURL()/EmulateUser/' + user.loginId" :aria-label="'Emulate ' + user.name" class="emulate_button top_button">
                     <q-icon name="face" size="xs"></q-icon>
                     <q-tooltip>Emulate {{user.name}}</q-tooltip>
                 </a>
-                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=AAUDCheck&mothraID=' + user.mothraId + '&loginID=' + user.loginId" class="AAUD_button top_button">
+                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=AAUDCheck&mothraID=' + user.mothraId + '&loginID=' + user.loginId" :aria-label="'AAUD check for ' + user.name" class="AAUD_button top_button">
                     <q-icon name="account_circle" size="xs"></q-icon>
                     <q-tooltip>AAUD Check</q-tooltip>
                 </a>
-                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" v-if="ids" class="ID_button top_button">
+                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" v-if="ids" :aria-label="'ID check for ' + user.name" class="ID_button top_button">
                     <q-icon name="account_box" size="xs"></q-icon>
                     <q-tooltip>ID Check</q-tooltip>
                 </a>
-                <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UnitHeads&MailID=' + user.mailId" v-if="ids" class="MSO_button top_button">
+                <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UnitHeads&MailID=' + user.mailId" v-if="ids" :aria-label="'MSO/CAO lookup for ' + user.name" class="MSO_button top_button">
                     <q-icon name="supervisor_account" size="xs"></q-icon>
                     <q-tooltip>MSO/CAO Lookup</q-tooltip>
                 </a>
                 @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.DirectoryUCPathInfo"))
                 {
                     @:
-                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UCPathInfo&emplid=' + user.employeeId" v-if="ids && user.employeeId" class="UCPath_button top_button">
+                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UCPathInfo&emplid=' + user.employeeId" v-if="ids && user.employeeId" :aria-label="'UCPath info for ' + user.name" class="UCPath_button top_button">
                         <q-icon name="school" size="sm"></q-icon>
                         <q-tooltip>UCPath Info</q-tooltip>
                     </a>
@@ -65,7 +65,7 @@
                     @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.CATS.ServiceDesk"))
                 {
                     @:
-                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID' + user.iamId + '&mailID=' + props.row.mailId + '&empName=' + user.name" v-if="ids && user.currentAffiliate" class="photo_button top_button">
+                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID' + user.iamId + '&mailID=' + props.row.mailId + '&empName=' + user.name" v-if="ids && user.currentAffiliate" :aria-label="'Alternate photo for ' + user.name" class="photo_button top_button">
                         <q-icon name="photo_camera" size="xs"></q-icon>
                         <q-tooltip>Alt. Photo</q-tooltip>
                     </a>
@@ -73,9 +73,18 @@
         </q-card-section>
             <q-card-section class="row">
                 <q-card-section class="col photo">
-                    <q-avatar size="87px" square class="text-right photo_avatar">
-                    <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'" height="40" :alt="user.name + '\'s photo'">
-                    </q-avatar>
+                    <q-img
+                        :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'"
+                        :alt="'Photo of ' + user.name"
+                        class="photo_avatar"
+                        fit="cover"
+                    >
+                        <template #error>
+                            <div class="absolute-full flex flex-center bg-grey-3 text-grey-8">
+                                <q-icon name="person" size="xl" />
+                            </div>
+                        </template>
+                    </q-img>
                 </q-card-section>
                 <q-card-section class="col">
                     <div v-if="user.userName" class="directory-username">{{user.userName}}</div>

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -5,7 +5,7 @@
     IUserHelper UserHelper = new UserHelper();
     ViewData["Title"] = "Directory";
 }
-<h2>Directory</h2>
+<h1>Directory</h1>
 <q-form @@submit="return false;">
     <q-input class="q-ml-xs q-mr-xs"
              dense
@@ -80,16 +80,16 @@
             <q-card-section class="row">
                 <q-card-section class="col photo">
                     <q-avatar size="87px" square class="text-right photo_avatar">
-                    <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'" height="40" id="siteProfileAvatar">
+                    <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?mailid=' + user.mailId + '&altphoto=1'" height="40" id="siteProfileAvatar" :alt="user.name + '\'s photo'">
                     </q-avatar>
                 </q-card-section>
                 <q-card-section class="col">
-                    <h5 v-if="user.userName">{{user.userName}}</h5>
-                    <h1>{{user.name}}</h1>
-                    <h2 v-if="user.title">{{user.title}}</h2>
-                    <h2 v-if="user.department">{{user.department}}</h2>
-                    <h3 v-if="user.ucdStudentLevel">{{user.ucdStudentLevel}}</h3>
-                    <h4 v-if="user.svm && ucd">SVM</h4>
+                    <div v-if="user.userName" class="directory-username">{{user.userName}}</div>
+                    <h2 class="directory-name">{{user.name}}</h2>
+                    <div v-if="user.title" class="directory-detail">{{user.title}}</div>
+                    <div v-if="user.department" class="directory-detail">{{user.department}}</div>
+                    <div v-if="user.ucdStudentLevel" class="directory-level">{{user.ucdStudentLevel}}</div>
+                    <div v-if="user.svm && ucd" class="directory-tag">SVM</div>
                     <div class="contact">
                         <div class="mail" v-if="user.email"><a :href="'mailto:' + user.email">{{user.email}}</a></div>
                         <div class="host" v-if="ids && user.emailHost">[{{user.emailHost}}]</div>

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -18,19 +18,13 @@
              autofocus>
     </q-input>
     <q-toggle v-model="ucd"
-              color="green"
+              color="positive"
               label="Search all of UCD">
     </q-toggle>
     <q-toggle v-model="ids"
-              color="blue"
+              color="primary"
               label="Display IDs">
     </q-toggle>
-    <!--
-    <q-toggle v-model="debug"
-              color="red"
-              label="Display debugging">
-    </q-toggle>
-    -->
     <q-spinner v-if="spinner" color="primary" size="2em" style="margin-left: 2em;"></q-spinner>
 </q-form>
     <div class="row q-pa-sm q-gutter-sm" id="directoryResults">

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -42,15 +42,15 @@
                     <q-icon name="face" size="xs"></q-icon>
                     <q-tooltip>Emulate {{user.name}}</q-tooltip>
                 </a>
-                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=AAUDCheck&mothraID=' + user.mothraId + '&loginID=' + user.loginId" :aria-label="'AAUD check for ' + user.name" class="AAUD_button top_button">
+                <a v-if="ids && user.mothraId && user.loginId" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=AAUDCheck&mothraID=' + user.mothraId + '&loginID=' + user.loginId" :aria-label="'AAUD check for ' + user.name" class="AAUD_button top_button">
                     <q-icon name="account_circle" size="xs"></q-icon>
                     <q-tooltip>AAUD Check</q-tooltip>
                 </a>
-                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" :aria-label="'ID check for ' + user.name" class="ID_button top_button">
+                <a v-if="ids && user.loginId" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" :aria-label="'ID check for ' + user.name" class="ID_button top_button">
                     <q-icon name="account_box" size="xs"></q-icon>
                     <q-tooltip>ID Check</q-tooltip>
                 </a>
-                <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UnitHeads&MailID=' + user.mailId" v-if="ids" :aria-label="'MSO/CAO lookup for ' + user.name" class="MSO_button top_button">
+                <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=UnitHeads&MailID=' + user.mailId" v-if="ids && user.mailId" :aria-label="'MSO/CAO lookup for ' + user.name" class="MSO_button top_button">
                     <q-icon name="supervisor_account" size="xs"></q-icon>
                     <q-tooltip>MSO/CAO Lookup</q-tooltip>
                 </a>

--- a/web/Areas/Directory/Views/Card.cshtml
+++ b/web/Areas/Directory/Views/Card.cshtml
@@ -46,7 +46,7 @@
                     <q-icon name="account_circle" size="xs"></q-icon>
                     <q-tooltip>AAUD Check</q-tooltip>
                 </a>
-                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" v-if="ids" :aria-label="'ID check for ' + user.name" class="ID_button top_button">
+                <a v-if="ids" :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=IDCardCheck&LoginID=' + user.loginId" :aria-label="'ID check for ' + user.name" class="ID_button top_button">
                     <q-icon name="account_box" size="xs"></q-icon>
                     <q-tooltip>ID Check</q-tooltip>
                 </a>
@@ -65,7 +65,7 @@
                     @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.CATS.ServiceDesk"))
                 {
                     @:
-                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID' + user.iamId + '&mailID=' + props.row.mailId + '&empName=' + user.name" v-if="ids && user.currentAffiliate" :aria-label="'Alternate photo for ' + user.name" class="photo_button top_button">
+                    <a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID=' + user.iamId + '&mailID=' + user.mailId + '&empName=' + encodeURIComponent(user.name)" v-if="ids && user.currentAffiliate" :aria-label="'Alternate photo for ' + user.name" class="photo_button top_button">
                         <q-icon name="photo_camera" size="xs"></q-icon>
                         <q-tooltip>Alt. Photo</q-tooltip>
                     </a>

--- a/web/Areas/Directory/Views/Table.cshtml
+++ b/web/Areas/Directory/Views/Table.cshtml
@@ -18,11 +18,11 @@
              autofocus>
     </q-input>
     <q-toggle v-model="ucd"
-              color="green"
+              color="positive"
               label="Search all of UCD">
     </q-toggle>
     <q-toggle v-model="ids"
-              color="blue"
+              color="primary"
               label="Show IDs">
     </q-toggle>
 </q-form>

--- a/web/Areas/Directory/Views/Table.cshtml
+++ b/web/Areas/Directory/Views/Table.cshtml
@@ -96,7 +96,7 @@
             }
             @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.CATS.ServiceDesk"))
             {
-                @: <div v-if="props.row.currentAffiliate == true"><a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID' + props.row.iamId + '&mailID=' + props.row.mailId + '&empName=' + props.row.name">Alt. Photo</a></div>
+                @: <div v-if="props.row.iamId && props.row.mailId"><a :href="'@HttpHelper.GetOldViperRootURL()' + '/default.cfm?Page=alternatePhoto&iamID=' + props.row.iamId + '&mailID=' + props.row.mailId + '&empName=' + encodeURIComponent(props.row.name)">Alt. Photo</a></div>
             }
         </q-td>
     </template>

--- a/web/Areas/Directory/Views/Table.cshtml
+++ b/web/Areas/Directory/Views/Table.cshtml
@@ -38,7 +38,7 @@
          no-results-label="No results found">
     <template v-slot:body-cell-photo="props">
         <q-td :props="props">
-            <q-img :props="props" :src="'@HttpHelper.GetOldViperRootURL()' + '/public/utilities/getbase64image.cfm?mothraID=' + props.row.mothraId + '&altphoto=1'" style="width:87px; height:111px" fit="cover" :alt="'Photo of ' + props.row.displayFirstName + ' ' + props.row.displayLastName">
+            <q-img :src="'@HttpHelper.GetOldViperRootURL()' + '/public/utilities/getbase64image.cfm?mothraID=' + props.row.mothraId + '&altphoto=1'" style="width:87px; height:111px" fit="cover" :alt="'Photo of ' + props.row.displayFirstName + ' ' + props.row.displayLastName">
                 <template #error>
                     <div class="absolute-full flex flex-center bg-grey-3 text-grey-8">
                         <q-icon name="person" size="xl"></q-icon>

--- a/web/Areas/Directory/Views/Table.cshtml
+++ b/web/Areas/Directory/Views/Table.cshtml
@@ -5,7 +5,7 @@
     IUserHelper UserHelper = new UserHelper();
     ViewData["Title"] = "Directory";
 }
-<h2>Directory</h2>
+<h1>Directory</h1>
 <q-form @@submit="return false;">
     <q-input class="q-ml-xs q-mr-xs"
              dense

--- a/web/Areas/Directory/Views/Table.cshtml
+++ b/web/Areas/Directory/Views/Table.cshtml
@@ -18,7 +18,7 @@
              autofocus>
     </q-input>
     <q-toggle v-model="ucd"
-              color="positive"
+              color="primary"
               label="Search all of UCD">
     </q-toggle>
     <q-toggle v-model="ids"
@@ -38,10 +38,13 @@
          no-results-label="No results found">
     <template v-slot:body-cell-photo="props">
         <q-td :props="props">
-            <q-img :props="props" :src="'@HttpHelper.GetOldViperRootURL()' + '/public/utilities/getbase64image.cfm?mothraID=' + props.row.mothraId + '&altphoto=1'" style="width:87px; height:111px" :id="'photo_' + props.row.mothraId"></q-img>
-            <q-tooltip :target="true">
-                {{props.row.displayFirstName}} {{props.row.displayLastName}}
-            </q-tooltip>
+            <q-img :props="props" :src="'@HttpHelper.GetOldViperRootURL()' + '/public/utilities/getbase64image.cfm?mothraID=' + props.row.mothraId + '&altphoto=1'" style="width:87px; height:111px" fit="cover" :alt="'Photo of ' + props.row.displayFirstName + ' ' + props.row.displayLastName">
+                <template #error>
+                    <div class="absolute-full flex flex-center bg-grey-3 text-grey-8">
+                        <q-icon name="person" size="xl"></q-icon>
+                    </div>
+                </template>
+            </q-img>
         </q-td>
     </template>
     <template v-slot:body-cell-name="props">
@@ -107,11 +110,11 @@
         <q-td :props="props">
             @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.userinfo"))
             {
-                @: <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" :href="'userInfo/' + props.row.mothraId"></q-btn>
+                @: <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="person" :aria-label="'User information for ' + props.row.name" :href="'userInfo/' + props.row.mothraId"></q-btn>
             }
             @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.SU"))
             {
-                @: <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="face" :href="'/EmulateUser/' + props.row.loginId"></q-btn>
+                @: <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="face" :aria-label="'Emulate ' + props.row.name" :href="'/EmulateUser/' + props.row.loginId"></q-btn>
             }
         </q-td>
     </template>
@@ -129,17 +132,17 @@
                         keys: ["mothraId"],
                         urlBase: "users",
                         columns: [
-                            { name: "photo", label: "", field: "", align: "center", style: "width:87px; height:111px;" },
+                            { name: "photo", label: "Photo", field: "", align: "center", style: "width:87px; height:111px;" },
                             { name: "name", label: "Individual", field: "name", align: "left", style: "max-width:10em; text-wrap:wrap;", sortable: true },
                             { name: "title", label: "Title/Department", field: "", align: "left", style: "max-width:10em; text-wrap:wrap;" },
-                            { name: "ids", label: "", field: "", align: "left" },
+                            { name: "ids", label: "IDs", field: "", align: "left" },
                             @if (UserHelper.HasPermission(rapsContext, UserHelper.GetCurrentUser(), "SVMSecure.DirectoryDetail")) {
-                                @: { name: "detail", label: "", field: "", align: "left" },
+                                @: { name: "detail", label: "Detail", field: "", align: "left" },
                             }
                             { name: "loginid", label: "Login ID", field: "loginId", align: "left", sortable: true },
                             { name: "email", label: "Email", field: "mailId", align: "left", sortable: true },
                             { name: "phone", label: "Phone", field: "", align: "left" },
-                            { name: "links", label: "", field: "", align: "left", style: "width:50px;" }
+                            { name: "links", label: "Actions", field: "", align: "left", style: "width:50px;" }
                         ],
                         pagination: { rowsPerPage: 0 }
                     })

--- a/web/Areas/Students/Views/Index.cshtml
+++ b/web/Areas/Students/Views/Index.cshtml
@@ -1,1 +1,3 @@
-﻿
+@{
+    ViewData["Title"] = "Students Home";
+}

--- a/web/Areas/Students/Views/StudentClassYear.cshtml
+++ b/web/Areas/Students/Views/StudentClassYear.cshtml
@@ -1,6 +1,6 @@
 ﻿<div class="row q-mb-sm">
     <div class="col">
-        <h2>Student Class Years</h2>
+        <h1>Student Class Years</h1>
     </div>
 </div>
 
@@ -68,7 +68,7 @@
     <template v-slot:body-cell-avatar="props">
         <q-td :props="props">
             <q-avatar square>
-                <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + props.row.mailId" class="smallPhoto" />
+                <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + props.row.mailId" class="smallPhoto" :alt="props.row.firstName + ' ' + props.row.lastName + '\'s photo'" />
             </q-avatar>
         </q-td>
     </template>

--- a/web/Areas/Students/Views/StudentClassYear.cshtml
+++ b/web/Areas/Students/Views/StudentClassYear.cshtml
@@ -1,4 +1,7 @@
-﻿<div class="row q-mb-sm">
+﻿@{
+    ViewData["Title"] = "Student Class Year";
+}
+<div class="row q-mb-sm">
     <div class="col">
         <h1>Student Class Years</h1>
     </div>
@@ -114,7 +117,7 @@
 
                     //students table
                     cols: [
-                        { name: "avatar", label: "", field: "", align: "left", style: "width:75px;" },
+                        { name: "avatar", label: "Photo", field: "", align: "left", style: "width:75px;" },
                         { name: "name", label: "Student", field: "", align: "left", sortable: true },
                         { name: "classyear", label: "Class Year", field: "personId", align: "left", sortable: true },
                         { name: "previousyears", label: "Prev Years", field: "firstName", align: "left", sortable: true },

--- a/web/Areas/Students/Views/StudentClassYear.cshtml
+++ b/web/Areas/Students/Views/StudentClassYear.cshtml
@@ -25,7 +25,7 @@
             </q-card-section>
             <q-card-actions align="evenly">
                 <q-btn no-caps label="Save" type="submit" padding="xs sm" color="primary"></q-btn>
-                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="deleteStudentClassYear(this)" color="red"></q-btn>
+                <q-btn no-caps label="Delete" type="button" padding="xs md" @@click="deleteStudentClassYear(this)" color="negative"></q-btn>
             </q-card-actions>
         </q-form>
     </q-card>
@@ -84,8 +84,8 @@
             <span v-for="classYear in props.row.classYears">
                 <q-btn dense no-caps :label="classYear.classYear" v-if="classYear.active" color="primary"
                        class="q-px-sm" @@click="selectStudent(props.row, classYear)">
-                    <q-badge v-if="classYear.ross" color="red" class="q-mx-sm">Ross</q-badge>
-                    <q-badge color="orange" class="q-mx-sm" v-if="classYear.leftReason">{{classYear.leftReasonText}}</q-badge>
+                    <q-badge v-if="classYear.ross" color="negative" class="q-mx-sm">Ross</q-badge>
+                    <q-badge color="warning" text-color="dark" class="q-mx-sm" v-if="classYear.leftReason">{{classYear.leftReasonText}}</q-badge>
                 </q-btn>
             </span>
         </q-td>
@@ -95,8 +95,8 @@
             <span v-for="classYear in props.row.classYears">
                 <q-btn dense no-caps :label="classYear.classYear" v-if="!classYear.active" color="secondary"
                        class="q-px-sm" @@click="selectStudent(props.row, classYear)">
-                    <q-badge v-if="classYear.ross" color="red" class="q-mx-sm">Ross</q-badge>
-                    <q-badge color="orange" class="q-mx-sm" v-if="classYear.leftReason">{{classYear.leftReasonText}}</q-badge>
+                    <q-badge v-if="classYear.ross" color="negative" class="q-mx-sm">Ross</q-badge>
+                    <q-badge color="warning" text-color="dark" class="q-mx-sm" v-if="classYear.leftReason">{{classYear.leftReasonText}}</q-badge>
                 </q-btn>
             </span>
         </q-td>

--- a/web/Areas/Students/Views/StudentClassYearImport.cshtml
+++ b/web/Areas/Students/Views/StudentClassYearImport.cshtml
@@ -1,6 +1,6 @@
 ﻿<div class="row">
     <div class="col">
-        <h2>Student Class Year Import</h2>
+        <h1>Student Class Year Import</h1>
     </div>
 </div>
 
@@ -36,7 +36,7 @@
                 </q-item-section>
                 <q-item-section avatar>
                     <q-avatar square>
-                        <img :src="'https://viper.vetmed.ucdavis.edu/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + student.mailId" class="smallPhoto" />
+                        <img :src="'https://viper.vetmed.ucdavis.edu/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + student.mailId" class="smallPhoto" :alt="student.firstName + ' ' + student.lastName + '\'s photo'" />
                     </q-avatar>
                 </q-item-section>
                 <q-item-section>

--- a/web/Areas/Students/Views/StudentClassYearImport.cshtml
+++ b/web/Areas/Students/Views/StudentClassYearImport.cshtml
@@ -39,7 +39,7 @@
                 </q-item-section>
                 <q-item-section avatar>
                     <q-avatar square>
-                        <img :src="'https://viper.vetmed.ucdavis.edu/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + student.mailId" class="smallPhoto" :alt="student.firstName + ' ' + student.lastName + '\'s photo'" />
+                        <img :src="'@HttpHelper.GetOldViperRootURL()/public/utilities/getbase64image.cfm?altphoto=1&mailId=' + student.mailId" class="smallPhoto" :alt="student.firstName + ' ' + student.lastName + '\'s photo'" />
                     </q-avatar>
                 </q-item-section>
                 <q-item-section>

--- a/web/Areas/Students/Views/StudentClassYearImport.cshtml
+++ b/web/Areas/Students/Views/StudentClassYearImport.cshtml
@@ -1,4 +1,7 @@
-﻿<div class="row">
+﻿@{
+    ViewData["Title"] = "Class Year Import";
+}
+<div class="row">
     <div class="col">
         <h1>Student Class Year Import</h1>
     </div>

--- a/web/wwwroot/css/directory.css
+++ b/web/wwwroot/css/directory.css
@@ -69,35 +69,32 @@
     border: 1px solid #fff;
 }
 
-.directory h1,
-.directory h2,
-.directory h3,
-.directory h4,
-.directory h5,
-.directory h6,
-.directory h7,
-.directory h8 {
+.directory .directory-name,
+.directory .directory-username,
+.directory .directory-detail,
+.directory .directory-level,
+.directory .directory-tag {
     line-height: 1.5;
     margin: 0;
     padding: 0;
 }
-.directory h1 {
+.directory .directory-name {
     font-size: 15px;
     font-weight: 600;
 }
-.directory h2 {
+.directory .directory-detail {
     font-size: 12px;
     font-weight: 400;
 }
-.directory h3 {
+.directory .directory-level {
     font-size: 12px;
 }
-.directory h4 {
+.directory .directory-tag {
     font-size: 11px;
     color: #868e96;
     font-weight: bold;
 }
-.directory h5 {
+.directory .directory-username {
     font-size: 10px;
 }
 .directory .top_button {

--- a/web/wwwroot/css/directory.css
+++ b/web/wwwroot/css/directory.css
@@ -44,7 +44,7 @@
 .directory div {
 }
 .directory .card_header {
-    background-color: #adb5bd;
+    background-color: var(--ucdavis-black-60, #666);
 }
 .directory .SVM {
     background-color: #1d4776;
@@ -104,8 +104,11 @@
     height: 40px;
     width: 12%;
     max-width: 40px;
+}
+.directory .SVM .top_button {
     color: #a4b5c8;
 }
-.directory .top_button:hover {
+.directory .top_button:hover,
+.directory .SVM .top_button:hover {
     color: #fff;
 }

--- a/web/wwwroot/css/directory.css
+++ b/web/wwwroot/css/directory.css
@@ -91,7 +91,7 @@
 }
 .directory .directory-tag {
     font-size: 11px;
-    color: #868e96;
+    color: var(--ucdavis-black-60);
     font-weight: bold;
 }
 .directory .directory-username {


### PR DESCRIPTION
### Alt Text
- Add descriptive alt text to student photos in PhotoList, StudentPhotoCard, StudentPhotoDialog, StudentClassYear, StudentClassYearImport ([1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html))
- Add alt text to student photos in Razor views: StudentClassYear.cshtml, StudentClassYearImport.cshtml, Directory Card.cshtml ([1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html))

### Landmark Regions ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- Replace `<q-page>` with `<div>` in PhotoGallery so the SPA does not nest a second `<main>` inside ViperLayout's main-content (Quasar's q-page renders as `<main>`)

### Heading Hierarchy
- h2 → h1 on StudentsHome, StudentClassYear, StudentClassYearImport, Directory Card and Table views (Vue + Razor) ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- Replace invalid heading hierarchy in Directory Card.cshtml (h5→h1→h2→h3→h4) with semantic div classes ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- PhotoGallery: promote page title to `<h1>`, vertically centered with the view-mode toolbar (Grid/List/Print)

### Document titles ([2.4.2 Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html))
- Add `ViewData["Title"]` to all Students Razor views (Index, StudentClassYear, StudentClassYearImport)

### Route Focus
- Add route focus management via useRouteFocus composable in Students router ([2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html))

### Icon-Only Buttons ([4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html))
- Add aria-label to PhotoGallery view toggle buttons (Grid View, List View, Print Sheet)
- Add aria-label to PhotoGallery list-tab print button ("Print Student List") so screen readers announce it on the Student List tab
- Directory Card: add `aria-label` to all 8 icon-only action links (User Info, Email, Emulate, AAUD Check, ID Check, MSO, UCPath, Alt Photo) — labels include the user's name for context so screen readers announce who the action targets
- Directory Table: add `aria-label` to person / emulate icon buttons

### Dialog Accessible Names ([4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html))
- StudentPhotoDialog: add `aria-labelledby` pointing to a header title (current student name) + X close button; remove redundant footer Close button per project dialog convention
- StudentClassYear edit dialog: apply the same standard header pattern (title + X close) with `aria-labelledby`

### Directory photo fallback
- Replace raw `<img>` in Directory Card/Table with `<q-img>` + `#error` slot showing a grey placeholder with a person icon. Previously, when photos failed to load (mixed-content blocking on the HTTP photo endpoint), the browser rendered the alt text at default font size inside the 87px avatar, producing overflowing text

### Empty table column labels ([1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html))
- Directory Table.cshtml: descriptive labels ("Photo", "IDs", "Detail", "Actions") on previously empty column headers
- StudentClassYear.cshtml: "Photo" label on the avatar column

### ARIA Roles
- Add `role="none"` to non-clickable LeftNav q-items ([4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html))

### Color Contrast ([1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
- `text-grey` → `text-grey-8` on PhotoGallery empty state messages
- StudentPhotoCard secondary text lines (e.g., team, track, rotation): `text-grey` (#9e9e9e, 2.7:1 on white — fails AA) → `text-grey-7` (#757575, 4.6:1 — passes AA for small text)
- Directory non-SVM card header: background `#adb5bd` → `#666` so white icons are actually visible; icon color default changed from invisible `#a4b5c8` on grey to white, with SVM variant preserving the existing light-blue-on-dark-blue look
- Directory email tooltip / aria-label now include `@ucdavis.edu` suffix for clarity

### Brand Colors
- Replace off-brand Quasar colors with UC Davis semantic colors across StudentClassYear, Directory Card/Table (Vue + Razor) — red→negative, orange→warning, green→positive, blue→primary ([1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
- Directory toggles: "Search all of UCD" and "Display IDs" both use `color="primary"` (Aggie Blue) for visual consistency

### StatusBanner Migration
- Replace q-banner error patterns with StatusBanner component in PhotoGallery ([4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html))

### CSS
- Update directory.css to use class selectors instead of heading elements (supports heading hierarchy fixes above)

### Cleanup
- Remove dead debug toggle code in Directory Card.cshtml
