### PR TITLE
Updating code to use MinConsecutiveWeeks instead of MinWeeks - legacy…

### DIFF
--- a/test/ClinicalScheduler/EvaluationPolicyServiceTest.cs
+++ b/test/ClinicalScheduler/EvaluationPolicyServiceTest.cs
@@ -91,7 +91,7 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act - Pass rotationClosed = true
-            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceWeekSize: 2, rotationClosed: true);
+            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceMinConsecutiveWeeks: 2, rotationClosed: true);
 
             // Assert
             Assert.False(result);
@@ -99,10 +99,10 @@ namespace Viper.test.ClinicalScheduler
 
         #endregion
 
-        #region WeekSize = 1 Tests
+        #region MinConsecutiveWeeks = 1 Tests
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize1_NonExtendedWeek_ReturnsTrue()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks1_NonExtendedWeek_ReturnsTrue()
         {
             // Arrange
             var weeks = new List<TestRotationWeekInfo>
@@ -111,14 +111,14 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceWeekSize: 1);
+            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceMinConsecutiveWeeks: 1);
 
             // Assert
             Assert.True(result);
         }
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize1_ExtendedWeek_ReturnsFalse()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks1_ExtendedWeek_ReturnsFalse()
         {
             // Arrange
             var weeks = new List<TestRotationWeekInfo>
@@ -127,7 +127,7 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceWeekSize: 1);
+            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceMinConsecutiveWeeks: 1);
 
             // Assert
             Assert.False(result);
@@ -135,10 +135,10 @@ namespace Viper.test.ClinicalScheduler
 
         #endregion
 
-        #region WeekSize = 2 Tests
+        #region MinConsecutiveWeeks = 2 Tests
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize2_StartWeek_ReturnsFalse()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks2_StartWeek_ReturnsFalse()
         {
             // Arrange - First week of a 2-week block
             var weeks = new List<TestRotationWeekInfo>
@@ -148,14 +148,14 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(28, weeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(28, weeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.False(result); // First week doesn't need evaluator
         }
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize2_SecondWeek_ReturnsTrue()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks2_SecondWeek_ReturnsTrue()
         {
             // Arrange - Second week of a 2-week block
             var weeks = new List<TestRotationWeekInfo>
@@ -165,14 +165,14 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(29, weeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(29, weeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.True(result); // Second week needs evaluator
         }
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize2_ThreeWeekRotationWithExtended_ReturnsFalse()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks2_ThreeWeekRotationWithExtended_ReturnsFalse()
         {
             // Arrange - 3-week rotation where week 3 is extended
             var weeks = new List<TestRotationWeekInfo>
@@ -183,14 +183,14 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act - Check week 32 (would normally be evaluation week, but week 33 is extended)
-            var result = _service.RequiresPrimaryEvaluator(32, weeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(32, weeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.False(result); // No evaluation needed because week 3 is extended
         }
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize2_RegularTwoWeekBlock_SecondWeekTrue()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks2_RegularTwoWeekBlock_SecondWeekTrue()
         {
             // Arrange - Regular 2-week block
             var weeks = new List<TestRotationWeekInfo>
@@ -201,14 +201,14 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act - Check week 36 (second week of block)
-            var result = _service.RequiresPrimaryEvaluator(36, weeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(36, weeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.True(result); // Second week needs evaluator
         }
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize2_LastWeekOfYear_ReturnsTrue()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks2_LastWeekOfYear_ReturnsTrue()
         {
             // Arrange - Last week with no next week
             var weeks = new List<TestRotationWeekInfo>
@@ -218,7 +218,7 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act - Check week 43 (last week, no next week)
-            var result = _service.RequiresPrimaryEvaluator(43, weeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(43, weeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.True(result); // Last week needs evaluator
@@ -289,7 +289,7 @@ namespace Viper.test.ClinicalScheduler
             var relevantWeeks = weeks.Where(w => w.WeekNum >= weekNum - 1 && w.WeekNum <= weekNum + 1).ToList();
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(weekNum, relevantWeeks, serviceWeekSize: 2);
+            var result = _service.RequiresPrimaryEvaluator(weekNum, relevantWeeks, serviceMinConsecutiveWeeks: 2);
 
             // Assert
             Assert.Equal(shouldRequireEvaluator, result);
@@ -297,10 +297,10 @@ namespace Viper.test.ClinicalScheduler
 
         #endregion
 
-        #region No WeekSize Configuration Tests
+        #region No MinConsecutiveWeeks Configuration Tests
 
         [Fact]
-        public void RequiresPrimaryEvaluator_NoWeekSize_ReturnsFalse()
+        public void RequiresPrimaryEvaluator_NoMinConsecutiveWeeks_ReturnsFalse()
         {
             // Arrange
             var weeks = new List<TestRotationWeekInfo>
@@ -308,17 +308,17 @@ namespace Viper.test.ClinicalScheduler
                 new() { WeekNum = 5, ExtendedRotation = false }
             };
 
-            // Act - No serviceWeekSize provided
+            // Act - No serviceMinConsecutiveWeeks provided
             var result = _service.RequiresPrimaryEvaluator(5, weeks);
 
             // Assert
-            Assert.False(result); // Default behavior when no weekSize
+            Assert.False(result); // Default behavior when no MinConsecutiveWeeks
         }
 
         [Theory]
         [InlineData(0)]
         [InlineData(-1)]
-        public void RequiresPrimaryEvaluator_InvalidWeekSize_ReturnsFalse(int weekSize)
+        public void RequiresPrimaryEvaluator_InvalidMinConsecutiveWeeks_ReturnsFalse(int MinConsecutiveWeeks)
         {
             // Arrange
             var weeks = new List<TestRotationWeekInfo>
@@ -327,15 +327,15 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceWeekSize: weekSize);
+            var result = _service.RequiresPrimaryEvaluator(5, weeks, serviceMinConsecutiveWeeks: MinConsecutiveWeeks);
 
             // Assert
-            Assert.False(result); // Invalid weekSize (0, negative) defaults to false
+            Assert.False(result); // Invalid MinConsecutiveWeeks (0, negative) defaults to false
         }
 
 
         [Fact]
-        public void RequiresPrimaryEvaluator_WeekSize4_OnlyLastWeekRequiresEvaluation()
+        public void RequiresPrimaryEvaluator_MinConsecutiveWeeks4_OnlyLastWeekRequiresEvaluation()
         {
             // Arrange - 4-week rotation blocks
             var weeks = new List<TestRotationWeekInfo>
@@ -348,10 +348,10 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act & Assert - For 4-week blocks, only the last week (4th) should require evaluation
-            Assert.False(_service.RequiresPrimaryEvaluator(10, weeks, serviceWeekSize: 4)); // First week
-            Assert.False(_service.RequiresPrimaryEvaluator(11, weeks, serviceWeekSize: 4)); // Second week
-            Assert.False(_service.RequiresPrimaryEvaluator(12, weeks, serviceWeekSize: 4)); // Third week
-            Assert.True(_service.RequiresPrimaryEvaluator(13, weeks, serviceWeekSize: 4));  // Fourth week (last)
+            Assert.False(_service.RequiresPrimaryEvaluator(10, weeks, serviceMinConsecutiveWeeks: 4)); // First week
+            Assert.False(_service.RequiresPrimaryEvaluator(11, weeks, serviceMinConsecutiveWeeks: 4)); // Second week
+            Assert.False(_service.RequiresPrimaryEvaluator(12, weeks, serviceMinConsecutiveWeeks: 4)); // Third week
+            Assert.True(_service.RequiresPrimaryEvaluator(13, weeks, serviceMinConsecutiveWeeks: 4));  // Fourth week (last)
         }
 
         #endregion

--- a/test/ClinicalScheduler/RotationMappingExtensionsTests.cs
+++ b/test/ClinicalScheduler/RotationMappingExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Test.ClinicalScheduler
                     ServiceId = 10,
                     ServiceName = "Surgery Service",
                     ShortName = "Surgery",
-                    WeekSize = 2,
+                    MinConsecutiveWeeks = 2,
                     ScheduleEditPermission = "SVMSecure.ClnSched.EditSurgery"
                 }
             };

--- a/test/ClinicalScheduler/RotationsControllerTest.cs
+++ b/test/ClinicalScheduler/RotationsControllerTest.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MockQueryable.NSubstitute;
 using NSubstitute;
 using Viper.Areas.ClinicalScheduler.Controllers;
 using Viper.Areas.ClinicalScheduler.Models.DTOs.Responses;
 using Viper.Areas.ClinicalScheduler.Services;
+using Viper.Models.ClinicalScheduler;
 
 namespace Viper.test.ClinicalScheduler
 {
@@ -329,6 +331,85 @@ namespace Viper.test.ClinicalScheduler
         // GetRotationSummary already has permission filtering implemented (lines 393-407 in controller)
         // The security is working correctly - users only see services they have permissions for
 
+
+        #endregion
+
+        #region BuildWeekScheduleItem Tests (lines 522-528)
+
+        // Empty InstructorSchedules avoids the Week navigation property NPE that occurs in
+        // GetRecentCliniciansAsync when MockQueryable doesn't load navigation properties.
+        private void SetupForScheduleResponse()
+        {
+			var instSched = new List<InstructorSchedule>().BuildMockDbSet();
+			var rwp = new List<RotationWeeklyPref>().BuildMockDbSet();
+
+            MockContext.InstructorSchedules.Returns(instSched);
+            MockContext.RotationWeeklyPrefs.Returns(rwp);
+
+            var baseDate = new DateTime(TestYear, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            _mockWeekService.GetWeeksAsync(Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(
+                [
+                    new() { WeekId = 1, WeekNum = 1, DateStart = baseDate, DateEnd = baseDate.AddDays(6), TermCode = TestTermCode },
+                    new() { WeekId = 2, WeekNum = 2, DateStart = baseDate.AddDays(7), DateEnd = baseDate.AddDays(13), TermCode = TestTermCode }
+                ]);
+        }
+
+        private static RotationDto CardiologyRotationWithMinConsecutiveWeeks(int? minConsecutiveWeeks) => new()
+        {
+            RotId = CardiologyRotationId,
+            Name = "Cardiology",
+            ServiceId = CardiologyServiceId,
+            Service = new ServiceDto
+            {
+                ServiceId = CardiologyServiceId,
+                ServiceName = "Cardiology Service",
+                MinConsecutiveWeeks = minConsecutiveWeeks
+            }
+        };
+
+        #endregion
+
+        #region BuildSimpleRotationResponse Tests (lines 621-627)
+
+        [Fact]
+        public async Task GetRotationSchedule_WhenNoWeeks_ServiceMinConsecutiveWeeksIsIncludedInResponse()
+        {
+            SetupMockPermissions(hasFullPermissions: true);
+            _mockWeekService.GetWeeksAsync(Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+
+            const int minConsecutiveWeeks = 4;
+            _mockRotationService.GetRotationAsync(CardiologyRotationId, Arg.Any<CancellationToken>())
+                .Returns(CardiologyRotationWithMinConsecutiveWeeks(minConsecutiveWeeks));
+            RecreateController();
+
+            var result = await _controller.GetRotationSchedule(CardiologyRotationId, TestYear);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var rotationProp = okResult.Value!.GetType().GetProperty("Rotation")?.GetValue(okResult.Value);
+            var serviceProp = rotationProp?.GetType().GetProperty("Service")?.GetValue(rotationProp);
+            var actual = serviceProp?.GetType().GetProperty("MinConsecutiveWeeks")?.GetValue(serviceProp);
+            Assert.Equal(minConsecutiveWeeks, (int?)actual);
+        }
+
+        [Fact]
+        public async Task GetRotationSchedule_WhenNoWeeks_AndServiceIsNull_ServiceIsNullInResponse()
+        {
+            SetupMockPermissions(hasFullPermissions: true);
+            _mockWeekService.GetWeeksAsync(Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+            _mockRotationService.GetRotationAsync(CardiologyRotationId, Arg.Any<CancellationToken>())
+                .Returns(new RotationDto { RotId = CardiologyRotationId, Name = "Cardiology", ServiceId = CardiologyServiceId, Service = null });
+            RecreateController();
+
+            var result = await _controller.GetRotationSchedule(CardiologyRotationId, TestYear);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var rotationProp = okResult.Value!.GetType().GetProperty("Rotation")?.GetValue(okResult.Value);
+            var serviceProp = rotationProp?.GetType().GetProperty("Service")?.GetValue(rotationProp);
+            Assert.Null(serviceProp);
+        }
 
         #endregion
 

--- a/test/ClinicalScheduler/ServiceMappingExtensionsTests.cs
+++ b/test/ClinicalScheduler/ServiceMappingExtensionsTests.cs
@@ -14,7 +14,7 @@ namespace Test.ClinicalScheduler
                 ServiceId = 10,
                 ServiceName = "Surgery Service",
                 ShortName = "Surgery",
-                WeekSize = 2,
+                MinConsecutiveWeeks = 2,
                 ScheduleEditPermission = "SVMSecure.ClnSched.EditSurgery"
             };
 
@@ -24,7 +24,7 @@ namespace Test.ClinicalScheduler
             // Assert
             Assert.Equal(service.ServiceId, dto.ServiceId);
             Assert.Equal(service.ServiceName, dto.ServiceName);
-            Assert.Equal(service.WeekSize, dto.WeekSize);
+            Assert.Equal(service.MinConsecutiveWeeks, dto.MinConsecutiveWeeks);
             Assert.Equal(service.ScheduleEditPermission, dto.ScheduleEditPermission);
         }
 
@@ -73,7 +73,7 @@ namespace Test.ClinicalScheduler
                 ServiceId = 10,
                 ServiceName = "Surgery Service",
                 ShortName = "Surgery",
-                WeekSize = 2,
+                MinConsecutiveWeeks = 2,
                 ScheduleEditPermission = null
             };
 
@@ -86,7 +86,7 @@ namespace Test.ClinicalScheduler
         }
 
         [Fact]
-        public void ToDto_HandlesZeroWeekSize()
+        public void ToDto_HandlesZeroMinConsecutiveWeeks()
         {
             // Arrange
             var service = new Service
@@ -94,14 +94,14 @@ namespace Test.ClinicalScheduler
                 ServiceId = 10,
                 ServiceName = "Special Service",
                 ShortName = "SPEC",
-                WeekSize = 0
+                MinConsecutiveWeeks = 0
             };
 
             // Act
             var dto = service.ToDto();
 
             // Assert
-            Assert.Equal(0, dto.WeekSize);
+            Assert.Equal(0, dto.MinConsecutiveWeeks);
         }
     }
 }

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -522,7 +522,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             var requiresPrimary = _evaluationPolicyService.RequiresPrimaryEvaluator(
                 week.WeekNum,
                 rotationWeeks,
-                rotation?.Service?.WeekSize,
+                rotation?.Service?.MinConsecutiveWeeks,
                 rotationClosed);
 
             return new
@@ -621,7 +621,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 {
                     rotation.Service.ServiceId,
                     rotation.Service.ServiceName,
-                    rotation.Service.WeekSize
+                    rotation.Service.MinConsecutiveWeeks
                 } : null
             };
         }

--- a/web/Areas/ClinicalScheduler/Extensions/ServiceMappingExtensions.cs
+++ b/web/Areas/ClinicalScheduler/Extensions/ServiceMappingExtensions.cs
@@ -19,7 +19,7 @@ namespace Viper.Areas.ClinicalScheduler.Extensions
             {
                 ServiceId = service.ServiceId,
                 ServiceName = service.ServiceName,
-                WeekSize = service.WeekSize,
+                MinConsecutiveWeeks = service.MinConsecutiveWeeks,
                 ScheduleEditPermission = service.ScheduleEditPermission
             };
         }

--- a/web/Areas/ClinicalScheduler/Models/DTOs/Responses/ServiceDto.cs
+++ b/web/Areas/ClinicalScheduler/Models/DTOs/Responses/ServiceDto.cs
@@ -7,7 +7,7 @@ namespace Viper.Areas.ClinicalScheduler.Models.DTOs.Responses
     {
         public int ServiceId { get; set; }
         public string ServiceName { get; set; } = string.Empty;
-        public int? WeekSize { get; set; }
+        public int? MinConsecutiveWeeks { get; set; }
         public string? ScheduleEditPermission { get; set; }
     }
 }

--- a/web/Areas/ClinicalScheduler/Services/EvaluationPolicyService.cs
+++ b/web/Areas/ClinicalScheduler/Services/EvaluationPolicyService.cs
@@ -13,11 +13,11 @@ namespace Viper.Areas.ClinicalScheduler.Services
         /// Determines if a week requires a primary evaluator based on simple business rules:
         ///
         /// 1. If RotationWeeklyPref.Closed = 1 for the rotation and week, no primary needed
-        /// 2. If weekSize = 1, every week needs a primary
-        /// 3. If weekSize > 1 (2, 3, 4, etc.), the last week of each block needs a primary:
-        ///    - For weekSize=2: usually the second week
-        ///    - For weekSize=3: usually the third week
-        ///    - For weekSize=4: usually the fourth week
+        /// 2. If MinConsecutiveWeeks = 1, every week needs a primary
+        /// 3. If MinConsecutiveWeeks > 1 (2, 3, 4, etc.), the last week of each block needs a primary:
+        ///    - For MinConsecutiveWeeks=2: usually the second week
+        ///    - For MinConsecutiveWeeks=3: usually the third week
+        ///    - For MinConsecutiveWeeks=4: usually the fourth week
         ///    - For blocks with ExtendedRotation=true weeks, no evaluation needed
         ///    - Logic: For StartWeek=false, check next week:
         ///      * If next week has ExtendedRotation=true, no primary needed
@@ -25,13 +25,13 @@ namespace Viper.Areas.ClinicalScheduler.Services
         /// </summary>
         /// <param name="weekNumber">The week number to check</param>
         /// <param name="rotationWeeks">All weeks for the rotation in the year</param>
-        /// <param name="serviceWeekSize">The WeekSize from the Service table (1, 2, 3, 4, etc.)</param>
+        /// <param name="serviceMinConsecutiveWeeks">The MinConsecutiveWeeks from the Service table (1, 2, 3, 4, etc.)</param>
         /// <param name="rotationClosed">Whether the rotation is closed this week (from RotationWeeklyPref)</param>
         /// <returns>True if the week requires a primary evaluator</returns>
         public bool RequiresPrimaryEvaluator(
             int weekNumber,
             IEnumerable<IRotationWeekInfo> rotationWeeks,
-            int? serviceWeekSize = null,
+            int? serviceMinConsecutiveWeeks = null,
             bool rotationClosed = false)
         {
             // Rule 1: If rotation is closed for this week, no primary needed
@@ -61,16 +61,16 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 return false;
             }
 
-            // Handle null or invalid WeekSize values
-            if (!serviceWeekSize.HasValue || serviceWeekSize.Value <= 0)
+            // Handle null or invalid MinConsecutiveWeeks values
+            if (!serviceMinConsecutiveWeeks.HasValue || serviceMinConsecutiveWeeks.Value <= 0)
             {
-                // NULL or 0 WeekSize indicates undefined rotation structure
+                // NULL or 0 MinConsecutiveWeeks indicates undefined rotation structure
                 // Default to no evaluation requirement for safety
                 return false;
             }
 
-            // Handle different WeekSize values
-            if (serviceWeekSize == 1)
+            // Handle different MinConsecutiveWeeks values
+            if (serviceMinConsecutiveWeeks == 1)
             {
                 // Single-week rotations: every week is a complete block requiring evaluation
                 return true;

--- a/web/Areas/ClinicalScheduler/Services/IEvaluationPolicyService.cs
+++ b/web/Areas/ClinicalScheduler/Services/IEvaluationPolicyService.cs
@@ -10,13 +10,13 @@ namespace Viper.Areas.ClinicalScheduler.Services
         /// </summary>
         /// <param name="weekNumber">Week number to check</param>
         /// <param name="rotationWeeks">Collection of rotation week info</param>
-        /// <param name="serviceWeekSize">Week size configuration for the service (1 or 2)</param>
+        /// <param name="serviceMinConsecutiveWeeks">Minimum number of consecutive weeks that require evaluation</param>
         /// <param name="rotationClosed">Whether the rotation is closed for this week</param>
         /// <returns>True if a primary evaluator is required for this week</returns>
         bool RequiresPrimaryEvaluator(
             int weekNumber,
             IEnumerable<IRotationWeekInfo> rotationWeeks,
-            int? serviceWeekSize = null,
+            int? serviceMinConsecutiveWeeks = null,
             bool rotationClosed = false);
     }
 }

--- a/web/Classes/SQLContext/ClinicalSchedulerContext.cs
+++ b/web/Classes/SQLContext/ClinicalSchedulerContext.cs
@@ -52,7 +52,7 @@ public class ClinicalSchedulerContext : DbContext
             entity.Property(e => e.ServiceName).HasColumnName("ServiceName");
             entity.Property(e => e.ShortName).HasColumnName("ShortName");
             entity.Property(e => e.ScheduleEditPermission).HasColumnName("ScheduleEditPermission").IsRequired(false);
-            entity.Property(e => e.WeekSize).HasColumnName("WeekSize").IsRequired(false);
+            entity.Property(e => e.MinConsecutiveWeeks).HasColumnName("MinConsecutiveWeeks").IsRequired(false);
         });
 
         modelBuilder.Entity<InstructorSchedule>(entity =>

--- a/web/Models/ClinicalScheduler/Service.cs
+++ b/web/Models/ClinicalScheduler/Service.cs
@@ -15,7 +15,7 @@ namespace Viper.Models.ClinicalScheduler
         /// Evaluation frequency in weeks. Determines how often a primary evaluator is required.
         /// Examples: 1 = every week, 2 = every 2 weeks, null = use default logic (last week only)
         /// </summary>
-        public int? WeekSize { get; set; }
+		public int? MinConsecutiveWeeks { get; set; }
 
         // Navigation properties
         public virtual ICollection<Rotation> Rotations { get; set; } = new List<Rotation>();


### PR DESCRIPTION
… clinical scheduler code does not show or update MinWeeks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed service configuration property from `WeekSize` to `MinConsecutiveWeeks` in clinical scheduler APIs and models.
  * Updated rotation and service response DTOs to expose `MinConsecutiveWeeks` instead of `WeekSize`.
  * Revised evaluation policy service method signature to use `serviceMinConsecutiveWeeks` parameter instead of `serviceWeekSize`.
  * Updated database mappings and internal services for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->