### PR TITLE
chore(coderabbit): gate auto-review behind review-ready label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,11 +13,16 @@ reviews:
   review_status: true
   collapse_walkthrough: true
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
+    auto_pause_after_reviewed_commits: 5
     base_branches:
       - main
       - "VPR-.*"
+    labels:
+      - "review-ready"
+    ignore_usernames:
+      - "dependabot[bot]"
     ignore_title_keywords:
       - WIP
 


### PR DESCRIPTION
- Disables auto_review globally; PRs opt in via the "review-ready" label or `@coderabbitai review` comment
- Skips dependabot PRs via ignore_usernames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation configuration settings to refine review processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->