### PR TITLE
VPR-139 fix(ldap): escape filter values per RFC 4515

### DIFF
--- a/test/Utilities/ActiveDirectoryServiceFilterTests.cs
+++ b/test/Utilities/ActiveDirectoryServiceFilterTests.cs
@@ -1,0 +1,178 @@
+using System.Runtime.Versioning;
+using Viper.Classes.Utilities;
+
+namespace Test.Utilities;
+
+[SupportedOSPlatform("windows")]
+public class ActiveDirectoryServiceFilterTests
+{
+    // ---- BuildGroupsFilter ----
+
+    [Theory]
+    // Benign baseline — no metacharacters, no escaping
+    [InlineData("admins", "admins")]
+    // Injection payloads
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    // Real-world benign inputs that contain characters requiring escape
+    [InlineData("Group (One)", @"Group \28One\29")]
+    public void BuildGroupsFilter_EscapesNamePerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildGroupsFilter(input);
+
+        Assert.Equal($"(&(objectClass=group)(cn=*{expectedEscaped}*))", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildGroupsFilter_EmptyName_ReturnsBaselineGroupFilter(string? name)
+    {
+        var filter = ActiveDirectoryService.BuildGroupsFilter(name);
+
+        Assert.Equal("(objectClass=group)", filter);
+    }
+
+    // ---- BuildGroupFilter ----
+
+    [Theory]
+    [InlineData("CN=Admins,OU=Groups,DC=ucdavis,DC=edu", "CN=Admins,OU=Groups,DC=ucdavis,DC=edu")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    [InlineData("CN=Group (One),OU=Groups", @"CN=Group \28One\29,OU=Groups")]
+    public void BuildGroupFilter_EscapesDnPerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildGroupFilter(input);
+
+        Assert.Equal($"(&(objectClass=group)(distinguishedName={expectedEscaped}))", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildGroupFilter_EmptyDn_ReturnsNull(string? dn)
+    {
+        var filter = ActiveDirectoryService.BuildGroupFilter(dn);
+
+        Assert.Null(filter);
+    }
+
+    // ---- BuildUsersFilter ----
+
+    [Fact]
+    public void BuildUsersFilter_AllNull_ReturnsBaselineUserFilter()
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter(null, null, null);
+
+        Assert.Equal("(objectClass=user)", filter);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("", "", "")]
+    [InlineData("   ", "   ", "   ")]
+    [InlineData(null, "", "   ")]
+    public void BuildUsersFilter_AllEmpty_ReturnsBaselineUserFilter(string? name, string? cn, string? samAccountName)
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter(name, cn, samAccountName);
+
+        Assert.Equal("(objectClass=user)", filter);
+    }
+
+    [Theory]
+    [InlineData("smith", "smith")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    [InlineData("Mary (Ann)", @"Mary \28Ann\29")]
+    public void BuildUsersFilter_NameOnly_EscapesValue(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter(input, null, null);
+
+        Assert.Equal($"(&(objectClass=user)(displayName=*{expectedEscaped}*))", filter);
+    }
+
+    [Theory]
+    [InlineData("smith", "smith")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    public void BuildUsersFilter_CnOnly_EscapesValue(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter(null, input, null);
+
+        Assert.Equal($"(&(objectClass=user)(cn=*{expectedEscaped}*))", filter);
+    }
+
+    [Theory]
+    [InlineData("smith", "smith")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    public void BuildUsersFilter_SamAccountNameOnly_EscapesValue(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter(null, null, input);
+
+        Assert.Equal($"(&(objectClass=user)(samAccountName=*{expectedEscaped}*))", filter);
+    }
+
+    [Fact]
+    public void BuildUsersFilter_AllThreeProvided_ComposesAllClauses()
+    {
+        var filter = ActiveDirectoryService.BuildUsersFilter("alice", "bob", "carol");
+
+        Assert.Equal("(&(objectClass=user)(displayName=*alice*)(cn=*bob*)(samAccountName=*carol*))", filter);
+    }
+
+    // ---- BuildUserFilter ----
+
+    [Theory]
+    [InlineData("jdoe", "jdoe")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    [InlineData("foo(bar)", @"foo\28bar\29")]
+    public void BuildUserFilter_EscapesSamAccountNamePerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildUserFilter(input);
+
+        Assert.Equal($"(&(objectClass=user)(samAccountName={expectedEscaped}))", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildUserFilter_EmptySamAccountName_ReturnsNull(string? samAccountName)
+    {
+        var filter = ActiveDirectoryService.BuildUserFilter(samAccountName);
+
+        Assert.Null(filter);
+    }
+
+    // ---- BuildGroupMembershipFilter ----
+
+    [Theory]
+    [InlineData("CN=Admins,OU=Groups,DC=ucdavis,DC=edu", "CN=Admins,OU=Groups,DC=ucdavis,DC=edu")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    [InlineData("CN=Group (One)", @"CN=Group \28One\29")]
+    public void BuildGroupMembershipFilter_EscapesGroupDnPerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = ActiveDirectoryService.BuildGroupMembershipFilter(input);
+
+        Assert.Equal($"(&(objectClass=user)(memberOf={expectedEscaped}))", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildGroupMembershipFilter_EmptyGroupDn_ReturnsNull(string? groupDn)
+    {
+        var filter = ActiveDirectoryService.BuildGroupMembershipFilter(groupDn);
+
+        Assert.Null(filter);
+    }
+}

--- a/test/Utilities/LdapFilterTests.cs
+++ b/test/Utilities/LdapFilterTests.cs
@@ -1,0 +1,44 @@
+using Viper.Classes.Utilities;
+
+namespace Test.Utilities;
+
+public class LdapFilterTests
+{
+    [Theory]
+    // Benign baselines
+    [InlineData("smith", "smith")]
+    [InlineData("Mary Ann", "Mary Ann")]
+    [InlineData("O'Brien", "O'Brien")]
+    [InlineData("Smith-Jones", "Smith-Jones")]
+    // Each metacharacter in isolation
+    [InlineData("*", @"\2a")]
+    [InlineData("(", @"\28")]
+    [InlineData(")", @"\29")]
+    [InlineData(@"\", @"\5c")]
+    [InlineData("\0", @"\00")]
+    // Injection payloads
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    [InlineData("name(with)parens", @"name\28with\29parens")]
+    // Embedded null character
+    [InlineData("foo\0bar", @"foo\00bar")]
+    // Backslash already followed by hex must itself be escaped, confirms we don't double-decode
+    [InlineData(@"\2a", @"\5c2a")]
+    public void Escape_ReturnsRfc4515EscapedOutput(string input, string expected)
+    {
+        Assert.Equal(expected, LdapFilter.Escape(input));
+    }
+
+    [Fact]
+    public void Escape_NullInput_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, LdapFilter.Escape(null));
+    }
+
+    [Fact]
+    public void Escape_EmptyInput_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, LdapFilter.Escape(string.Empty));
+    }
+}

--- a/test/Utilities/LdapServiceFilterTests.cs
+++ b/test/Utilities/LdapServiceFilterTests.cs
@@ -1,0 +1,142 @@
+using System.Runtime.Versioning;
+using Viper.Classes.Utilities;
+
+namespace Test.Utilities;
+
+[SupportedOSPlatform("windows")]
+public class LdapServiceFilterTests
+{
+    [Theory]
+    // Benign baseline
+    [InlineData("smith", "smith")]
+    // Injection payloads
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    // Real-world benign inputs that contain characters requiring escape
+    [InlineData("Mary Ann", "Mary Ann")]                 // space — not escaped
+    [InlineData("O'Brien", "O'Brien")]                   // apostrophe — not escaped
+    [InlineData("Smith-Jones", "Smith-Jones")]           // hyphen — not escaped
+    [InlineData("Smith (Jr)", @"Smith \28Jr\29")]        // parens in names — must be escaped
+    public void BuildUsersContactFilter_EscapesValuePerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = LdapService.BuildUsersContactFilter(input);
+
+        var expected =
+            $"(|(telephoneNumber=*{expectedEscaped})" +
+            $"(sn={expectedEscaped}*)" +
+            $"(givenName={expectedEscaped}*)" +
+            $"(uid={expectedEscaped}*)" +
+            $"(cn={expectedEscaped})" +
+            $"(mail={expectedEscaped}*))";
+
+        Assert.Equal(expected, filter);
+    }
+
+    [Theory]
+    [InlineData("1234567890", "1234567890")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    public void BuildUserByIDFilter_EscapesValuePerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = LdapService.BuildUserByIDFilter(input);
+
+        Assert.Equal($"(ucdpersoniamid = {expectedEscaped})", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildUserByIDFilter_ReturnsNullForEmptyInput(string? input)
+    {
+        var filter = LdapService.BuildUserByIDFilter(input);
+
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_SingleId_ProducesEqualityOr()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string> { "abc123" });
+
+        Assert.Equal("(|(ucdpersonuuid = abc123))", filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_MultipleIds_ProducesMultipleEqualityClauses()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string> { "a", "b", "c" });
+
+        Assert.Equal("(|(ucdpersonuuid = a)(ucdpersonuuid = b)(ucdpersonuuid = c))", filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_EscapesInjectionPayloadPerId()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string>
+        {
+            "*)(objectClass=*",
+            "admin)(|",
+            @"a\b"
+        });
+
+        Assert.Equal(
+            @"(|(ucdpersonuuid = \2a\29\28objectClass=\2a)(ucdpersonuuid = admin\29\28|)(ucdpersonuuid = a\5cb))",
+            filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_NullList_ReturnsNull()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(null);
+
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_EmptyList_ReturnsNull()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string>());
+
+        Assert.Null(filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_SkipsNullOrEmptyIdsInList()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string> { "a", "", null!, "b" });
+
+        Assert.Equal("(|(ucdpersonuuid = a)(ucdpersonuuid = b))", filter);
+    }
+
+    [Fact]
+    public void BuildUsersByIDsFilter_AllIdsNullOrEmpty_ReturnsNull()
+    {
+        var filter = LdapService.BuildUsersByIDsFilter(new List<string> { "", null!, "" });
+
+        Assert.Null(filter);
+    }
+
+    [Theory]
+    [InlineData("jsmith", "jsmith")]
+    [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
+    [InlineData("admin)(|", @"admin\29\28|")]
+    [InlineData(@"a\b", @"a\5cb")]
+    public void BuildUserBySamAccountNameFilter_EscapesValuePerRfc4515(string input, string expectedEscaped)
+    {
+        var filter = LdapService.BuildUserBySamAccountNameFilter(input);
+
+        Assert.Equal($"(&(objectClass=user)(samAccountName={expectedEscaped}))", filter);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildUserBySamAccountNameFilter_ReturnsNullForEmptyInput(string? input)
+    {
+        var filter = LdapService.BuildUserBySamAccountNameFilter(input);
+
+        Assert.Null(filter);
+    }
+}

--- a/test/Utilities/LdapServiceFilterTests.cs
+++ b/test/Utilities/LdapServiceFilterTests.cs
@@ -34,6 +34,17 @@ public class LdapServiceFilterTests
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildUsersContactFilter_ReturnsNullForEmptyInput(string? input)
+    {
+        var filter = LdapService.BuildUsersContactFilter(input);
+
+        Assert.Null(filter);
+    }
+
+    [Theory]
     [InlineData("1234567890", "1234567890")]
     [InlineData("*)(objectClass=*", @"\2a\29\28objectClass=\2a")]
     [InlineData("admin)(|", @"admin\29\28|")]

--- a/web/Classes/Utilities/ActiveDirectoryService.cs
+++ b/web/Classes/Utilities/ActiveDirectoryService.cs
@@ -91,12 +91,7 @@ namespace Viper.Classes.Utilities
         /// <returns>List of groups</returns>
         public static List<LdapGroup> GetGroups(string? name = null)
         {
-            string filter = "(objectClass=group)";
-            if (name != null)
-            {
-                filter = string.Format("(&{0}(cn=*{1}*))", filter, name);
-            }
-
+            string filter = BuildGroupsFilter(name);
 
             var searchResults = SearchActiveDirectory(filter, Server.OU, ObjectType.Group);
             List<LdapGroup> groups = new();
@@ -117,7 +112,11 @@ namespace Viper.Classes.Utilities
         /// <returns>The group, if found</returns>
         public static LdapGroup? GetGroup(string dn)
         {
-            string filter = string.Format("(&(objectClass=group)(distinguishedName={0}))", dn);
+            string? filter = BuildGroupFilter(dn);
+            if (filter == null)
+            {
+                return null;
+            }
             var searchResults = SearchActiveDirectory(filter, Server.OU, ObjectType.Group);
             LdapGroup? group = null;
             if (searchResults.Count == 1)
@@ -138,24 +137,7 @@ namespace Viper.Classes.Utilities
         /// <returns>List of users</returns>
         public static List<LdapUser> GetUsers(bool fromOu = false, string? name = null, string? cn = null, string? samAccountName = null)
         {
-            string filter = "(objectClass=user)";
-            string additionalFilters = "";
-            if (name != null)
-            {
-                additionalFilters += string.Format("(displayName=*{0}*)", name);
-            }
-            if (cn != null)
-            {
-                additionalFilters += string.Format("(cn=*{0}*)", cn);
-            }
-            if (samAccountName != null)
-            {
-                additionalFilters += string.Format("(samAccountName=*{0}*)", samAccountName);
-            }
-            if (additionalFilters.Length > 0)
-            {
-                filter = string.Format("(&{0}{1})", filter, additionalFilters);
-            }
+            string filter = BuildUsersFilter(name, cn, samAccountName);
 
             var searchResults = SearchActiveDirectory(filter, fromOu ? Server.OU : Server.AD3, ObjectType.Person);
 
@@ -176,8 +158,13 @@ namespace Viper.Classes.Utilities
         /// <returns></returns>
         public static LdapUser? GetUser(string samAccountName, bool fromOu = false)
         {
+            string? filter = BuildUserFilter(samAccountName);
+            if (filter == null)
+            {
+                return null;
+            }
             var searchResults = SearchActiveDirectory(
-                string.Format("(&(objectClass=user)(samAccountName={0}))", samAccountName),
+                filter,
                 fromOu ? Server.OU : Server.AD3,
                 ObjectType.Person);
             return searchResults.Count == 1 ? new LdapUser(searchResults[0]) : null;
@@ -190,8 +177,12 @@ namespace Viper.Classes.Utilities
         /// <returns>List of members of the group</returns>
         public static List<LdapUser> GetGroupMembership(string groupDn)
         {
+            string? filter = BuildGroupMembershipFilter(groupDn);
+            if (filter == null)
+            {
+                return new List<LdapUser>();
+            }
             List<LdapUser> users = new();
-            string filter = string.Format("(&(objectClass=user)(memberOf={0}))", groupDn);
             ////Need to get users from both AD3 and OU
             var ouSearchResults = SearchActiveDirectory(filter, Server.OU, ObjectType.Person);
             var ad3SearchResults = SearchActiveDirectory(filter, Server.AD3, ObjectType.Person);
@@ -258,6 +249,66 @@ namespace Viper.Classes.Utilities
             {
                 HttpHelper.Logger.Error(ex);
             }
+        }
+
+        internal static string BuildGroupsFilter(string? name)
+        {
+            const string baseFilter = "(objectClass=group)";
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return baseFilter;
+            }
+            return string.Format("(&{0}(cn=*{1}*))", baseFilter, LdapFilter.Escape(name));
+        }
+
+        internal static string? BuildGroupFilter(string? dn)
+        {
+            if (string.IsNullOrWhiteSpace(dn))
+            {
+                return null;
+            }
+            return string.Format("(&(objectClass=group)(distinguishedName={0}))", LdapFilter.Escape(dn));
+        }
+
+        internal static string? BuildUserFilter(string? samAccountName)
+        {
+            if (string.IsNullOrWhiteSpace(samAccountName))
+            {
+                return null;
+            }
+            return string.Format("(&(objectClass=user)(samAccountName={0}))", LdapFilter.Escape(samAccountName));
+        }
+
+        internal static string? BuildGroupMembershipFilter(string? groupDn)
+        {
+            if (string.IsNullOrWhiteSpace(groupDn))
+            {
+                return null;
+            }
+            return string.Format("(&(objectClass=user)(memberOf={0}))", LdapFilter.Escape(groupDn));
+        }
+
+        internal static string BuildUsersFilter(string? name, string? cn, string? samAccountName)
+        {
+            const string baseFilter = "(objectClass=user)";
+            string additionalFilters = "";
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                additionalFilters += string.Format("(displayName=*{0}*)", LdapFilter.Escape(name));
+            }
+            if (!string.IsNullOrWhiteSpace(cn))
+            {
+                additionalFilters += string.Format("(cn=*{0}*)", LdapFilter.Escape(cn));
+            }
+            if (!string.IsNullOrWhiteSpace(samAccountName))
+            {
+                additionalFilters += string.Format("(samAccountName=*{0}*)", LdapFilter.Escape(samAccountName));
+            }
+            if (additionalFilters.Length > 0)
+            {
+                return string.Format("(&{0}{1})", baseFilter, additionalFilters);
+            }
+            return baseFilter;
         }
 
         //Sort users by description first, or sam account name

--- a/web/Classes/Utilities/LdapFilter.cs
+++ b/web/Classes/Utilities/LdapFilter.cs
@@ -1,0 +1,35 @@
+using System.Text;
+
+namespace Viper.Classes.Utilities
+{
+    public static class LdapFilter
+    {
+        /// <summary>
+        /// Escapes a value for safe use inside an LDAP search filter per RFC 4515.
+        /// Apply to individual assertion values only — never to full filter expressions,
+        /// composed fragments, or operator characters.
+        /// </summary>
+        public static string Escape(string? input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder(input.Length);
+            foreach (var c in input)
+            {
+                switch (c)
+                {
+                    case '*': sb.Append(@"\2a"); break;
+                    case '(': sb.Append(@"\28"); break;
+                    case ')': sb.Append(@"\29"); break;
+                    case '\\': sb.Append(@"\5c"); break;
+                    case '\0': sb.Append(@"\00"); break;
+                    default: sb.Append(c); break;
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/web/Classes/Utilities/LdapService.cs
+++ b/web/Classes/Utilities/LdapService.cs
@@ -173,9 +173,8 @@ namespace Viper.Classes.Utilities
 
             var filterBuilder = new StringBuilder("(|");
             int appended = 0;
-            foreach (string i in ids)
+            foreach (string i in ids.Where(i => !string.IsNullOrEmpty(i)))
             {
-                if (string.IsNullOrEmpty(i)) continue;
                 var escaped = LdapFilter.Escape(i);
                 filterBuilder.Append($"(ucdpersonuuid = {escaped})");
                 appended++;

--- a/web/Classes/Utilities/LdapService.cs
+++ b/web/Classes/Utilities/LdapService.cs
@@ -44,7 +44,7 @@ namespace Viper.Classes.Utilities
         public static List<LdapUserContact> GetUsersContact(string search)
         {
             List<LdapUserContact> users = new();
-            string filter = string.Format("(|(telephoneNumber=*{0})(sn={0}*)(givenName={0}*)(uid={0}*)(cn={0})(mail={0}*))", search);
+            string filter = BuildUsersContactFilter(search);
             var results = SearchLdap(filter);
 
             foreach (SearchResultEntry entry in results.Entries)
@@ -66,7 +66,7 @@ namespace Viper.Classes.Utilities
         public static Dictionary<string, LdapUserContact> GetUsersContactDictionary(string search)
         {
             Dictionary<string, LdapUserContact> users = new();
-            string filter = string.Format("(|(telephoneNumber=*{0})(sn={0}*)(givenName={0}*)(uid={0}*)(cn={0})(mail={0}*))", search);
+            string filter = BuildUsersContactFilter(search);
             var results = SearchLdap(filter);
             foreach (SearchResultEntry entry in results.Entries)
             {
@@ -86,7 +86,7 @@ namespace Viper.Classes.Utilities
         /// <returns>LdapUserContact</returns>
         public static LdapUserContact? GetUserContact(string search)
         {
-            string filter = string.Format("(|(telephoneNumber=*{0})(sn={0}*)(givenName={0}*)(uid={0}*)(cn={0})(mail={0}*))", search);
+            string filter = BuildUsersContactFilter(search);
             var results = SearchLdap(filter);
 
             if (results.Entries.Count > 0)
@@ -104,8 +104,8 @@ namespace Viper.Classes.Utilities
         /// <returns>LdapUserContact</returns>
         public static LdapUserContact? GetUserByID(string? id)
         {
-            if (id == null) return null;
-            string filter = string.Format("(ucdpersoniamid = {0})", id);
+            string? filter = BuildUserByIDFilter(id);
+            if (filter == null) return null;
             var results = SearchLdap(filter);
             if (results.Entries.Count > 0)
             {
@@ -121,13 +121,8 @@ namespace Viper.Classes.Utilities
         /// <returns>Dictionary of Users, indexed by mothraID</returns>
         public static Dictionary<string, LdapUserContact> GetUsersByIDs(List<string> ids)
         {
-            var filterBuilder = new StringBuilder("(|");
-            foreach (string i in ids)
-            {
-                filterBuilder.Append($"(ucdpersonuuid = {i})");
-            }
-            filterBuilder.Append(')');
-            string filter = filterBuilder.ToString();
+            string? filter = BuildUsersByIDsFilter(ids);
+            if (filter == null) return new Dictionary<string, LdapUserContact>();
             var results = SearchLdap(filter);
             var users = new Dictionary<string, LdapUserContact>();
             foreach (SearchResultEntry entry in results.Entries)
@@ -149,13 +144,52 @@ namespace Viper.Classes.Utilities
         /// <returns></returns>
         public static LdapUserContact? GetUserBySamAccountName(string? samAccountName)
         {
-            string filter = string.Format("(&(objectClass=user)(samAccountName={0}))", samAccountName);
+            string? filter = BuildUserBySamAccountNameFilter(samAccountName);
+            if (filter == null) return null;
             var results = SearchLdap(filter);
             if (results.Entries.Count > 0)
             {
                 return new LdapUserContact(results.Entries[0]);
             }
             return null;
+        }
+
+        internal static string BuildUsersContactFilter(string search)
+        {
+            var escaped = LdapFilter.Escape(search);
+            return string.Format("(|(telephoneNumber=*{0})(sn={0}*)(givenName={0}*)(uid={0}*)(cn={0})(mail={0}*))", escaped);
+        }
+
+        internal static string? BuildUserByIDFilter(string? id)
+        {
+            if (string.IsNullOrEmpty(id)) return null;
+            var escaped = LdapFilter.Escape(id);
+            return string.Format("(ucdpersoniamid = {0})", escaped);
+        }
+
+        internal static string? BuildUsersByIDsFilter(List<string>? ids)
+        {
+            if (ids == null || ids.Count == 0) return null;
+
+            var filterBuilder = new StringBuilder("(|");
+            int appended = 0;
+            foreach (string i in ids)
+            {
+                if (string.IsNullOrEmpty(i)) continue;
+                var escaped = LdapFilter.Escape(i);
+                filterBuilder.Append($"(ucdpersonuuid = {escaped})");
+                appended++;
+            }
+            if (appended == 0) return null;
+            filterBuilder.Append(')');
+            return filterBuilder.ToString();
+        }
+
+        internal static string? BuildUserBySamAccountNameFilter(string? samAccountName)
+        {
+            if (string.IsNullOrEmpty(samAccountName)) return null;
+            var escaped = LdapFilter.Escape(samAccountName);
+            return string.Format("(&(objectClass=user)(samAccountName={0}))", escaped);
         }
 
         //Sort users by description first, or sam account name

--- a/web/Classes/Utilities/LdapService.cs
+++ b/web/Classes/Utilities/LdapService.cs
@@ -1,6 +1,5 @@
 using System.Runtime.Versioning;
 using System.DirectoryServices.Protocols;
-using System.Text;
 using Viper.Areas.Directory.Models;
 
 namespace Viper.Classes.Utilities
@@ -44,7 +43,8 @@ namespace Viper.Classes.Utilities
         public static List<LdapUserContact> GetUsersContact(string search)
         {
             List<LdapUserContact> users = new();
-            string filter = BuildUsersContactFilter(search);
+            string? filter = BuildUsersContactFilter(search);
+            if (filter == null) return users;
             var results = SearchLdap(filter);
 
             foreach (SearchResultEntry entry in results.Entries)
@@ -66,7 +66,8 @@ namespace Viper.Classes.Utilities
         public static Dictionary<string, LdapUserContact> GetUsersContactDictionary(string search)
         {
             Dictionary<string, LdapUserContact> users = new();
-            string filter = BuildUsersContactFilter(search);
+            string? filter = BuildUsersContactFilter(search);
+            if (filter == null) return users;
             var results = SearchLdap(filter);
             foreach (SearchResultEntry entry in results.Entries)
             {
@@ -86,7 +87,8 @@ namespace Viper.Classes.Utilities
         /// <returns>LdapUserContact</returns>
         public static LdapUserContact? GetUserContact(string search)
         {
-            string filter = BuildUsersContactFilter(search);
+            string? filter = BuildUsersContactFilter(search);
+            if (filter == null) return null;
             var results = SearchLdap(filter);
 
             if (results.Entries.Count > 0)
@@ -154,8 +156,9 @@ namespace Viper.Classes.Utilities
             return null;
         }
 
-        internal static string BuildUsersContactFilter(string search)
+        internal static string? BuildUsersContactFilter(string? search)
         {
+            if (string.IsNullOrWhiteSpace(search)) return null;
             var escaped = LdapFilter.Escape(search);
             return string.Format("(|(telephoneNumber=*{0})(sn={0}*)(givenName={0}*)(uid={0}*)(cn={0})(mail={0}*))", escaped);
         }
@@ -169,19 +172,12 @@ namespace Viper.Classes.Utilities
 
         internal static string? BuildUsersByIDsFilter(List<string>? ids)
         {
-            if (ids == null || ids.Count == 0) return null;
-
-            var filterBuilder = new StringBuilder("(|");
-            int appended = 0;
-            foreach (string i in ids.Where(i => !string.IsNullOrEmpty(i)))
-            {
-                var escaped = LdapFilter.Escape(i);
-                filterBuilder.Append($"(ucdpersonuuid = {escaped})");
-                appended++;
-            }
-            if (appended == 0) return null;
-            filterBuilder.Append(')');
-            return filterBuilder.ToString();
+            if (ids == null) return null;
+            var clauses = ids
+                .Where(i => !string.IsNullOrEmpty(i))
+                .Select(i => $"(ucdpersonuuid = {LdapFilter.Escape(i)})")
+                .ToList();
+            return clauses.Count == 0 ? null : $"(|{string.Concat(clauses)})";
         }
 
         internal static string? BuildUserBySamAccountNameFilter(string? samAccountName)


### PR DESCRIPTION
## Summary

- Add `LdapFilter.Escape` (RFC 4515) helper at `web/Classes/Utilities/LdapFilter.cs`
- Route every filter construction in `LdapService` and `ActiveDirectoryService` through internal `Build*Filter` helpers that escape assertion values; structural operators stay literal
- Tighten empty-input handling: `GetUsers` and `GetGroups` short-circuit to the baseline filter for null/whitespace inputs; single-value methods return null or empty result instead of issuing `(attr=)`

## Inventory sweep

Grepped the repo for filter-construction patterns: `SearchRequest(`, `"(objectClass=`, `"(samAccountName=`, `"(distinguishedName=`, `"(memberOf=`, `"(cn=`, `"(uid=`, `"(mail=`, `"(displayName=`, `"(telephoneNumber=`, `"(ucdperson`. All hits resolve to the two patched services or the new test files. No additional filter sites surfaced.

## Tests

- `test/Utilities/LdapFilterTests.cs`: direct helper tests covering each metacharacter in isolation, embedded null character, null/empty input, and a no-double-decode case (`\2a` re-escapes to `\5c2a`)
- `test/Utilities/LdapServiceFilterTests.cs`: every `Build*Filter` covered with benign baseline, injection payloads (`*)(objectClass=*`, `admin)(|`, `a\b`), and empty-input handling
- `test/Utilities/ActiveDirectoryServiceFilterTests.cs`: same coverage for the AD service

All 1902 backend tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for LDAP filter construction and escaping validation across multiple service methods.

* **New Features**
  * Introduced standardized LDAP character escaping utility for search filters.

* **Refactor**
  * Refactored filter construction in directory and LDAP services to use centralized escaping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->