### PR TITLE
feat(effort): block manual re-import of VET 4XX Harvest courses

### DIFF
--- a/VueApp/src/Effort/__tests__/course-add-dialog.test.ts
+++ b/VueApp/src/Effort/__tests__/course-add-dialog.test.ts
@@ -138,7 +138,6 @@ describe("CourseAddDialog - Error Handling", () => {
 
     describe("Form Reset Behavior", () => {
         it("should reset form data to defaults", () => {
-            const defaultDepartment = "APC"
             const formData = ref({
                 subjCode: "OLD",
                 crseNumb: "999",
@@ -157,12 +156,12 @@ describe("CourseAddDialog - Error Handling", () => {
                 crn: "",
                 enrollment: 0,
                 units: 0,
-                custDept: defaultDepartment,
+                custDept: "",
             }
 
             expect(formData.value.subjCode).toBe("")
             expect(formData.value.enrollment).toBe(0)
-            expect(formData.value.custDept).toBe("APC")
+            expect(formData.value.custDept).toBe("")
         })
     })
 })

--- a/VueApp/src/Effort/__tests__/course-import-dialog.test.ts
+++ b/VueApp/src/Effort/__tests__/course-import-dialog.test.ts
@@ -1,5 +1,6 @@
 import { ref } from "vue"
 import { setActivePinia, createPinia } from "pinia"
+import { shouldShowImportButton, importButtonLabel, shouldShortcutToImport } from "../utils/import-button-rules"
 
 /**
  * Tests for CourseImportDialog error handling behavior.
@@ -158,6 +159,72 @@ describe("CourseImportDialog - Error Handling", () => {
             searchError.value = ""
 
             expect(searchError.value).toBe("")
+        })
+    })
+})
+
+/**
+ * The backend's `alreadyImported` flag is true for fixed-unit courses that
+ * exist in Effort for the term AND for VET 4XX courses (any unit type) that
+ * exist for the term — the latter are harvested during the Harvest period and
+ * cannot be manually re-imported. The frontend renders off this flag.
+ */
+describe("CourseImportDialog - alreadyImported Button Behavior", () => {
+    describe("Import Button Visibility", () => {
+        it("hides the button in staff mode when the course is already imported", () => {
+            expect(shouldShowImportButton(false, { alreadyImported: true })).toBeFalsy()
+        })
+
+        it("shows the button in staff mode when the course is not yet imported", () => {
+            expect(shouldShowImportButton(false, { alreadyImported: false })).toBeTruthy()
+        })
+
+        it("always shows the button in self mode so instructors can 'Use Course'", () => {
+            expect(shouldShowImportButton(true, { alreadyImported: true })).toBeTruthy()
+            expect(shouldShowImportButton(true, { alreadyImported: false })).toBeTruthy()
+        })
+    })
+
+    describe("Import Button Label", () => {
+        it("shows 'Use Course' in self mode when the course is already imported", () => {
+            expect(importButtonLabel(true, { alreadyImported: true })).toBe("Use Course")
+        })
+
+        it("shows 'Import' in self mode when the course is not yet imported", () => {
+            expect(importButtonLabel(true, { alreadyImported: false })).toBe("Import")
+        })
+
+        it("always shows 'Import' in staff mode", () => {
+            expect(importButtonLabel(false, { alreadyImported: true })).toBe("Import")
+            expect(importButtonLabel(false, { alreadyImported: false })).toBe("Import")
+        })
+    })
+
+    describe("startImport Shortcut (self-mode bypass of units dialog)", () => {
+        // Self mode shortcuts the options dialog when the course is already
+        // imported AND fixed-unit — the backend returns the existing row by
+        // CRN match. Variable-unit courses always open the dialog so the user
+        // can pick the unit value for a new import.
+        it("shortcuts fixed-unit already-imported courses in self mode", () => {
+            expect(shouldShortcutToImport(true, { alreadyImported: true, isVariableUnits: false })).toBeTruthy()
+        })
+
+        it("opens the dialog for non-harvest variable-unit courses so the user can pick units", () => {
+            // Non-VET-4XX variable-unit: alreadyImported is false, so no shortcut.
+            expect(shouldShortcutToImport(true, { alreadyImported: false, isVariableUnits: true })).toBeFalsy()
+        })
+
+        it("opens the dialog for VET 4XX variable-unit courses even when alreadyImported", () => {
+            // Under the new backend semantics, VET 4XX variable-unit existing in
+            // Effort has alreadyImported=true. The current shortcut check bails
+            // out on isVariableUnits, so the user goes through the units dialog
+            // (backend will return the existing row regardless of the unit value).
+            expect(shouldShortcutToImport(true, { alreadyImported: true, isVariableUnits: true })).toBeFalsy()
+        })
+
+        it("never shortcuts in staff mode (the button is hidden when alreadyImported)", () => {
+            expect(shouldShortcutToImport(false, { alreadyImported: true, isVariableUnits: false })).toBeFalsy()
+            expect(shouldShortcutToImport(false, { alreadyImported: true, isVariableUnits: true })).toBeFalsy()
         })
     })
 })

--- a/VueApp/src/Effort/components/CourseAddDialog.vue
+++ b/VueApp/src/Effort/components/CourseAddDialog.vue
@@ -147,7 +147,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue"
-import { useQuasar, QForm } from "quasar"
+import { useQuasar } from "quasar"
+import type { QForm } from "quasar"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import { courseService } from "../services/course-service"
 import { requiredRule, nonNegativeRule, wholeNumberRule } from "../validation"
@@ -200,7 +201,8 @@ watch(
                 crn: "",
                 enrollment: 0,
                 units: 0,
-                custDept: props.departments[0] ?? "",
+                // No default: force the user to make an explicit department choice.
+                custDept: "",
             }
             formRef.value?.resetValidation()
             setInitialState()

--- a/VueApp/src/Effort/components/CourseImportDialog.vue
+++ b/VueApp/src/Effort/components/CourseImportDialog.vue
@@ -70,15 +70,17 @@
                             color="primary"
                             :loading="isSearching"
                             :disable="!canSearch"
-                            class="full-width-xs"
+                            class="full-width-xs loading-btn"
                             @click="searchCourses"
                         >
                             <template #loading>
-                                <q-spinner
-                                    size="1em"
-                                    class="q-mr-sm"
-                                />
-                                Search
+                                <div class="row no-wrap items-center text-no-wrap">
+                                    <q-spinner
+                                        size="1em"
+                                        class="q-mr-sm"
+                                    />
+                                    Search
+                                </div>
                             </template>
                         </q-btn>
                     </div>
@@ -158,11 +160,11 @@
                                 | Enrollment: {{ course.enrollment }}
                             </div>
                             <div
-                                v-if="isSelfMode || !course.alreadyImported"
+                                v-if="shouldShowImportButton(isSelfMode, course)"
                                 class="q-mt-sm"
                             >
                                 <q-btn
-                                    :label="isSelfMode && course.alreadyImported ? 'Use Course' : 'Import'"
+                                    :label="importButtonLabel(isSelfMode, course)"
                                     color="primary"
                                     dense
                                     size="sm"
@@ -170,11 +172,13 @@
                                     @click="startImport(course)"
                                 >
                                     <template #loading>
-                                        <q-spinner
-                                            size="1em"
-                                            class="q-mr-sm"
-                                        />
-                                        {{ isSelfMode && course.alreadyImported ? "Use Course" : "Import" }}
+                                        <div class="row no-wrap items-center text-no-wrap">
+                                            <q-spinner
+                                                size="1em"
+                                                class="q-mr-sm"
+                                            />
+                                            {{ importButtonLabel(isSelfMode, course) }}
+                                        </div>
                                     </template>
                                 </q-btn>
                             </div>
@@ -243,8 +247,8 @@
                     <template #body-cell-actions="slotProps">
                         <q-td :props="slotProps">
                             <q-btn
-                                v-if="isSelfMode || !slotProps.row.alreadyImported"
-                                :label="isSelfMode && slotProps.row.alreadyImported ? 'Use Course' : 'Import'"
+                                v-if="shouldShowImportButton(isSelfMode, slotProps.row)"
+                                :label="importButtonLabel(isSelfMode, slotProps.row)"
                                 color="primary"
                                 dense
                                 size="sm"
@@ -252,11 +256,13 @@
                                 @click="startImport(slotProps.row)"
                             >
                                 <template #loading>
-                                    <q-spinner
-                                        size="1em"
-                                        class="q-mr-sm"
-                                    />
-                                    {{ isSelfMode && slotProps.row.alreadyImported ? "Use Course" : "Import" }}
+                                    <div class="row no-wrap items-center text-no-wrap">
+                                        <q-spinner
+                                            size="1em"
+                                            class="q-mr-sm"
+                                        />
+                                        {{ importButtonLabel(isSelfMode, slotProps.row) }}
+                                    </div>
                                 </template>
                             </q-btn>
                         </q-td>
@@ -337,18 +343,21 @@
                     flat
                 />
                 <q-btn
-                    :label="isSelfMode && selectedBannerCourse?.alreadyImported ? 'Use Course' : 'Import'"
+                    :label="importButtonLabel(isSelfMode, selectedBannerCourse ?? { alreadyImported: false })"
                     color="primary"
                     :loading="isImporting"
                     :disable="!canImport"
+                    class="loading-btn loading-btn--wide"
                     @click="doImport"
                 >
                     <template #loading>
-                        <q-spinner
-                            size="1em"
-                            class="q-mr-sm"
-                        />
-                        {{ isSelfMode && selectedBannerCourse?.alreadyImported ? "Use Course" : "Import" }}
+                        <div class="row no-wrap items-center text-no-wrap">
+                            <q-spinner
+                                size="1em"
+                                class="q-mr-sm"
+                            />
+                            {{ importButtonLabel(isSelfMode, selectedBannerCourse ?? { alreadyImported: false }) }}
+                        </div>
                     </template>
                 </q-btn>
             </q-card-actions>
@@ -363,6 +372,7 @@ import StatusBanner from "@/components/StatusBanner.vue"
 import { courseService } from "../services/course-service"
 import type { BannerCourseDto } from "../types"
 import type { QTableColumn } from "quasar"
+import { shouldShowImportButton, importButtonLabel, shouldShortcutToImport } from "../utils/import-button-rules"
 
 const props = withDefaults(
     defineProps<{
@@ -488,8 +498,10 @@ function startImport(course: BannerCourseDto) {
     importUnits.value = course.unitLow
     importError.value = null
 
-    // Self mode: fixed-unit already-imported shortcut (bypass options dialog)
-    if (isSelfMode.value && course.alreadyImported && !course.isVariableUnits) {
+    // Self mode: already-imported shortcut (bypass options dialog).
+    // Backend returns the existing row by CRN match.
+    // Variable-unit courses must go through the dialog so the user can choose the unit value.
+    if (shouldShortcutToImport(isSelfMode.value, course)) {
         doImport()
         return
     }
@@ -544,3 +556,15 @@ async function doImport() {
     }
 }
 </script>
+
+<style scoped>
+/* Width reserved for the spinner + label loading overlay. */
+.loading-btn {
+    min-width: 8rem;
+}
+
+/* Footer "Use Course" button needs more room than the table-row variant. */
+.loading-btn--wide {
+    min-width: 9rem;
+}
+</style>

--- a/VueApp/src/Effort/pages/CourseList.vue
+++ b/VueApp/src/Effort/pages/CourseList.vue
@@ -530,7 +530,7 @@ async function loadCourses() {
         if (token !== loadToken) return
 
         courses.value = coursesResult
-        departments.value = deptsResult
+        departments.value = [...deptsResult].sort()
     } finally {
         if (token === loadToken) {
             isLoading.value = false
@@ -586,7 +586,8 @@ async function deleteCourse(courseId: number) {
     const success = await courseService.deleteCourse(courseId)
     if (success) {
         $q.notify({ type: "positive", message: "Course deleted successfully" })
-        await loadCourses()
+        // Skip the full reload so the list doesn't flash.
+        courses.value = courses.value.filter((c) => c.id !== courseId)
     } else {
         $q.notify({ type: "negative", message: "Failed to delete course" })
     }

--- a/VueApp/src/Effort/utils/import-button-rules.ts
+++ b/VueApp/src/Effort/utils/import-button-rules.ts
@@ -1,0 +1,35 @@
+/**
+ * Rules governing the Import / "Use Course" button in CourseImportDialog.
+ *
+ * The backend's `alreadyImported` flag is true for fixed-unit courses that
+ * exist in Effort for the term AND for VET 4XX courses (any unit type) that
+ * exist for the term — the latter are harvested during the Harvest period and
+ * cannot be manually re-imported.
+ *
+ * Extracted so the component and its tests share one source of truth.
+ */
+
+type AlreadyImportedCourse = { alreadyImported: boolean }
+type VariableUnitCourse = AlreadyImportedCourse & { isVariableUnits: boolean }
+
+/** Whether the Import/Use Course button should render for this course row. */
+function shouldShowImportButton(isSelfMode: boolean, course: AlreadyImportedCourse): boolean {
+    return isSelfMode || !course.alreadyImported
+}
+
+/** The label to display on the button. */
+function importButtonLabel(isSelfMode: boolean, course: AlreadyImportedCourse): string {
+    return isSelfMode && course.alreadyImported ? "Use Course" : "Import"
+}
+
+/**
+ * Whether `startImport` should bypass the units-selection dialog and import
+ * immediately. Self mode + already-imported + fixed-unit lets the backend
+ * return the existing row by CRN match. Variable-unit courses always open the
+ * dialog so the user can pick the unit value.
+ */
+function shouldShortcutToImport(isSelfMode: boolean, course: VariableUnitCourse): boolean {
+    return isSelfMode && course.alreadyImported && !course.isVariableUnits
+}
+
+export { shouldShowImportButton, importButtonLabel, shouldShortcutToImport }

--- a/test/Effort/CourseServiceTests.cs
+++ b/test/Effort/CourseServiceTests.cs
@@ -858,4 +858,111 @@ public sealed class CourseServiceTests : IDisposable
     }
 
     #endregion
+
+    #region IsVet4xxCourse Tests
+
+    [Theory]
+    [InlineData("VET", "410", true)]
+    [InlineData("VET", "400", true)]
+    [InlineData("VET", "499", true)]
+    [InlineData("VET", "410A", true)]
+    [InlineData("vet", "410", true)]
+    [InlineData(" VET ", " 410 ", true)]
+    [InlineData("VET", "40", false)]
+    [InlineData("VET", "4000", false)]
+    [InlineData("VET", "300", false)]
+    [InlineData("VET", "500", false)]
+    [InlineData("VME", "410", false)]
+    [InlineData("DVM", "410", false)]
+    [InlineData("", "410", false)]
+    [InlineData("VET", "", false)]
+    public void IsVet4xxCourse_ClassifiesCorrectly(string subjCode, string crseNumb, bool expected)
+    {
+        var result = _courseService.IsVet4xxCourse(subjCode, crseNumb);
+
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region CheckImportConflictAsync Tests
+
+    [Fact]
+    public async Task CheckImportConflictAsync_ReturnsNone_WhenCrnNotInTerm()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "99999", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false);
+
+        Assert.Equal(ImportConflict.None, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_ReturnsDuplicateSameUnits_WhenCrnAndUnitsMatch()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false);
+
+        Assert.Equal(ImportConflict.DuplicateSameUnits, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_ReturnsNone_WhenCrnMatchesButUnitsDiffer_NonVet4xx()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 2, isVet4xx: false);
+
+        Assert.Equal(ImportConflict.None, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_ReturnsHarvestBlocked_WhenVet4xxAndAnyExistingRow()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 2, CustDept = "DVM" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+
+        Assert.Equal(ImportConflict.HarvestBlocked, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_ReturnsHarvestBlocked_WhenVet4xxTakesPrecedenceOverDuplicateSameUnits()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "DVM" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+
+        Assert.Equal(ImportConflict.HarvestBlocked, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_TrimsCrnBeforeMatching()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "  12345  ", 4, isVet4xx: false);
+
+        Assert.Equal(ImportConflict.DuplicateSameUnits, result);
+    }
+
+    [Fact]
+    public async Task CheckImportConflictAsync_IgnoresOtherTerms()
+    {
+        _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202310, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "DVM" });
+        await _context.SaveChangesAsync();
+
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+
+        Assert.Equal(ImportConflict.None, result);
+    }
+
+    #endregion
 }

--- a/test/Effort/CoursesControllerTests.cs
+++ b/test/Effort/CoursesControllerTests.cs
@@ -616,9 +616,9 @@ public sealed class CoursesControllerTests
         var importedCourse = new CourseDto { Id = 10, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "VME" };
 
         _courseServiceMock.GetBannerCourseAsync(202410, "12345", Arg.Any<CancellationToken>()).Returns(bannerCourse);
-        _courseServiceMock.CourseExistsAsync(202410, "12345", 4, Arg.Any<CancellationToken>()).Returns(false);
         _courseServiceMock.GetCustodialDepartmentForBannerCode("72030").Returns("VME");
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
+        _courseServiceMock.CheckImportConflictAsync(202410, "12345", 4, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ImportConflict.None);
         _courseServiceMock.ImportCourseFromBannerAsync(request, bannerCourse, Arg.Any<CancellationToken>()).Returns(importedCourse);
 
         // Act
@@ -641,7 +641,6 @@ public sealed class CoursesControllerTests
         var bannerCourse = new BannerCourseDto { Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 20, UnitType = "F", UnitLow = 4, UnitHigh = 4, DeptCode = "72030" };
 
         _courseServiceMock.GetBannerCourseAsync(202410, "12345", Arg.Any<CancellationToken>()).Returns(bannerCourse);
-        _courseServiceMock.CourseExistsAsync(202410, "12345", 4, Arg.Any<CancellationToken>()).Returns(false);
         _courseServiceMock.GetCustodialDepartmentForBannerCode("72030").Returns("VME");
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
@@ -665,7 +664,9 @@ public sealed class CoursesControllerTests
         var bannerCourse = new BannerCourseDto { Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, UnitType = "F", UnitLow = 4, UnitHigh = 4, DeptCode = "72030" };
 
         _courseServiceMock.GetBannerCourseAsync(202410, "12345", Arg.Any<CancellationToken>()).Returns(bannerCourse);
-        _courseServiceMock.CourseExistsAsync(202410, "12345", 4, Arg.Any<CancellationToken>()).Returns(true);
+        _courseServiceMock.GetCustodialDepartmentForBannerCode("72030").Returns("VME");
+        _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
+        _courseServiceMock.CheckImportConflictAsync(202410, "12345", 4, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ImportConflict.DuplicateSameUnits);
 
         // Act
         var result = await _controller.ImportCourse(request);

--- a/test/Effort/CoursesControllerTests.cs
+++ b/test/Effort/CoursesControllerTests.cs
@@ -677,6 +677,32 @@ public sealed class CoursesControllerTests
     }
 
     [Fact]
+    public async Task ImportCourse_ReturnsConflict_WhenHarvestBlockedForVet4xxCourse()
+    {
+        // Arrange
+        var request = new ImportCourseRequest
+        {
+            TermCode = 202410,
+            Crn = "12345"
+        };
+        var bannerCourse = new BannerCourseDto { Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 20, UnitType = "F", UnitLow = 4, UnitHigh = 4, DeptCode = "72030" };
+
+        _courseServiceMock.GetBannerCourseAsync(202410, "12345", Arg.Any<CancellationToken>()).Returns(bannerCourse);
+        _courseServiceMock.GetCustodialDepartmentForBannerCode("72030").Returns("VME");
+        _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
+        _courseServiceMock.IsVet4xxCourse("VET", "410").Returns(true);
+        _courseServiceMock.CheckImportConflictAsync(202410, "12345", 4, true, Arg.Any<CancellationToken>()).Returns(ImportConflict.HarvestBlocked);
+
+        // Act
+        var result = await _controller.ImportCourse(request);
+
+        // Assert
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
+        Assert.Contains("Harvest period", conflictResult.Value?.ToString());
+        await _courseServiceMock.DidNotReceive().ImportCourseFromBannerAsync(Arg.Any<ImportCourseRequest>(), Arg.Any<BannerCourseDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ImportCourse_ReturnsNotFound_WhenBannerCourseNotFound()
     {
         // Arrange

--- a/web/Areas/Effort/Controllers/CoursesController.cs
+++ b/web/Areas/Effort/Controllers/CoursesController.cs
@@ -207,20 +207,30 @@ public class CoursesController : BaseEffortController
             units = bannerCourse.UnitLow;
         }
 
-        // Validate: Course not already imported with same units
-        if (await _courseService.CourseExistsAsync(request.TermCode, request.Crn, units, ct))
-        {
-            _logger.LogWarning("Course {Crn} with {Units} units already exists for term {TermCode}",
-                LogSanitizer.SanitizeId(request.Crn), units, request.TermCode);
-            return Conflict($"Course {bannerCourse.SubjCode} {bannerCourse.CrseNumb} with {units} units already exists for this term");
-        }
-
+        // Authorize department access BEFORE conflict checks to avoid leaking
+        // existence of a CRN (or its Harvest-import status) to unauthorized users.
         var targetDept = _courseService.GetCustodialDepartmentForBannerCode(bannerCourse.DeptCode);
         if (!await _permissionService.CanViewDepartmentAsync(targetDept, ct))
         {
             _logger.LogWarning("User not authorized for department {CustDept} when importing course {Crn}",
                 targetDept, LogSanitizer.SanitizeId(request.Crn));
             return NotFound($"Course with CRN {request.Crn} not found in Banner for term {request.TermCode}");
+        }
+
+        // One round-trip covers both the same-units duplicate check and the VET 4XX
+        // Harvest-period block. Harvest wins if both apply (any existing row blocks re-import).
+        var isVet4xx = _courseService.IsVet4xxCourse(bannerCourse.SubjCode, bannerCourse.CrseNumb);
+        var conflict = await _courseService.CheckImportConflictAsync(request.TermCode, request.Crn, units, isVet4xx, ct);
+        switch (conflict)
+        {
+            case ImportConflict.HarvestBlocked:
+                _logger.LogWarning("Blocked manual import of harvested VET 4XX course {Crn} for term {TermCode}",
+                    LogSanitizer.SanitizeId(request.Crn), request.TermCode);
+                return Conflict($"{bannerCourse.SubjCode} {bannerCourse.CrseNumb} is imported during the Harvest period and cannot be manually imported again.");
+            case ImportConflict.DuplicateSameUnits:
+                _logger.LogWarning("Course {Crn} with {Units} units already exists for term {TermCode}",
+                    LogSanitizer.SanitizeId(request.Crn), units, request.TermCode);
+                return Conflict($"Course {bannerCourse.SubjCode} {bannerCourse.CrseNumb} with {units} units already exists for this term");
         }
 
         try

--- a/web/Areas/Effort/Services/CourseService.cs
+++ b/web/Areas/Effort/Services/CourseService.cs
@@ -142,7 +142,11 @@ public class CourseService : ICourseService
             {
                 var isFixed = course.UnitType == "F";
                 var importedUnits = importedByCrn.GetValueOrDefault(course.Crn, new List<decimal>());
-                course.AlreadyImported = isFixed && importedUnits.Count > 0;
+                // VET 4XX courses are imported during the Harvest period and cannot be
+                // re-imported — treat them as already-imported regardless of unit type so
+                // variable-unit VET 4XX courses are also blocked from re-import.
+                var isVet4xx = IsVet4xxCourse(course.SubjCode, course.CrseNumb);
+                course.AlreadyImported = importedUnits.Count > 0 && (isFixed || isVet4xx);
                 course.ImportedUnitValues = importedUnits;
             }
         }
@@ -160,7 +164,36 @@ public class CourseService : ICourseService
     public async Task<bool> CourseExistsAsync(int termCode, string crn, decimal units, CancellationToken ct = default)
     {
         return await _context.Courses
+            .AsNoTracking()
             .AnyAsync(c => c.TermCode == termCode && c.Crn.Trim() == crn.Trim() && c.Units == units, ct);
+    }
+
+    public async Task<ImportConflict> CheckImportConflictAsync(int termCode, string crn, decimal units, bool isVet4xx, CancellationToken ct = default)
+    {
+        var crnTrimmed = crn.Trim();
+        var existingUnits = await _context.Courses
+            .AsNoTracking()
+            .Where(c => c.TermCode == termCode && c.Crn.Trim() == crnTrimmed)
+            .Select(c => c.Units)
+            .ToListAsync(ct);
+
+        if (isVet4xx && existingUnits.Count > 0) return ImportConflict.HarvestBlocked;
+        if (existingUnits.Contains(units)) return ImportConflict.DuplicateSameUnits;
+        return ImportConflict.None;
+    }
+
+    public bool IsVet4xxCourse(string subjCode, string crseNumb)
+    {
+        if (string.IsNullOrWhiteSpace(subjCode) || string.IsNullOrWhiteSpace(crseNumb)) return false;
+        if (!subjCode.Trim().Equals("VET", StringComparison.OrdinalIgnoreCase)) return false;
+        var trimmed = crseNumb.Trim();
+        // Require exactly three leading digits starting with '4' (matches 400-499).
+        // A digit in position 3 would indicate a 4-digit number like "4000" — not a 4XX course.
+        return trimmed.Length >= 3
+            && trimmed[0] == '4'
+            && char.IsDigit(trimmed[1])
+            && char.IsDigit(trimmed[2])
+            && (trimmed.Length == 3 || !char.IsDigit(trimmed[3]));
     }
 
     public async Task<CourseDto> ImportCourseFromBannerAsync(ImportCourseRequest request, BannerCourseDto bannerCourse, CancellationToken ct = default)

--- a/web/Areas/Effort/Services/ICourseService.cs
+++ b/web/Areas/Effort/Services/ICourseService.cs
@@ -4,6 +4,24 @@ using Viper.Areas.Effort.Models.DTOs.Responses;
 namespace Viper.Areas.Effort.Services;
 
 /// <summary>
+/// Outcome of the pre-import conflict check for a Banner course.
+/// </summary>
+public enum ImportConflict
+{
+    /// <summary>No conflict — the course can be imported.</summary>
+    None,
+
+    /// <summary>A course with this term/CRN already exists at the same unit value.</summary>
+    DuplicateSameUnits,
+
+    /// <summary>
+    /// The course is a VET 4XX course already imported during the Harvest period.
+    /// Any unit value is blocked from re-import.
+    /// </summary>
+    HarvestBlocked,
+}
+
+/// <summary>
 /// Service for course-related operations in the Effort system.
 /// </summary>
 public interface ICourseService
@@ -61,6 +79,30 @@ public interface ICourseService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if a course with this key exists, false otherwise.</returns>
     Task<bool> CourseExistsAsync(int termCode, string crn, decimal units, CancellationToken ct = default);
+
+    /// <summary>
+    /// Determine whether an import of the given CRN/units would conflict with existing data.
+    /// One round-trip combines the same-units duplicate check and the VET 4XX Harvest block,
+    /// returning a discriminator so the controller can render the appropriate response.
+    /// </summary>
+    /// <param name="termCode">The term code.</param>
+    /// <param name="crn">The course reference number.</param>
+    /// <param name="units">The unit value the caller intends to import.</param>
+    /// <param name="isVet4xx">True if the Banner course is VET 4XX (pre-evaluated by the caller).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The conflict kind, or <see cref="ImportConflict.None"/> if the import can proceed.</returns>
+    Task<ImportConflict> CheckImportConflictAsync(int termCode, string crn, decimal units, bool isVet4xx, CancellationToken ct = default);
+
+    /// <summary>
+    /// Check if a course is a VET 4XX course (subject code "VET" with course number 400-499).
+    /// These courses are imported during the Harvest period and are blocked from manual re-import.
+    /// Matches numeric 400-499 with optional non-digit suffix (e.g., "410", "410A", "499R"),
+    /// but excludes two-digit numbers like "40" and four-digit numbers like "4000".
+    /// </summary>
+    /// <param name="subjCode">The subject code (e.g., "VET", "VME").</param>
+    /// <param name="crseNumb">The course number (e.g., "410", "410A").</param>
+    /// <returns>True if the course is a VET 4XX course.</returns>
+    bool IsVet4xxCourse(string subjCode, string crseNumb);
 
     /// <summary>
     /// Import a course from Banner into the Effort system.


### PR DESCRIPTION
- Mark any-units VET 4XX rows as alreadyImported so the import UI hides the button (staff) or offers "Use Course" (self)
- Move department authorization ahead of conflict checks to close a CRN existence oracle for users without the dept permission