### PR TITLE
VPR-157 feat(a11y): accessible Word, PDF, and Excel exports

### DIFF
--- a/VueApp/src/ClinicalScheduler/__tests__/normalize-schedule-semesters.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/normalize-schedule-semesters.test.ts
@@ -1,5 +1,5 @@
 import { normalizeScheduleSemesters } from "../composables/use-schedule-normalization"
-import type { ScheduleSemester } from "../components/ScheduleView.vue"
+import type { ScheduleSemester } from "../components/schedule-view-types"
 
 describe(normalizeScheduleSemesters, () => {
     it("should return empty array when input is undefined", () => {

--- a/VueApp/src/ClinicalScheduler/components/ScheduleView.vue
+++ b/VueApp/src/ClinicalScheduler/components/ScheduleView.vue
@@ -78,33 +78,11 @@
 import { computed, ref } from "vue"
 import { useKeyModifier, useEventListener } from "@vueuse/core"
 import WeekCell from "./WeekCell.vue"
-
-export interface WeekItem {
-    weekId: number
-    weekNumber: number
-    dateStart: string
-    dateEnd?: string
-    requiresPrimaryEvaluator?: boolean
-    [key: string]: unknown
-}
 import ScheduleLegend from "./ScheduleLegend.vue"
 import StatusBanner from "@/components/StatusBanner.vue"
+import type { WeekItem, ScheduleAssignment, ScheduleSemester, ViewMode } from "./schedule-view-types"
 
-export interface ScheduleAssignment {
-    id: number
-    displayName: string
-    isPrimary?: boolean
-    [key: string]: unknown
-}
-
-export interface ScheduleSemester {
-    semester?: string // For clinician view
-    name?: string // For rotation view
-    displayName?: string // For rotation view
-    weeks: (WeekItem & { dateEnd: string })[]
-}
-
-export type ViewMode = "rotation" | "clinician"
+export type { WeekItem, ScheduleAssignment, ScheduleSemester, ViewMode }
 
 // Helper callable type to avoid parameter-name linting within Props
 interface WeekFn<T> {

--- a/VueApp/src/ClinicalScheduler/components/schedule-view-types.ts
+++ b/VueApp/src/ClinicalScheduler/components/schedule-view-types.ts
@@ -1,0 +1,24 @@
+export interface WeekItem {
+    weekId: number
+    weekNumber: number
+    dateStart: string
+    dateEnd?: string
+    requiresPrimaryEvaluator?: boolean
+    [key: string]: unknown
+}
+
+export interface ScheduleAssignment {
+    id: number
+    displayName: string
+    isPrimary?: boolean
+    [key: string]: unknown
+}
+
+export interface ScheduleSemester {
+    semester?: string // For clinician view
+    name?: string // For rotation view
+    displayName?: string // For rotation view
+    weeks: (WeekItem & { dateEnd: string })[]
+}
+
+export type ViewMode = "rotation" | "clinician"

--- a/VueApp/src/ClinicalScheduler/composables/use-bulk-deletion-logic.ts
+++ b/VueApp/src/ClinicalScheduler/composables/use-bulk-deletion-logic.ts
@@ -1,6 +1,6 @@
 import type { Ref } from "vue"
 import { useQuasar } from "quasar"
-import type { ScheduleSemester } from "../components/ScheduleView.vue"
+import type { ScheduleSemester } from "../components/schedule-view-types"
 import type { ScheduleData } from "../utils/schedule-update-helpers"
 import { useBulkDeletion } from "./use-bulk-deletion"
 import { showBulkDeleteConfirmation } from "../utils/confirmation-dialog"

--- a/VueApp/src/ClinicalScheduler/composables/use-delete-mode.ts
+++ b/VueApp/src/ClinicalScheduler/composables/use-delete-mode.ts
@@ -1,6 +1,6 @@
 import { computed } from "vue"
 import type { Ref } from "vue"
-import type { ScheduleAssignment, ScheduleSemester } from "../components/ScheduleView.vue"
+import type { ScheduleAssignment, ScheduleSemester } from "../components/schedule-view-types"
 
 /**
  * Generic interface for selectable items that can be in delete mode

--- a/VueApp/src/ClinicalScheduler/composables/use-schedule-normalization.ts
+++ b/VueApp/src/ClinicalScheduler/composables/use-schedule-normalization.ts
@@ -1,5 +1,5 @@
 import { isRotationExcluded } from "../constants/rotation-constants"
-import type { ScheduleSemester } from "../components/ScheduleView.vue"
+import type { ScheduleSemester } from "../components/schedule-view-types"
 import type { ClinicianScheduleData } from "../services/clinician-service"
 import type { RotationScheduleData } from "../services/rotation-service"
 

--- a/VueApp/src/Effort/components/ReportLayout.vue
+++ b/VueApp/src/Effort/components/ReportLayout.vue
@@ -77,7 +77,6 @@
 
     /* Prevent rows from breaking across pages */
     tr {
-        page-break-inside: avoid;
         break-inside: avoid;
     }
 

--- a/VueApp/src/Effort/composables/use-report-page.ts
+++ b/VueApp/src/Effort/composables/use-report-page.ts
@@ -1,7 +1,8 @@
-import { ref, computed } from "vue"
-import type { Ref } from "vue"
+import { ref, computed, unref } from "vue"
+import type { Ref, MaybeRef } from "vue"
 import { useQuasar } from "quasar"
 import { useRoute } from "vue-router"
+import { useTitle } from "@vueuse/core"
 import {
     useEffortTypeColumns,
     SPACING_COLUMNS,
@@ -11,16 +12,54 @@ import {
 import { useReportUrlParams } from "./use-report-url-params"
 import type { ReportFilterParams } from "../types"
 
+// Wires document.title to "{base} - {term} | VIPER" once the report loads.
+// `getSuffix` lets callers override the default `academicYear || termName`
+// extraction for reports whose DTOs don't follow the common shape.
+function useReportDocumentTitle<T>(
+    base: MaybeRef<string>,
+    report: Ref<T | null>,
+    getSuffix?: (report: T) => string | null | undefined,
+) {
+    const suffix = computed(() => {
+        if (!report.value) {
+            return ""
+        }
+        if (getSuffix) {
+            return getSuffix(report.value) ?? ""
+        }
+        // Default: prefer academicYear, fall back to termName. Both fields
+        // are present on every report DTO under VueApp/src/Effort/types/;
+        // the cast is safe because pages with different shapes override
+        // via the getSuffix argument.
+        const r = report.value as { academicYear?: string | null; termName?: string | null }
+        return r.academicYear || r.termName || ""
+    })
+    useTitle(
+        computed(() => {
+            const baseTitle = unref(base)
+            return suffix.value ? `${baseTitle} - ${suffix.value} | VIPER` : `${baseTitle} | VIPER`
+        }),
+    )
+}
+
 /**
  * Shared composable for effort report pages.
  * Handles term code extraction, loading states, effort type columns,
- * URL param sync, and PDF export — the pattern common to all report pages.
+ * URL param sync, PDF export, and document title — the pattern common to
+ * all report pages. The `title` option is the human-readable report name
+ * (e.g. "Merit Detail Report"); the document title is rendered as
+ * "{title} - {term} | VIPER" once a report is loaded, where {term} is
+ * the report's `academicYear` if set, otherwise its `termName`. Pages
+ * with non-standard shapes can override via `getTitleSuffix`.
  */
 export function useReportPage<T>(options: {
+    title: MaybeRef<string>
     fetchReport: (params: ReportFilterParams) => Promise<T | null>
-    fetchPdf?: (params: ReportFilterParams) => Promise<boolean>
+    fetchPdf?: (params: ReportFilterParams) => void
     fetchExcel?: (params: ReportFilterParams) => Promise<boolean>
     getEffortTypes?: (report: T) => string[]
+    hasData?: (report: T) => boolean
+    getTitleSuffix?: (report: T) => string | null | undefined
 }) {
     const $q = useQuasar()
     const route = useRoute()
@@ -34,8 +73,9 @@ export function useReportPage<T>(options: {
     const loading = ref(false)
     const report = ref<T | null>(null) as Ref<T | null>
     const lastParams = ref<ReportFilterParams | null>(null)
-    const printLoading = ref(false)
     const excelLoading = ref(false)
+
+    useReportDocumentTitle(options.title, report, options.getTitleSuffix)
 
     // Effort type columns (only set up if getEffortTypes is provided)
     const effortTypes = computed(() => {
@@ -62,19 +102,17 @@ export function useReportPage<T>(options: {
         }
     }
 
-    async function handlePrint() {
+    function handlePrint() {
         if (!lastParams.value || !options.fetchPdf) {
             return
         }
-        printLoading.value = true
-        try {
-            const opened = await options.fetchPdf(lastParams.value)
-            if (!opened) {
-                $q.notify({ type: "warning", message: "No data to export for the selected filters." })
-            }
-        } finally {
-            printLoading.value = false
+        // PDFs open in a new tab via GET, so the empty-data preflight has to happen here
+        // — otherwise the controller's 204 response paints a blank tab.
+        if (options.hasData && (!report.value || !options.hasData(report.value))) {
+            $q.notify({ type: "warning", message: "No data to export for the selected filters." })
+            return
         }
+        options.fetchPdf(lastParams.value)
     }
 
     async function handleExcelDownload() {
@@ -84,7 +122,9 @@ export function useReportPage<T>(options: {
         excelLoading.value = true
         try {
             const success = await options.fetchExcel(lastParams.value)
-            if (!success) {
+            if (success) {
+                $q.notify({ type: "positive", message: "Excel report downloaded." })
+            } else {
                 $q.notify({ type: "warning", message: "No data to export for the selected filters." })
             }
         } finally {
@@ -101,7 +141,6 @@ export function useReportPage<T>(options: {
         loading,
         report,
         lastParams,
-        printLoading,
         excelLoading,
         initialFilters,
         effortTypes,

--- a/VueApp/src/Effort/pages/ClinicalEffort.vue
+++ b/VueApp/src/Effort/pages/ClinicalEffort.vue
@@ -173,8 +173,8 @@
 import { ref, computed, onMounted } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar } from "quasar"
+import { useTitle } from "@vueuse/core"
 import { reportService } from "../services/report-service"
-import { postForBlob } from "@/composables/ViperFetch"
 import { termService } from "../services/term-service"
 import { useEffortTypeColumns, getEffortTypeLabel, loadEffortTypeLabels } from "../composables/use-effort-type-columns"
 import ExportToolbar from "@/components/ExportToolbar.vue"
@@ -186,9 +186,15 @@ const route = useRoute()
 const router = useRouter()
 
 const loading = ref(false)
-const printLoading = ref(false)
 const excelLoading = ref(false)
 const report = ref<ClinicalEffortReport | null>(null)
+useTitle(
+    computed(() => {
+        const r = report.value
+        const term = r?.academicYear || r?.termName
+        return term ? `Clinical Effort Report - ${term} | VIPER` : "Clinical Effort Report | VIPER"
+    }),
+)
 const yearOptions = ref<{ label: string; value: string }[]>([])
 
 const clinicalTypeOptions = [
@@ -240,25 +246,13 @@ async function generateReport() {
     }
 }
 
-async function handlePrint() {
+function handlePrint() {
     if (!selectedYear.value) return
-    printLoading.value = true
-    try {
-        const baseUrl = `${import.meta.env.VITE_API_URL}effort/reports`
-        const { blob } = await postForBlob(`${baseUrl}/merit/clinical/pdf`, {
-            academicYear: selectedYear.value,
-            clinicalType: selectedType.value,
-        })
-        if (blob.size === 0) {
-            $q.notify({ type: "warning", message: "No data to export for the selected filters." })
-        } else {
-            const url = globalThis.URL.createObjectURL(blob)
-            globalThis.open(url, "_blank")
-            globalThis.setTimeout(() => globalThis.URL.revokeObjectURL(url), 1000)
-        }
-    } finally {
-        printLoading.value = false
+    if (!report.value || report.value.jobGroups.length === 0) {
+        $q.notify({ type: "warning", message: "No data to export for the selected filters." })
+        return
     }
+    reportService.openClinicalEffortPdf(selectedYear.value, selectedType.value)
 }
 
 async function handleExcelDownload() {

--- a/VueApp/src/Effort/pages/DeptSummary.vue
+++ b/VueApp/src/Effort/pages/DeptSummary.vue
@@ -180,10 +180,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<DeptSummaryReport>({
+    title: "Department Summary Report",
     fetchReport: (params) => reportService.getDeptSummary(params),
     fetchPdf: (params) => reportService.openPdf("teaching/dept-summary/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("teaching/dept-summary/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.departments.length > 0,
 })
 </script>
 

--- a/VueApp/src/Effort/pages/EvalDetail.vue
+++ b/VueApp/src/Effort/pages/EvalDetail.vue
@@ -166,9 +166,11 @@ import type { EvalDetailReport } from "../types"
 
 const { termCode, loading, report, initialFilters, generateReport, handlePrint, handleExcelDownload } =
     useReportPage<EvalDetailReport>({
+        title: "Evaluation Detail Report",
         fetchReport: (params) => reportService.getEvalDetail(params),
         fetchPdf: (params) => reportService.openPdf("eval/detail/pdf", params),
         fetchExcel: (params) => reportService.downloadExcel("eval/detail/excel", params),
+        hasData: (r) => r.departments.length > 0,
     })
 
 function formatDecimal(value: number): string {

--- a/VueApp/src/Effort/pages/EvalSummary.vue
+++ b/VueApp/src/Effort/pages/EvalSummary.vue
@@ -109,9 +109,11 @@ import type { EvalSummaryReport } from "../types"
 
 const { termCode, loading, report, initialFilters, generateReport, handlePrint, handleExcelDownload } =
     useReportPage<EvalSummaryReport>({
+        title: "Evaluation Summary Report",
         fetchReport: (params) => reportService.getEvalSummary(params),
         fetchPdf: (params) => reportService.openPdf("eval/summary/pdf", params),
         fetchExcel: (params) => reportService.downloadExcel("eval/summary/excel", params),
+        hasData: (r) => r.departments.length > 0,
     })
 
 function formatDecimal(value: number): string {

--- a/VueApp/src/Effort/pages/MeritAverage.vue
+++ b/VueApp/src/Effort/pages/MeritAverage.vue
@@ -216,10 +216,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<MeritAverageReport>({
+    title: "Merit & Promotion Report - Average",
     fetchReport: (params) => reportService.getMeritAverage(params),
     fetchPdf: (params) => reportService.openPdf("merit/average/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("merit/average/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.jobGroups.length > 0,
 })
 </script>
 

--- a/VueApp/src/Effort/pages/MeritDetail.vue
+++ b/VueApp/src/Effort/pages/MeritDetail.vue
@@ -209,10 +209,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<MeritDetailReport>({
+    title: "Merit Detail Report",
     fetchReport: (params) => reportService.getMeritDetail(params),
     fetchPdf: (params) => reportService.openPdf("merit/detail/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("merit/detail/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.departments.length > 0,
 })
 </script>
 

--- a/VueApp/src/Effort/pages/MeritSummary.vue
+++ b/VueApp/src/Effort/pages/MeritSummary.vue
@@ -160,10 +160,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<MeritSummaryReport>({
+    title: "Merit Summary Report",
     fetchReport: (params) => reportService.getMeritSummary(params),
     fetchPdf: (params) => reportService.openPdf("merit/summary/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("merit/summary/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.jobGroups.length > 0,
 })
 </script>
 

--- a/VueApp/src/Effort/pages/MultiYearReport.vue
+++ b/VueApp/src/Effort/pages/MultiYearReport.vue
@@ -601,6 +601,7 @@
 import { ref, computed, onMounted } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar } from "quasar"
+import { useTitle } from "@vueuse/core"
 import { reportService } from "../services/report-service"
 import { instructorService } from "../services/instructor-service"
 import { termService } from "../services/term-service"
@@ -623,9 +624,15 @@ const router = useRouter()
 const { isAdmin } = useEffortPermissions()
 
 const loading = ref(false)
-const printLoading = ref(false)
 const excelLoading = ref(false)
 const report = ref<MultiYearReport | null>(null)
+useTitle(
+    computed(() => {
+        const r = report.value
+        if (!r) return "Multi-Year Merit & Promotion Report | VIPER"
+        return `Multi-Year Merit & Promotion Report - ${r.instructor} (${r.startYear}-${r.endYear}) | VIPER`
+    }),
+)
 
 // Filter state
 const selectedPersonId = ref<number | null>(null)
@@ -835,17 +842,13 @@ async function generateReport() {
     }
 }
 
-async function handlePrint() {
+function handlePrint() {
     if (selectedPersonId.value === null || !selectedStartYear.value || !selectedEndYear.value) return
-    printLoading.value = true
-    try {
-        const opened = await reportService.openMultiYearPdf(buildApiParams())
-        if (!opened) {
-            $q.notify({ type: "warning", message: "No data to export for the selected filters." })
-        }
-    } finally {
-        printLoading.value = false
+    if (!report.value || (!hasMeritData.value && !hasEvalData.value)) {
+        $q.notify({ type: "warning", message: "No data to export for the selected filters." })
+        return
     }
+    reportService.openMultiYearPdf(buildApiParams())
 }
 
 async function handleExcelDownload() {

--- a/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
+++ b/VueApp/src/Effort/pages/ScheduledCliWeeks.vue
@@ -89,9 +89,11 @@ import type { QTableColumn } from "quasar"
 
 const { termCode, loading, report, initialFilters, generateReport, handlePrint, handleExcelDownload } =
     useReportPage<ScheduledCliWeeksReport>({
+        title: "Scheduled Clinical Weeks",
         fetchReport: (params) => reportService.getScheduledCliWeeks(params),
         fetchPdf: (params) => reportService.openPdf("clinical-schedule/pdf", params),
         fetchExcel: (params) => reportService.downloadExcel("clinical-schedule/excel", params),
+        hasData: (r) => r.instructors.length > 0,
     })
 
 type CliWeeksRow = {

--- a/VueApp/src/Effort/pages/SchoolSummary.vue
+++ b/VueApp/src/Effort/pages/SchoolSummary.vue
@@ -206,10 +206,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<SchoolSummaryReport>({
+    title: "School Summary Report",
     fetchReport: (params) => reportService.getSchoolSummary(params),
     fetchPdf: (params) => reportService.openPdf("teaching/school-summary/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("teaching/school-summary/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.departments.length > 0,
 })
 </script>
 

--- a/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityGrouped.vue
@@ -224,10 +224,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<TeachingActivityReport>({
+    title: "Teaching Activity Report - Grouped by Department",
     fetchReport: (params) => reportService.getTeachingActivityGrouped(params),
     fetchPdf: (params) => reportService.openPdf("teaching/grouped/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("teaching/grouped/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.departments.length > 0,
 })
 
 /** Strip trailing zeros: 12.00 → "12", 10.50 → "10.5" */

--- a/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
+++ b/VueApp/src/Effort/pages/TeachingActivityIndividual.vue
@@ -185,10 +185,12 @@ const {
     handlePrint,
     handleExcelDownload,
 } = useReportPage<TeachingActivityReport>({
+    title: "Teaching Activity by Instructor",
     fetchReport: (params) => reportService.getTeachingActivityIndividual(params),
     fetchPdf: (params) => reportService.openPdf("teaching/individual/pdf", params),
     fetchExcel: (params) => reportService.downloadExcel("teaching/individual/excel", params),
     getEffortTypes: (r) => r.effortTypes,
+    hasData: (r) => r.departments.some((d) => d.instructors.length > 0),
 })
 
 /** Strip trailing zeros: 12.00 -> "12", 10.50 -> "10.5" */

--- a/VueApp/src/Effort/services/report-service.ts
+++ b/VueApp/src/Effort/services/report-service.ts
@@ -17,9 +17,6 @@ import type {
 
 const { get, put } = useFetch()
 
-/** Delay before revoking a blob URL opened in a new tab */
-const BLOB_REVOKE_DELAY_MS = 1000
-
 /**
  * Service for report API calls.
  */
@@ -207,32 +204,31 @@ class ReportService {
     }
 
     /**
-     * Export multi-year report as PDF. Returns false if no data.
+     * Open multi-year merit + evaluation PDF in a new tab. The PDF is served inline so the
+     * browser viewer renders it and Save preserves the server-supplied filename.
      */
-    async openMultiYearPdf(params: {
+    openMultiYearPdf(params: {
         personId: number
         startYear: number
         endYear: number
         excludeClinTerms?: string
         excludeDidTerms?: string
         useAcademicYear?: boolean
-    }): Promise<boolean> {
-        const body = {
-            personId: params.personId,
-            startYear: params.startYear,
-            endYear: params.endYear,
-            excludeClinicalTerms: params.excludeClinTerms || null,
-            excludeDidacticTerms: params.excludeDidTerms || null,
-            useAcademicYear: params.useAcademicYear || false,
+    }): void {
+        const searchParams = new URLSearchParams()
+        searchParams.set("personId", params.personId.toString())
+        searchParams.set("startYear", params.startYear.toString())
+        searchParams.set("endYear", params.endYear.toString())
+        if (params.excludeClinTerms) {
+            searchParams.set("excludeClinicalTerms", params.excludeClinTerms)
         }
-        const { blob } = await postForBlob(`${this.baseUrl}/merit/multiyear/pdf`, body)
-        if (blob.size === 0) {
-            return false
+        if (params.excludeDidTerms) {
+            searchParams.set("excludeDidacticTerms", params.excludeDidTerms)
         }
-        const url = globalThis.URL.createObjectURL(blob)
-        globalThis.open(url, "_blank", "noopener")
-        globalThis.setTimeout(() => globalThis.URL.revokeObjectURL(url), BLOB_REVOKE_DELAY_MS)
-        return true
+        if (params.useAcademicYear) {
+            searchParams.set("useAcademicYear", "true")
+        }
+        globalThis.open(`${this.baseUrl}/merit/multiyear/pdf?${searchParams.toString()}`, "_blank", "noopener")
     }
 
     /**
@@ -257,6 +253,13 @@ class ReportService {
         }
         downloadBlob(blob, filename ?? "report.xlsx")
         return true
+    }
+
+    openClinicalEffortPdf(academicYear: string, clinicalType: number): void {
+        const searchParams = new URLSearchParams()
+        searchParams.set("academicYear", academicYear)
+        searchParams.set("clinicalType", clinicalType.toString())
+        globalThis.open(`${this.baseUrl}/merit/clinical/pdf?${searchParams.toString()}`, "_blank", "noopener")
     }
 
     async downloadMultiYearExcel(params: {
@@ -284,17 +287,12 @@ class ReportService {
     }
 
     /**
-     * Open a report PDF in a new tab. Returns false if the report has no data.
+     * Open a report PDF in a new tab. The endpoint is served inline so the browser viewer
+     * renders it and Save preserves the server-supplied filename.
      */
-    async openPdf(endpoint: string, params: ReportFilterParams): Promise<boolean> {
-        const { blob } = await postForBlob(`${this.baseUrl}/${endpoint}`, params)
-        if (blob.size === 0) {
-            return false
-        }
-        const url = globalThis.URL.createObjectURL(blob)
+    openPdf(endpoint: string, params: ReportFilterParams): void {
+        const url = this.buildUrl(endpoint, params)
         globalThis.open(url, "_blank", "noopener")
-        globalThis.setTimeout(() => globalThis.URL.revokeObjectURL(url), BLOB_REVOKE_DELAY_MS)
-        return true
     }
 
     private buildUrl(endpoint: string, params: ReportFilterParams): string {

--- a/VueApp/src/Students/EmergencyContact/__tests__/contact-section.test.ts
+++ b/VueApp/src/Students/EmergencyContact/__tests__/contact-section.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest"
 import { ref, computed } from "vue"
 import { patterns } from "quasar"
 import type { ContactInfo } from "../types"

--- a/VueApp/src/Students/EmergencyContact/__tests__/emergency-contact-service.test.ts
+++ b/VueApp/src/Students/EmergencyContact/__tests__/emergency-contact-service.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
 import { emergencyContactService } from "../services/emergency-contact-service"
 import type { UpdateStudentContactRequest } from "../types"
 

--- a/VueApp/src/Students/EmergencyContact/pages/EmergencyContactList.vue
+++ b/VueApp/src/Students/EmergencyContact/pages/EmergencyContactList.vue
@@ -90,11 +90,20 @@ function navigateToStudent(row: StudentContactListItem): void {
 }
 
 async function handleExcelExport(): Promise<void> {
-    await emergencyContactService.downloadOverviewExcel()
+    const success = await emergencyContactService.downloadOverviewExcel()
+    if (success) {
+        $q.notify({ type: "positive", message: "Excel report downloaded." })
+    } else {
+        $q.notify({ type: "warning", message: "No data to export." })
+    }
 }
 
-async function handlePdfExport(): Promise<void> {
-    await emergencyContactService.openOverviewPdf()
+function handlePdfExport(): void {
+    if (rows.value.length === 0) {
+        $q.notify({ type: "warning", message: "No data to export." })
+        return
+    }
+    emergencyContactService.openOverviewPdf()
 }
 
 async function loadGrantedIds(): Promise<void> {

--- a/VueApp/src/Students/EmergencyContact/pages/EmergencyContactReport.vue
+++ b/VueApp/src/Students/EmergencyContact/pages/EmergencyContactReport.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, useTemplateRef } from "vue"
+import { useQuasar } from "quasar"
 import type { QTable, QTableProps } from "quasar"
 import { emergencyContactService } from "../services/emergency-contact-service"
 import ExportToolbar from "@/components/ExportToolbar.vue"
 import { formatPhone } from "../utils/phone"
 import type { StudentContactReport, ContactInfo } from "../types"
 
+const $q = useQuasar()
 const loading = ref(false)
 const rows = ref<StudentContactReport[]>([])
 const filter = ref("")
@@ -54,11 +56,20 @@ function formatContact(contact: ContactInfo | null | undefined): string[] {
 }
 
 async function handleExcelExport(): Promise<void> {
-    await emergencyContactService.downloadExcel()
+    const success = await emergencyContactService.downloadExcel()
+    if (success) {
+        $q.notify({ type: "positive", message: "Excel report downloaded." })
+    } else {
+        $q.notify({ type: "warning", message: "No data to export." })
+    }
 }
 
-async function handlePdfExport(): Promise<void> {
-    await emergencyContactService.openPdf()
+function handlePdfExport(): void {
+    if (rows.value.length === 0) {
+        $q.notify({ type: "warning", message: "No data to export." })
+        return
+    }
+    emergencyContactService.openPdf()
 }
 
 async function load(): Promise<void> {

--- a/VueApp/src/Students/EmergencyContact/services/emergency-contact-service.ts
+++ b/VueApp/src/Students/EmergencyContact/services/emergency-contact-service.ts
@@ -7,8 +7,6 @@ import type {
     AppAccessStatus,
 } from "../types"
 
-const REVOKE_DELAY_MS = 1000
-
 class EmergencyContactService {
     private baseUrl = `${import.meta.env.VITE_API_URL}students/emergency-contacts`
 
@@ -97,15 +95,8 @@ class EmergencyContactService {
         return true
     }
 
-    openOverviewPdf = async (): Promise<boolean> => {
-        const { blob } = await postForBlob(`${this.baseUrl}/export/overview/pdf`, {})
-        if (blob.size === 0) {
-            return false
-        }
-        const url = globalThis.URL.createObjectURL(blob)
-        globalThis.open(url, "_blank", "noopener")
-        globalThis.setTimeout(() => globalThis.URL.revokeObjectURL(url), REVOKE_DELAY_MS)
-        return true
+    openOverviewPdf = (): void => {
+        globalThis.open(`${this.baseUrl}/export/overview/pdf`, "_blank", "noopener")
     }
 
     downloadExcel = async (): Promise<boolean> => {
@@ -117,15 +108,8 @@ class EmergencyContactService {
         return true
     }
 
-    openPdf = async (): Promise<boolean> => {
-        const { blob } = await postForBlob(`${this.baseUrl}/export/pdf`, {})
-        if (blob.size === 0) {
-            return false
-        }
-        const url = globalThis.URL.createObjectURL(blob)
-        globalThis.open(url, "_blank", "noopener")
-        globalThis.setTimeout(() => globalThis.URL.revokeObjectURL(url), REVOKE_DELAY_MS)
-        return true
+    openPdf = (): void => {
+        globalThis.open(`${this.baseUrl}/export/pdf`, "_blank", "noopener")
     }
 }
 

--- a/VueApp/src/Students/components/PhotoGallery/PhotoSheet.vue
+++ b/VueApp/src/Students/components/PhotoGallery/PhotoSheet.vue
@@ -103,6 +103,13 @@ function photoUrl(student: StudentPhoto): string {
 </script>
 
 <style scoped>
+/* The parent page renders the title in its bg-grey-2 toolbar; this print-header
+   only exists so the saved PDF / browser-printed page carries the title. Hide
+   it on screen to avoid the duplicate the user reported. */
+.print-header {
+    display: none;
+}
+
 .photo-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(55px, 55px));

--- a/VueApp/src/Students/pages/PhotoGallery.vue
+++ b/VueApp/src/Students/pages/PhotoGallery.vue
@@ -61,20 +61,6 @@
                             </q-btn>
                         </q-btn-group>
                     </div>
-                    <div
-                        v-if="activeTab === 'list' && studentListData.length > 0"
-                        class="col-auto"
-                    >
-                        <q-btn
-                            flat
-                            icon="print"
-                            color="primary"
-                            aria-label="Print Student List"
-                            @click="handlePrint"
-                        >
-                            <q-tooltip>Print Student List</q-tooltip>
-                        </q-btn>
-                    </div>
                 </div>
             </q-card-section>
 
@@ -205,22 +191,19 @@
                         class="q-mt-lg"
                     >
                         <!-- Title bar with export toolbar -->
-                        <div class="row items-center q-mb-md q-pa-sm bg-grey-2 rounded-borders no-print">
+                        <div class="row items-center q-pa-sm bg-grey-2 rounded-borders no-print">
                             <div class="col">
                                 <h2 class="text-h5 text-weight-bold q-my-none">{{ pageTitle }}</h2>
                             </div>
                             <div class="col-auto">
+                                <!-- One toolbar drives all gallery views; sheet view hides the
+                                     search input but keeps the same accessible PDF/Word exports. -->
                                 <ExportToolbar
-                                    v-if="galleryStore.galleryView !== 'sheet'"
                                     v-model:filter="photoFilter"
-                                    show-search
+                                    :show-search="galleryStore.galleryView !== 'sheet'"
                                     :busy="galleryStore.exportInProgress"
                                     :pdf-export="handleExportToPDF"
                                     :word-export="handleExportToWord"
-                                />
-                                <ExportToolbar
-                                    v-else
-                                    :print-action="handlePrint"
                                 />
                             </div>
                         </div>
@@ -464,22 +447,22 @@
                         v-else-if="studentListData.length > 0"
                         class="q-mt-lg"
                     >
-                        <!-- Print Button for Student List -->
-                        <div class="row q-mb-md no-print">
-                            <q-btn
-                                color="primary"
-                                icon="print"
-                                label="Print"
-                                @click="handlePrint"
-                            />
-                        </div>
-
-                        <div class="row items-center q-mb-md no-print">
+                        <!-- Title bar matches the gallery view pattern: title + caption
+                             on the left, ExportToolbar (search input + Print/PDF button)
+                             on the right, all on a single row. -->
+                        <div class="row items-center q-mb-md q-pa-sm bg-grey-2 rounded-borders no-print">
                             <div class="col">
-                                <h2 class="text-subtitle1 q-my-none">
+                                <h2 class="text-subtitle1 q-my-none student-list-title">
                                     {{ studentListTitle }}
                                 </h2>
                                 <div class="text-caption text-grey-7">Generated: {{ currentDateFormatted }}</div>
+                            </div>
+                            <div class="col-auto">
+                                <ExportToolbar
+                                    v-model:filter="studentListFilter"
+                                    show-search
+                                    :pdf-export="handleExportStudentListToPDF"
+                                />
                             </div>
                         </div>
 
@@ -491,23 +474,7 @@
                             :pagination="{ rowsPerPage: 0 }"
                             :filter="studentListFilter"
                             class="student-list-table"
-                        >
-                            <template #top-right>
-                                <div class="no-print">
-                                    <q-input
-                                        v-model="studentListFilter"
-                                        dense
-                                        outlined
-                                        debounce="300"
-                                        placeholder="Filter students"
-                                    >
-                                        <template #append>
-                                            <q-icon name="search" />
-                                        </template>
-                                    </q-input>
-                                </div>
-                            </template>
-                        </q-table>
+                        />
                     </div>
 
                     <div
@@ -538,6 +505,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, nextTick } from "vue"
+import { useTitle } from "@vueuse/core"
 import { useQuasar } from "quasar"
 import { useRoute, useRouter } from "vue-router"
 import { usePhotoGalleryStore } from "../stores/photo-gallery-store"
@@ -556,8 +524,6 @@ import type { QTableColumn } from "quasar"
 import type { StudentPhoto } from "../services/photo-gallery-service"
 
 // Constants
-const PRINT_DELAY_MS = 1000 // Delay before triggering print dialog to ensure images are loaded
-
 const $q = useQuasar()
 const route = useRoute()
 const router = useRouter()
@@ -1229,6 +1195,7 @@ async function handleExportToWord() {
         await galleryStore.exportToWord({
             groupType: selectedGroupType.value || undefined,
             groupId: selectedGroup.value || undefined,
+            view: galleryStore.galleryView,
         })
         $q.notify({
             type: "positive",
@@ -1242,28 +1209,40 @@ async function handleExportToWord() {
     }
 }
 
-async function handleExportToPDF() {
-    try {
-        // Pass local group type/id to ensure proper grouping in export
-        await galleryStore.exportToPDF({
-            groupType: selectedGroupType.value || undefined,
-            groupId: selectedGroup.value || undefined,
-        })
-        $q.notify({
-            type: "positive",
-            message: "Export to PDF completed successfully",
-        })
-    } catch (error: any) {
-        $q.notify({
-            type: "negative",
-            message: error.message || "Failed to export to PDF",
-        })
-    }
+function handleExportToPDF() {
+    photoGalleryService.openPdf({
+        ...galleryStore.exportParams,
+        groupType: selectedGroupType.value || undefined,
+        groupId: selectedGroup.value || undefined,
+        exportFormat: "pdf",
+        view: galleryStore.galleryView,
+    })
 }
 
-function handlePrint() {
-    globalThis.print()
+function handleExportStudentListToPDF() {
+    const classYearInfo = classYears.value.find((cy) => cy.year === selectedStudentListYear.value)
+    if (!classYearInfo) {
+        $q.notify({ type: "warning", message: "Select a class year before exporting." })
+        return
+    }
+    if (studentListData.value.length === 0) {
+        $q.notify({ type: "warning", message: "No students to export." })
+        return
+    }
+    photoGalleryService.openStudentListPdf({
+        classLevel: classYearInfo.classLevel,
+        includeRossStudents: includeRossStudentsInList.value,
+    })
 }
+
+// Page title reflects the active tab so the browser tab + saved-file
+// suggestion (when users print or save) match the content on screen.
+const pageDocumentTitle = computed(() => {
+    const base = activeTab.value === "list" ? studentListTitle.value : pageTitle.value
+    const trimmed = (base || "Students").trim()
+    return trimmed.length > 0 ? `${trimmed} | VIPER` : "VIPER - Students"
+})
+useTitle(pageDocumentTitle)
 
 async function handleStudentClickByMailId(mailId: string) {
     if (!galleryStore.students || galleryStore.students.length === 0) {
@@ -1347,20 +1326,10 @@ watch(
 watch(
     () => galleryStore.galleryView,
     async (newView, oldView) => {
-        // Reload data and auto-trigger print dialog when switching to sheet view
+        // Refresh photo data when switching into sheet view so the rendered
+        // sheet reflects the current selection.
         if (newView === "sheet" && oldView !== "sheet") {
-            // Reload Photo Gallery data to ensure it's fresh
             await reloadPhotoGalleryData()
-
-            // Auto-trigger print dialog after data loads
-            if (galleryStore.hasStudents) {
-                // Use nextTick + setTimeout to ensure images are loaded before printing
-                nextTick(() => {
-                    setTimeout(() => {
-                        window.print()
-                    }, PRINT_DELAY_MS)
-                })
-            }
         }
     },
 )
@@ -1423,6 +1392,16 @@ watch(selectedStudentIndex, (newIndex) => {
 
 <style>
 h1.page-main-title {
+    margin: 0;
+}
+
+/* Tighten the line-height and zero the margin so the "Generated:" caption
+   sits flush below the student list title. text-subtitle1 sets a
+   line-height around 1.75 with the same class-level specificity as our
+   override, so we use the element+class selector (matching the
+   page-main-title rule above) to win the cascade against Quasar. */
+h2.student-list-title {
+    line-height: 1.2;
     margin: 0;
 }
 

--- a/VueApp/src/Students/services/photo-gallery-service.ts
+++ b/VueApp/src/Students/services/photo-gallery-service.ts
@@ -58,6 +58,12 @@ interface PhotoExportRequest {
     crn?: string
     includeRossStudents?: boolean
     exportFormat?: string
+    /**
+     * On-screen view that triggered the export ("grid" | "list" | "sheet").
+     * Carried into the saved filename so multiple downloads of the same class
+     * can be told apart.
+     */
+    view?: string
 }
 
 interface GalleryMenu {
@@ -151,6 +157,55 @@ class PhotoGalleryService {
 
     exportToPDF = (request: PhotoExportRequest): Promise<{ blob: Blob; filename: string | null }> =>
         postForBlob(`${this.baseUrl}/export/pdf`, request)
+
+    /**
+     * Opens the photo-gallery PDF in a new browser tab via the GET endpoint
+     * so the document renders in the browser's built-in viewer. Use this for
+     * inline preview; use `exportToPDF` when you need a Blob for download.
+     */
+    openPdf = (request: PhotoExportRequest): void => {
+        const params = new URLSearchParams()
+        if (request.classLevel) {
+            params.set("classLevel", request.classLevel)
+        }
+        if (request.groupType) {
+            params.set("groupType", request.groupType)
+        }
+        if (request.groupId) {
+            params.set("groupId", request.groupId)
+        }
+        if (request.termCode) {
+            params.set("termCode", request.termCode)
+        }
+        if (request.crn) {
+            params.set("crn", request.crn)
+        }
+        if (request.includeRossStudents) {
+            params.set("includeRossStudents", "true")
+        }
+        if (request.view) {
+            params.set("view", request.view)
+        }
+        const qs = params.toString()
+        const url = qs ? `${this.baseUrl}/export/pdf?${qs}` : `${this.baseUrl}/export/pdf`
+        globalThis.open(url, "_blank", "noopener")
+    }
+
+    exportStudentListToPDF = (request: PhotoExportRequest): Promise<{ blob: Blob; filename: string | null }> =>
+        postForBlob(`${this.baseUrl}/export/list/pdf`, request)
+
+    /**
+     * Opens the tabular student-list PDF in a new browser tab via the GET
+     * endpoint so the document renders in the browser's built-in viewer.
+     */
+    openStudentListPdf = (request: { classLevel: string; includeRossStudents?: boolean }): void => {
+        const params = new URLSearchParams()
+        params.set("classLevel", request.classLevel)
+        if (request.includeRossStudents) {
+            params.set("includeRossStudents", "true")
+        }
+        globalThis.open(`${this.baseUrl}/export/list/pdf?${params.toString()}`, "_blank", "noopener")
+    }
 
     getAvailableGroups = async (): Promise<any> => {
         const { get } = useFetch()

--- a/VueApp/src/components/ExportToolbar.vue
+++ b/VueApp/src/components/ExportToolbar.vue
@@ -8,7 +8,7 @@ const props = withDefaults(
         filter?: string
         showSearch?: boolean
         excelExport?: () => Promise<void>
-        pdfExport?: () => Promise<void>
+        pdfExport?: () => void | Promise<void>
         wordExport?: () => Promise<void>
         printAction?: () => void
         busy?: boolean

--- a/VueApp/src/config/colors.ts
+++ b/VueApp/src/config/colors.ts
@@ -259,9 +259,10 @@ function getAccessibleTextColor(color: string | null | undefined): "dark" | "whi
     return color && LIGHT_BACKGROUND_COLORS.has(color) ? "dark" : "white"
 }
 
-// Quasar's grey (alias for grey-5, #9e9e9e) and grey-6 (#757575) sit in the
-// contrast dead zone where neither white nor dark foreground reaches 4.5:1.
-// Remap to the nearest shade that clears AA with white text.
+// Quasar's grey (alias for grey-6, #9e9e9e), grey-5 (#bdbdbd), and grey-6
+// (#9e9e9e) sit in the contrast dead zone where neither white nor dark
+// foreground reaches 4.5:1. Remap to the nearest shade that clears AA
+// with white text.
 const CONTRAST_SAFE_SWAPS = new Map<string, string>([
     ["grey", "grey-7"],
     ["grey-5", "grey-7"],

--- a/test/Classes/Utilities/ExcelAccessibilityHelperTests.cs
+++ b/test/Classes/Utilities/ExcelAccessibilityHelperTests.cs
@@ -1,0 +1,102 @@
+using ClosedXML.Excel;
+using Viper.Classes.Utilities;
+
+namespace Viper.test.Classes.Utilities;
+
+public class ExcelAccessibilityHelperTests
+{
+    [Fact]
+    public void SetCoreProperties_PopulatesTitleSubjectAuthor()
+    {
+        using var wb = new XLWorkbook();
+
+        ExcelAccessibilityHelper.SetCoreProperties(wb,
+            title: "Annual Report",
+            subject: "FY26 figures",
+            author: "Test Suite");
+
+        Assert.Equal("Annual Report", wb.Properties.Title);
+        Assert.Equal("FY26 figures", wb.Properties.Subject);
+        Assert.Equal("Test Suite", wb.Properties.Author);
+    }
+
+    [Fact]
+    public void SetCoreProperties_DefaultsAuthorToUcDavisSvm()
+    {
+        using var wb = new XLWorkbook();
+
+        ExcelAccessibilityHelper.SetCoreProperties(wb, title: "Doc");
+
+        Assert.Equal(ExcelAccessibilityHelper.DefaultAuthor, wb.Properties.Author);
+    }
+
+    [Fact]
+    public void SetCoreProperties_FallsBackSubjectToTitleWhenNull()
+    {
+        using var wb = new XLWorkbook();
+
+        ExcelAccessibilityHelper.SetCoreProperties(wb, title: "Just A Title");
+
+        Assert.Equal("Just A Title", wb.Properties.Subject);
+    }
+
+    [Fact]
+    public void PromoteToAccessibleTable_CreatesTableWithGivenName()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Data");
+        ws.Cell(1, 1).Value = "Name";
+        ws.Cell(1, 2).Value = "Score";
+        ws.Cell(2, 1).Value = "Alice";
+        ws.Cell(2, 2).Value = 42;
+
+        var table = ExcelAccessibilityHelper.PromoteToAccessibleTable(
+            ws.Range(1, 1, 2, 2), "ScoresTable");
+
+        Assert.Equal("ScoresTable", table.Name);
+        Assert.True(table.ShowHeaderRow);
+    }
+
+    [Fact]
+    public void PromoteToAccessibleTable_SanitizesInvalidCharactersInTableName()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Data");
+        ws.Cell(1, 1).Value = "Header";
+        ws.Cell(2, 1).Value = "Row";
+
+        var table = ExcelAccessibilityHelper.PromoteToAccessibleTable(
+            ws.Range(1, 1, 2, 1), "Cardiology - Group A");
+
+        Assert.Equal("Cardiology___Group_A", table.Name);
+    }
+
+    [Fact]
+    public void PromoteToAccessibleTable_PrependsLetterWhenNameStartsWithDigit()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Data");
+        ws.Cell(1, 1).Value = "Header";
+        ws.Cell(2, 1).Value = "Row";
+
+        var table = ExcelAccessibilityHelper.PromoteToAccessibleTable(
+            ws.Range(1, 1, 2, 1), "2026Report");
+
+        Assert.StartsWith("T_", table.Name);
+        Assert.Contains("2026Report", table.Name);
+    }
+
+    [Fact]
+    public void PromoteToAccessibleTable_HidesAutoFilterDropdowns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Data");
+        ws.Cell(1, 1).Value = "Header";
+        ws.Cell(2, 1).Value = "Row";
+
+        var table = ExcelAccessibilityHelper.PromoteToAccessibleTable(
+            ws.Range(1, 1, 2, 1), "T1");
+
+        Assert.False(table.ShowAutoFilter);
+    }
+}

--- a/test/Classes/Utilities/PdfAccessibilityHelperTests.cs
+++ b/test/Classes/Utilities/PdfAccessibilityHelperTests.cs
@@ -1,0 +1,82 @@
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+using Viper.Classes.Utilities;
+
+namespace Viper.test.Classes.Utilities;
+
+public class PdfAccessibilityHelperTests
+{
+    private static Document MinimalDocument() =>
+        Document.Create(container =>
+            container.Page(page => page.Content().Text("placeholder")));
+
+    [Fact]
+    public void WithAccessibility_PopulatesAllMetadataFields()
+    {
+        var document = MinimalDocument().WithAccessibility(
+            title: "Annual Report",
+            subject: "FY26 figures",
+            keywords: "merit, evaluation",
+            author: "Test Suite",
+            language: "en-GB");
+
+        var meta = document.GetMetadata();
+        Assert.Equal("Annual Report", meta.Title);
+        Assert.Equal("FY26 figures", meta.Subject);
+        Assert.Equal("merit, evaluation", meta.Keywords);
+        Assert.Equal("Test Suite", meta.Author);
+        Assert.Equal("en-GB", meta.Language);
+    }
+
+    [Fact]
+    public void WithAccessibility_DefaultsAuthorToUcDavisSvm()
+    {
+        var document = MinimalDocument().WithAccessibility(title: "Doc");
+
+        Assert.Equal(PdfAccessibilityHelper.DefaultAuthor, document.GetMetadata().Author);
+    }
+
+    [Fact]
+    public void WithAccessibility_DefaultsLanguageToEnUs()
+    {
+        var document = MinimalDocument().WithAccessibility(title: "Doc");
+
+        Assert.Equal(PdfAccessibilityHelper.DefaultLanguage, document.GetMetadata().Language);
+    }
+
+    [Fact]
+    public void WithAccessibility_SubjectFallsBackToTitleWhenNull()
+    {
+        var document = MinimalDocument().WithAccessibility(title: "Title Only");
+
+        Assert.Equal("Title Only", document.GetMetadata().Subject);
+    }
+
+    [Fact]
+    public void WithAccessibility_KeywordsDefaultToEmptyStringWhenNull()
+    {
+        var document = MinimalDocument().WithAccessibility(title: "Doc");
+
+        Assert.Equal(string.Empty, document.GetMetadata().Keywords);
+    }
+
+    [Fact]
+    public void WithAccessibility_EnablesPdfUa1Conformance()
+    {
+        var document = MinimalDocument().WithAccessibility(title: "Doc");
+
+        Assert.Equal(PDFUA_Conformance.PDFUA_1, document.GetSettings().PDFUA_Conformance);
+    }
+
+    [Fact]
+    public void WithAccessibility_StampsCreationAndModifiedDates()
+    {
+        var before = DateTimeOffset.Now.AddSeconds(-5);
+        var document = MinimalDocument().WithAccessibility(title: "Doc");
+        var after = DateTimeOffset.Now.AddSeconds(5);
+
+        var meta = document.GetMetadata();
+        Assert.InRange(meta.CreationDate, before, after);
+        Assert.InRange(meta.ModifiedDate, before, after);
+    }
+}

--- a/test/Classes/Utilities/WordAccessibilityHelperTests.cs
+++ b/test/Classes/Utilities/WordAccessibilityHelperTests.cs
@@ -1,0 +1,223 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Viper.Classes.Utilities;
+using DrawingNonVisualPicture = DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties;
+using DrawingDocProperties = DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties;
+
+namespace Viper.test.Classes.Utilities;
+
+public class WordAccessibilityHelperTests
+{
+#pragma warning disable S3220 // OpenXML SDK uses params overloads by design for fluent object construction
+    private static (WordprocessingDocument doc, MainDocumentPart mainPart) NewDocument(MemoryStream stream)
+    {
+        var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document);
+        var mainPart = doc.AddMainDocumentPart();
+        mainPart.Document = new Document(new Body());
+        return (doc, mainPart);
+    }
+#pragma warning restore S3220
+
+    private static Style? FindStyle(Styles styles, string styleId) =>
+        styles.Elements<Style>().FirstOrDefault(s => s.StyleId?.Value == styleId);
+
+    [Fact]
+    public void EnsureAccessibilityStyles_RegistersHeading1WithOutlineLevel0()
+    {
+        using var stream = new MemoryStream();
+        var (doc, mainPart) = NewDocument(stream);
+
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+
+        var styles = mainPart.StyleDefinitionsPart!.Styles!;
+        var h1 = FindStyle(styles, WordAccessibilityHelper.Heading1StyleId);
+        Assert.NotNull(h1);
+        var outline = h1.StyleParagraphProperties?.Elements<OutlineLevel>().FirstOrDefault();
+        Assert.NotNull(outline);
+        Assert.Equal(0, outline.Val?.Value);
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void EnsureAccessibilityStyles_TitleStyleIsNotMarkedDefault()
+    {
+        // Regression guard: Default = true on the Title paragraph style is wrong —
+        // only the Normal style should be default for its type.
+        using var stream = new MemoryStream();
+        var (doc, mainPart) = NewDocument(stream);
+
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+
+        var styles = mainPart.StyleDefinitionsPart!.Styles!;
+        var title = FindStyle(styles, WordAccessibilityHelper.TitleStyleId);
+        Assert.NotNull(title);
+        Assert.False(title.Default?.Value ?? false);
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void EnsureAccessibilityStyles_TitleAndHeading1HaveDifferentFontSizes()
+    {
+        // Regression guard: visually distinguishable so users can tell the document
+        // title apart from a top-level heading.
+        using var stream = new MemoryStream();
+        var (doc, mainPart) = NewDocument(stream);
+
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+
+        var styles = mainPart.StyleDefinitionsPart!.Styles!;
+        var titleSize = FindStyle(styles, WordAccessibilityHelper.TitleStyleId)
+            ?.StyleRunProperties?.Elements<FontSize>().FirstOrDefault()?.Val?.Value;
+        var h1Size = FindStyle(styles, WordAccessibilityHelper.Heading1StyleId)
+            ?.StyleRunProperties?.Elements<FontSize>().FirstOrDefault()?.Val?.Value;
+
+        Assert.NotNull(titleSize);
+        Assert.NotNull(h1Size);
+        Assert.NotEqual(titleSize, h1Size);
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void EnsureAccessibilityStyles_SetsDefaultDocumentLanguage()
+    {
+        using var stream = new MemoryStream();
+        var (doc, mainPart) = NewDocument(stream);
+
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart, language: "fr-FR");
+
+        var docDefaults = mainPart.StyleDefinitionsPart!.Styles!.Elements<DocDefaults>().Single();
+        var lang = docDefaults.RunPropertiesDefault?.RunPropertiesBaseStyle?
+            .Elements<Languages>().FirstOrDefault()?.Val?.Value;
+        Assert.Equal("fr-FR", lang);
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void EnsureAccessibilityStyles_IsIdempotent()
+    {
+        using var stream = new MemoryStream();
+        var (doc, mainPart) = NewDocument(stream);
+
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+        WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+
+        var styles = mainPart.StyleDefinitionsPart!.Styles!;
+        var styleIds = new[]
+        {
+            WordAccessibilityHelper.TitleStyleId,
+            WordAccessibilityHelper.Heading1StyleId,
+            WordAccessibilityHelper.Heading2StyleId,
+            WordAccessibilityHelper.Heading3StyleId,
+        };
+        foreach (var id in styleIds)
+        {
+            Assert.Equal(1, styles.Elements<Style>().Count(s => s.StyleId?.Value == id));
+        }
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void SetImageAltText_OnlyDescription_LeavesTitleNull()
+    {
+        // Regression guard: setting the same string for Title + Description
+        // raises an Office Accessibility Checker warning. Title must stay null
+        // unless caller explicitly opts in.
+        var wpDocProps = new DrawingDocProperties { Id = 1U, Name = "Img1" };
+        var picProps = new DrawingNonVisualPicture { Id = 1U, Name = "Img1.jpg" };
+
+        WordAccessibilityHelper.SetImageAltText(wpDocProps, picProps, "Photo of student");
+
+        Assert.Equal("Photo of student", wpDocProps.Description?.Value);
+        Assert.Equal("Photo of student", picProps.Description?.Value);
+        Assert.Null(wpDocProps.Title?.Value);
+        Assert.Null(picProps.Title?.Value);
+    }
+
+    [Fact]
+    public void SetImageAltText_WithExplicitTitle_SetsBoth()
+    {
+        var wpDocProps = new DrawingDocProperties { Id = 1U, Name = "Img1" };
+        var picProps = new DrawingNonVisualPicture { Id = 1U, Name = "Img1.jpg" };
+
+        WordAccessibilityHelper.SetImageAltText(wpDocProps, picProps,
+            description: "Detailed long description for the chart",
+            title: "Q3 revenue");
+
+        Assert.Equal("Q3 revenue", wpDocProps.Title?.Value);
+        Assert.Equal("Q3 revenue", picProps.Title?.Value);
+        Assert.Equal("Detailed long description for the chart", wpDocProps.Description?.Value);
+    }
+
+    [Fact]
+    public void CreateHeadingParagraph_AppliesGivenStyleId()
+    {
+        var paragraph = WordAccessibilityHelper.CreateHeadingParagraph(
+            "Section 1", WordAccessibilityHelper.Heading2StyleId);
+
+        var styleId = paragraph.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
+        Assert.Equal(WordAccessibilityHelper.Heading2StyleId, styleId);
+        Assert.Equal("Section 1", paragraph.InnerText);
+    }
+
+    [Fact]
+    public void MarkAsTableHeaderRow_AddsTblHeaderProperty()
+    {
+        var row = new TableRow();
+
+        WordAccessibilityHelper.MarkAsTableHeaderRow(row);
+
+        var props = row.Elements<TableRowProperties>().Single();
+        Assert.Single(props.Elements<TableHeader>());
+    }
+
+    [Fact]
+    public void MarkAsTableHeaderRow_IsIdempotent()
+    {
+        var row = new TableRow();
+
+        WordAccessibilityHelper.MarkAsTableHeaderRow(row);
+        WordAccessibilityHelper.MarkAsTableHeaderRow(row);
+
+        var props = row.Elements<TableRowProperties>().Single();
+        Assert.Single(props.Elements<TableHeader>());
+    }
+
+    [Fact]
+    public void SetCoreProperties_PopulatesTitleSubjectCreatorLanguage()
+    {
+        using var stream = new MemoryStream();
+        var (doc, _) = NewDocument(stream);
+
+        WordAccessibilityHelper.SetCoreProperties(doc,
+            title: "Annual Report",
+            subject: "FY26 figures",
+            creator: "Test Suite",
+            language: "en-GB");
+
+        Assert.Equal("Annual Report", doc.PackageProperties.Title);
+        Assert.Equal("FY26 figures", doc.PackageProperties.Subject);
+        Assert.Equal("Test Suite", doc.PackageProperties.Creator);
+        Assert.Equal("en-GB", doc.PackageProperties.Language);
+
+        doc.Dispose();
+    }
+
+    [Fact]
+    public void SetCoreProperties_FallsBackSubjectToTitleWhenNull()
+    {
+        using var stream = new MemoryStream();
+        var (doc, _) = NewDocument(stream);
+
+        WordAccessibilityHelper.SetCoreProperties(doc, title: "Just A Title");
+
+        Assert.Equal("Just A Title", doc.PackageProperties.Subject);
+
+        doc.Dispose();
+    }
+}

--- a/test/Students/EmergencyContactControllerTests.cs
+++ b/test/Students/EmergencyContactControllerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -32,7 +33,10 @@ public class EmergencyContactControllerTests
         _rapsContext = Substitute.For<RAPSContext>();
         _userHelper = Substitute.For<IUserHelper>();
         _logger = Substitute.For<ILogger<EmergencyContactController>>();
-        _controller = new EmergencyContactController(_service, _exportService, _rapsContext, _userHelper, _logger);
+        _controller = new EmergencyContactController(_service, _exportService, _rapsContext, _userHelper, _logger)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
     }
 
     #region GetStudentContactList Tests
@@ -596,7 +600,7 @@ public class EmergencyContactControllerTests
     }
 
     [Fact]
-    public async Task ExportPdf_WithData_ReturnsFile()
+    public async Task ExportPdf_WithData_ReturnsInlineFile()
     {
         var data = new List<StudentContactReportDto> { new() { PersonId = 1 } };
         _service.GetStudentContactReportAsync().Returns(data);
@@ -606,6 +610,11 @@ public class EmergencyContactControllerTests
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
+        // InlineFile must set Content-Disposition: inline with a filename so the browser
+        // renders the PDF in its built-in viewer instead of forcing a download.
+        var disposition = _controller.Response.Headers.ContentDisposition.ToString();
+        Assert.StartsWith("inline", disposition);
+        Assert.Contains("EmergencyContacts_", disposition);
     }
 
     [Fact]

--- a/web/Areas/Effort/Controllers/ReportsController.cs
+++ b/web/Areas/Effort/Controllers/ReportsController.cs
@@ -162,10 +162,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export teaching activity report as PDF.
     /// </summary>
-    [HttpPost("teaching/grouped/pdf")]
+    [HttpGet("teaching/grouped/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportTeachingActivityGroupedPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -217,7 +217,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _teachingActivityService.GenerateReportPdfAsync(report);
         var filename = $"TeachingActivity_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("teaching/grouped/excel")]
@@ -266,10 +266,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export individual teaching activity report as PDF (one section per instructor).
     /// </summary>
-    [HttpPost("teaching/individual/pdf")]
+    [HttpGet("teaching/individual/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportTeachingActivityIndividualPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -321,7 +321,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _teachingActivityService.GenerateIndividualReportPdfAsync(report);
         var filename = $"TeachingActivityIndividual_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("teaching/individual/excel")]
@@ -627,10 +627,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export department summary report as PDF.
     /// </summary>
-    [HttpPost("teaching/dept-summary/pdf")]
+    [HttpGet("teaching/dept-summary/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportDeptSummaryPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -668,7 +668,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _deptSummaryService.GenerateReportPdfAsync(report);
         var filename = $"DeptSummary_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("teaching/dept-summary/excel")]
@@ -777,10 +777,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export school summary report as PDF. Requires SVMSecure.Effort.SchoolSummary permission.
     /// </summary>
-    [HttpPost("teaching/school-summary/pdf")]
+    [HttpGet("teaching/school-summary/pdf")]
     [Permission(Allow = $"{EffortPermissions.SchoolSummary},{EffortPermissions.ViewAllDepartments}")]
     public async Task<ActionResult> ExportSchoolSummaryPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -814,7 +814,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _schoolSummaryService.GenerateReportPdfAsync(report);
         var filename = $"SchoolSummary_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("teaching/school-summary/excel")]
@@ -921,10 +921,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export merit detail report as PDF.
     /// </summary>
-    [HttpPost("merit/detail/pdf")]
+    [HttpGet("merit/detail/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportMeritDetailPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -962,7 +962,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _meritReportService.GenerateMeritDetailPdfAsync(report);
         var filename = $"MeritDetail_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("merit/detail/excel")]
@@ -1067,10 +1067,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export merit average report as PDF.
     /// </summary>
-    [HttpPost("merit/average/pdf")]
+    [HttpGet("merit/average/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportMeritAveragePdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -1108,7 +1108,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _meritReportService.GenerateMeritAveragePdfAsync(report);
         var filename = $"MeritAverage_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("merit/average/excel")]
@@ -1210,10 +1210,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export merit summary report as PDF.
     /// </summary>
-    [HttpPost("merit/summary/pdf")]
+    [HttpGet("merit/summary/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportMeritSummaryPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -1251,7 +1251,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _meritSummaryService.GenerateReportPdfAsync(report);
         var filename = $"MeritSummary_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("merit/summary/excel")]
@@ -1347,10 +1347,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export clinical effort report as PDF.
     /// </summary>
-    [HttpPost("merit/clinical/pdf")]
+    [HttpGet("merit/clinical/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportClinicalEffortPdf(
-        [FromBody] ClinicalEffortPdfRequest request,
+        [FromQuery] ClinicalEffortPdfRequest request,
         CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(request.AcademicYear))
@@ -1387,7 +1387,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _clinicalEffortService.GenerateReportPdfAsync(report);
         var filename = $"ClinicalEffort_{report.ClinicalTypeName}_{report.AcademicYear}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     [HttpPost("merit/clinical/excel")]
@@ -1473,10 +1473,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export scheduled clinical weeks report as PDF.
     /// </summary>
-    [HttpPost("clinical-schedule/pdf")]
+    [HttpGet("clinical-schedule/pdf")]
     [Permission(Allow = EffortPermissions.ViewAllDepartments)]
     public async Task<ActionResult> ExportScheduledCliWeeksPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear);
@@ -1508,7 +1508,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _clinicalScheduleService.GenerateReportPdfAsync(report);
         var filename = $"ScheduledClinicalWeeks_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     /// <summary>
@@ -1620,10 +1620,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export evaluation summary report as PDF.
     /// </summary>
-    [HttpPost("eval/summary/pdf")]
+    [HttpGet("eval/summary/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportEvalSummaryPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -1661,7 +1661,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _evaluationReportService.GenerateSummaryPdfAsync(report);
         var filename = $"EvalSummary_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     /// <summary>
@@ -1776,10 +1776,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export evaluation detail report as PDF.
     /// </summary>
-    [HttpPost("eval/detail/pdf")]
+    [HttpGet("eval/detail/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportEvalDetailPdf(
-        [FromBody] ReportPdfRequest request,
+        [FromQuery] ReportPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateTermAndYear(request.TermCode, request.AcademicYear)
@@ -1817,7 +1817,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _evaluationReportService.GenerateDetailPdfAsync(report);
         var filename = $"EvalDetail_{report.TermName}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     /// <summary>
@@ -1924,10 +1924,10 @@ public partial class ReportsController : BaseEffortController
     /// <summary>
     /// Export multi-year merit + evaluation report as PDF.
     /// </summary>
-    [HttpPost("merit/multiyear/pdf")]
+    [HttpGet("merit/multiyear/pdf")]
     [Permission(Allow = $"{EffortPermissions.ViewAllDepartments},{EffortPermissions.ViewDept},{EffortPermissions.Reports}")]
     public async Task<ActionResult> ExportMeritMultiYearPdf(
-        [FromBody] MultiYearPdfRequest request,
+        [FromQuery] MultiYearPdfRequest request,
         CancellationToken ct = default)
     {
         var validationResult = ValidateMultiYearParams(request.PersonId, request.StartYear, request.EndYear);
@@ -1964,7 +1964,7 @@ public partial class ReportsController : BaseEffortController
 
         var pdfBytes = await _meritMultiYearService.GenerateReportPdfAsync(report);
         var filename = $"MultiYear_{report.Instructor}_{report.StartYear}-{report.EndYear}_{DateTime.Now:yyyyMMdd}.pdf";
-        return File(pdfBytes, "application/pdf", filename);
+        return InlineFile(pdfBytes, "application/pdf", filename);
     }
 
     /// <summary>

--- a/web/Areas/Effort/Services/BaseReportService.cs
+++ b/web/Areas/Effort/Services/BaseReportService.cs
@@ -215,6 +215,37 @@ public abstract partial class BaseReportService
         });
     }
 
+    // ── PDF Page Footer ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Render the standard report footer — a filter summary plus "Page N of M".
+    /// Only the page counter is wrapped in
+    /// <see cref="QuestPDF.Fluent.SemanticExtensions.SemanticIgnore"/> (the
+    /// number itself is a repeating page artifact). The filter summary stays
+    /// in the semantic tree because for some reports (e.g. evaluation reports)
+    /// the filter values appear nowhere else in the PDF, and assistive tech
+    /// would otherwise lose that context.
+    /// </summary>
+    protected static void AddPdfPageNumberFooter(
+        IContainer footer,
+        params (string Label, string? Value)[] filters)
+    {
+        footer.Column(col =>
+        {
+            if (filters.Length > 0)
+            {
+                AddPdfFilterLine(col.Item(), filters);
+            }
+            col.Item().SemanticIgnore().AlignCenter().Text(x =>
+            {
+                x.Span("Page ");
+                x.CurrentPageNumber();
+                x.Span(" of ");
+                x.TotalPages();
+            });
+        });
+    }
+
     // ── Excel Header / Filter Line ─────────────────────────────────
 
     /// <summary>

--- a/web/Areas/Effort/Services/ClinicalEffortService.cs
+++ b/web/Areas/Effort/Services/ClinicalEffortService.cs
@@ -300,8 +300,6 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
 
     public Task<byte[]> GenerateReportPdfAsync(ClinicalEffortReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
         var compact = orderedTypes.Count > 14;
@@ -311,6 +309,8 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
         var cellPadV = compact ? ReportPdfSettings.CellPadVCompact : ReportPdfSettings.CellPadV;
         var percentWidth = compact ? 50f : 60f;
         var ratioWidth = compact ? 65f : 85f;
+
+        var reportTitle = $"Merit & Promotion Report - Clinical Effort - {report.ClinicalTypeName}";
 
         var document = Document.Create(container =>
         {
@@ -325,21 +325,23 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        // Institution name + date row repeats on every page —
+                        // mark it as artifact so screen readers don't replay it.
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text($"Merit & Promotion Report - Clinical Effort - {report.ClinicalTypeName}").SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text($"Academic Year {report.TermName}").SemiBold().FontSize(12);
                         });
                         col.Item().BorderBottom(1.5f).BorderColor(Colors.Black)
-                            .PaddingBottom(3).Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
+                            .PaddingBottom(3).SemanticHeader2().Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -402,41 +404,37 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
                         }
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(), ("Type", report.ClinicalTypeName));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(), ("Type", report.ClinicalTypeName));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Clinical effort report for academic year {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
 
     public MemoryStream GenerateReportExcel(ClinicalEffortReport report)
     {
-        var wb = new XLWorkbook();
-        var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
+        using var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Report - Clinical Effort";
         var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Clinical effort for {termName}");
+
+        var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
         foreach (var jobGroup in report.JobGroups)
         {
             var ws = wb.Worksheets.Add(ExcelHelper.SanitizeSheetName(jobGroup.JobGroupDescription));
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Merit & Promotion Report - Clinical Effort",
+            int row = AddExcelHeader(ws, reportTitle,
                 termName, subtitle: jobGroup.JobGroupDescription);
             row = AddExcelFilterLine(ws, row, ("Type", report.ClinicalTypeName));
             row++; // blank separator
 
             // Column headers (no Job Group column — it's in the sheet name/header)
+            int headerRow = row;
             int col = 1;
             ws.Cell(row, col++).Value = "Instructor";
             ws.Cell(row, col++).Value = "Department";
@@ -451,6 +449,7 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
                 }
                 ws.Cell(row, col++).Value = type;
             }
+            int totalCols = col - 1;
             ws.Range($"{row}:{row}").Style.Font.Bold = true;
             ws.SheetView.FreezeRows(row);
             row++;
@@ -481,12 +480,19 @@ public class ClinicalEffortService : BaseReportService, IClinicalEffortService
                 row++;
             }
 
+            // Promote uniform instructor rows to a structured table for AT navigation.
+            if (row > headerRow + 1)
+            {
+                ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                    ws.Range(headerRow, 1, row - 1, totalCols),
+                    $"ClinicalEffort_{jobGroup.JobGroupDescription}");
+            }
+
             ws.Columns().AdjustToContents();
         }
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/ClinicalScheduleService.cs
+++ b/web/Areas/Effort/Services/ClinicalScheduleService.cs
@@ -295,8 +295,6 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
 
     public Task<byte[]> GenerateReportPdfAsync(ScheduledCliWeeksReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var showTotal = report.TermNames.Count > 1;
         var termCount = report.TermNames.Count;
         var fontSize = ReportPdfSettings.FontSize;
@@ -304,6 +302,8 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
         var cellPadV = ReportPdfSettings.CellPadV;
         // Use landscape for multi-term, portrait for single term
         var useLandscape = termCount > 1;
+
+        const string reportTitle = "Merit & Promotion Report - Scheduled Clinical Weeks";
 
         var document = Document.Create(container =>
         {
@@ -316,7 +316,7 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
 
                 page.Header().Column(col =>
                 {
-                    col.Item().Row(row =>
+                    col.Item().SemanticIgnore().Row(row =>
                     {
                         row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                         row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
@@ -324,7 +324,7 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
                     col.Item().BorderBottom(1.5f).BorderColor(Colors.Black)
                         .PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem(3).Text("Merit & Promotion Report - Scheduled Clinical Weeks").SemiBold().FontSize(12);
+                            row.RelativeItem(3).SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
                             var termLabel = report.AcademicYear != null
                                 ? $"Academic Year {report.TermName}"
                                 : report.TermName;
@@ -332,7 +332,7 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
                         });
                 });
 
-                page.Content().Table(table =>
+                page.Content().SemanticTable().Table(table =>
                 {
                     table.ColumnsDefinition(columns =>
                     {
@@ -384,7 +384,7 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
                             else
                             {
                                 table.Cell().BorderBottom(0.5f).BorderColor(Colors.Grey.Lighten2)
-                                    .PaddingVertical(cellPadV).Text("");
+                                    .PaddingVertical(cellPadV).Text("—");
                             }
                         }
 
@@ -396,33 +396,30 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
                     }
                 });
 
-                page.Footer().Column(col =>
-                {
-                    col.Item().AlignCenter().Text(x =>
-                    {
-                        x.Span("Page ");
-                        x.CurrentPageNumber();
-                        x.Span(" of ");
-                        x.TotalPages();
-                    });
-                });
+                AddPdfPageNumberFooter(page.Footer());
             });
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Scheduled clinical weeks for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
 
     public MemoryStream GenerateReportExcel(ScheduledCliWeeksReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Report - Scheduled Clinical Weeks";
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Scheduled clinical weeks for {report.TermName}");
+
         var ws = wb.Worksheets.Add("Scheduled CLI Weeks");
         var showTotal = report.TermNames.Count > 1;
 
         // Header rows matching PDF (term is already in the column headers)
-        int row = AddExcelHeader(ws, "Merit & Promotion Report - Scheduled Clinical Weeks", null);
+        int row = AddExcelHeader(ws, reportTitle, null);
         row++; // blank separator
 
         // Column headers
+        int headerRow = row;
         int col = 1;
         ws.Cell(row, col++).Value = "Instructor";
         foreach (var termName in report.TermNames)
@@ -435,6 +432,10 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
         }
         ws.Range($"{row}:{row}").Style.Font.Bold = true;
         ws.SheetView.FreezeRows(row);
+        // After the term loop, col is one past the last term column. The
+        // "AY Total" cell sits at col (no further increment) when showTotal,
+        // so the last filled column is col when showTotal else col - 1.
+        int totalCols = showTotal ? col : col - 1;
         row++;
         foreach (var instructor in report.Instructors)
         {
@@ -463,11 +464,17 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
             row++;
         }
 
+        if (row > headerRow + 1)
+        {
+            ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                ws.Range(headerRow, 1, row - 1, totalCols),
+                "ScheduledClinicalWeeks");
+        }
+
         ws.Columns().AdjustToContents();
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/DeptSummaryService.cs
+++ b/web/Areas/Effort/Services/DeptSummaryService.cs
@@ -180,10 +180,9 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
 
     public Task<byte[]> GenerateReportPdfAsync(DeptSummaryReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
+        const string reportTitle = "Department Summary Report";
         var compact = orderedTypes.Count > 14;
         var fontSize = compact ? ReportPdfSettings.FontSizeCompact : ReportPdfSettings.FontSize;
         var headerFontSize = compact ? ReportPdfSettings.HeaderFontSizeCompact : ReportPdfSettings.HeaderFontSize;
@@ -206,20 +205,20 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Department Summary Report").SemiBold().FontSize(12);
-                            row.RelativeItem().AlignCenter().Text(dept.Department).SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                            row.RelativeItem().AlignCenter().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                         });
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -251,7 +250,7 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
                         }
 
                         // Re-display effort type headers before totals
-                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("");
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Instructor").Style(hdrStyle);
                         foreach (var type in orderedTypes)
                         {
                             table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text(type).Style(hdrStyle);
@@ -268,15 +267,20 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
                                 .PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0").Bold();
                         }
 
-                        // Number Faculty row
-                        table.Cell().PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
+                        // Number Faculty row (single label/value spanning the full row).
+                        // Trailing ConstantItem absorbs the N effort columns' widths so the
+                        // leading RelativeItem only fills column 1, keeping the right-aligned
+                        // label visually anchored to column 1's right edge (matching the
+                        // "Faculty w/ CLI assigned:" row below).
+                        var numFacAbsorbedWidth = orderedTypes.Sum(t => SpacerColumns.Contains(t) ? spacerWidth : effortWidth);
+                        table.Cell().ColumnSpan((uint)(orderedTypes.Count + 1))
+                            .PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
                         {
                             row.RelativeItem().AlignRight().Text("Number Faculty:").SemiBold();
                             row.ConstantItem(30).AlignRight().Text(dept.FacultyCount.ToString()).SemiBold();
                             row.ConstantItem(55);
+                            row.ConstantItem(numFacAbsorbedWidth);
                         });
-                        foreach (var _ in orderedTypes)
-                            table.Cell().PaddingVertical(cellPadV);
 
                         // Faculty w/ CLI assigned + averages row
                         table.Cell().Background("#E0E0E0").PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
@@ -293,22 +297,13 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
                         }
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
-                            ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
+                        ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Department effort summary for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -316,23 +311,28 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
     public MemoryStream GenerateReportExcel(DeptSummaryReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Department Summary Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Department effort summary for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 1 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         foreach (var dept in report.Departments)
         {
             var ws = wb.Worksheets.Add(dept.Department);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Department Summary Report", termName, dept.Department);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept.Department);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
                 ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
             row++; // blank separator
 
             // Column headers
+            int headerRow = row;
             int col = 1;
             ws.Cell(row, col++).Value = "Instructor";
             foreach (var (type, isSpacer) in effortCols)
@@ -354,6 +354,16 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
                     col++;
                 }
                 row++;
+            }
+
+            // Promote the instructor rows (header + data) to a structured table so
+            // screen readers announce each instructor's effort columns by name.
+            // Summary rows (totals/faculty counts) intentionally sit outside.
+            if (row > headerRow + 1)
+            {
+                ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                    ws.Range(headerRow, 1, row - 1, lastCol),
+                    $"DeptSummary_{dept.Department}");
             }
 
             // Re-display effort type headers before totals

--- a/web/Areas/Effort/Services/EvaluationReportService.cs
+++ b/web/Areas/Effort/Services/EvaluationReportService.cs
@@ -502,7 +502,7 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
     public Task<byte[]> GenerateSummaryPdfAsync(EvalSummaryReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
+        const string reportTitle = "Eval Summary Report";
 
         var document = Document.Create(container =>
         {
@@ -517,21 +517,21 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Eval Summary Report").SemiBold().FontSize(12);
-                            row.AutoItem().Text(dept.Department).SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                            row.AutoItem().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.AcademicYear ?? report.TermName).SemiBold().FontSize(12);
                         });
                         col.Item().BorderBottom(1.5f).BorderColor(Colors.Black).PaddingBottom(3);
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -557,23 +557,14 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
                         table.Cell().Background("#D0D0D0").PaddingVertical(2).AlignCenter().Text(dept.DepartmentAverage.ToString("F2")).Bold();
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment),
-                            ("Person", report.FilterPersonId?.ToString()),
-                            ("Role", report.FilterRole));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment),
+                        ("Person", report.FilterPersonId?.ToString()),
+                        ("Role", report.FilterRole));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Evaluation summary for {report.AcademicYear ?? report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -584,7 +575,7 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
     public Task<byte[]> GenerateDetailPdfAsync(EvalDetailReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
+        const string reportTitle = "Eval Detail Report";
 
         var document = Document.Create(container =>
         {
@@ -599,21 +590,21 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Eval Detail Report").SemiBold().FontSize(12);
-                            row.AutoItem().Text(dept.Department).SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                            row.AutoItem().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.AcademicYear ?? report.TermName).SemiBold().FontSize(12);
                         });
                         col.Item().BorderBottom(1.5f).BorderColor(Colors.Black).PaddingBottom(3);
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -644,11 +635,14 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
                             {
                                 var course = instructor.Courses[i];
 
-                                // Instructor name rowspanned across course rows only
+                                // Per-row instructor cell instead of RowSpan (PDF/UA clause 7.2 test 15)
                                 if (i == 0)
                                 {
-                                    table.Cell().RowSpan((uint)courseCount)
-                                        .PaddingVertical(1.5f).PaddingLeft(4).Text(instructor.Instructor);
+                                    table.Cell().PaddingVertical(1.5f).PaddingLeft(4).Text(instructor.Instructor);
+                                }
+                                else
+                                {
+                                    table.Cell().PaddingVertical(1.5f).PaddingLeft(4).Text(instructor.Instructor).FontColor("#FFFFFF");
                                 }
 
                                 table.Cell().PaddingVertical(1.5f).AlignCenter().Text(course.Role);
@@ -662,36 +656,25 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
                             // Instructor average row (full width background)
                             table.Cell().ColumnSpan(4).Background("#E8E8E8").PaddingVertical(1.5f)
                                 .Text("Instructor Average").Italic().FontSize(8).AlignRight();
-                            table.Cell().Background("#E8E8E8").PaddingVertical(1.5f).AlignCenter()
+                            table.Cell().ColumnSpan(2).Background("#E8E8E8").PaddingVertical(1.5f).AlignCenter()
                                 .Text(instructor.InstructorAverage.ToString("F2")).Bold();
-                            table.Cell().Background("#E8E8E8").PaddingVertical(1.5f).Text("");
                         }
 
                         // Department average row
                         table.Cell().ColumnSpan(4).Background("#D0D0D0").PaddingVertical(2)
                             .Text("Department Average").Italic().FontSize(9).AlignRight();
-                        table.Cell().Background("#D0D0D0").PaddingVertical(2).AlignCenter()
+                        table.Cell().ColumnSpan(2).Background("#D0D0D0").PaddingVertical(2).AlignCenter()
                             .Text(dept.DepartmentAverage.ToString("F2")).Bold();
-                        table.Cell().Background("#D0D0D0").PaddingVertical(2).Text("");
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment),
-                            ("Person", report.FilterPersonId?.ToString()),
-                            ("Role", report.FilterRole));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment),
+                        ("Person", report.FilterPersonId?.ToString()),
+                        ("Role", report.FilterRole));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Evaluation detail for {report.AcademicYear ?? report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -699,14 +682,17 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
     public MemoryStream GenerateEvalSummaryExcel(EvalSummaryReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Eval Summary Report";
         var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Evaluation summary for {termName}");
 
         foreach (var dept in report.Departments)
         {
             var ws = wb.Worksheets.Add(dept.Department);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Eval Summary Report", termName, dept.Department);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept.Department);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment),
                 ("Person", report.FilterPersonId?.ToString()),
@@ -714,6 +700,7 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
             row++; // blank separator
 
             // Column headers
+            int headerRow = row;
             ws.Cell(row, 1).Value = "Instructor";
             ws.Cell(row, 2).Value = "Average";
             ws.Range($"{row}:{row}").Style.Font.Bold = true;
@@ -726,6 +713,13 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
                 ws.Cell(row, 2).Value = instructor.WeightedAverage;
                 ws.Cell(row, 2).Style.NumberFormat.Format = "0.00";
                 row++;
+            }
+
+            if (row > headerRow + 1)
+            {
+                ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                    ws.Range(headerRow, 1, row - 1, 2),
+                    $"EvalSummary_{dept.Department}");
             }
 
             // Department average
@@ -749,14 +743,17 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
     public MemoryStream GenerateEvalDetailExcel(EvalDetailReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Eval Detail Report";
         var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Evaluation detail for {termName}");
 
         foreach (var dept in report.Departments)
         {
             var ws = wb.Worksheets.Add(dept.Department);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Eval Detail Report", termName, dept.Department);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept.Department);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment),
                 ("Person", report.FilterPersonId?.ToString()),

--- a/web/Areas/Effort/Services/IClinicalEffortService.cs
+++ b/web/Areas/Effort/Services/IClinicalEffortService.cs
@@ -24,5 +24,10 @@ public interface IClinicalEffortService
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(ClinicalEffortReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a clinical effort report.
+    /// One worksheet per job group; instructor rows are promoted to a
+    /// structured Excel Table.
+    /// </summary>
     MemoryStream GenerateReportExcel(ClinicalEffortReport report);
 }

--- a/web/Areas/Effort/Services/IClinicalScheduleService.cs
+++ b/web/Areas/Effort/Services/IClinicalScheduleService.cs
@@ -2,6 +2,9 @@ using Viper.Areas.Effort.Models.DTOs.Responses;
 
 namespace Viper.Areas.Effort.Services;
 
+/// <summary>
+/// Service interface for the scheduled clinical weeks report.
+/// </summary>
 public interface IClinicalScheduleService
 {
     Task<ScheduledCliWeeksReport> GetScheduledCliWeeksReportAsync(
@@ -12,7 +15,16 @@ public interface IClinicalScheduleService
         string academicYear,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Generate a PDF document from a scheduled clinical weeks report.
+    /// Landscape for multi-term, portrait for single-term; instructor rows
+    /// list services per term cell.
+    /// </summary>
     Task<byte[]> GenerateReportPdfAsync(ScheduledCliWeeksReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a scheduled clinical weeks report.
+    /// Single worksheet, instructor rows promoted to a structured Excel Table.
+    /// </summary>
     MemoryStream GenerateReportExcel(ScheduledCliWeeksReport report);
 }

--- a/web/Areas/Effort/Services/IDeptSummaryService.cs
+++ b/web/Areas/Effort/Services/IDeptSummaryService.cs
@@ -32,8 +32,16 @@ public interface IDeptSummaryService
 
     /// <summary>
     /// Generate a PDF document from a department summary report.
+    /// One landscape page per department; instructor effort columns followed
+    /// by department-totals and faculty-count summary rows.
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(DeptSummaryReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a department summary report.
+    /// One worksheet per department; instructor rows are promoted to a
+    /// structured Excel Table while the totals/faculty-count rows stay
+    /// outside (their shape isn't uniform with the data rows).
+    /// </summary>
     MemoryStream GenerateReportExcel(DeptSummaryReport report);
 }

--- a/web/Areas/Effort/Services/IEvaluationReportService.cs
+++ b/web/Areas/Effort/Services/IEvaluationReportService.cs
@@ -52,15 +52,30 @@ public interface IEvaluationReportService
 
     /// <summary>
     /// Generate a PDF document from an evaluation summary report.
+    /// One page per department, instructor weighted averages followed by a
+    /// department-average row.
     /// </summary>
     Task<byte[]> GenerateSummaryPdfAsync(EvalSummaryReport report);
 
     /// <summary>
     /// Generate a PDF document from an evaluation detail report.
+    /// One landscape page per department, course-level rows per instructor
+    /// followed by instructor-average and department-average summary rows.
     /// </summary>
     Task<byte[]> GenerateDetailPdfAsync(EvalDetailReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from an evaluation summary report.
+    /// One worksheet per department; instructor rows are promoted to a
+    /// structured Excel Table while the department-average row stays outside.
+    /// </summary>
     MemoryStream GenerateEvalSummaryExcel(EvalSummaryReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from an evaluation detail report.
+    /// One worksheet per department. Data isn't promoted to a structured
+    /// table because instructor-average and department-average rows
+    /// interleave the course detail rows.
+    /// </summary>
     MemoryStream GenerateEvalDetailExcel(EvalDetailReport report);
 }

--- a/web/Areas/Effort/Services/IMeritMultiYearService.cs
+++ b/web/Areas/Effort/Services/IMeritMultiYearService.cs
@@ -24,6 +24,8 @@ public interface IMeritMultiYearService
 
     /// <summary>
     /// Generate a PDF document from a multi-year report.
+    /// Two pages: merit activity then evaluations (or a summary fallback when
+    /// no per-course eval data exists).
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(MultiYearReport report);
 
@@ -33,5 +35,11 @@ public interface IMeritMultiYearService
     /// </summary>
     Task<InstructorYearRangeDto?> GetInstructorYearRangeAsync(int personId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Generate an Excel workbook from a multi-year report. Single worksheet
+    /// with merit and evaluation sections. Data rows aren't promoted to a
+    /// structured table because per-year header rows and summary rows
+    /// interleave the data.
+    /// </summary>
     MemoryStream GenerateReportExcel(MultiYearReport report);
 }

--- a/web/Areas/Effort/Services/IMeritReportService.cs
+++ b/web/Areas/Effort/Services/IMeritReportService.cs
@@ -49,15 +49,30 @@ public interface IMeritReportService
 
     /// <summary>
     /// Generate a PDF document from a merit detail report.
+    /// One landscape page per department; courses listed per instructor with
+    /// instructor-totals and department-totals rows.
     /// </summary>
     Task<byte[]> GenerateMeritDetailPdfAsync(MeritDetailReport report);
 
     /// <summary>
     /// Generate a PDF document from a merit average report.
+    /// One legal-landscape page per (job group, department) pair; per-term
+    /// effort by instructor with totals/averages summary rows.
     /// </summary>
     Task<byte[]> GenerateMeritAveragePdfAsync(MeritAverageReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a merit detail report. One worksheet
+    /// per department. Data isn't promoted to a structured table because
+    /// course rows are interleaved with instructor-totals and
+    /// department-totals rows.
+    /// </summary>
     MemoryStream GenerateMeritDetailExcel(MeritDetailReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a merit average report. One worksheet
+    /// per (job group, department) pair. Per-term rows interleave with
+    /// instructor-totals so no structured table is built.
+    /// </summary>
     MemoryStream GenerateMeritAverageExcel(MeritAverageReport report);
 }

--- a/web/Areas/Effort/Services/IMeritSummaryService.cs
+++ b/web/Areas/Effort/Services/IMeritSummaryService.cs
@@ -26,8 +26,15 @@ public interface IMeritSummaryService
 
     /// <summary>
     /// Generate a PDF document from a merit summary report.
+    /// One legal-landscape page per (job group, department) pair; each page
+    /// holds totals + faculty-count + averages rows.
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(MeritSummaryReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a merit summary report. One worksheet
+    /// per (job group, department) pair. Sheets are summary-only so no
+    /// structured table is built.
+    /// </summary>
     MemoryStream GenerateReportExcel(MeritSummaryReport report);
 }

--- a/web/Areas/Effort/Services/ISchoolSummaryService.cs
+++ b/web/Areas/Effort/Services/ISchoolSummaryService.cs
@@ -32,8 +32,17 @@ public interface ISchoolSummaryService
 
     /// <summary>
     /// Generate a PDF document from a school summary report.
+    /// Single landscape page; each department contributes a totals row + a
+    /// faculty-count row + a faculty-with-CLI/averages row, followed by
+    /// grand-total rows.
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(SchoolSummaryReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a school summary report. Single
+    /// worksheet. Data isn't promoted to a structured table because each
+    /// department block emits totals + faculty-count + averages rows of
+    /// differing shape.
+    /// </summary>
     MemoryStream GenerateReportExcel(SchoolSummaryReport report);
 }

--- a/web/Areas/Effort/Services/ITeachingActivityService.cs
+++ b/web/Areas/Effort/Services/ITeachingActivityService.cs
@@ -33,16 +33,30 @@ public interface ITeachingActivityService
         CancellationToken ct = default);
 
     /// <summary>
-    /// Generate a PDF document from a teaching activity report (grouped layout, one page per department).
+    /// Generate a PDF document from a teaching activity report
+    /// (grouped layout, one page per department).
     /// </summary>
     Task<byte[]> GenerateReportPdfAsync(TeachingActivityReport report);
 
     /// <summary>
-    /// Generate a PDF document from a teaching activity report in individual (per-instructor) layout.
+    /// Generate a PDF document from a teaching activity report in individual
+    /// (per-instructor) layout.
     /// </summary>
     Task<byte[]> GenerateIndividualReportPdfAsync(TeachingActivityReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a teaching activity report
+    /// (grouped layout, one worksheet per department). Instructor-totals
+    /// rows interleave the course rows so no single structured table is
+    /// built.
+    /// </summary>
     MemoryStream GenerateReportExcel(TeachingActivityReport report);
 
+    /// <summary>
+    /// Generate an Excel workbook from a teaching activity report
+    /// (individual layout, one worksheet per instructor). Course rows are
+    /// promoted to a structured Excel Table; the instructor-totals row stays
+    /// outside it.
+    /// </summary>
     MemoryStream GenerateIndividualReportExcel(TeachingActivityReport report);
 }

--- a/web/Areas/Effort/Services/MeritMultiYearService.cs
+++ b/web/Areas/Effort/Services/MeritMultiYearService.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Globalization;
 using ClosedXML.Excel;
 using Microsoft.EntityFrameworkCore;
 using QuestPDF.Fluent;
@@ -896,8 +897,6 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
     public Task<byte[]> GenerateReportPdfAsync(MultiYearReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var lastType = orderedTypes[^1];
         var compact = orderedTypes.Count > 10;
@@ -911,6 +910,8 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
             ? $"{report.StartYear}-{report.StartYear + 1} to {report.EndYear}-{report.EndYear + 1}"
             : $"{report.StartYear} to {report.EndYear}";
 
+        var reportTitle = $"Merit & Promotion Multi-Year Report \u2014 {report.Instructor}";
+
         var document = Document.Create(container =>
         {
             // Page 1: Merit Activity
@@ -923,18 +924,18 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
                 page.Header().Column(col =>
                 {
-                    col.Item().Row(row =>
+                    col.Item().SemanticIgnore().Row(row =>
                     {
                         row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                         row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                     });
                     col.Item().PaddingVertical(4)
-                        .Text($"Merit & Promotion Multi-Year Report \u2014 {report.Instructor}").SemiBold().FontSize(12);
+                        .SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
                     var yearTypeLabel = report.UseAcademicYear ? "Academic Year" : "Calendar Year";
                     col.Item().Text($"{yearLabel} ({yearTypeLabel})").SemiBold().FontSize(10);
                 });
 
-                page.Content().PaddingTop(8).Table(table =>
+                page.Content().PaddingTop(8).SemanticTable().Table(table =>
                 {
                     table.ColumnsDefinition(columns =>
                     {
@@ -1048,7 +1049,7 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
                     }
                 });
 
-                page.Footer().AlignCenter().Text(x =>
+                page.Footer().SemanticIgnore().AlignCenter().Text(x =>
                 {
                     x.Span("Page ");
                     x.CurrentPageNumber();
@@ -1069,12 +1070,12 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
-                        col.Item().PaddingVertical(4).Text("Multi-Year Evaluation Report").SemiBold().FontSize(12);
+                        col.Item().PaddingVertical(4).SemanticHeader2().Text("Multi-Year Evaluation Report").SemiBold().FontSize(12);
                         col.Item().Row(row =>
                         {
                             row.RelativeItem().Text($"{report.Instructor} ({report.Department})").SemiBold().FontSize(10);
@@ -1085,7 +1086,7 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
                     page.Content().PaddingTop(8).Column(contentCol =>
                     {
                         contentCol.Item().Text("Instructor").Bold();
-                        contentCol.Item().PaddingTop(4).Table(table =>
+                        contentCol.Item().PaddingTop(4).SemanticTable().Table(table =>
                         {
                             table.ColumnsDefinition(columns =>
                             {
@@ -1130,40 +1131,36 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
                                     table.Cell().PaddingVertical(cellPadV).Text(course.Course);
                                     table.Cell().PaddingVertical(cellPadV).Text(course.Average.ToString("F2"));
                                     table.Cell().PaddingVertical(cellPadV)
-                                        .Text(course.Median.HasValue ? Math.Round(course.Median.Value).ToString() : "");
+                                        .Text(course.Median.HasValue ? Math.Round(course.Median.Value).ToString(CultureInfo.InvariantCulture) : " ");
                                 }
 
                                 // Year average (value only in Average column)
                                 table.Cell().ColumnSpan(5).PaddingVertical(cellPadV).AlignRight().PaddingRight(4)
                                     .Text($"Average for {year.YearLabel}").Bold().Italic();
-                                table.Cell().PaddingVertical(cellPadV)
+                                table.Cell().ColumnSpan(2).PaddingVertical(cellPadV)
                                     .Text(year.YearAverage.ToString("F2")).Bold();
-                                table.Cell(); // empty median
                             }
 
                             // Overall average (value only in Average column)
                             table.Cell().ColumnSpan(5).BorderTop(1.5f).BorderColor("#666666")
                                 .Background("#E0E0E0").PaddingVertical(cellPadV).AlignRight().PaddingRight(4)
                                 .Text("Overall Average:").Bold();
-                            table.Cell().BorderTop(1.5f).BorderColor("#666666")
+                            table.Cell().ColumnSpan(2).BorderTop(1.5f).BorderColor("#666666")
                                 .Background("#E0E0E0").PaddingVertical(cellPadV)
                                 .Text(report.EvalSection.OverallAverage.ToString("F2")).Bold();
-                            table.Cell().BorderTop(1.5f).BorderColor("#666666")
-                                .Background("#E0E0E0"); // empty median
 
                             // Department average
                             if (report.EvalSection.DepartmentAverage.HasValue)
                             {
                                 table.Cell().ColumnSpan(5).PaddingVertical(cellPadV).AlignRight().PaddingRight(4)
                                     .Text($"{report.Department} Department Average for {report.StartYear} - {report.EndYear}").Italic();
-                                table.Cell().PaddingVertical(cellPadV)
+                                table.Cell().ColumnSpan(2).PaddingVertical(cellPadV)
                                     .Text(report.EvalSection.DepartmentAverage.Value.ToString("F2"));
-                                table.Cell(); // empty median
                             }
                         });
                     });
 
-                    page.Footer().AlignCenter().Text(x =>
+                    page.Footer().SemanticIgnore().AlignCenter().Text(x =>
                     {
                         x.Span("Page ");
                         x.CurrentPageNumber();
@@ -1184,12 +1181,12 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
-                        col.Item().PaddingVertical(4).Text("Multi-Year Evaluation Report").SemiBold().FontSize(12);
+                        col.Item().PaddingVertical(4).SemanticHeader2().Text("Multi-Year Evaluation Report").SemiBold().FontSize(12);
                         col.Item().Row(row =>
                         {
                             row.RelativeItem().Text($"{report.Instructor} ({report.Department})").SemiBold().FontSize(10);
@@ -1223,7 +1220,7 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
                         });
                     });
 
-                    page.Footer().AlignCenter().Text(x =>
+                    page.Footer().SemanticIgnore().AlignCenter().Text(x =>
                     {
                         x.Span("Page ");
                         x.CurrentPageNumber();
@@ -1232,7 +1229,8 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
                     });
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Multi-year merit and evaluation summary for {report.Instructor}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -1264,13 +1262,17 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
     public MemoryStream GenerateReportExcel(MultiYearReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Report - Multi-Year";
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Multi-year merit and evaluation summary for {report.Instructor}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 4 + effortCols.Count;
         var ws = wb.Worksheets.Add("Multi-Year Report");
 
         // Report title header matching PDF
-        int row = AddExcelHeader(ws, "Merit & Promotion Report - Multi-Year", null);
+        int row = AddExcelHeader(ws, reportTitle, null);
 
         // Instructor/Department/Period info
         ws.Cell(row, 1).Value = "Instructor";

--- a/web/Areas/Effort/Services/MeritReportService.cs
+++ b/web/Areas/Effort/Services/MeritReportService.cs
@@ -588,9 +588,9 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
     public Task<byte[]> GenerateMeritDetailPdfAsync(MeritDetailReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
+
+        const string reportTitle = "Merit & Promotion Detail Report";
 
         // Compact when 12+ effort types: with fixed columns, non-compact overflows the page
         var compact = orderedTypes.Count > 11;
@@ -618,20 +618,20 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Merit & Promotion Detail Report").SemiBold().FontSize(12);
-                            row.RelativeItem().AlignCenter().Text(dept.Department).SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                            row.RelativeItem().AlignCenter().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                         });
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -667,10 +667,17 @@ public class MeritReportService : BaseReportService, IMeritReportService
                                 table.Cell().PaddingVertical(cellPadV).Text(course.TermCode.ToString());
                                 table.Cell().PaddingVertical(cellPadV).PaddingLeft(4).Text(course.RoleId);
 
+                                // Instructor cell emitted per row (visible on first, invisible on
+                                // subsequent) instead of RowSpan — QuestPDF's RowSpan tagging
+                                // produces overlapping cells in the structure tree that veraPDF
+                                // flags as PDF/UA clause 7.2 test 15 violations.
                                 if (i == 0)
                                 {
-                                    table.Cell().RowSpan((uint)courses.Count).PaddingVertical(cellPadV)
-                                        .Text(instructor.Instructor).SemiBold();
+                                    table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold();
+                                }
+                                else
+                                {
+                                    table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold().FontColor("#FFFFFF");
                                 }
 
                                 table.Cell().PaddingVertical(cellPadV).Text(course.Course);
@@ -682,31 +689,50 @@ public class MeritReportService : BaseReportService, IMeritReportService
                                 }
                             }
 
-                            // Instructor totals row
-                            table.Cell().ColumnSpan(4).Background("#F8F8F8").BorderTop(0.5f).BorderColor("#CCCCCC")
+                            // Instructor totals row — replace ColumnSpan(4) with 4 individual TDs
+                            // so each cell's column header is algorithmically determinable
+                            // (PDF/UA clause 7.5 test 1). Cols 1-3 carry the same label in
+                            // background color so they're tagged but visually blank.
+                            const string instTotalsLabel = "Instructor Totals:";
+                            const string instTotalsBg = "#F8F8F8";
+                            for (var col = 0; col < 3; col++)
+                            {
+                                table.Cell().Background(instTotalsBg).BorderTop(0.5f).BorderColor("#CCCCCC")
+                                    .PaddingVertical(cellPadV).Text(instTotalsLabel).FontColor(instTotalsBg);
+                            }
+                            table.Cell().Background(instTotalsBg).BorderTop(0.5f).BorderColor("#CCCCCC")
                                 .PaddingVertical(cellPadV).AlignRight().PaddingRight(8)
-                                .Text("Instructor Totals:").Italic().Bold();
+                                .Text(instTotalsLabel).Italic().Bold();
                             foreach (var type in orderedTypes)
                             {
                                 var val = instructor.InstructorTotals.GetValueOrDefault(type, 0);
-                                table.Cell().Background("#F8F8F8").BorderTop(0.5f).BorderColor("#CCCCCC")
+                                table.Cell().Background(instTotalsBg).BorderTop(0.5f).BorderColor("#CCCCCC")
                                     .PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0").Bold();
                             }
                         }
 
-                        // Re-display effort type headers before department totals
-                        table.Cell().ColumnSpan(4).BorderTop(1).BorderColor("#999999")
-                            .PaddingVertical(cellPadV).Text("");
+                        // Re-display column headers before department totals
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Qtr").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Role").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Instructor").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Course").Style(hdrStyle);
                         foreach (var type in orderedTypes)
                         {
                             table.Cell().BorderTop(1).BorderColor("#999999")
                                 .PaddingVertical(cellPadV).Text(type).Style(hdrStyle);
                         }
 
-                        // Department totals row
-                        table.Cell().ColumnSpan(4).Background("#E8E8E8").BorderTop(1.5f).BorderColor("#666666")
+                        // Department totals row — same ColumnSpan(4) → 4 individual TDs treatment
+                        const string deptTotalsLabel = "Department Totals:";
+                        const string deptTotalsBg = "#E8E8E8";
+                        for (var col = 0; col < 3; col++)
+                        {
+                            table.Cell().Background(deptTotalsBg).BorderTop(1.5f).BorderColor("#666666")
+                                .PaddingVertical(cellPadV).Text(deptTotalsLabel).FontColor(deptTotalsBg);
+                        }
+                        table.Cell().Background(deptTotalsBg).BorderTop(1.5f).BorderColor("#666666")
                             .PaddingVertical(cellPadV).AlignRight().PaddingRight(8)
-                            .Text("Department Totals:").Italic().Bold();
+                            .Text(deptTotalsLabel).Italic().Bold();
                         foreach (var type in orderedTypes)
                         {
                             var val = dept.DepartmentTotals.GetValueOrDefault(type, 0);
@@ -715,32 +741,22 @@ public class MeritReportService : BaseReportService, IMeritReportService
                         }
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
-                            ("Faculty", report.FilterPersonId?.ToString()));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
+                        ("Faculty", report.FilterPersonId?.ToString()));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Merit and promotion detail for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
 
     public Task<byte[]> GenerateMeritAveragePdfAsync(MeritAverageReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
+        const string reportTitle = "Merit & Promotion Average Report";
         var compact = orderedTypes.Count > 14;
         var fontSize = compact ? ReportPdfSettings.FontSizeCompact : ReportPdfSettings.FontSize;
         var headerFontSize = compact ? ReportPdfSettings.HeaderFontSizeCompact : ReportPdfSettings.HeaderFontSize;
@@ -766,23 +782,23 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
                         page.Header().Column(col =>
                         {
-                            col.Item().Row(row =>
+                            col.Item().SemanticIgnore().Row(row =>
                             {
                                 row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                                 row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                             });
                             col.Item().PaddingVertical(6).Row(row =>
                             {
-                                row.RelativeItem().Text("Merit & Promotion Average Report").SemiBold().FontSize(12);
-                                row.RelativeItem().AlignCenter().Text(dept.Department).SemiBold().FontSize(12);
+                                row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                                row.RelativeItem().AlignCenter().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                                 row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                             });
-                            col.Item().Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
+                            col.Item().SemanticHeader3().Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
                         });
 
                         var totalColumns = (uint)(2 + orderedTypes.Count);
 
-                        page.Content().Table(table =>
+                        page.Content().SemanticTable().Table(table =>
                         {
                             table.ColumnsDefinition(columns =>
                             {
@@ -807,7 +823,6 @@ public class MeritReportService : BaseReportService, IMeritReportService
                             foreach (var instructor in dept.Instructors)
                             {
                                 var terms = instructor.Terms;
-                                var termCount = terms.Count > 0 ? terms.Count : 1;
 
                                 if (terms.Count > 0)
                                 {
@@ -815,10 +830,14 @@ public class MeritReportService : BaseReportService, IMeritReportService
                                     {
                                         var term = terms[i];
 
+                                        // Per-row instructor cell instead of RowSpan (PDF/UA clause 7.2 test 15)
                                         if (i == 0)
                                         {
-                                            table.Cell().RowSpan((uint)termCount).PaddingVertical(cellPadV)
-                                                .Text(instructor.Instructor).SemiBold();
+                                            table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold();
+                                        }
+                                        else
+                                        {
+                                            table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold().FontColor("#FFFFFF");
                                         }
 
                                         table.Cell().PaddingVertical(cellPadV)
@@ -835,7 +854,7 @@ public class MeritReportService : BaseReportService, IMeritReportService
                                 {
                                     // Fallback: single row with aggregated totals
                                     table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold();
-                                    table.Cell().PaddingVertical(cellPadV).Text("");
+                                    table.Cell().PaddingVertical(cellPadV).Text("—");
                                     foreach (var type in orderedTypes)
                                     {
                                         var val = instructor.EffortByType.GetValueOrDefault(type, 0);
@@ -886,22 +905,13 @@ public class MeritReportService : BaseReportService, IMeritReportService
                             }
                         });
 
-                        page.Footer().Column(col =>
-                        {
-                            AddPdfFilterLine(col.Item(),
-                                ("Dept", report.FilterDepartment), ("Faculty", report.FilterPersonId?.ToString()));
-                            col.Item().AlignCenter().Text(x =>
-                            {
-                                x.Span("Page ");
-                                x.CurrentPageNumber();
-                                x.Span(" of ");
-                                x.TotalPages();
-                            });
-                        });
+                        AddPdfPageNumberFooter(page.Footer(),
+                            ("Dept", report.FilterDepartment), ("Faculty", report.FilterPersonId?.ToString()));
                     });
                 }
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Merit and promotion averages for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -909,17 +919,21 @@ public class MeritReportService : BaseReportService, IMeritReportService
     public MemoryStream GenerateMeritDetailExcel(MeritDetailReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Detail Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Merit and promotion detail for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 2 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         foreach (var dept in report.Departments)
         {
             var ws = wb.Worksheets.Add(dept.Department);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Merit & Promotion Detail Report", termName, dept.Department);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept.Department);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
                 ("Faculty", report.FilterPersonId?.ToString()));
@@ -985,8 +999,8 @@ public class MeritReportService : BaseReportService, IMeritReportService
             ws.Range($"{row}:{row}").Style.Font.Bold = true;
             row++;
 
-            // Department totals
-            col = 1;
+            // Department totals (col 2 = under Course column, matching Instructor Totals row)
+            col = 2;
             ws.Cell(row, col).Value = "Department Totals";
             ws.Range(row, 1, row, lastCol).Style.Font.Bold = true;
             ShadeExcelRow(ws, row, lastCol, "#E8E8E8");
@@ -1011,10 +1025,14 @@ public class MeritReportService : BaseReportService, IMeritReportService
     public MemoryStream GenerateMeritAverageExcel(MeritAverageReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Average Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Merit and promotion averages for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 2 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         foreach (var jobGroup in report.JobGroups)
         {
@@ -1024,7 +1042,7 @@ public class MeritReportService : BaseReportService, IMeritReportService
                 var ws = wb.Worksheets.Add(sheetName);
 
                 // Header rows matching PDF
-                int row = AddExcelHeader(ws, "Merit & Promotion Average Report",
+                int row = AddExcelHeader(ws, reportTitle,
                     termName, dept.Department, jobGroup.JobGroupDescription);
                 row = AddExcelFilterLine(ws, row,
                     ("Dept", report.FilterDepartment), ("Faculty", report.FilterPersonId?.ToString()));

--- a/web/Areas/Effort/Services/MeritSummaryService.cs
+++ b/web/Areas/Effort/Services/MeritSummaryService.cs
@@ -252,10 +252,9 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
 
     public Task<byte[]> GenerateReportPdfAsync(MeritSummaryReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
+        const string reportTitle = "Merit & Promotion Summary Report";
         var compact = orderedTypes.Count > 14;
         var fontSize = compact ? ReportPdfSettings.FontSizeCompact : ReportPdfSettings.FontSize;
         var headerFontSize = compact ? ReportPdfSettings.HeaderFontSizeCompact : ReportPdfSettings.HeaderFontSize;
@@ -279,21 +278,21 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
 
                         page.Header().Column(col =>
                         {
-                            col.Item().Row(row =>
+                            col.Item().SemanticIgnore().Row(row =>
                             {
                                 row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                                 row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                             });
                             col.Item().PaddingVertical(6).Row(row =>
                             {
-                                row.RelativeItem().Text("Merit & Promotion Summary Report").SemiBold().FontSize(12);
-                                row.RelativeItem().AlignCenter().Text(dept.Department).SemiBold().FontSize(12);
+                                row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                                row.RelativeItem().AlignCenter().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                                 row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                             });
-                            col.Item().Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
+                            col.Item().SemanticHeader3().Text(jobGroup.JobGroupDescription).SemiBold().FontSize(11);
                         });
 
-                        page.Content().Table(table =>
+                        page.Content().SemanticTable().Table(table =>
                         {
                             table.ColumnsDefinition(columns =>
                             {
@@ -307,7 +306,12 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
                             var hdrStyle = TextStyle.Default.FontSize(headerFontSize).Bold().Underline();
                             table.Header(header =>
                             {
-                                header.Cell().PaddingVertical(cellPadV).Text("").Style(hdrStyle);
+                                // Corner cell is visually blank by design but must exist as a TH so
+                                // the header row covers all columns (PDF/UA clause 7.2). Whitespace-only
+                                // content is dropped from the tag tree by QuestPDF, so we render an
+                                // em-dash in white (invisible against the page) — the cell stays tagged
+                                // while the corner remains visually empty.
+                                header.Cell().PaddingVertical(cellPadV).Text("—").FontColor("#FFFFFF");
                                 foreach (var type in orderedTypes)
                                 {
                                     header.Cell().PaddingVertical(cellPadV).Text(type).Style(hdrStyle);
@@ -324,15 +328,19 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
                                 .ForEach(val => table.Cell().Background("#E8E8E8").BorderTop(1.5f).BorderColor("#666666")
                                     .PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0").Bold());
 
-                            // Number Faculty row
-                            table.Cell().PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
+                            // Number Faculty row (single label/value spanning the full row).
+                            // Trailing ConstantItem absorbs the N effort columns' widths so
+                            // the leading RelativeItem only fills column 1, keeping the
+                            // right-aligned label visually anchored to column 1's right edge.
+                            var numFacAbsorbedWidth = orderedTypes.Sum(t => SpacerColumns.Contains(t) ? spacerWidth : effortWidth);
+                            table.Cell().ColumnSpan((uint)(orderedTypes.Count + 1))
+                                .PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
                             {
                                 row.RelativeItem().AlignRight().Text("Number Faculty:").SemiBold();
                                 row.ConstantItem(30).AlignRight().Text(dept.FacultyCount.ToString()).SemiBold();
                                 row.ConstantItem(55);
+                                row.ConstantItem(numFacAbsorbedWidth);
                             });
-                            foreach (var _ in orderedTypes)
-                                table.Cell().PaddingVertical(cellPadV);
 
                             // Faculty w/ CLI assigned + averages row
                             table.Cell().Background("#E0E0E0").PaddingVertical(cellPadV).PaddingRight(8).Row(row =>
@@ -348,21 +356,12 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
                                     .Text(val.ToString("F1")).Bold());
                         });
 
-                        page.Footer().Column(col =>
-                        {
-                            AddPdfFilterLine(col.Item(), ("Dept", report.FilterDepartment));
-                            col.Item().AlignCenter().Text(x =>
-                            {
-                                x.Span("Page ");
-                                x.CurrentPageNumber();
-                                x.Span(" of ");
-                                x.TotalPages();
-                            });
-                        });
+                        AddPdfPageNumberFooter(page.Footer(), ("Dept", report.FilterDepartment));
                     });
                 }
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Merit and promotion summary for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -370,10 +369,14 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
     public MemoryStream GenerateReportExcel(MeritSummaryReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Merit & Promotion Summary Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Merit and promotion summary for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 1 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         foreach (var jobGroup in report.JobGroups)
         {
@@ -383,7 +386,7 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
                 var ws = wb.Worksheets.Add(sheetName);
 
                 // Header rows matching PDF
-                int row = AddExcelHeader(ws, "Merit & Promotion Summary Report",
+                int row = AddExcelHeader(ws, reportTitle,
                     termName, dept.Department, jobGroup.JobGroupDescription);
                 row = AddExcelFilterLine(ws, row, ("Dept", report.FilterDepartment));
                 row++; // blank separator

--- a/web/Areas/Effort/Services/SchoolSummaryService.cs
+++ b/web/Areas/Effort/Services/SchoolSummaryService.cs
@@ -190,10 +190,9 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
 
     public Task<byte[]> GenerateReportPdfAsync(SchoolSummaryReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
 
+        const string reportTitle = "School Summary Report";
         var compact = orderedTypes.Count > 14;
         var fontSize = compact ? ReportPdfSettings.FontSizeCompact : ReportPdfSettings.FontSize;
         var headerFontSize = compact ? ReportPdfSettings.HeaderFontSizeCompact : ReportPdfSettings.HeaderFontSize;
@@ -216,19 +215,19 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
 
                 page.Header().Column(col =>
                 {
-                    col.Item().Row(row =>
+                    col.Item().SemanticIgnore().Row(row =>
                     {
                         row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                         row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                     });
                     col.Item().PaddingVertical(6).Row(row =>
                     {
-                        row.RelativeItem().Text("School Summary Report").SemiBold().FontSize(12);
+                        row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
                         row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                     });
                 });
 
-                page.Content().Table(table =>
+                page.Content().SemanticTable().Table(table =>
                 {
                     var totalColumns = (uint)(1 + orderedTypes.Count);
 
@@ -263,14 +262,12 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
                             table.Cell().PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0");
                         }
 
-                        // # Faculty row
-                        table.Cell().PaddingVertical(cellPadV).Row(row =>
+                        // # Faculty row (single label/value spanning the full row)
+                        table.Cell().ColumnSpan(totalColumns).PaddingVertical(cellPadV).Row(row =>
                         {
                             row.ConstantItem(facultyLabelWidth).Text("# Faculty").SemiBold();
                             row.AutoItem().Text(dept.FacultyCount.ToString()).SemiBold();
                         });
-                        foreach (var _ in orderedTypes)
-                            table.Cell().PaddingVertical(cellPadV).Text("");
 
                         // # Faculty with CLI + averages row
                         table.Cell().Background("#E0E0E0").PaddingVertical(cellPadV).Row(row =>
@@ -286,16 +283,12 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
                                 .Text(val.ToString("F1")).Italic();
                         }
 
-                        // Divider between departments
-                        if (deptIdx < report.Departments.Count - 1)
-                        {
-                            table.Cell().ColumnSpan(totalColumns).PaddingVertical(4)
-                                .BorderBottom(0.5f).BorderColor("#CCCCCC").Text("");
-                        }
+                        // Divider between departments removed for PDF/UA compliance
+                        // (single-cell rows of whitespace are dropped by QuestPDF, leaving an empty TR)
                     }
 
                     // Re-display effort type headers before grand totals
-                    table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("");
+                    table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Department").Style(hdrStyle);
                     foreach (var type in orderedTypes)
                     {
                         table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV)
@@ -312,14 +305,12 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
                             .PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0").Bold();
                     }
 
-                    // # Faculty row (grand)
-                    table.Cell().PaddingVertical(cellPadV).Row(row =>
+                    // # Faculty row (grand) — single label/value spanning the full row
+                    table.Cell().ColumnSpan(totalColumns).PaddingVertical(cellPadV).Row(row =>
                     {
                         row.ConstantItem(facultyLabelWidth).Text("# Faculty").Bold();
                         row.AutoItem().Text(report.GrandTotals.FacultyCount.ToString()).Bold();
                     });
-                    foreach (var _ in orderedTypes)
-                        table.Cell().PaddingVertical(cellPadV).Text("");
 
                     // # Faculty with CLI + grand averages row
                     table.Cell().Background("#E0E0E0").PaddingVertical(cellPadV).Row(row =>
@@ -336,21 +327,12 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
                     }
                 });
 
-                page.Footer().Column(col =>
-                {
-                    AddPdfFilterLine(col.Item(),
-                        ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
-                        ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
-                    col.Item().AlignCenter().Text(x =>
-                    {
-                        x.Span("Page ");
-                        x.CurrentPageNumber();
-                        x.Span(" of ");
-                        x.TotalPages();
-                    });
-                });
+                AddPdfPageNumberFooter(page.Footer(),
+                    ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
+                    ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
             });
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"School-wide effort summary for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -358,14 +340,18 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
     public MemoryStream GenerateReportExcel(SchoolSummaryReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "School Summary Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"School-wide effort summary for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 1 + effortCols.Count;
         var ws = wb.Worksheets.Add("School Summary");
-        var termName = report.AcademicYear ?? report.TermName;
 
         // Header rows matching PDF
-        int row = AddExcelHeader(ws, "School Summary Report", termName);
+        int row = AddExcelHeader(ws, reportTitle, termName);
         row = AddExcelFilterLine(ws, row,
             ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
             ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));

--- a/web/Areas/Effort/Services/TeachingActivityService.cs
+++ b/web/Areas/Effort/Services/TeachingActivityService.cs
@@ -209,9 +209,9 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
     public Task<byte[]> GenerateReportPdfAsync(TeachingActivityReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
+
+        const string reportTitle = "Teaching Activity Report";
 
         // Compact when 12+ effort types: with 6 fixed columns (Qtr, Role, Instructor,
         // Course, Units, Enroll), non-compact overflows the page at 12+ effort types
@@ -242,20 +242,20 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Teaching Activity Report").SemiBold().FontSize(12);
-                            row.RelativeItem().AlignCenter().Text(dept.Department).SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
+                            row.RelativeItem().AlignCenter().SemanticHeader2().Text(dept.Department).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                         });
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -295,10 +295,14 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
                                 table.Cell().PaddingVertical(cellPadV).Text(course.TermCode.ToString());
                                 table.Cell().PaddingVertical(cellPadV).PaddingLeft(4).Text(course.RoleId);
 
+                                // Per-row instructor cell instead of RowSpan (PDF/UA clause 7.2 test 15)
                                 if (i == 0)
                                 {
-                                    table.Cell().RowSpan((uint)courses.Count).PaddingVertical(cellPadV)
-                                        .Text(instructor.Instructor).SemiBold();
+                                    table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold();
+                                }
+                                else
+                                {
+                                    table.Cell().PaddingVertical(cellPadV).Text(instructor.Instructor).SemiBold().FontColor("#FFFFFF");
                                 }
 
                                 table.Cell().PaddingVertical(cellPadV).Text(course.Course);
@@ -324,8 +328,13 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
                             }
                         }
 
-                        // Re-display effort type headers before dept totals
-                        table.Cell().ColumnSpan(6).BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("");
+                        // Re-display column headers before dept totals
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Qtr").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Role").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Instructor").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Course").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Units").Style(hdrStyle);
+                        table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text("Enroll").Style(hdrStyle);
                         foreach (var type in orderedTypes)
                         {
                             table.Cell().BorderTop(1).BorderColor("#999999").PaddingVertical(cellPadV).Text(type).Style(hdrStyle);
@@ -343,31 +352,22 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
                         }
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
-                            ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
+                        ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Teaching activity by department for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
 
     public Task<byte[]> GenerateIndividualReportPdfAsync(TeachingActivityReport report)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
+
+        const string reportTitle = "Teaching Activity Report (Individual)";
 
         // Compact when 12+ effort types: with fixed columns, non-compact overflows the page
         var compact = orderedTypes.Count > 11;
@@ -402,22 +402,22 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
                     page.Header().Column(col =>
                     {
-                        col.Item().Row(row =>
+                        col.Item().SemanticIgnore().Row(row =>
                         {
                             row.RelativeItem().Text("UCD School of Veterinary Medicine").Bold().FontSize(11);
                             row.RelativeItem().AlignRight().Text(DateTime.Now.ToString("d MMMM yyyy")).Bold().FontSize(11);
                         });
                         col.Item().PaddingVertical(6).Row(row =>
                         {
-                            row.RelativeItem().Text("Teaching Activity Report (Individual)").SemiBold().FontSize(12);
+                            row.RelativeItem().SemanticHeader1().Text(reportTitle).SemiBold().FontSize(12);
                             row.RelativeItem().AlignCenter().Text(dept).SemiBold().FontSize(12);
                             row.RelativeItem().AlignRight().Text(report.TermName).SemiBold().FontSize(12);
                         });
                         // Instructor name below the sub-header
-                        col.Item().PaddingBottom(4).Text(instructor.Instructor).Bold().FontSize(11);
+                        col.Item().PaddingBottom(4).SemanticHeader2().Text(instructor.Instructor).Bold().FontSize(11);
                     });
 
-                    page.Content().Table(table =>
+                    page.Content().SemanticTable().Table(table =>
                     {
                         table.ColumnsDefinition(columns =>
                         {
@@ -472,22 +472,13 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
                         }
                     });
 
-                    page.Footer().Column(col =>
-                    {
-                        AddPdfFilterLine(col.Item(),
-                            ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
-                            ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
-                        col.Item().AlignCenter().Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                    });
+                    AddPdfPageNumberFooter(page.Footer(),
+                        ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
+                        ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
                 });
             }
-        });
+        })
+        .WithAccessibility(reportTitle, subject: $"Teaching activity by instructor for {report.TermName}");
 
         return Task.FromResult(document.GeneratePdf());
     }
@@ -495,17 +486,21 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
     public MemoryStream GenerateReportExcel(TeachingActivityReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Teaching Activity Report";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Teaching activity by department for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 4 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         foreach (var dept in report.Departments)
         {
             var ws = wb.Worksheets.Add(dept.Department);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Teaching Activity Report", termName, dept.Department);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept.Department);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
                 ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
@@ -609,10 +604,14 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
     public MemoryStream GenerateIndividualReportExcel(TeachingActivityReport report)
     {
         var wb = new XLWorkbook();
+        const string reportTitle = "Teaching Activity Report (Individual)";
+        var termName = report.AcademicYear ?? report.TermName;
+        ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
+            subject: $"Teaching activity by instructor for {termName}");
+
         var orderedTypes = GetOrderedEffortTypes(report.EffortTypes);
         var effortCols = BuildExcelEffortColumns(orderedTypes);
         var lastCol = 3 + effortCols.Count;
-        var termName = report.AcademicYear ?? report.TermName;
 
         var allInstructors = report.Departments
             .SelectMany(d => d.Instructors.Select(i => (Dept: d.Department, Instructor: i)))
@@ -629,14 +628,14 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
             var ws = wb.Worksheets.Add(sheetName);
 
             // Header rows matching PDF
-            int row = AddExcelHeader(ws, "Teaching Activity Report (Individual)",
-                termName, dept, instructor.Instructor);
+            int row = AddExcelHeader(ws, reportTitle, termName, dept, instructor.Instructor);
             row = AddExcelFilterLine(ws, row,
                 ("Dept", report.FilterDepartment), ("Role", report.FilterRole),
                 ("Faculty", report.FilterPerson), ("Title", report.FilterTitle));
             row++; // blank separator
 
             // Column headers
+            int headerRow = row;
             int col = 1;
             ws.Cell(row, col++).Value = "Course";
             ws.Cell(row, col++).Value = "Units";
@@ -662,6 +661,13 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
                     col++;
                 }
                 row++;
+            }
+
+            if (row > headerRow + 1)
+            {
+                ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                    ws.Range(headerRow, 1, row - 1, lastCol),
+                    $"Teaching_{sheetName}");
             }
 
             // Totals row

--- a/web/Areas/Students/Controllers/EmergencyContactController.cs
+++ b/web/Areas/Students/Controllers/EmergencyContactController.cs
@@ -282,7 +282,7 @@ public class EmergencyContactController : ApiController
     /// <summary>
     /// Export the overview (completeness summary) as a PDF file.
     /// </summary>
-    [HttpPost("export/overview/pdf")]
+    [HttpGet("export/overview/pdf")]
     [Permission(Allow = "SVMSecure.Students.EmergencyContactAdmin,SVMSecure.SIS.AllStudents")]
     public async Task<ActionResult> ExportOverviewPdf()
     {
@@ -293,7 +293,7 @@ public class EmergencyContactController : ApiController
         }
 
         var pdfBytes = _exportService.GenerateOverviewPdf(data);
-        return File(pdfBytes, "application/pdf", $"EmergencyContactOverview_{DateTime.Now:yyyyMMdd}.pdf");
+        return InlineFile(pdfBytes, "application/pdf", $"EmergencyContactOverview_{DateTime.Now:yyyyMMdd}.pdf");
     }
 
     /// <summary>
@@ -320,7 +320,7 @@ public class EmergencyContactController : ApiController
     /// <summary>
     /// Export all emergency contacts as a PDF file.
     /// </summary>
-    [HttpPost("export/pdf")]
+    [HttpGet("export/pdf")]
     [Permission(Allow = "SVMSecure.Students.EmergencyContactAdmin,SVMSecure.SIS.AllStudents")]
     public async Task<ActionResult> ExportPdf()
     {
@@ -331,6 +331,6 @@ public class EmergencyContactController : ApiController
         }
 
         var pdfBytes = _exportService.GeneratePdf(data);
-        return File(pdfBytes, "application/pdf", $"EmergencyContacts_{DateTime.Now:yyyyMMdd}.pdf");
+        return InlineFile(pdfBytes, "application/pdf", $"EmergencyContacts_{DateTime.Now:yyyyMMdd}.pdf");
     }
 }

--- a/web/Areas/Students/Controllers/PhotoGalleryController.cs
+++ b/web/Areas/Students/Controllers/PhotoGalleryController.cs
@@ -306,6 +306,76 @@ namespace Viper.Areas.Students.Controllers
             return await ExecuteExport(request, _photoExportService.ExportToPdfAsync, "PDF");
         }
 
+        /// <summary>
+        /// Streams the photo-gallery PDF inline (Content-Disposition: inline)
+        /// so it renders in the browser's built-in viewer instead of being
+        /// downloaded by the user agent.
+        /// </summary>
+        [HttpGet("export/pdf")]
+        public async Task<IActionResult> ExportToPdfInline([FromQuery] PhotoExportRequest request)
+        {
+            var validationError = ValidatePhotoExportRequest(request);
+            if (validationError != null) return validationError;
+
+            try
+            {
+                var result = await _photoExportService.ExportToPdfAsync(request);
+                if (result == null)
+                {
+                    return NotFound("No students to export.");
+                }
+                return InlineFile(result.FileData, result.ContentType, result.FileName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogError(ex, "Invalid operation exporting photo gallery PDF inline");
+                return StatusCode(500, "An error occurred while generating the PDF");
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Invalid argument exporting photo gallery PDF inline");
+                return BadRequest("Invalid export parameters.");
+            }
+        }
+
+        [HttpPost("export/list/pdf")]
+        public async Task<IActionResult> ExportStudentListToPdf([FromBody] PhotoExportRequest request)
+        {
+            return await ExecuteExport(request, _photoExportService.ExportStudentListToPdfAsync, "Student list PDF");
+        }
+
+        /// <summary>
+        /// Streams the tabular student-list PDF inline (Content-Disposition:
+        /// inline) so it renders in the browser's built-in viewer instead of
+        /// being downloaded by the user agent.
+        /// </summary>
+        [HttpGet("export/list/pdf")]
+        public async Task<IActionResult> ExportStudentListToPdfInline([FromQuery] PhotoExportRequest request)
+        {
+            var validationError = ValidatePhotoExportRequest(request);
+            if (validationError != null) return validationError;
+
+            try
+            {
+                var result = await _photoExportService.ExportStudentListToPdfAsync(request);
+                if (result == null)
+                {
+                    return NotFound("No students to export.");
+                }
+                return InlineFile(result.FileData, result.ContentType, result.FileName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogError(ex, "Invalid operation exporting student list PDF inline");
+                return StatusCode(500, "An error occurred while generating the student list PDF");
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Invalid argument exporting student list PDF inline");
+                return BadRequest("Invalid export parameters.");
+            }
+        }
+
         [HttpGet("metadata/groups")]
         public async Task<IActionResult> GetAvailableGroups()
         {
@@ -386,26 +456,7 @@ namespace Viper.Areas.Students.Controllers
             Func<PhotoExportRequest, Task<PhotoExportResult?>> exportFunc,
             string formatName)
         {
-            // Validate class level
-            if (!string.IsNullOrEmpty(request.ClassLevel) && !ValidClassLevels.Contains(request.ClassLevel))
-            {
-                return BadRequest($"Invalid class level. Must be one of: {string.Join(", ", ValidClassLevels)}");
-            }
-
-            // Validate group type
-            if (!string.IsNullOrEmpty(request.GroupType) && !ValidGroupTypes.Contains(request.GroupType.ToLower()))
-            {
-                return BadRequest($"Invalid group type. Must be one of: {string.Join(", ", ValidGroupTypes)}");
-            }
-
-            // Validate group ID
-            if (!string.IsNullOrEmpty(request.GroupId) && (string.IsNullOrWhiteSpace(request.GroupId) || request.GroupId.Length > 50))
-            {
-                return BadRequest("Invalid group ID. Must be non-empty and less than 50 characters");
-            }
-
-            // Validate course parameters
-            var validationError = ValidateCourseParams(request.TermCode, request.Crn, required: false);
+            var validationError = ValidatePhotoExportRequest(request);
             if (validationError != null)
             {
                 return validationError;
@@ -449,6 +500,34 @@ namespace Viper.Areas.Students.Controllers
             var wrappedJson = $"{{\"statusCode\":200,\"success\":true,\"result\":{jsonString}}}";
 
             return Content(wrappedJson, "application/json");
+        }
+
+        /// <summary>
+        /// Validates the optional fields on a photo export request against the
+        /// same allow-lists used by the JSON POST endpoints. Inline GET endpoints
+        /// must call this before invoking the service so external callers cannot
+        /// reach the service layer with malformed input.
+        /// </summary>
+        /// <param name="request">The export request to validate.</param>
+        /// <returns>BadRequestObjectResult if validation fails, null if valid.</returns>
+        private BadRequestObjectResult? ValidatePhotoExportRequest(PhotoExportRequest request)
+        {
+            if (!string.IsNullOrEmpty(request.ClassLevel) && !ValidClassLevels.Contains(request.ClassLevel))
+            {
+                return BadRequest($"Invalid class level. Must be one of: {string.Join(", ", ValidClassLevels)}");
+            }
+
+            if (!string.IsNullOrEmpty(request.GroupType) && !ValidGroupTypes.Contains(request.GroupType.ToLower()))
+            {
+                return BadRequest($"Invalid group type. Must be one of: {string.Join(", ", ValidGroupTypes)}");
+            }
+
+            if (!string.IsNullOrEmpty(request.GroupId) && (string.IsNullOrWhiteSpace(request.GroupId) || request.GroupId.Length > 50))
+            {
+                return BadRequest("Invalid group ID. Must be non-empty and less than 50 characters");
+            }
+
+            return ValidateCourseParams(request.TermCode, request.Crn, required: false);
         }
 
         /// <summary>

--- a/web/Areas/Students/Models/PhotoGalleryViewModel.cs
+++ b/web/Areas/Students/Models/PhotoGalleryViewModel.cs
@@ -1,7 +1,10 @@
 using System.Text.Json.Serialization;
+using UsedImplicitly = JetBrains.Annotations.UsedImplicitlyAttribute;
+using ImplicitUseTargetFlags = JetBrains.Annotations.ImplicitUseTargetFlags;
 
 namespace Viper.Areas.Students.Models
 {
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class PhotoGalleryViewModel
     {
         public string? ClassLevel { get; set; }
@@ -11,6 +14,7 @@ namespace Viper.Areas.Students.Models
         public required ExportOptions ExportOptions { get; set; }
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class StudentPhoto
     {
         public required string MailId { get; set; }
@@ -52,6 +56,7 @@ namespace Viper.Areas.Students.Models
         }
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class GroupingInfo
     {
         public required string GroupType { get; set; }
@@ -59,6 +64,7 @@ namespace Viper.Areas.Students.Models
         public required List<string> AvailableGroups { get; set; }
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class ExportOptions
     {
         public required string Format { get; set; }
@@ -68,6 +74,7 @@ namespace Viper.Areas.Students.Models
         public required string Subtitle { get; set; }
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class PhotoExportRequest
     {
         public string? ClassLevel { get; set; }
@@ -77,8 +84,16 @@ namespace Viper.Areas.Students.Models
         public string? Crn { get; set; }
         public required bool IncludeRossStudents { get; set; }
         public string? ExportFormat { get; set; }
+
+        /// <summary>
+        /// The on-screen view that triggered the export ("grid" | "list" | "sheet").
+        /// Carried into the saved filename so users can tell exports apart when
+        /// they have multiple downloads of the same class.
+        /// </summary>
+        public string? View { get; set; }
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public class PhotoExportResult
     {
         public required string ExportId { get; set; }

--- a/web/Areas/Students/Services/EmergencyContactExportService.cs
+++ b/web/Areas/Students/Services/EmergencyContactExportService.cs
@@ -7,11 +7,34 @@ using Viper.Classes.Utilities;
 
 namespace Viper.Areas.Students.Services;
 
+/// <summary>
+/// Exports for the student emergency-contact app. Each report has a
+/// completeness-summary "overview" variant and a full-detail variant.
+/// </summary>
 public interface IEmergencyContactExportService
 {
+    /// <summary>
+    /// Generate the overview Excel workbook — one row per student with
+    /// completeness counts for each contact category.
+    /// </summary>
     MemoryStream GenerateOverviewExcel(List<StudentContactListItemDto> data);
+
+    /// <summary>
+    /// Generate the overview PDF — one row per student with completeness
+    /// counts for each contact category.
+    /// </summary>
     byte[] GenerateOverviewPdf(List<StudentContactListItemDto> data);
+
+    /// <summary>
+    /// Generate the full-detail Excel workbook — one row per student with
+    /// the formatted blocks for each contact category.
+    /// </summary>
     MemoryStream GenerateExcel(List<StudentContactReportDto> data);
+
+    /// <summary>
+    /// Generate the full-detail PDF — one row per student with formatted
+    /// blocks for each contact category.
+    /// </summary>
     byte[] GeneratePdf(List<StudentContactReportDto> data);
 }
 
@@ -23,7 +46,11 @@ public class EmergencyContactExportService : IEmergencyContactExportService
     public MemoryStream GenerateOverviewExcel(List<StudentContactListItemDto> data)
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Emergency Contact Overview");
+        const string title = "Emergency Contact Overview";
+        ExcelAccessibilityHelper.SetCoreProperties(wb, title,
+            subject: "Student emergency contact overview");
+
+        var ws = wb.Worksheets.Add(title);
 
         ws.Cell(1, 1).Value = BuildGeneratedLabel(DateTime.Now);
         ws.Cell(1, 1).Style.Font.Italic = true;
@@ -57,6 +84,13 @@ public class EmergencyContactExportService : IEmergencyContactExportService
             ws.Cell(row, 9).Value = d.LastUpdated?.ToString("M/d/yyyy") ?? "";
         }
 
+        if (data.Count > 0)
+        {
+            ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                ws.Range(2, 1, data.Count + 2, headers.Length),
+                "EmergencyContactOverview");
+        }
+
         ws.Columns().AdjustToContents();
 
         var stream = new MemoryStream();
@@ -67,10 +101,9 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
     public byte[] GenerateOverviewPdf(List<StudentContactListItemDto> data)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         // Capture once so per-page header delegates don't drift across pages.
         var generatedLabel = BuildGeneratedLabel(DateTime.Now);
+        const string title = "Emergency Contact Overview";
 
         var document = Document.Create(container =>
         {
@@ -82,13 +115,13 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
                 page.Header().Column(col =>
                 {
-                    col.Item().Text("Emergency Contact Overview")
+                    col.Item().SemanticHeader1().Text(title)
                         .SemiBold().FontSize(14).AlignCenter();
                     col.Item().Text(generatedLabel)
                         .FontSize(8).Italic().AlignCenter();
                 });
 
-                page.Content().Table(table =>
+                page.Content().SemanticTable().Table(table =>
                 {
                     table.ColumnsDefinition(columns =>
                     {
@@ -119,19 +152,19 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
                     foreach (var d in data)
                     {
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.FullName);
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.ClassLevel);
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.Email);
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.CellPhone ?? "");
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.FullName));
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.ClassLevel));
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.Email));
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.CellPhone));
                         table.Cell().BorderBottom(0.5f).Padding(2).Text(CompletenessLabel(d.StudentInfoComplete, d.StudentInfoTotal));
                         table.Cell().BorderBottom(0.5f).Padding(2).Text(CompletenessLabel(d.LocalContactComplete, d.LocalContactTotal));
                         table.Cell().BorderBottom(0.5f).Padding(2).Text(CompletenessLabel(d.EmergencyContactComplete, d.EmergencyContactTotal));
                         table.Cell().BorderBottom(0.5f).Padding(2).Text(CompletenessLabel(d.PermanentContactComplete, d.PermanentContactTotal));
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.LastUpdated?.ToString("M/d/yyyy") ?? "");
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.LastUpdated?.ToString("M/d/yyyy") ?? "—");
                     }
                 });
 
-                page.Footer().AlignCenter().Text(x =>
+                page.Footer().SemanticIgnore().AlignCenter().Text(x =>
                 {
                     x.Span("Page ");
                     x.CurrentPageNumber();
@@ -139,7 +172,8 @@ public class EmergencyContactExportService : IEmergencyContactExportService
                     x.TotalPages();
                 });
             });
-        });
+        })
+        .WithAccessibility(title, subject: "Student emergency contact overview");
 
         return document.GeneratePdf();
     }
@@ -147,7 +181,11 @@ public class EmergencyContactExportService : IEmergencyContactExportService
     public MemoryStream GenerateExcel(List<StudentContactReportDto> data)
     {
         using var wb = new XLWorkbook();
-        var ws = wb.Worksheets.Add("Emergency Contact Report");
+        const string title = "Emergency Contact Report";
+        ExcelAccessibilityHelper.SetCoreProperties(wb, title,
+            subject: "Student emergency contact report");
+
+        var ws = wb.Worksheets.Add(title);
 
         ws.Cell(1, 1).Value = BuildGeneratedLabel(DateTime.Now);
         ws.Cell(1, 1).Style.Font.Italic = true;
@@ -177,6 +215,13 @@ public class EmergencyContactExportService : IEmergencyContactExportService
             ws.Cell(row, 6).Style.Alignment.WrapText = true;
         }
 
+        if (data.Count > 0)
+        {
+            ExcelAccessibilityHelper.PromoteToAccessibleTable(
+                ws.Range(2, 1, data.Count + 2, headers.Length),
+                "EmergencyContactReport");
+        }
+
         ws.Columns().AdjustToContents();
 
         var stream = new MemoryStream();
@@ -187,9 +232,8 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
     public byte[] GeneratePdf(List<StudentContactReportDto> data)
     {
-        QuestPDF.Settings.License = LicenseType.Community;
-
         var generatedLabel = BuildGeneratedLabel(DateTime.Now);
+        const string title = "Emergency Contact Report";
 
         var document = Document.Create(container =>
         {
@@ -201,13 +245,13 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
                 page.Header().Column(col =>
                 {
-                    col.Item().Text("Emergency Contact Report")
+                    col.Item().SemanticHeader1().Text(title)
                         .SemiBold().FontSize(14).AlignCenter();
                     col.Item().Text(generatedLabel)
                         .FontSize(8).Italic().AlignCenter();
                 });
 
-                page.Content().Table(table =>
+                page.Content().SemanticTable().Table(table =>
                 {
                     table.ColumnsDefinition(columns =>
                     {
@@ -232,8 +276,8 @@ public class EmergencyContactExportService : IEmergencyContactExportService
 
                     foreach (var d in data)
                     {
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.ClassLevel);
-                        table.Cell().BorderBottom(0.5f).Padding(2).Text(d.FullName);
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.ClassLevel));
+                        table.Cell().BorderBottom(0.5f).Padding(2).Text(OrDash(d.FullName));
                         PdfMultiLineCell(table, FormatStudentInfoLines(d));
                         PdfMultiLineCell(table, FormatContactLines(d.LocalContact));
                         PdfMultiLineCell(table, FormatContactLines(d.EmergencyContact));
@@ -241,7 +285,7 @@ public class EmergencyContactExportService : IEmergencyContactExportService
                     }
                 });
 
-                page.Footer().AlignCenter().Text(x =>
+                page.Footer().SemanticIgnore().AlignCenter().Text(x =>
                 {
                     x.Span("Page ");
                     x.CurrentPageNumber();
@@ -249,7 +293,8 @@ public class EmergencyContactExportService : IEmergencyContactExportService
                     x.TotalPages();
                 });
             });
-        });
+        })
+        .WithAccessibility(title, subject: "Student emergency contact report");
 
         return document.GeneratePdf();
     }
@@ -260,6 +305,14 @@ public class EmergencyContactExportService : IEmergencyContactExportService
         if (complete == 0) return "No";
         return "Partial";
     }
+
+    /// <summary>
+    /// Returns an em-dash placeholder when the value is null or empty so that
+    /// QuestPDF emits the cell as a tagged TD (whitespace-only and empty Text
+    /// elements are dropped from the structure tree, breaking PDF/UA clause 7.2).
+    /// </summary>
+    private static string OrDash(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "—" : value.Trim();
 
     /// <summary>Formats student info as a multi-line block for Excel cells.</summary>
     private static string FormatStudentInfoBlock(StudentContactReportDto d)
@@ -300,9 +353,18 @@ public class EmergencyContactExportService : IEmergencyContactExportService
     {
         table.Cell().BorderBottom(0.5f).Padding(2).Column(col =>
         {
-            foreach (var line in lines)
+            if (lines.Count == 0)
             {
-                col.Item().Text(line);
+                // Empty Column children would cause QuestPDF to drop the cell from the
+                // tag tree, breaking PDF/UA clause 7.2 (rows must have matching column counts).
+                col.Item().Text("—");
+            }
+            else
+            {
+                foreach (var line in lines)
+                {
+                    col.Item().Text(line);
+                }
             }
         });
     }

--- a/web/Areas/Students/Services/PhotoExportService.cs
+++ b/web/Areas/Students/Services/PhotoExportService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -13,14 +14,45 @@ using PdfDocument = QuestPDF.Fluent.Document;
 
 namespace Viper.Areas.Students.Services
 {
+    /// <summary>
+    /// Builds Word and PDF photo galleries for a class / course / student-group
+    /// selection.
+    /// </summary>
     public interface IPhotoExportService
     {
+        /// <summary>
+        /// Export student photos to a Word document (.docx). Layout is either
+        /// the standard 6-up grid or, for grouped exports, a 3-up large layout.
+        /// </summary>
         Task<PhotoExportResult?> ExportToWordAsync(PhotoExportRequest request);
+
+        /// <summary>
+        /// Export student photos to a PDF. Layout matches the Word variant.
+        /// Returns null when no students match the request.
+        /// </summary>
         Task<PhotoExportResult?> ExportToPdfAsync(PhotoExportRequest request);
+
+        /// <summary>
+        /// Export the tabular student list (no photos) to a PDF — mirrors the
+        /// "Student List" tab on the gallery page. Used by the list-tab
+        /// Print/PDF button so the saved file is a real, accessible PDF
+        /// instead of a browser-rendered print capture.
+        /// </summary>
+        Task<PhotoExportResult?> ExportStudentListToPdfAsync(PhotoExportRequest request);
     }
 
     public class PhotoExportService : IPhotoExportService
     {
+        // Source data (student names, group labels) occasionally contains stray
+        // double-spaces from upstream systems. Microsoft's accessibility checker
+        // and our own home-grown checker flag 3+ consecutive whitespace chars
+        // ("RepeatedBlanks"); collapsing them on the way out is a safe no-op for
+        // clean data and a structural improvement for messy data.
+        private static readonly Regex RepeatedWhitespaceRegex = new(@"\s{2,}", RegexOptions.Compiled);
+
+        private static string CollapseWhitespace(string? text) =>
+            string.IsNullOrEmpty(text) ? string.Empty : RepeatedWhitespaceRegex.Replace(text, " ").Trim();
+
         // Photo dimensions in EMUs (English Metric Units) for Word/PDF export
         // EMU = 1/914400 inch
 
@@ -86,6 +118,11 @@ namespace Viper.Areas.Students.Services
                 var layout = GetLayoutConfiguration(request);
                 var useLargeLayout = ShouldUseLargeLayout(request);
 
+                // Resolve title up-front so the same string is used for both core
+                // properties and the visible H1 paragraph.
+                var titleLines = (await GetExportTitleAsync(request)).Split('\n');
+                var documentTitle = titleLines[0];
+
                 using var stream = new MemoryStream();
                 using (var wordDocument = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
                 {
@@ -93,28 +130,40 @@ namespace Viper.Areas.Students.Services
                     mainPart.Document = new WordDocument();
                     var body = mainPart.Document.AppendChild(new Body());
 
-                    // Only show title and date for non-group exports
+                    WordAccessibilityHelper.EnsureAccessibilityStyles(mainPart);
+                    WordAccessibilityHelper.EnsureModernCompatibility(mainPart);
+                    WordAccessibilityHelper.SetCoreProperties(wordDocument, documentTitle, subject: "Student photo gallery export");
+
+                    // Only show title and date for non-group exports.
+                    // Use Heading1, not Title — accessibility checkers (Microsoft's
+                    // built-in and our own check-docx-accessibility.ps1) recognise
+                    // Heading1-9 as document headings; Word's "Title" style is a
+                    // separate concept and doesn't satisfy the heading-styles rule.
                     if (!useLargeLayout)
                     {
-                        var titleLines = (await GetExportTitleAsync(request)).Split('\n');
+                        body.AppendChild(WordAccessibilityHelper.CreateHeadingParagraph(
+                            CollapseWhitespace(documentTitle), WordAccessibilityHelper.Heading1StyleId));
 
-                        var titleParagraph = body.AppendChild(new Paragraph());
-                        var titleRun = titleParagraph.AppendChild(new Run());
-                        titleRun.AppendChild(new Text(titleLines[0]));
-
-                        var titleProps = titleRun.PrependChild(new RunProperties());
-                        titleProps.AppendChild(new Bold());
-                        titleProps.AppendChild(new FontSize() { Val = "32" });
-
-                        // Add export date on new line with smaller font
+                        // Date subtitle is regular body text, not a heading — keeps the
+                        // outline a single H1 instead of two competing top-level entries.
                         if (titleLines.Length > 1)
                         {
-                            titleRun.AppendChild(new Break());
-                            var dateRun = titleParagraph.AppendChild(new Run());
-                            dateRun.AppendChild(new Text(titleLines[1]));
+                            var dateParagraph = body.AppendChild(new Paragraph());
+                            // Tight spacing keeps the date hugging the title like the
+                            // original soft-break version before the H1 split.
+                            var dateParaProps = dateParagraph.AppendChild(new ParagraphProperties());
+                            dateParaProps.AppendChild(new SpacingBetweenLines
+                            {
+                                Before = "0",
+                                After = "0",
+                            });
+                            var dateRun = dateParagraph.AppendChild(new Run());
+                            dateRun.AppendChild(new Text(CollapseWhitespace(titleLines[1])));
                             var dateProps = dateRun.PrependChild(new RunProperties());
                             dateProps.AppendChild(new FontSize() { Val = "16" });
-                            dateProps.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "808080" }); // Gray color
+                            // Matches Quasar's grey-7 (the same theme color the on-page caption
+                            // text uses); ≈4.6:1 contrast against white clears WCAG AA.
+                            dateProps.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "757575" });
                         }
                     }
 
@@ -148,15 +197,12 @@ namespace Viper.Areas.Students.Services
                                 // Add group header with student range numbering
                                 if (ShouldShowGroupHeaders(groupedStudents))
                                 {
-                                    var groupHeaderPara = body.AppendChild(new Paragraph());
-                                    var groupHeaderRun = groupHeaderPara.AppendChild(new Run());
-                                    groupHeaderRun.AppendChild(new Text($"{group.Key} ({chunkStart + 1}-{chunkEnd})"));
-                                    var groupHeaderProps = groupHeaderRun.PrependChild(new RunProperties());
-                                    groupHeaderProps.AppendChild(new Bold());
-                                    groupHeaderProps.AppendChild(new FontSize() { Val = "24" });
+                                    body.AppendChild(WordAccessibilityHelper.CreateHeadingParagraph(
+                                        CollapseWhitespace($"{group.Key} ({chunkStart + 1}-{chunkEnd})"),
+                                        WordAccessibilityHelper.Heading2StyleId));
                                 }
 
-                                // Create a borderless table for this chunk
+                                // Create a borderless table for this chunk (layout table — photos in a grid)
                                 var chunkTable = body.AppendChild(new Table());
                                 var chunkTableProps = chunkTable.AppendChild(new TableProperties());
                                 chunkTableProps.AppendChild(new TableBorders(
@@ -167,6 +213,7 @@ namespace Viper.Areas.Students.Services
                                     new InsideHorizontalBorder() { Val = new EnumValue<BorderValues>(BorderValues.None), Size = 0 },
                                     new InsideVerticalBorder() { Val = new EnumValue<BorderValues>(BorderValues.None), Size = 0 }
                                 ));
+                                WordAccessibilityHelper.MarkAsLayoutTable(chunkTable, "Photo gallery layout grid");
 
                                 // Render rows for this chunk
                                 for (int i = 0; i < chunkStudents.Count; i += layout.PerRow)
@@ -194,17 +241,33 @@ namespace Viper.Areas.Students.Services
 
                                             imageId++; // Increment before use to avoid duplicate IDs
 
+                                            // Alt text follows the rule from PLAN-Word-PDF-WCAG.md:
+                                            // photos that convey identity get the student's displayed name.
+                                            var altText = $"Photo of {student.GroupExportName}";
+
+                                            var wpDocProps = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties()
+                                            {
+                                                Id = (UInt32Value)imageId,
+                                                Name = $"Photo{imageId}"
+                                            };
+                                            var picNonVisualProps = new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties()
+                                            {
+                                                Id = (UInt32Value)imageId,
+                                                Name = $"Photo{imageId}.jpg"
+                                            };
+                                            WordAccessibilityHelper.SetImageAltText(wpDocProps, picNonVisualProps, altText);
+
                                             var inline = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline(
                                                 new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() { Cx = layout.Width, Cy = layout.Height },
                                                 new DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L },
-                                                new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = (UInt32Value)imageId, Name = $"Photo{imageId}" },
+                                                wpDocProps,
                                                 new DocumentFormat.OpenXml.Drawing.Wordprocessing.NonVisualGraphicFrameDrawingProperties(
                                                     new DocumentFormat.OpenXml.Drawing.GraphicFrameLocks() { NoChangeAspect = true }),
                                                 new DocumentFormat.OpenXml.Drawing.Graphic(
                                                     new DocumentFormat.OpenXml.Drawing.GraphicData(
                                                         new DocumentFormat.OpenXml.Drawing.Pictures.Picture(
                                                             new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties(
-                                                                new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties() { Id = (UInt32Value)imageId, Name = $"Photo{imageId}.jpg" },
+                                                                picNonVisualProps,
                                                                 new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties()),
                                                             new DocumentFormat.OpenXml.Drawing.Pictures.BlipFill(
                                                                 new DocumentFormat.OpenXml.Drawing.Blip() { Embed = mainPart.GetIdOfPart(imagePart) },
@@ -232,7 +295,7 @@ namespace Viper.Areas.Students.Services
                                         var cellParagraphProps = cellParagraph.AppendChild(new ParagraphProperties());
                                         cellParagraphProps.AppendChild(new Justification() { Val = JustificationValues.Center });
                                         var cellRun = cellParagraph.AppendChild(new Run());
-                                        cellRun.AppendChild(new Text(student.GroupExportName));
+                                        cellRun.AppendChild(new Text(CollapseWhitespace(student.GroupExportName)));
                                     }
 
                                     for (int j = rowStudents.Count; j < layout.PerRow; j++)
@@ -256,19 +319,12 @@ namespace Viper.Areas.Students.Services
                         // Add group header if there are multiple groups
                         if (ShouldShowGroupHeaders(groupedStudents))
                         {
-                            var groupHeaderPara = body.AppendChild(new Paragraph());
-                            var groupHeaderRun = groupHeaderPara.AppendChild(new Run());
-
-                            // Show count in parentheses
-                            var headerText = GetGroupHeaderText(group.Key, groupStudents.Count);
-                            groupHeaderRun.AppendChild(new Text(headerText));
-
-                            var groupHeaderProps = groupHeaderRun.PrependChild(new RunProperties());
-                            groupHeaderProps.AppendChild(new Bold());
-                            groupHeaderProps.AppendChild(new FontSize() { Val = "24" });
+                            body.AppendChild(WordAccessibilityHelper.CreateHeadingParagraph(
+                                CollapseWhitespace(GetGroupHeaderText(group.Key, groupStudents.Count)),
+                                WordAccessibilityHelper.Heading2StyleId));
                         }
 
-                        // Create a borderless table for this group
+                        // Create a borderless table for this group (layout table — photos in a grid)
                         var table = body.AppendChild(new Table());
                         var tableProps = table.AppendChild(new TableProperties());
                         tableProps.AppendChild(new TableBorders(
@@ -279,6 +335,7 @@ namespace Viper.Areas.Students.Services
                             new InsideHorizontalBorder() { Val = new EnumValue<BorderValues>(BorderValues.None), Size = 0 },
                             new InsideVerticalBorder() { Val = new EnumValue<BorderValues>(BorderValues.None), Size = 0 }
                         ));
+                        WordAccessibilityHelper.MarkAsLayoutTable(table, "Photo gallery layout grid");
 
                         for (int i = 0; i < groupStudents.Count; i += layout.PerRow)
                         {
@@ -305,17 +362,32 @@ namespace Viper.Areas.Students.Services
 
                                     imageId++; // Increment before use to avoid duplicate IDs
 
+                                    var displayedName = useLargeLayout ? student.GroupExportName : student.FullName;
+                                    var altText = $"Photo of {displayedName}";
+
+                                    var wpDocProps = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties()
+                                    {
+                                        Id = (UInt32Value)imageId,
+                                        Name = $"Photo{imageId}"
+                                    };
+                                    var picNonVisualProps = new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties()
+                                    {
+                                        Id = (UInt32Value)imageId,
+                                        Name = $"Photo{imageId}.jpg"
+                                    };
+                                    WordAccessibilityHelper.SetImageAltText(wpDocProps, picNonVisualProps, altText);
+
                                     var inline = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Inline(
                                         new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() { Cx = layout.Width, Cy = layout.Height },
                                         new DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L },
-                                        new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = (UInt32Value)imageId, Name = $"Photo{imageId}" },
+                                        wpDocProps,
                                         new DocumentFormat.OpenXml.Drawing.Wordprocessing.NonVisualGraphicFrameDrawingProperties(
                                             new DocumentFormat.OpenXml.Drawing.GraphicFrameLocks() { NoChangeAspect = true }),
                                         new DocumentFormat.OpenXml.Drawing.Graphic(
                                             new DocumentFormat.OpenXml.Drawing.GraphicData(
                                                 new DocumentFormat.OpenXml.Drawing.Pictures.Picture(
                                                     new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties(
-                                                        new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties() { Id = (UInt32Value)imageId, Name = $"Photo{imageId}.jpg" },
+                                                        picNonVisualProps,
                                                         new DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties()),
                                                     new DocumentFormat.OpenXml.Drawing.Pictures.BlipFill(
                                                         new DocumentFormat.OpenXml.Drawing.Blip() { Embed = mainPart.GetIdOfPart(imagePart) },
@@ -343,7 +415,7 @@ namespace Viper.Areas.Students.Services
                                 var cellParagraphProps = cellParagraph.AppendChild(new ParagraphProperties());
                                 cellParagraphProps.AppendChild(new Justification() { Val = JustificationValues.Center });
                                 var cellRun = cellParagraph.AppendChild(new Run());
-                                cellRun.AppendChild(new Text(useLargeLayout ? student.GroupExportName : student.FullName));
+                                cellRun.AppendChild(new Text(CollapseWhitespace(useLargeLayout ? student.GroupExportName : student.FullName)));
 
                                 // Only show secondary text (group info) if not using large layout
                                 if (!useLargeLayout)
@@ -351,7 +423,7 @@ namespace Viper.Areas.Students.Services
                                     foreach (var line in student.SecondaryTextLines)
                                     {
                                         cellRun.AppendChild(new Break());
-                                        cellRun.AppendChild(new Text(line));
+                                        cellRun.AppendChild(new Text(CollapseWhitespace(line)));
                                     }
                                 }
                             }
@@ -433,8 +505,7 @@ namespace Viper.Areas.Students.Services
 
                 // Fetch title before entering QuestPDF builder to avoid async void lambda
                 var titleLines = (await GetExportTitleAsync(request)).Split('\n');
-
-                QuestPDF.Settings.License = LicenseType.Community;
+                var documentTitle = titleLines[0];
 
                 const int studentsPerPage = 9; // For large layouts: 3 rows × 3 students
 
@@ -466,11 +537,14 @@ namespace Viper.Areas.Students.Services
                                     page.Header()
                                         .Column(column =>
                                         {
-                                            // Add group header with student range numbering
+                                            // Large layout intentionally has no on-page H1 — the
+                                            // document title is exposed via core properties (see
+                                            // WithAccessibility below) and the visual design has
+                                            // never shown a title for grouped photo sheets.
                                             if (ShouldShowGroupHeaders(groupedStudents))
                                             {
                                                 var headerText = $"{group.Key} ({chunkStart + 1}-{chunkEnd})";
-                                                column.Item().Text(headerText)
+                                                column.Item().SemanticHeader2().Text(headerText)
                                                     .SemiBold()
                                                     .FontSize(16)
                                                     .FontColor(Colors.Black);
@@ -504,7 +578,9 @@ namespace Viper.Areas.Students.Services
                                                             // Add photo from cache with explicit dimensions
                                                             if (photoCache.TryGetValue(student.MailId, out var photoBytes))
                                                             {
-                                                                innerColumn.Item().Width(1.74f, Unit.Inch).Height(2.26f, Unit.Inch).Image(photoBytes);
+                                                                innerColumn.Item()
+                                                                    .SemanticImage($"Photo of {student.GroupExportName}")
+                                                                    .Width(1.74f, Unit.Inch).Height(2.26f, Unit.Inch).Image(photoBytes);
                                                             }
 
                                                             // Show student name (centered)
@@ -523,6 +599,7 @@ namespace Viper.Areas.Students.Services
                                         });
 
                                     page.Footer()
+                                        .SemanticIgnore()
                                         .AlignCenter()
                                         .Text(x =>
                                         {
@@ -552,7 +629,7 @@ namespace Viper.Areas.Students.Services
                                         // Only show title and date for non-group exports
                                         if (!useLargeLayout)
                                         {
-                                            column.Item().Text(titleLines[0])
+                                            column.Item().SemanticHeader1().Text(titleLines[0])
                                                 .SemiBold()
                                                 .FontSize(20)
                                                 .FontColor(Colors.Black);
@@ -569,7 +646,7 @@ namespace Viper.Areas.Students.Services
                                         if (ShouldShowGroupHeaders(groupedStudents))
                                         {
                                             var headerText = GetGroupHeaderText(group.Key, groupStudents.Count);
-                                            column.Item().PaddingTop(useLargeLayout ? 0 : 10).Text(headerText)
+                                            column.Item().PaddingTop(useLargeLayout ? 0 : 10).SemanticHeader2().Text(headerText)
                                                 .SemiBold()
                                                 .FontSize(16)
                                                 .FontColor(Colors.Black);
@@ -603,15 +680,20 @@ namespace Viper.Areas.Students.Services
                                                         // Add photo from cache with explicit dimensions based on layout
                                                         if (photoCache.TryGetValue(student.MailId, out var photoBytes))
                                                         {
+                                                            var displayedName = useLargeLayout ? student.GroupExportName : student.FullName;
+                                                            var altText = $"Photo of {displayedName}";
+
                                                             if (useLargeLayout)
                                                             {
                                                                 // Large layout: 1.74" x 2.26"
-                                                                innerColumn.Item().Width(1.74f, Unit.Inch).Height(2.26f, Unit.Inch).Image(photoBytes);
+                                                                innerColumn.Item().SemanticImage(altText)
+                                                                    .Width(1.74f, Unit.Inch).Height(2.26f, Unit.Inch).Image(photoBytes);
                                                             }
                                                             else
                                                             {
                                                                 // Standard layout: 0.69" x 0.92"
-                                                                innerColumn.Item().Width(0.69f, Unit.Inch).Height(0.92f, Unit.Inch).Image(photoBytes);
+                                                                innerColumn.Item().SemanticImage(altText)
+                                                                    .Width(0.69f, Unit.Inch).Height(0.92f, Unit.Inch).Image(photoBytes);
                                                             }
                                                         }
 
@@ -642,6 +724,7 @@ namespace Viper.Areas.Students.Services
                                     });
 
                                 page.Footer()
+                                    .SemanticIgnore()
                                     .AlignCenter()
                                     .Text(x =>
                                     {
@@ -653,7 +736,8 @@ namespace Viper.Areas.Students.Services
                             });
                         }
                     }
-                });
+                })
+                .WithAccessibility(documentTitle, subject: "Student photo gallery export");
 
                 var pdfBytes = document.GeneratePdf();
 
@@ -683,6 +767,122 @@ namespace Viper.Areas.Students.Services
             catch (ArgumentException ex)
             {
                 _logger.LogError(ex, "Invalid argument exporting photos to PDF");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Exports the student list (no photos) as a tabular PDF. Mirrors the
+        /// "Student List" tab on the gallery page so the Print/PDF button can
+        /// download a real accessible PDF instead of a browser print capture.
+        /// </summary>
+        public async Task<PhotoExportResult?> ExportStudentListToPdfAsync(PhotoExportRequest request)
+        {
+            try
+            {
+                _logger.LogDebug("ExportStudentListToPdfAsync called with ClassLevel={ClassLevel}, IncludeRoss={IncludeRoss}",
+                    LogSanitizer.SanitizeString(request.ClassLevel), request.IncludeRossStudents);
+
+                var students = await GetStudentsForExport(request);
+                if (!students.Any())
+                {
+                    _logger.LogWarning("No students found for student list PDF export");
+                    return null;
+                }
+
+                var ordered = students.OrderBy(s => s.LastName).ThenBy(s => s.FirstName).ToList();
+
+                var titleLines = (await GetExportTitleAsync(request)).Split('\n');
+                var documentTitle = titleLines[0];
+                var generatedLabel = titleLines.Length > 1 ? titleLines[1] : $"As of {DateTime.Now:M/d/yyyy}";
+                var fullTitle = $"{documentTitle} - {ordered.Count} Student{(ordered.Count != 1 ? "s" : "")}";
+
+                var document = PdfDocument.Create(container =>
+                {
+                    container.Page(page =>
+                    {
+                        page.Size(PageSizes.Letter);
+                        page.Margin(0.5f, Unit.Inch);
+                        page.PageColor(Colors.White);
+                        page.DefaultTextStyle(x => x.FontSize(10));
+
+                        page.Header().Column(col =>
+                        {
+                            col.Item().SemanticHeader1().Text(fullTitle).SemiBold().FontSize(16);
+                            col.Item().PaddingTop(2).Text(generatedLabel).FontSize(9).FontColor(Colors.Grey.Darken1);
+                        });
+
+                        page.Content().PaddingVertical(0.5f, Unit.Centimetre).SemanticTable().Table(table =>
+                        {
+                            table.ColumnsDefinition(columns =>
+                            {
+                                columns.ConstantColumn(40);     // #
+                                columns.RelativeColumn(2);      // Name
+                                columns.RelativeColumn(3);      // Email
+                            });
+
+                            var hdrStyle = TextStyle.Default.SemiBold().Underline();
+                            table.Header(header =>
+                            {
+                                header.Cell().Background(Colors.Grey.Lighten3).PaddingVertical(4).PaddingHorizontal(4).Text("#").Style(hdrStyle);
+                                header.Cell().Background(Colors.Grey.Lighten3).PaddingVertical(4).PaddingHorizontal(4).Text("Name").Style(hdrStyle);
+                                header.Cell().Background(Colors.Grey.Lighten3).PaddingVertical(4).PaddingHorizontal(4).Text("Email").Style(hdrStyle);
+                            });
+
+                            for (int i = 0; i < ordered.Count; i++)
+                            {
+                                var s = ordered[i];
+                                var rowBg = i % 2 == 0 ? "#FFFFFF" : "#FAFAFA";
+                                var fullName = !string.IsNullOrWhiteSpace(s.LastName) || !string.IsNullOrWhiteSpace(s.FirstName)
+                                    ? $"{s.LastName}, {s.FirstName}".Trim(',', ' ')
+                                    : s.GroupExportName;
+                                var email = !string.IsNullOrWhiteSpace(s.MailId) ? $"{s.MailId}@ucdavis.edu" : "—";
+
+                                table.Cell().Background(rowBg).PaddingVertical(3).PaddingHorizontal(4).Text((i + 1).ToString());
+                                table.Cell().Background(rowBg).PaddingVertical(3).PaddingHorizontal(4).Text(CollapseWhitespace(fullName));
+                                table.Cell().Background(rowBg).PaddingVertical(3).PaddingHorizontal(4).Text(CollapseWhitespace(email));
+                            }
+                        });
+
+                        page.Footer().SemanticIgnore().AlignCenter().Text(x =>
+                        {
+                            x.Span("Page ");
+                            x.CurrentPageNumber();
+                            x.Span(" of ");
+                            x.TotalPages();
+                        });
+                    });
+                })
+                .WithAccessibility(fullTitle, subject: "Student list export");
+
+                var pdfBytes = document.GeneratePdf();
+
+                return new PhotoExportResult
+                {
+                    ExportId = Guid.NewGuid().ToString(),
+                    FileData = pdfBytes,
+                    FileName = await GetExportFilenameAsync(request, ".pdf"),
+                    ContentType = "application/pdf"
+                };
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogError(ex, "Access denied exporting student list to PDF");
+                return null;
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "I/O error exporting student list to PDF");
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogError(ex, "Invalid operation exporting student list to PDF");
+                return null;
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Invalid argument exporting student list to PDF");
                 return null;
             }
         }
@@ -1012,6 +1212,11 @@ namespace Viper.Areas.Students.Services
                 // When filtering by a specific group, include the group ID
                 var groupTypeLabel = request.GroupType?.ToLower() ?? "group";
                 filenameParts.Add($"{groupTypeLabel} {request.GroupId}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.View))
+            {
+                filenameParts.Add(request.View.Trim().ToLowerInvariant());
             }
 
             // Build filename with spaces (not underscores) and add extension

--- a/web/Classes/ApiController.cs
+++ b/web/Classes/ApiController.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
 using Viper.Models;
 
 namespace Viper.Classes
@@ -50,6 +51,24 @@ namespace Viper.Classes
         protected ActionResult ForbidApi(string message = "Access Denied.")
         {
             return StatusCode(StatusCodes.Status403Forbidden, message);
+        }
+
+        /// <summary>
+        /// Returns a file response with Content-Disposition: inline so the browser renders it
+        /// in the built-in viewer (e.g. PDF) and uses <paramref name="filename"/> when the user
+        /// saves from the viewer. RFC 6266 filename encoding is handled by SetHttpFileName.
+        /// </summary>
+        protected FileContentResult InlineFile(byte[] bytes, string contentType, string filename)
+        {
+            var disposition = new ContentDispositionHeaderValue("inline");
+            disposition.SetHttpFileName(filename);
+            Response.Headers.ContentDisposition = disposition.ToString();
+            // Inline exports often contain PII (student/effort data); GET responses are easily
+            // cached by browsers and intermediaries, so force private + no-store.
+            Response.Headers.CacheControl = "private, no-store, max-age=0";
+            Response.Headers.Pragma = "no-cache";
+            Response.Headers.Expires = "0";
+            return File(bytes, contentType);
         }
     }
 }

--- a/web/Classes/Utilities/ExcelAccessibilityHelper.cs
+++ b/web/Classes/Utilities/ExcelAccessibilityHelper.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+using ClosedXML.Excel;
+
+namespace Viper.Classes.Utilities;
+
+/// <summary>
+/// ClosedXML helpers for the structural accessibility features Excel's
+/// Accessibility Checker expects: workbook core properties, structured
+/// Excel Tables (so screen readers announce column headers), and image
+/// alt text. Pair with <see cref="ExcelHelper.SanitizeSheetName"/> for
+/// worksheet naming. There is no PDF/UA-equivalent ISO standard for
+/// spreadsheets, but the Microsoft checker is the de-facto target for
+/// WCAG-derived guidance.
+/// </summary>
+public static partial class ExcelAccessibilityHelper
+{
+    public const string DefaultAuthor = "UC Davis School of Veterinary Medicine";
+    public const string DefaultLanguage = "en-US";
+
+    [GeneratedRegex(@"[^A-Za-z0-9_]")]
+    private static partial Regex InvalidTableNameCharsRegex();
+
+    /// <summary>
+    /// Set the workbook properties Excel reads for accessibility checks
+    /// and the title bar (Title, Subject, Author).
+    /// </summary>
+    public static void SetCoreProperties(
+        XLWorkbook workbook,
+        string title,
+        string? subject = null,
+        string author = DefaultAuthor)
+    {
+        var props = workbook.Properties;
+        props.Title = title;
+        props.Subject = subject ?? title;
+        props.Author = author;
+        props.Created = DateTime.Now;
+    }
+
+    /// <summary>
+    /// Promote a data range (column-header row + body rows) to a structured
+    /// Excel Table. This is what makes assistive tech announce row data in
+    /// terms of column-header labels — without it, a worksheet is just a
+    /// bag of cells.
+    /// <para>
+    /// Excel requires table names that start with a letter / underscore
+    /// and contain only letters, digits, and underscores. Table names must
+    /// also be unique within the workbook; pass a sheet-derived suffix
+    /// (e.g. the worksheet name) if calling on multiple sheets.
+    /// </para>
+    /// </summary>
+    public static IXLTable PromoteToAccessibleTable(IXLRange range, string tableName)
+    {
+        var safeName = SanitizeTableName(tableName);
+        var table = range.CreateTable(safeName);
+        // Default table style adds banded rows and a styled header row, which
+        // also satisfies the visual-distinction requirement.
+        table.Theme = XLTableTheme.TableStyleLight1;
+        table.ShowAutoFilter = false;
+        return table;
+    }
+
+    private static string SanitizeTableName(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return "Table1";
+        }
+
+        var cleaned = InvalidTableNameCharsRegex().Replace(raw, "_");
+        if (!char.IsLetter(cleaned[0]) && cleaned[0] != '_')
+        {
+            cleaned = "T_" + cleaned;
+        }
+
+        // Excel caps table names at 255 characters.
+        return cleaned.Length > 255 ? cleaned[..255] : cleaned;
+    }
+}

--- a/web/Classes/Utilities/PdfAccessibilityHelper.cs
+++ b/web/Classes/Utilities/PdfAccessibilityHelper.cs
@@ -1,0 +1,56 @@
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+
+namespace Viper.Classes.Utilities;
+
+/// <summary>
+/// QuestPDF accessibility defaults. Centralizes PDF/UA conformance and document
+/// metadata so every report PDF gets consistent tagging and core properties.
+/// The QuestPDF Community licence is configured once at application startup
+/// (see <c>Program.cs</c>); this helper does not touch global settings.
+/// Pair with <see cref="QuestPDF.Fluent.SemanticExtensions"/> calls inside the
+/// document body (SemanticHeader1, SemanticImage, SemanticIgnore, etc.) to
+/// satisfy WCAG 2.1 SC 1.3.1 / PDF-UA-1 expectations.
+/// </summary>
+public static class PdfAccessibilityHelper
+{
+    public const string DefaultAuthor = "UC Davis School of Veterinary Medicine";
+    public const string DefaultLanguage = "en-US";
+
+    /// <summary>
+    /// Apply document metadata and PDF/UA conformance to a QuestPDF document
+    /// in one call.
+    /// </summary>
+    /// <param name="document">Result of <c>Document.Create(...)</c>.</param>
+    /// <param name="title">Document title — surfaces in the PDF reader title bar and is required for PDF/UA.</param>
+    /// <param name="subject">Optional subject / brief description.</param>
+    /// <param name="keywords">Optional comma-separated keyword list.</param>
+    /// <param name="author">Defaults to <see cref="DefaultAuthor"/>.</param>
+    /// <param name="language">BCP-47 / ISO 639 language tag. Defaults to <see cref="DefaultLanguage"/>.</param>
+    public static Document WithAccessibility(
+        this Document document,
+        string title,
+        string? subject = null,
+        string? keywords = null,
+        string author = DefaultAuthor,
+        string language = DefaultLanguage)
+    {
+        var now = DateTimeOffset.Now;
+
+        return document
+            .WithMetadata(new DocumentMetadata
+            {
+                Title = title,
+                Author = author,
+                Subject = subject ?? title,
+                Keywords = keywords ?? string.Empty,
+                Language = language,
+                CreationDate = now,
+                ModifiedDate = now
+            })
+            .WithSettings(new DocumentSettings
+            {
+                PDFUA_Conformance = PDFUA_Conformance.PDFUA_1
+            });
+    }
+}

--- a/web/Classes/Utilities/WordAccessibilityHelper.cs
+++ b/web/Classes/Utilities/WordAccessibilityHelper.cs
@@ -1,0 +1,284 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DrawingNonVisualPicture = DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties;
+using DrawingDocProperties = DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties;
+
+namespace Viper.Classes.Utilities;
+
+/// <summary>
+/// OpenXML helpers that add the structural accessibility features assistive
+/// technology expects in tagged Word documents — heading styles, image alt
+/// text, table-header rows, document language, and core file properties.
+/// Pair these with the existing OpenXML calls in *ExportService.cs files to
+/// satisfy WCAG 2.1 SC 1.3.1 / Word Accessibility Checker expectations.
+/// </summary>
+#pragma warning disable S3220 // OpenXML SDK uses params overloads by design for fluent object construction
+public static class WordAccessibilityHelper
+{
+    public const string DefaultLanguage = "en-US";
+    public const string DefaultCreator = "UC Davis School of Veterinary Medicine";
+
+    /// <summary>
+    /// Built-in Word style identifier for the document title.
+    /// </summary>
+    public const string TitleStyleId = "Title";
+
+    /// <summary>Built-in Word style identifier for first-level heading.</summary>
+    public const string Heading1StyleId = "Heading1";
+
+    /// <summary>Built-in Word style identifier for second-level heading.</summary>
+    public const string Heading2StyleId = "Heading2";
+
+    /// <summary>Built-in Word style identifier for third-level heading.</summary>
+    public const string Heading3StyleId = "Heading3";
+
+    /// <summary>
+    /// Add a styles part containing the heading and title style definitions
+    /// the document references. Without this, paragraphs that point to
+    /// "Heading1" / "Title" via <see cref="ParagraphStyleId"/> are treated
+    /// as Normal by Word — defeating the structural intent.
+    /// Also sets the default document language so screen readers pronounce
+    /// content correctly.
+    /// Intended for documents being built fresh; this overwrites any existing
+    /// <see cref="DocDefaults"/> and is not safe to call on a template-derived
+    /// document.
+    /// </summary>
+    public static void EnsureAccessibilityStyles(
+        MainDocumentPart mainPart,
+        string language = DefaultLanguage)
+    {
+        var stylesPart = mainPart.StyleDefinitionsPart
+            ?? mainPart.AddNewPart<StyleDefinitionsPart>();
+
+        // Reuse the existing Styles tree when present. Reassigning
+        // stylesPart.Styles to a tree that's already attached throws on
+        // some OpenXML SDK versions; only set it on a fresh part.
+        var existingStyles = stylesPart.Styles;
+        var styles = existingStyles ?? new Styles();
+
+        // Document defaults — sets baseline language for the whole document.
+        var docDefaults = new DocDefaults(
+            new RunPropertiesDefault(
+                new RunPropertiesBaseStyle(
+                    new Languages { Val = language }
+                )
+            ),
+            new ParagraphPropertiesDefault(
+                new ParagraphPropertiesBaseStyle()
+            )
+        );
+
+        styles.RemoveAllChildren<DocDefaults>();
+        styles.AppendChild(docDefaults);
+
+        AddStyleIfMissing(styles, TitleStyleId, "Title",
+            fontSize: "40", bold: true);
+        AddStyleIfMissing(styles, Heading1StyleId, "Heading 1",
+            fontSize: "32", bold: true, outlineLevel: 0);
+        AddStyleIfMissing(styles, Heading2StyleId, "Heading 2",
+            fontSize: "26", bold: true, outlineLevel: 1);
+        AddStyleIfMissing(styles, Heading3StyleId, "Heading 3",
+            fontSize: "22", bold: true, outlineLevel: 2);
+
+        if (existingStyles is null)
+        {
+            stylesPart.Styles = styles;
+        }
+        styles.Save(stylesPart);
+    }
+
+    /// <summary>
+    /// Mark the document as Word 2013+ (compatibility mode 15) so Word does
+    /// NOT open it in legacy compatibility mode. Without this setting, Word
+    /// shows the title-bar message "This document is in an older format with
+    /// limited functionality" and the Accessibility Checker is unavailable.
+    /// </summary>
+    public static void EnsureModernCompatibility(MainDocumentPart mainPart)
+    {
+        var settingsPart = mainPart.DocumentSettingsPart
+            ?? mainPart.AddNewPart<DocumentSettingsPart>();
+
+        // OpenXML annotates Settings as non-null, but it IS null on a freshly
+        // added DocumentSettingsPart until we assign it below.
+        var existingSettings = settingsPart.Settings;
+        // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+        var settings = existingSettings ?? new Settings();
+
+        var compatibility = settings.GetFirstChild<Compatibility>()
+            ?? settings.AppendChild(new Compatibility());
+
+        // Replace any existing CompatibilityMode entry; leave other settings alone.
+        var existingMode = compatibility.Elements<CompatibilitySetting>()
+            .FirstOrDefault(s => s.Name?.Value == CompatSettingNameValues.CompatibilityMode);
+        existingMode?.Remove();
+
+        compatibility.AppendChild(new CompatibilitySetting
+        {
+            Name = CompatSettingNameValues.CompatibilityMode,
+            Uri = "http://schemas.microsoft.com/office/word",
+            Val = "15",
+        });
+
+        if (existingSettings is null)
+        {
+            settingsPart.Settings = settings;
+        }
+        settings.Save(settingsPart);
+    }
+
+    /// <summary>
+    /// Add a description to a layout table (one used purely for visual grid
+    /// layout, e.g. a photo gallery). The description tells assistive tech
+    /// the table's purpose so screen readers don't try to announce it as
+    /// data. Pair with NOT calling <see cref="MarkAsTableHeaderRow"/> — layout
+    /// tables have no header row.
+    /// </summary>
+    public static void MarkAsLayoutTable(Table table, string description)
+    {
+        var tblProperties = table.Elements<TableProperties>().FirstOrDefault()
+            ?? table.PrependChild(new TableProperties());
+
+        tblProperties.RemoveAllChildren<TableCaption>();
+        tblProperties.RemoveAllChildren<TableDescription>();
+
+        tblProperties.AppendChild(new TableCaption { Val = description });
+        tblProperties.AppendChild(new TableDescription { Val = description });
+    }
+
+    /// <summary>
+    /// Set the core document properties Word reads for accessibility checks
+    /// and the title bar (Title, Subject, Creator, Language).
+    /// </summary>
+    public static void SetCoreProperties(
+        WordprocessingDocument document,
+        string title,
+        string? subject = null,
+        string creator = DefaultCreator,
+        string language = DefaultLanguage)
+    {
+        var corePart = document.PackageProperties;
+        corePart.Title = title;
+        corePart.Subject = subject ?? title;
+        corePart.Creator = creator;
+        corePart.Language = language;
+        corePart.Created = DateTime.Now;
+        corePart.Modified = DateTime.Now;
+    }
+
+    /// <summary>
+    /// Build a paragraph that uses a built-in heading style.
+    /// Pass one of the <c>*StyleId</c> constants on this class.
+    /// </summary>
+    public static Paragraph CreateHeadingParagraph(string text, string styleId)
+    {
+        var paragraph = new Paragraph();
+
+        var paragraphProperties = new ParagraphProperties(
+            new ParagraphStyleId { Val = styleId }
+        );
+        paragraph.AppendChild(paragraphProperties);
+
+        var run = paragraph.AppendChild(new Run());
+        run.AppendChild(new Text(text));
+
+        return paragraph;
+    }
+
+    /// <summary>
+    /// Set descriptive alt text on an inline drawing.
+    /// <para>
+    /// <paramref name="description"/> is the long alt text — Word reads
+    /// <see cref="DrawingDocProperties.Description"/> as the primary
+    /// accessibility label, and the underlying picture's
+    /// <see cref="DrawingNonVisualPicture.Description"/> is also set so
+    /// downstream PDF-conversion paths (e.g. Word → Save As PDF) carry the
+    /// alt text into the tagged PDF.
+    /// </para>
+    /// <para>
+    /// <paramref name="title"/> is the optional short label. Office 2019+
+    /// distinguishes Title from Description, and the accessibility checker
+    /// flags identical Title + Description as a warning. Pass a Title only
+    /// when it adds information beyond <paramref name="description"/>;
+    /// otherwise leave it null.
+    /// </para>
+    /// </summary>
+    public static void SetImageAltText(
+        DrawingDocProperties wpDocProperties,
+        DrawingNonVisualPicture pictureProperties,
+        string description,
+        string? title = null)
+    {
+        wpDocProperties.Description = description;
+        pictureProperties.Description = description;
+
+        if (!string.IsNullOrEmpty(title))
+        {
+            wpDocProperties.Title = title;
+            pictureProperties.Title = title;
+        }
+    }
+
+    /// <summary>
+    /// Mark a table row as a header row that repeats on each page break.
+    /// Screen readers announce subsequent data rows in terms of the labels
+    /// in marked header rows. Apply only to data tables — never to layout
+    /// tables (e.g. photo grids).
+    /// </summary>
+    public static void MarkAsTableHeaderRow(TableRow row)
+    {
+        var rowProperties = row.Elements<TableRowProperties>().FirstOrDefault();
+        if (rowProperties == null)
+        {
+            rowProperties = new TableRowProperties();
+            row.PrependChild(rowProperties);
+        }
+
+        if (!rowProperties.Elements<TableHeader>().Any())
+        {
+            rowProperties.AppendChild(new TableHeader());
+        }
+    }
+
+    private static void AddStyleIfMissing(Styles styles, string styleId,
+        string styleName, string fontSize, bool bold,
+        int? outlineLevel = null)
+    {
+        if (styles.Elements<Style>().Any(s => s.StyleId?.Value == styleId))
+        {
+            return;
+        }
+
+        var style = new Style
+        {
+            Type = StyleValues.Paragraph,
+            StyleId = styleId,
+            CustomStyle = false,
+            Default = false
+        };
+
+        style.AppendChild(new StyleName { Val = styleName });
+        style.AppendChild(new BasedOn { Val = "Normal" });
+        style.AppendChild(new NextParagraphStyle { Val = "Normal" });
+        style.AppendChild(new PrimaryStyle());
+
+        var paragraphProperties = new StyleParagraphProperties();
+        if (outlineLevel.HasValue)
+        {
+            paragraphProperties.AppendChild(new OutlineLevel { Val = outlineLevel.Value });
+        }
+        style.AppendChild(paragraphProperties);
+
+        var runProperties = new StyleRunProperties();
+        if (bold)
+        {
+            runProperties.AppendChild(new Bold());
+            runProperties.AppendChild(new BoldComplexScript());
+        }
+        runProperties.AppendChild(new FontSize { Val = fontSize });
+        runProperties.AppendChild(new FontSizeComplexScript { Val = fontSize });
+        style.AppendChild(runProperties);
+
+        styles.AppendChild(style);
+    }
+}
+#pragma warning restore S3220

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -17,6 +17,7 @@ using NLog.Web;
 using Polly;
 using Polly.Extensions.Http;
 using Polly.Timeout;
+using QuestPDF.Infrastructure;
 using System.Net;
 using System.Security.Claims;
 using System.Xml.Linq;
@@ -42,6 +43,10 @@ string[] VueAppNames = { "CAHFS", "ClinicalScheduler", "CMS", "Computing", "CTS"
 
 var builder = WebApplication.CreateBuilder(args);
 string awsCredentialsFilePath = Directory.GetCurrentDirectory() + "\\awscredentials.xml";
+
+// Configure QuestPDF for the whole process. Must run before any export
+// service generates a PDF; assigning at startup covers every export.
+QuestPDF.Settings.License = LicenseType.Community;
 
 // Early init of NLog to allow startup and exception logging, before host is built
 var logger = NLog.LogManager.Setup().LoadConfigurationFromAppSettings().GetCurrentClassLogger();

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.7" />


### PR DESCRIPTION
## Summary

Adds WCAG 2.1 / PDF/UA-1 tagging and Excel a11y to every export pipeline currently shipping in VIPER:

**New helpers** (`web/Classes/Utilities/`)
- `WordAccessibilityHelper` — heading styles, image alt text, table-header rows, document language, core file properties.
- `PdfAccessibilityHelper` — `WithAccessibility(...)` extension wrapping `DocumentMetadata` + `DocumentSettings.PDFUA_Conformance = PDFUA_1`.
- `ExcelAccessibilityHelper` — workbook core properties, `PromoteToAccessibleTable` for structured Excel Tables.
- QuestPDF Community license assignment moved to `Program.cs` so it's set once at startup.

**Word export tagged**
- Photo Gallery (`PhotoExportService`): heading styles, alt text on every photo, document language, core properties.

**PDF exports tagged** (institution/date row → `SemanticIgnore`, title → `SemanticHeader1`, dept/sub-headers → `SemanticHeader2`/`SemanticHeader3`, content tables → `SemanticTable`, footers → artifact via shared `AddPdfPageNumberFooter` helper, `WithAccessibility` for metadata + PDF/UA conformance):
- Photo Gallery (Students)
- Emergency Contact Overview + Report (Students)
- Clinical Effort (Effort)
- Clinical Schedule (Effort)
- School Summary (Effort)
- Department Summary (Effort)
- Teaching Activity — Grouped + Individual (Effort)
- Merit Summary (Effort)
- Merit Detail + Merit Average (Effort)
- Evaluation Summary + Evaluation Detail (Effort)
- Multi-Year Merit (Effort)

**Excel exports tagged** (workbook core properties on all; structured `PromoteToAccessibleTable` where data rows are uniform):
- Emergency Contact Overview + Report (structured tables)
- Clinical Effort — per job-group structured tables
- Clinical Schedule — structured table
- Department Summary — instructor rows promoted; summary rows stay outside
- Teaching Activity Individual — course rows promoted
- School Summary, Teaching Activity Grouped, Merit Summary, Merit Detail/Average, Eval Summary/Detail, Multi-Year — core properties only (interleaved totals/summary rows aren't safe to wrap as a single table).

**Tests** — 32 unit tests across `WordAccessibilityHelperTests`, `PdfAccessibilityHelperTests`, `ExcelAccessibilityHelperTests`. Includes regression guards for the review issues addressed in the helpers commit (Title style not marked default, Title vs H1 font sizes differ, alt text leaves Title null when caller doesn't pass one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF reports now open inline in the browser and include standardized "Page N of M" footers.
  * New accessible metadata and semantics applied to PDF, Excel, and Word exports (titles, subjects, language, timestamps).
  * Photo Gallery: new student-list PDF export and improved image alt text for exported PDFs/Word.

* **Improvements**
  * Excel exports promoted to accessible tables with sanitized names and improved workbook properties.
  * UI: export actions show clearer success/no-data notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->