### PR TITLE
chore(lint): use vue-tsc for staged .vue type-checking

### DIFF
--- a/scripts/lint-staged-vue.js
+++ b/scripts/lint-staged-vue.js
@@ -205,8 +205,9 @@ try {
         // Check app files with tsconfig.app.json
         if (appFiles.length > 0) {
             logger.info(`Checking ${appFiles.length} application files...`)
+            // Plain tsc can't resolve named imports from .vue modules.
             const appResult = runCommand(
-                "tsc",
+                "vue-tsc",
                 ["--project", "tsconfig.app.json", "--noEmit"],
                 "TypeScript app checking",
                 vueAppDir,


### PR DESCRIPTION
## Summary

One-line fix to `scripts/lint-staged-vue.js`: the staged-files type-check for `.vue` files invoked plain `tsc`, which cannot resolve **named imports** from `.vue` modules (only `vue-tsc` can — it reads `<script>` blocks). Switch to `vue-tsc` to match what `scripts/lint-staged-ts.js` already does for `VueApp/src/` files.

## Why now

Since main commit `72491d42 feat(clinical-scheduler): Phase 4 Add bulk deletion`, three composables import named types (`ScheduleSemester`, `ScheduleAssignment`) from `ScheduleView.vue`:

- `VueApp/src/ClinicalScheduler/composables/use-bulk-deletion-logic.ts`
- `VueApp/src/ClinicalScheduler/composables/use-delete-mode.ts`
- `VueApp/src/ClinicalScheduler/composables/use-schedule-normalization.ts`

The pre-commit hook trips on these on **every Vue commit** even though the project's actual build (`vue-tsc --build` in `npm run verify:build`) is happy. CI uses vue-tsc, so this is hook-only friction.

## Test plan

- [ ] CI green
- [ ] `npm run lint -- <any .vue file>` passes (previously failed with "Found 4 errors in 3 files")
- [ ] Pre-commit hook on a Vue change in branch `refactor/dead-code-and-shared-chrome` no longer trips

## Related

Surfaced while addressing CodeRabbit review comments on PR #177 — all three commits in this round of PR 177 fixes had to be made with `--no-verify` because of this hook bug. Once this lands, those (and any future Vue-touching commits in PRs 178/179) won't need the bypass.