### PR TITLE
PR 2: chore(quality): add C# analyzers + ReSharper PR gate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "libman"
       ]
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2026.1.1",
+      "commands": [
+        "jb"
+      ]
     }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,25 @@ dotnet_diagnostic.IDE0005.severity = error
 dotnet_diagnostic.IDE0059.severity = warning
 # CS8601: Possible null reference assignment.
 dotnet_diagnostic.CS8601.severity = silent
+
+# Maintainability rules (off by default in NetAnalyzers; enable explicitly)
+# CA1502: Avoid excessive cyclomatic complexity (default threshold 25)
+dotnet_diagnostic.CA1502.severity = warning
+# CA1505: Avoid unmaintainable code (maintainability index < 10)
+dotnet_diagnostic.CA1505.severity = warning
+# CA1501: Avoid excessive inheritance (default 5 levels)
+dotnet_diagnostic.CA1501.severity = warning
+# CA1507: Use nameof in place of string literal
+dotnet_diagnostic.CA1507.severity = warning
+# CA1508: Avoid dead conditional code (dataflow analysis - on trial; investigate FP rate)
+dotnet_diagnostic.CA1508.severity = warning
+# CA1510-CA1513: Use throw-helper APIs (.NET 6+ shorthands for argument validation)
+dotnet_diagnostic.CA1510.severity = warning
+dotnet_diagnostic.CA1511.severity = warning
+dotnet_diagnostic.CA1512.severity = warning
+dotnet_diagnostic.CA1513.severity = warning
+# CA1514: Avoid redundant length argument (Substring/Span slicing)
+dotnet_diagnostic.CA1514.severity = warning
 csharp_indent_labels = one_less_than_current
 csharp_using_directive_placement = outside_namespace:silent
 csharp_prefer_simple_using_statement = true:suggestion

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,9 @@ on:
 # Detects whether a PR *adds* new dead code or duplication compared to main.
 # - fallow covers VueApp (dead code, unused exports, complexity, duplication)
 # - jscpd covers C# (web/Areas/**/*.cs) since fallow is JS/TS-only
+# - resharper-pr-gate covers C# inspections (dead-conditional, NRT-contract, and
+#   redundancy findings the Roslyn build doesn't catch); PR-scoped so pre-existing
+#   issues are not blocking — only NEW findings at lines this PR added/modified fail.
 # Passes if counts are equal to or lower than main.
 
 jobs:
@@ -110,3 +113,44 @@ jobs:
 
       - name: Check jscpd regression on PR
         run: node scripts/audit-jscpd-regression.js --check .jscpd-baseline-vue.json VueApp/src
+
+  resharper-pr-gate:
+    name: ReSharper PR-scoped gate (C#)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install dependencies (root)
+        run: npm ci
+
+      - name: Restore dotnet local tools (jb / dotnet-ef / libman)
+        run: dotnet tool restore
+
+      - name: Restore NuGet
+        run: dotnet restore Viper.sln
+
+      - name: Run inspectcode + PR-diff gate
+        # The script runs the full inspectcode scan, parses the SARIF, and only
+        # fails on findings located at lines this PR added/modified vs base ref.
+        run: node scripts/audit-resharper-regression.js --base origin/${{ github.base_ref }}
+
+      - name: Upload SARIF report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resharper-sarif
+          path: inspect-report/inspect.sarif
+          retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -492,13 +492,15 @@ awscredentials.xml
 # Precommit build artifacts (isolated from dev server)
 .artifacts-precommit/
 .artifacts-lint/
+.artifacts-resharper/
 
 # Effort migration script outputs
 web/Areas/Effort/Scripts/AnalysisOutput/
 web/Areas/Effort/Scripts/RemediationOutput/
 web/Areas/Effort/Scripts/Effort_Database_Schema_And_Data_LEGACY.txt
 
-# Code-quality tool outputs (fallow cache + jscpd reports)
+# Code-quality tool outputs (fallow cache + jscpd + ReSharper reports)
 .fallow/
 VueApp/.fallow/
 jscpd-report/
+inspect-report/

--- a/README.md
+++ b/README.md
@@ -179,6 +179,24 @@ The project includes VS Code launch configurations for debugging both frontend a
 - `npm run lint:staged` - Lint only git-staged files
 - `npm run precommit` - Run full pre-commit checks manually (lint, test, build verify)
 
+### Auditing (regression detection)
+
+Heavier whole-project scanners that surface dead code, duplication, and C# inspection findings that the per-file linter doesn't catch. Outputs land in gitignored report directories (`.fallow/`, `jscpd-report/`, `inspect-report/`).
+
+**Whole-project scans** — run locally for human review:
+
+- `npm run audit` - Run all whole-project audits (fallow + jscpd + ReSharper); takes several minutes due to the ReSharper scan
+- `npm run audit:fallow` - Vue/TS dead code, unused exports, complexity, duplication (`VueApp/`)
+- `npm run audit:dupes` - jscpd duplicate-code report across `VueApp/src/` and `web/Areas/`
+- `npm run audit:resharper` - ReSharper `inspectcode` whole-solution scan (writes SARIF + HTML to `inspect-report/`); takes several minutes
+
+**Diff-scoped gates** — fail only on *new* findings at touched lines, so pre-existing issues never block:
+
+- `npm run audit:resharper:pr` - C# inspection gate vs `origin/main`. Same gate the `Code Quality` GitHub Actions workflow runs on PRs.
+- `npm run audit:resharper-staged` - C# inspection gate vs the git index (`git diff --cached`). Useful as a manual pre-commit check. For fast iteration after one full scan, append `-- --skip-scan` to reuse the existing SARIF: `npm run audit:resharper-staged -- --skip-scan`.
+
+**CI integration** — `.github/workflows/code-quality.yml` runs four gates on every PR to `main`: `fallow-regression` (Vue), `jscpd-regression-csharp`, `jscpd-regression-vue`, and `resharper-pr-gate` (C# inspections). All four are diff-scoped so existing technical debt doesn't block merges.
+
 ### Build Cache
 
 The linter, test, and build verification scripts use caching to avoid redundant rebuilds. If you encounter stale cache issues (e.g., linter showing warnings for already-fixed code), clear the cache:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "audit": "node scripts/audit.js",
         "audit:fallow": "node scripts/audit-fallow.js",
         "audit:dupes": "node scripts/audit-jscpd.js",
+        "audit:resharper": "node scripts/audit-resharper.js",
+        "audit:resharper:pr": "node scripts/audit-resharper-regression.js",
         "mailpit:start": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js start",
         "mailpit:status": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js status",
         "mailpit:stop": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js stop",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "audit:dupes": "node scripts/audit-jscpd.js",
         "audit:resharper": "node scripts/audit-resharper.js",
         "audit:resharper:pr": "node scripts/audit-resharper-regression.js",
+        "audit:resharper-staged": "node scripts/audit-resharper-regression.js --staged",
         "mailpit:start": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js start",
         "mailpit:status": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js status",
         "mailpit:stop": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js stop",

--- a/scripts/audit-resharper-regression.js
+++ b/scripts/audit-resharper-regression.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+// PR-scoped ReSharper inspectcode gate.
+//
+// Runs inspectcode on the working tree, parses the SARIF report, filters to
+// findings located at lines the PR added or modified relative to a base ref,
+// and exits non-zero if any are found. This avoids requiring a baseline scrub
+// of pre-existing issues — only NEW findings at PR-touched lines block.
+//
+// Usage:
+//   node scripts/audit-resharper-regression.js [--base origin/main]
+//                                              [--sarif inspect-report/inspect.sarif]
+//                                              [--skip-scan]
+//
+// --skip-scan reuses the SARIF from a prior `audit:resharper` run, useful in
+// CI where the full scan and the gate are split into separate steps so the
+// expensive scan output can be uploaded as an artifact.
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { spawnSync } = require("node:child_process")
+
+const PROJECT_ROOT = path.join(__dirname, "..")
+const DEFAULT_SARIF = path.join(PROJECT_ROOT, "inspect-report", "inspect.sarif")
+
+// `git diff` output for a large solution can exceed Node's 1 MB default.
+const MAX_BUFFER_BYTES = 268_435_456
+
+// Cap how many findings we print per rule before summarising the rest.
+const MAX_FINDINGS_PER_RULE = 5
+
+function parseArgs(argv) {
+    const args = { base: "origin/main", sarif: DEFAULT_SARIF, skipScan: false }
+    const remaining = [...argv]
+    while (remaining.length > 0) {
+        const flag = remaining.shift()
+        if (flag === "--base") {
+            args.base = remaining.shift()
+        } else if (flag === "--sarif") {
+            args.sarif = remaining.shift()
+        } else if (flag === "--skip-scan") {
+            args.skipScan = true
+        } else {
+            console.error(`Unknown arg: ${flag}`)
+            process.exit(2)
+        }
+    }
+    return args
+}
+
+// Returns Map<repoRelativePath, Set<lineNumber>> of lines added/modified in
+// the PR, derived from `git diff --unified=0 base...HEAD`.
+function getChangedLines(baseRef) {
+    const result = spawnSync("git", ["diff", "--unified=0", `${baseRef}...HEAD`, "--", "*.cs"], {
+        cwd: PROJECT_ROOT,
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: MAX_BUFFER_BYTES,
+    })
+    if (result.error || result.status !== 0) {
+        const reason = result.error?.message ?? `exit ${result.status}`
+        console.error(`❌ git diff failed: ${reason}`)
+        process.exit(1)
+    }
+
+    const map = new Map()
+    let currentFile = null
+    for (const line of result.stdout.split(/\r?\n/)) {
+        const fileMatch = line.match(/^\+\+\+ b\/(?<file>.+)$/)
+        if (fileMatch?.groups) {
+            currentFile = fileMatch.groups.file
+            if (!map.has(currentFile)) {
+                map.set(currentFile, new Set())
+            }
+        } else if (currentFile) {
+            const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(?<start>\d+)(?:,(?<count>\d+))? @@/)
+            if (hunkMatch?.groups) {
+                const start = Number(hunkMatch.groups.start)
+                // A hunk count of 0 means lines were removed only at this position; nothing was added.
+                const count = hunkMatch.groups.count === undefined ? 1 : Number(hunkMatch.groups.count)
+                for (let offset = 0; offset < count; offset += 1) {
+                    map.get(currentFile).add(start + offset)
+                }
+            }
+        }
+    }
+    // Drop entries for files where nothing was added (pure deletions).
+    for (const [file, lines] of map) {
+        if (lines.size === 0) {
+            map.delete(file)
+        }
+    }
+    return map
+}
+
+function runScan() {
+    console.log("Running inspectcode (this takes a few minutes on a full solution)...")
+    // Skip HTML; the gate only consumes SARIF, and inspectcode runs are expensive.
+    const result = spawnSync(process.execPath, [path.join(__dirname, "audit-resharper.js"), "--format=sarif"], {
+        cwd: PROJECT_ROOT,
+        stdio: "inherit",
+        windowsHide: true,
+    })
+    if (result.error || result.status !== 0) {
+        const reason = result.error?.message ?? `exit ${result.status}`
+        console.error(`❌ inspectcode scan failed: ${reason}`)
+        process.exit(1)
+    }
+}
+
+// SARIF artifactLocation URIs use forward slashes and are repo-relative; git
+// diff emits forward slashes too, so a direct case-sensitive compare suffices
+// on Linux/macOS. On Windows match case-insensitively.
+function normalizeUri(uri) {
+    let s = uri.replaceAll("\\", "/")
+    if (s.startsWith("./")) {
+        s = s.slice(2)
+    }
+    if (process.platform === "win32") {
+        s = s.toLowerCase()
+    }
+    return s
+}
+
+function findRegressions(sarifPath, changedLines) {
+    const sarif = JSON.parse(fs.readFileSync(sarifPath, "utf8"))
+    const results = sarif.runs?.[0]?.results ?? []
+
+    const changedNorm = new Map()
+    for (const [file, lines] of changedLines) {
+        changedNorm.set(normalizeUri(file), lines)
+    }
+
+    const regressions = []
+    for (const r of results) {
+        const ruleId = r.ruleId ?? "?"
+        for (const loc of r.locations ?? []) {
+            const uri = loc.physicalLocation?.artifactLocation?.uri
+            const line = loc.physicalLocation?.region?.startLine
+            if (uri && line) {
+                const lines = changedNorm.get(normalizeUri(uri))
+                if (lines?.has(line)) {
+                    regressions.push({
+                        file: uri,
+                        line,
+                        ruleId,
+                        message: r.message?.text ?? "",
+                    })
+                }
+            }
+        }
+    }
+    return regressions
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+if (!args.skipScan) {
+    runScan()
+}
+
+if (!fs.existsSync(args.sarif)) {
+    console.error(`❌ SARIF not found: ${args.sarif}`)
+    process.exit(1)
+}
+
+const changed = getChangedLines(args.base)
+console.log(`Comparing against base ${args.base}: ${changed.size} C# file(s) with added/modified lines`)
+if (changed.size === 0) {
+    console.log("✅ No C# changes in this PR; nothing to gate.")
+    process.exit(0)
+}
+
+const regressions = findRegressions(args.sarif, changed)
+if (regressions.length === 0) {
+    console.log("✅ No new ReSharper warnings at PR-touched lines.")
+    process.exit(0)
+}
+
+console.error(`\n❌ ${regressions.length} new ReSharper warning(s) at PR-touched lines:\n`)
+const byRule = new Map()
+for (const r of regressions) {
+    if (!byRule.has(r.ruleId)) {
+        byRule.set(r.ruleId, [])
+    }
+    byRule.get(r.ruleId).push(r)
+}
+for (const [ruleId, items] of byRule) {
+    console.error(`  ${ruleId} (${items.length})`)
+    for (const it of items.slice(0, MAX_FINDINGS_PER_RULE)) {
+        console.error(`    ${it.file}:${it.line}  ${it.message}`)
+    }
+    if (items.length > MAX_FINDINGS_PER_RULE) {
+        console.error(`    ... and ${items.length - MAX_FINDINGS_PER_RULE} more`)
+    }
+}
+process.exit(1)

--- a/scripts/audit-resharper-regression.js
+++ b/scripts/audit-resharper-regression.js
@@ -11,10 +11,15 @@
 //   node scripts/audit-resharper-regression.js [--base origin/main]
 //                                              [--sarif inspect-report/inspect.sarif]
 //                                              [--skip-scan]
+//                                              [--staged]
 //
 // --skip-scan reuses the SARIF from a prior `audit:resharper` run, useful in
 // CI where the full scan and the gate are split into separate steps so the
 // expensive scan output can be uploaded as an artifact.
+//
+// --staged filters findings to staged C# lines (`git diff --cached`) instead of
+// PR-diff lines. Pair with --skip-scan for fast iterative pre-commit checks
+// against an existing SARIF report.
 
 const fs = require("node:fs")
 const path = require("node:path")
@@ -30,7 +35,7 @@ const MAX_BUFFER_BYTES = 268_435_456
 const MAX_FINDINGS_PER_RULE = 5
 
 function parseArgs(argv) {
-    const args = { base: "origin/main", sarif: DEFAULT_SARIF, skipScan: false }
+    const args = { base: "origin/main", sarif: DEFAULT_SARIF, skipScan: false, staged: false }
     const remaining = [...argv]
     while (remaining.length > 0) {
         const flag = remaining.shift()
@@ -40,6 +45,8 @@ function parseArgs(argv) {
             args.sarif = remaining.shift()
         } else if (flag === "--skip-scan") {
             args.skipScan = true
+        } else if (flag === "--staged") {
+            args.staged = true
         } else {
             console.error(`Unknown arg: ${flag}`)
             process.exit(2)
@@ -49,9 +56,10 @@ function parseArgs(argv) {
 }
 
 // Returns Map<repoRelativePath, Set<lineNumber>> of lines added/modified in
-// the PR, derived from `git diff --unified=0 base...HEAD`.
-function getChangedLines(baseRef) {
-    const result = spawnSync("git", ["diff", "--unified=0", `${baseRef}...HEAD`, "--", "*.cs"], {
+// the diff selection: PR-mode uses `git diff base...HEAD`; staged-mode uses
+// `git diff --cached` (staged-vs-HEAD).
+function getChangedLines(diffSelector) {
+    const result = spawnSync("git", ["diff", "--unified=0", ...diffSelector, "--", "*.cs"], {
         cwd: PROJECT_ROOT,
         encoding: "utf8",
         windowsHide: true,
@@ -164,20 +172,27 @@ if (!fs.existsSync(args.sarif)) {
     process.exit(1)
 }
 
-const changed = getChangedLines(args.base)
-console.log(`Comparing against base ${args.base}: ${changed.size} C# file(s) with added/modified lines`)
+const diffSelector = args.staged ? ["--cached"] : [`${args.base}...HEAD`]
+const diffLabel = args.staged ? "staged C# changes" : `base ${args.base}`
+const noChangesMsg = args.staged
+    ? "✅ No staged C# changes; nothing to gate."
+    : "✅ No C# changes in this PR; nothing to gate."
+const touchedLabel = args.staged ? "staged" : "PR-touched"
+
+const changed = getChangedLines(diffSelector)
+console.log(`Comparing against ${diffLabel}: ${changed.size} C# file(s) with added/modified lines`)
 if (changed.size === 0) {
-    console.log("✅ No C# changes in this PR; nothing to gate.")
+    console.log(noChangesMsg)
     process.exit(0)
 }
 
 const regressions = findRegressions(args.sarif, changed)
 if (regressions.length === 0) {
-    console.log("✅ No new ReSharper warnings at PR-touched lines.")
+    console.log(`✅ No new ReSharper warnings at ${touchedLabel} lines.`)
     process.exit(0)
 }
 
-console.error(`\n❌ ${regressions.length} new ReSharper warning(s) at PR-touched lines:\n`)
+console.error(`\n❌ ${regressions.length} new ReSharper warning(s) at ${touchedLabel} lines:\n`)
 const byRule = new Map()
 for (const r of regressions) {
     if (!byRule.has(r.ruleId)) {

--- a/scripts/audit-resharper.js
+++ b/scripts/audit-resharper.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+// Whole-solution ReSharper inspectcode scan via the dotnet local tool.
+// Reports to ./inspect-report/ (html + sarif).
+// Build artifacts isolated under .artifacts-resharper/ so the dev server's
+// locked Viper.exe doesn't collide with inspectcode's build step.
+// For CI regression detection see scripts/audit-resharper-regression.js.
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { spawnSync } = require("node:child_process")
+
+const { env } = process
+
+const PROJECT_ROOT = path.join(__dirname, "..")
+const OUT_DIR = path.join(PROJECT_ROOT, "inspect-report")
+const ARTIFACTS_DIR = path.join(PROJECT_ROOT, ".artifacts-resharper")
+const SLN = path.join(PROJECT_ROOT, "Viper.sln")
+
+// On Windows, jb inspectcode autodetects MSBuild and picks SSMS's MSBuild
+// toolset 18.0 over the .NET SDK MSBuild (verified on a machine with SSMS
+// 22 installed: workload SDK references like
+// Microsoft.NET.SDK.WorkloadAutoImportPropsLocator fail to resolve under
+// the SSMS toolset). Force the dotnet SDK MSBuild to avoid this.
+function findDotnetSdkMsbuild() {
+    const candidateRoots = [
+        env.DOTNET_ROOT && path.join(env.DOTNET_ROOT, "sdk"),
+        path.join("C:", "Program Files", "dotnet", "sdk"),
+        path.join("C:", "Program Files (x86)", "dotnet", "sdk"),
+    ].filter(Boolean)
+    for (const sdkRoot of candidateRoots) {
+        if (fs.existsSync(sdkRoot)) {
+            const versions = fs
+                .readdirSync(sdkRoot, { withFileTypes: true })
+                .filter((d) => d.isDirectory() && /^\d+\.\d+\.\d+/.test(d.name))
+                .map((d) => d.name)
+                .toSorted((a, b) => b.localeCompare(a, undefined, { numeric: true }))
+            for (const version of versions) {
+                const dll = path.join(sdkRoot, version, "MSBuild.dll")
+                if (fs.existsSync(dll)) {
+                    return { dll, version }
+                }
+            }
+        }
+    }
+    return null
+}
+
+function runInspectCode(format, outFile) {
+    const args = [
+        "tool",
+        "run",
+        "jb",
+        "inspectcode",
+        SLN,
+        `--output=${outFile}`,
+        `--format=${format}`,
+        "--severity=WARNING",
+        // Keep build artifacts out of web/bin so the dev server's locked
+        // Viper.exe does not break the inspectcode build.
+        `--properties:UseArtifactsOutput=true`,
+        `--properties:ArtifactsPath=${ARTIFACTS_DIR}`,
+    ]
+
+    if (process.platform === "win32") {
+        const sdk = findDotnetSdkMsbuild()
+        if (sdk) {
+            args.push(`--toolset-path=${sdk.dll}`, `--dotnetcoresdk=${sdk.version}`)
+        }
+    }
+
+    console.log(`\n━━━ inspectcode → ${path.relative(PROJECT_ROOT, outFile)} ━━━`)
+    // No shell: passing args directly avoids cmd.exe re-splitting them at
+    // spaces inside paths like "C:\Program Files\dotnet\sdk\..\MSBuild.dll".
+    const result = spawnSync("dotnet", args, {
+        cwd: PROJECT_ROOT,
+        stdio: "inherit",
+        windowsHide: true,
+    })
+    if (result.error || result.status !== 0) {
+        const reason = result.error?.message ?? `exit ${result.status}`
+        console.error(`❌ inspectcode failed: ${reason}`)
+        process.exit(1)
+    }
+}
+
+// --format=sarif|html|both (default: both). The regression gate only needs
+// SARIF; skipping HTML roughly halves CI scan time.
+function parseFormat(argv) {
+    for (const arg of argv) {
+        const m = arg.match(/^--format=(?<value>sarif|html|both)$/i)
+        if (m?.groups) {
+            return m.groups.value.toLowerCase()
+        }
+    }
+    return "both"
+}
+
+const format = parseFormat(process.argv.slice(2))
+
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+// SARIF for parseable CI consumption, HTML for human review.
+if (format === "sarif" || format === "both") {
+    runInspectCode("Sarif", path.join(OUT_DIR, "inspect.sarif"))
+}
+if (format === "html" || format === "both") {
+    runInspectCode("Html", path.join(OUT_DIR, "inspect.html"))
+}
+
+console.log(`\n✅ Reports written to ${path.relative(PROJECT_ROOT, OUT_DIR)}/`)

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-// `npm run audit` — run both fallow and jscpd whole-project audits.
+// `npm run audit` — run all whole-project audits (fallow, jscpd, ReSharper).
+// Note: ReSharper inspectcode adds several minutes to the run.
 
 const path = require("node:path")
 const { spawnSync } = require("node:child_process")
@@ -16,9 +17,9 @@ function runNode(script) {
     return result.status ?? 1
 }
 
-// Run both audits unconditionally so a failure in the first doesn't hide the
-// second's findings; aggregate exit codes at the end.
-const codes = ["audit-fallow.js", "audit-jscpd.js"].map(runNode)
+// Run all audits unconditionally so a failure in one doesn't hide the
+// others' findings; aggregate exit codes at the end.
+const codes = ["audit-fallow.js", "audit-jscpd.js", "audit-resharper.js"].map(runNode)
 const max = Math.max(0, ...codes)
 if (max !== 0) {
     process.exit(max)


### PR DESCRIPTION
## Summary

Part 2 of 6. **Stacks on top of PR #174.**

Adds C# static-analysis tooling. No source rewrites yet — those follow in PR 3.

- **Roslyn maintainability rules**: CA1501/1502/1505/1507/1508/1510-1513/1514 enabled in `.editorconfig`. CA1506 and CA1515 skipped (heavy false positives on ASP.NET Core controllers and DTOs).
- **SonarAnalyzer.CSharp.Roslyn** continues to drive Sonar rules; rule set tightened in tandem.
- **ReSharper inspectcode** registered as `resharper-pr-gate` CI job. Like the fallow/jscpd gates, only *new* findings at PR-touched lines vs `origin/main` fail — pre-existing findings don't block.

## Commits

- `chore(quality): add C# static analysis + PR-scoped gate`
- `feat(tooling): add ReSharper staged-files gate, expand audit umbrella`

## Why these are bundled

The ReSharper PR-gate script (`scripts/audit-resharper-regression.js`) was created in the C# analyzer commit and immediately extended in the gate commit — they share the same `inspectcode` infrastructure. Splitting them creates an artificial mid-state with no working tooling.

## Note on `npm run audit`

After this PR, `npm run audit` includes the ReSharper inspectcode pass and takes several minutes. For fast iteration use the per-tool scripts (`audit:fallow`, `audit:dupes`, `audit:resharper`).

## PR stack

- PR 1 → tooling: fallow + jscpd (#174)
- **PR 2 (this)** → tooling: CodeQL + Roslyn + SonarAnalyzer + ReSharper
- PR 3 → quality: mechanical analyzer-driven cleanup (~470 files)
- PR 4 → refactor: dead-code + shared chrome
- PR 5 → refactor: Effort component extraction
- PR 6 → refactor: per-area small

## Test plan

- [ ] CI green
- [ ] `npm run audit:resharper` runs locally
- [ ] `resharper-pr-gate` workflow surfaces CA1xxx and Sonar findings on a sample diff