### PR TITLE
VPR-156 chore: enable CodeRabbit and expand copilot review rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+tone_instructions: >
+  Direct and concise. Skip preamble and praise. Lead with the issue, then the
+  fix.
+
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - "VPR-.*"
+    ignore_title_keywords:
+      - WIP
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/bin/**"
+    - "!**/obj/**"
+    - "!web/wwwroot/vue/**"
+    - "!**/*.lock"
+    - "!**/package-lock.json"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+
+  tools:
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      level: default
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - ".github/copilot-instructions.md"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,95 @@
 # Copilot Instructions
 
-## C# Conventions
+Code-review rules for VIPER (ASP.NET 10 + Vue 3 + Quasar). Flag violations
+of the following.
 
-- **DateTime**: Use `DateTime.Now` and `DateTimeKind.Local`, never `DateTime.UtcNow`. The application operates in a single-timezone campus environment and all database timestamps are local.
+## C\#
 
-## Database
+- **Exceptions**: prefer specific types (`DbUpdateException`, `SqlException`,
+  `InvalidOperationException`). Don't catch `Exception` unless it's a top-level
+  boundary (middleware, controller action, background-job entry point) or you
+  rethrow/wrap after logging — flag broad catches inside service/business
+  logic.
+- **DateTime**: default to `DateTime.Now` / `DateTimeKind.Local` (DB stores
+  local). `UtcNow` only where required by spec (HTTP date headers,
+  Unix-epoch math, protocol timestamps).
+- **Paths**: prefer `Path.Join()` over `Path.Combine()` for new code.
+- **LINQ**: `.Where()` for filtering (not `if` inside `foreach`), `.Select()`
+  for mapping (not `foreach + Add`).
+- **Mapping**: prefer Mapperly. Static partial mapper per area with
+  `[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.None)]`. Avoid
+  hand-written property-by-property mapping.
+- **DI**: prefer Scrutor convention registration over manual `AddScoped`.
+  Follow `IFooService` / `FooService` naming.
+- **Comments**: explain *why*, not *what*. Sparingly, complex logic only.
 
-- **SQL Server 2016** compatibility required — do not suggest `STRING_AGG`, `TRIM`, `CONCAT_WS`, `GREATEST`, or `LEAST`.
+## EF Core / Database
+
+- **SQL Server 2016** target — reject `STRING_AGG`, `TRIM`, `CONCAT_WS`,
+  `GREATEST`, `LEAST`.
+- **Read-only queries** must use `.AsNoTracking()`.
+- `.Include()` before `.Select()` is unnecessary — EF resolves navigations in
+  projections.
+- Avoid correlated subqueries: `.Any()` inside `.Where()` / `.CountAsync()` on
+  large tables. Pre-load ID sets and use `.Contains()`, or replace with
+  `.Join()`.
+- `.Contains()` with 10+ items: wrap with `EF.Parameter(...)` for `OPENJSON`
+  translation.
+- Never mix raw SQL with EF entities (causes auth failures). Raw SQL only for
+  non-EF tables via `GetConnectionString()`.
+- `DbContext` is not thread-safe — flag parallel EF queries.
+
+## API & Auth
+
+- Routes: absolute `/api/{area}/{controller}` with `ApiController` base.
+  `[Area("...")]` is allowed alongside the route attribute (existing API
+  controllers use it); flag only when an API route is missing the absolute
+  `/api/...` prefix or the `ApiController` attribute, not for the presence of
+  `[Area]`.
+- Authorization: `[Permission(Allow = "SVMSecure.{Area}.{Action}")]`.
+  Authenticate before validating params.
 
 ## Security
 
-- **Log injection**: User-supplied values must be sanitized before logging via `LogSanitizer` (`SanitizeId()`, `SanitizeString()`, `SanitizeYear()`). Hard-coded strings, enums, and DB-sourced values do not need sanitization.
+- **Log injection**: sanitize user input before logging via `LogSanitizer`
+  (`SanitizeId()`, `SanitizeString()`, `SanitizeYear()`). Skip for hard-coded
+  strings, enums, DB-sourced values.
+
+## Vue / Quasar
+
+- Use Quasar components (`q-btn`, `q-dialog`, `q-banner`, etc.). Selects need
+  `dense` + `options-dense`.
+- **Dialogs (`q-dialog`)**: must have an accessible name (`aria-labelledby`
+  pointing to the title `id`, or `aria-label`) **and** an accessible close
+  affordance. Persistent dialogs use `@click="handleClose"`, not
+  `v-close-popup`.
+- **Badges**: use the `StatusBadge` component (not raw `q-badge` with manual
+  `getAccessibleTextColor`).
+- **Banners (Vue SPAs)**: use `StatusBanner`. `type="error"` auto-maps to
+  `role="alert"`; warning/info default to `role="status"`. Use
+  `live="assertive"` only for direct user-action responses, not persistent
+  state indicators. Razor pages use `q-banner` with accessible classes
+  (`bg-warning text-dark`, `role="status"` or `role="alert"`).
+- **Button colors**: `primary` (Aggie Blue), `positive` (create), `negative`
+  (delete), `info text-color="dark"` (tertiary), `warning text-color="dark"`
+  (caution), `secondary`.
+- **Pluralization**: `inflect("word", count)` from the `inflection` package.
+  Reject hand-rolled ternaries.
+- Prefer **VueUse** composables over custom reactive helpers.
+
+## Accessibility
+
+- `<main>` landmark is provided by layouts (`_VIPERLayout.cshtml`,
+  `VIPERLayoutSimplified.cshtml`, `ViperLayout.vue`, `ViperLayoutSimple.vue`).
+  Do not add `<main>` to `App.vue` or page components.
+- Interactive non-button elements need `@keyup.enter` + `@keyup.space` +
+  `tabindex="0"` + `role="button"` + `aria-label`. Prefer `q-btn`.
+
+## Frontend API & CSS
+
+- API calls go through the service layer with `useFetch()` (unwraps
+  `{ result, success }`). Never raw `fetch()`.
+- Use `${import.meta.env.VITE_API_URL}`. Never hardcode `/api/` (TEST uses
+  `/2/` prefix).
+- No inline styles, no `!important`. Prefer Quasar utility classes. Use `rem`
+  (not `px`) for spacing/sizing/typography.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses Node.js 24 LTS. We recommend using [Volta](https://volta.sh/) 
 ```sh
 winget install Volta.Volta
 
-# After installation, restart your terminal and install Node.js 20.6.1
+# After installation, restart your terminal and install Node.js.
 volta install node@24
 ```
 


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` to enable CodeRabbit auto-reviews on PRs targeting `main` and `VPR-*` base branches (drafts skipped, `WIP` titles ignored, assertive profile).
- Rewrite `.github/copilot-instructions.md` as the shared code-review rule source — consumed by GitHub Copilot in the IDE and by CodeRabbit via `knowledge_base.code_guidelines`.
- Path filters exclude generated/vendor output (`node_modules`, `dist`, `bin`, `obj`, `wwwroot/vue`, lock files, minified assets).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration and development guidelines to standardize coding practices and review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->