### PR TITLE
VPR-54 feat(scheduler): Hangfire-backed scheduler

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,6 +15,13 @@
 # Default: C:\Tools\mailpit
 #MAILPIT_INSTALL_DIR=C:\Tools\mailpit
 
+# Hangfire Scheduler (Enabled by Default)
+# Master toggle for the background scheduler. Defaults to true; the app
+# registers Hangfire and starts the background server. Set to false to
+# disable the scheduler in this environment. Hangfire's tables live in
+# the VIPER database under the HangFire schema.
+#Hangfire__Enabled=false
+
 # Jenkins Build Trigger (pre-push hook)
 # Get your API token from Jenkins: User menu > Configure > API Token
 #JENKINS_USER=your-username

--- a/VueApp/src/layouts/LeftNav.vue
+++ b/VueApp/src/layouts/LeftNav.vue
@@ -60,8 +60,8 @@
                                 clickable
                                 v-ripple
                                 :href="menuItem.menuItemUrl"
-                                target="_blank"
-                                rel="noopener noreferrer"
+                                :target="menuItem.isExternalSite ? '_blank' : undefined"
+                                :rel="menuItem.isExternalSite ? 'noopener noreferrer' : undefined"
                                 :class="menuItem.displayClass"
                             >
                                 <q-item-section>
@@ -162,6 +162,22 @@ function isItemActive(routeTo: string | null): boolean {
     return score > 0 && score === bestMatchScore.value
 }
 
+// True when the URL resolves to a real SPA route. Vue Router's catch-all
+// (path: "/:catchAll(.*)*" etc.) matches anything not otherwise registered,
+// so a successful resolve isn't enough — we also reject paths that match
+// only via a regex catch-all segment.
+function isInSpaRoute(url: string): boolean {
+    try {
+        const matched = router.resolve(url).matched
+        if (matched.length === 0) {
+            return false
+        }
+        return matched.some((r) => !/\(\.\*\)/.test(r.path))
+    } catch {
+        return false
+    }
+}
+
 type OverflowTitleElement = HTMLElement & {
     _overflowTitleObserver?: ResizeObserver
 }
@@ -252,17 +268,29 @@ async function getLeftNav() {
                 }
             }
 
-            let routeToUrl = null
+            // Resolve to either an in-SPA route (RouterLink, client-side nav)
+            // or a same-tab anchor (full page load). URLs that don't match
+            // any registered SPA route fall through to the catch-all 404 if
+            // RouterLink-handled, so render those as plain anchors instead.
+            let routeToUrl: string | null = null
+            let internalAnchorUrl: string | undefined = undefined
             if (!isExternalUrl && r.menuItemURL.length > 0) {
-                if (isRelativeUrl && props.navarea && props.nav) {
-                    routeToUrl = `/${props.nav.toUpperCase()}/${r.menuItemURL}`
+                const candidate =
+                    isRelativeUrl && props.navarea && props.nav
+                        ? `/${props.nav.toUpperCase()}/${r.menuItemURL}`
+                        : r.menuItemURL
+                if (isInSpaRoute(candidate)) {
+                    routeToUrl = candidate
                 } else {
-                    routeToUrl = r.menuItemURL
+                    // Plain-anchor hrefs need the SPA's base path prepended
+                    // (e.g. `/2/`) since the browser won't apply Vue Router's
+                    // base for direct hrefs. router.resolve handles this.
+                    internalAnchorUrl = router.resolve(candidate).href
                 }
             }
 
             return {
-                menuItemUrl: isExternalUrl ? r.menuItemURL : undefined,
+                menuItemUrl: isExternalUrl ? r.menuItemURL : internalAnchorUrl,
                 routeTo: routeToUrl,
                 menuItemText: r.menuItemText,
                 clickable: r.menuItemURL.length > 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,9 +2616,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "dev": true,
             "funding": [
                 {

--- a/test/HealthChecks/HangfireHealthCheckTests.cs
+++ b/test/HealthChecks/HangfireHealthCheckTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Viper.Classes.HealthChecks;
+
+namespace Viper.test.HealthChecks
+{
+    public class HangfireHealthCheckTests
+    {
+        private static HealthCheckContext CreateContext(HangfireHealthCheck sut)
+        {
+            return new HealthCheckContext
+            {
+                Registration = new HealthCheckRegistration("hangfire", sut, null, null)
+            };
+        }
+
+        private static (Hangfire.JobStorage storage, Hangfire.Storage.IMonitoringApi monitoring) CreateStorage()
+        {
+            var monitoring = Substitute.For<Hangfire.Storage.IMonitoringApi>();
+            var storage = Substitute.For<Hangfire.JobStorage>();
+            storage.GetMonitoringApi().Returns(monitoring);
+            return (storage, monitoring);
+        }
+
+        private static Hangfire.Storage.Monitoring.StatisticsDto SampleStats(long servers = 1) => new()
+        {
+            Servers = servers,
+            Enqueued = 2,
+            Scheduled = 3,
+            Processing = 4,
+            Failed = 5,
+            Recurring = 6
+        };
+
+        [Fact]
+        public async Task CheckHealthAsync_HealthyWhenServersHaveRecentHeartbeats()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(SampleStats());
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>
+            {
+                new() { Name = "srv-1", Heartbeat = DateTime.UtcNow }
+            });
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains("Hangfire OK", result.Description);
+            Assert.Equal(1L, result.Data["servers"]);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenNoServersRegistered()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(SampleStats(0));
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>());
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("no servers registered", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_UnhealthyWhenAllHeartbeatsStale()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(SampleStats());
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>
+            {
+                new() { Name = "srv-stale", Heartbeat = DateTime.UtcNow.AddMinutes(-10) }
+            });
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("stale", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_UnhealthyWhenServerHasNullHeartbeat()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(SampleStats());
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>
+            {
+                new() { Name = "srv-never", Heartbeat = null }
+            });
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("never", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_HealthyWhenAtLeastOneHeartbeatIsRecent()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(SampleStats(2));
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>
+            {
+                new() { Name = "srv-stale", Heartbeat = DateTime.UtcNow.AddMinutes(-10) },
+                new() { Name = "srv-fresh", Heartbeat = DateTime.UtcNow }
+            });
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains("Hangfire OK", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_UnhealthyWhenStorageThrows()
+        {
+            var storage = Substitute.For<Hangfire.JobStorage>();
+            var boom = new InvalidOperationException("boom");
+            storage.GetMonitoringApi().Returns(_ => throw boom);
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("unreachable", result.Description);
+            Assert.Same(boom, result.Exception);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DataDictionaryContainsAllStatsKeys()
+        {
+            var (storage, monitoring) = CreateStorage();
+            monitoring.GetStatistics().Returns(new Hangfire.Storage.Monitoring.StatisticsDto
+            {
+                Servers = 1,
+                Enqueued = 7,
+                Scheduled = 8,
+                Processing = 9,
+                Failed = 10,
+                Recurring = 11
+            });
+            monitoring.Servers().Returns(new List<Hangfire.Storage.Monitoring.ServerDto>
+            {
+                new() { Name = "srv-1", Heartbeat = DateTime.UtcNow }
+            });
+
+            var sut = new HangfireHealthCheck(storage);
+            var result = await sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+            Assert.Contains("servers", result.Data.Keys);
+            Assert.Contains("enqueued", result.Data.Keys);
+            Assert.Contains("scheduled", result.Data.Keys);
+            Assert.Contains("processing", result.Data.Keys);
+            Assert.Contains("failed", result.Data.Keys);
+            Assert.Contains("recurring", result.Data.Keys);
+            Assert.Equal(1L, result.Data["servers"]);
+            Assert.Equal(7L, result.Data["enqueued"]);
+            Assert.Equal(11L, result.Data["recurring"]);
+        }
+    }
+}

--- a/test/RAPS/RapsRoleRefreshScheduledJobTests.cs
+++ b/test/RAPS/RapsRoleRefreshScheduledJobTests.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using Viper.Areas.RAPS.Jobs;
+using Viper.Areas.Scheduler.Services;
+
+namespace Viper.test.RAPS
+{
+    public sealed class RapsRoleRefreshScheduledJobTests
+    {
+        [Fact]
+        public void Class_IsDecoratedWithScheduledJob()
+        {
+            var attr = typeof(RapsRoleRefreshScheduledJob).GetCustomAttribute<ScheduledJobAttribute>();
+
+            Assert.NotNull(attr);
+            Assert.Equal("raps:role-refresh", attr.Id);
+            Assert.Equal("0 0 * * *", attr.Cron);
+            Assert.Equal("Pacific Standard Time", attr.TimeZoneId);
+        }
+    }
+}

--- a/test/Scheduler/HangfireJobLoggingFilterTests.cs
+++ b/test/Scheduler/HangfireJobLoggingFilterTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+using Viper.Classes.Scheduler;
+
+namespace Viper.test.Scheduler
+{
+    public class HangfireJobLoggingFilterTests
+    {
+        // Concrete method target for Hangfire.Common.Job — needs a real MethodInfo.
+        private static class FakeJob
+        {
+            public static void Run(string s, int i)
+            {
+                _ = s;
+                _ = i;
+            }
+        }
+
+        private static Hangfire.Server.PerformContext BuildPerformContext(
+            string? recurringJobId = null,
+            string jobId = "123")
+        {
+            var method = typeof(FakeJob).GetMethod(nameof(FakeJob.Run))!;
+            var job = new Hangfire.Common.Job(typeof(FakeJob), method, new object[] { "arg1", 42 });
+            var backgroundJob = new Hangfire.BackgroundJob(jobId, job, DateTime.UtcNow);
+
+            var storage = Substitute.For<Hangfire.JobStorage>();
+            var connection = Substitute.For<Hangfire.Storage.IStorageConnection>();
+            // Hangfire JSON-deserializes parameter values via SerializationHelper, so the mock
+            // must return a JSON-encoded string (or null), not a raw value.
+            var encodedParam = recurringJobId is null
+                ? null
+                : Hangfire.Common.SerializationHelper.Serialize(recurringJobId);
+            connection.GetJobParameter(jobId, "RecurringJobId").Returns(encodedParam);
+
+            var cancel = Substitute.For<Hangfire.IJobCancellationToken>();
+            return new Hangfire.Server.PerformContext(storage, connection, backgroundJob, cancel);
+        }
+
+        private static IDisposable CaptureScope(ILogger<HangfireJobLoggingFilter> logger, out List<Dictionary<string, object>> captured)
+        {
+            var list = new List<Dictionary<string, object>>();
+            captured = list;
+            var scope = Substitute.For<IDisposable>();
+            logger.BeginScope(Arg.Do<Dictionary<string, object>>(d => list.Add(d))).Returns(scope);
+            return scope;
+        }
+
+        // ILogger.Log<TState> is generic; the TState passed by extension methods is an internal
+        // struct (FormattedLogValues) which makes Arg.Any<object>() unreliable. Inspecting the
+        // recorded calls directly avoids the generic-arg matching problem.
+        private static IReadOnlyList<ICall> GetLogCalls(ILogger logger, LogLevel level)
+        {
+            return logger.ReceivedCalls()
+                .Where(c => c.GetMethodInfo().Name == nameof(ILogger.Log)
+                            && c.GetArguments().Length >= 1
+                            && c.GetArguments()[0] is LogLevel l
+                            && l == level)
+                .ToList();
+        }
+
+        private static string GetMessage(ICall call)
+        {
+            // Args layout: [LogLevel, EventId, TState, Exception, Func<TState, Exception, string>]
+            var args = call.GetArguments();
+            return args[2]?.ToString() ?? string.Empty;
+        }
+
+        private static Exception? GetException(ICall call)
+        {
+            return call.GetArguments()[3] as Exception;
+        }
+
+        [Fact]
+        public void OnPerforming_LogsStartMessageWithSanitizedJobInfo()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            CaptureScope(logger, out _);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext();
+            var performing = new Hangfire.Server.PerformingContext(perf);
+
+            sut.OnPerforming(performing);
+
+            var infoCalls = GetLogCalls(logger, LogLevel.Information);
+            Assert.Single(infoCalls);
+            Assert.Contains("Hangfire job starting", GetMessage(infoCalls[0]));
+        }
+
+        [Fact]
+        public void OnPerforming_BeginsScopeWithJobMetadata()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            CaptureScope(logger, out var captured);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext(recurringJobId: "daily-cleanup");
+            var performing = new Hangfire.Server.PerformingContext(perf);
+
+            sut.OnPerforming(performing);
+
+            logger.Received(1).BeginScope(Arg.Any<Dictionary<string, object>>());
+            Assert.Single(captured);
+            var dict = captured[0];
+            Assert.Contains("jobId", dict.Keys);
+            Assert.Contains("recurringJobId", dict.Keys);
+        }
+
+        [Fact]
+        public void OnPerformed_LogsCompletionWhenNoException()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            CaptureScope(logger, out _);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext();
+            var performed = new Hangfire.Server.PerformedContext(perf, result: null, canceled: false, exception: null);
+
+            sut.OnPerformed(performed);
+
+            var infoCalls = GetLogCalls(logger, LogLevel.Information);
+            Assert.Single(infoCalls);
+            Assert.Contains("Hangfire job completed", GetMessage(infoCalls[0]));
+        }
+
+        [Fact]
+        public void OnPerformed_LogsErrorWhenExceptionPresent()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            CaptureScope(logger, out _);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext();
+            var failure = new InvalidOperationException("kaboom");
+            var performed = new Hangfire.Server.PerformedContext(perf, result: null, canceled: false, exception: failure);
+
+            sut.OnPerformed(performed);
+
+            var errorCalls = GetLogCalls(logger, LogLevel.Error);
+            Assert.Single(errorCalls);
+            Assert.Same(failure, GetException(errorCalls[0]));
+        }
+
+        [Fact]
+        public void OnPerformed_DisposesScopeStashedByOnPerforming()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            var scope = CaptureScope(logger, out _);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext();
+            var performing = new Hangfire.Server.PerformingContext(perf);
+            var performed = new Hangfire.Server.PerformedContext(perf, result: null, canceled: false, exception: null);
+
+            sut.OnPerforming(performing);
+            sut.OnPerformed(performed);
+
+            scope.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void OnPerformed_DoesNotThrowWhenScopeMissing()
+        {
+            var logger = Substitute.For<ILogger<HangfireJobLoggingFilter>>();
+            CaptureScope(logger, out _);
+            var sut = new HangfireJobLoggingFilter(logger);
+            var perf = BuildPerformContext();
+            var performed = new Hangfire.Server.PerformedContext(perf, result: null, canceled: false, exception: null);
+
+            // No prior OnPerforming, so context.Items has no scope key.
+            var ex = Record.Exception(() => sut.OnPerformed(performed));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/test/Scheduler/ScheduledJobDiscoveryTests.cs
+++ b/test/Scheduler/ScheduledJobDiscoveryTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Viper.Areas.Scheduler.Models;
+using Viper.Areas.Scheduler.Services;
+
+namespace Viper.test.Scheduler
+{
+    public sealed class ScheduledJobDiscoveryTests
+    {
+        [ScheduledJob(id: "test:good", cron: "0 0 * * *")]
+        public sealed class GoodJob : IScheduledJob
+        {
+            public Task RunAsync(ScheduledJobContext context, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        [ScheduledJob(id: "test:second", cron: "0 1 * * *")]
+        public sealed class SecondJob : IScheduledJob
+        {
+            public Task RunAsync(ScheduledJobContext context, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        public class JobMissingAttribute : IScheduledJob
+        {
+            public Task RunAsync(ScheduledJobContext context, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public void RegisterScheduledJobs_DiscoversValidJobs()
+        {
+            var services = new ServiceCollection();
+            var found = ManualDiscover(services, new[] { typeof(GoodJob), typeof(SecondJob) });
+
+            Assert.Equal(2, found.Count);
+            Assert.Contains(found, m => m.Id == "test:good");
+            Assert.Contains(found, m => m.Id == "test:second");
+        }
+
+        [Fact]
+        public void RegisterScheduledJobs_ThrowsWhenAttributeMissing()
+        {
+            var services = new ServiceCollection();
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                ManualDiscover(services, new[] { typeof(JobMissingAttribute) }));
+            Assert.Contains("[ScheduledJob]", ex.Message);
+        }
+
+        [Fact]
+        public void RegisterScheduledJobs_ThrowsOnDuplicateId()
+        {
+            var services = new ServiceCollection();
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                ManualDiscover(services, new[] { typeof(GoodJob), typeof(DuplicateIdJob) }));
+            Assert.Contains("Duplicate", ex.Message);
+        }
+
+        [ScheduledJob(id: "test:good", cron: "0 0 * * *")]
+        public sealed class DuplicateIdJob : IScheduledJob
+        {
+            public Task RunAsync(ScheduledJobContext context, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        private static IReadOnlyList<ScheduledJobMetadata> ManualDiscover(
+            IServiceCollection services,
+            Type[] types)
+        {
+            var stub = new StubAssembly(types);
+            return ScheduledJobDiscovery.RegisterScheduledJobs(services, new[] { stub });
+        }
+
+        private sealed class StubAssembly : System.Reflection.Assembly
+        {
+            private readonly Type[] _types;
+            public StubAssembly(Type[] types) { _types = types; }
+            public override Type[] GetTypes() => _types;
+        }
+    }
+}

--- a/test/Scheduler/ScheduledJobRunnerTests.cs
+++ b/test/Scheduler/ScheduledJobRunnerTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Viper.Areas.Scheduler.Models;
+using Viper.Areas.Scheduler.Services;
+
+namespace Viper.test.Scheduler
+{
+    public sealed class ScheduledJobRunnerTests
+    {
+        // Captures the ScheduledJobContext the runner hands the job, so tests
+        // can assert that ModBy is set correctly.
+        private sealed class CapturingJob : IScheduledJob
+        {
+            public ScheduledJobContext? CapturedContext { get; private set; }
+            public bool Ran { get; private set; }
+
+            public Task RunAsync(ScheduledJobContext context, CancellationToken ct)
+            {
+                CapturedContext = context;
+                Ran = true;
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task RunAsync_ResolvesJobByIdAndStampsSchedulerActor()
+        {
+            var capturing = new CapturingJob();
+            var services = new ServiceCollection();
+            services.AddSingleton(capturing);
+
+            var registry = new ScheduledJobRegistry(new Dictionary<string, ScheduledJobMetadata>
+            {
+                ["test:capturing"] = new ScheduledJobMetadata(
+                    typeof(CapturingJob), "test:capturing", "0 0 * * *", "UTC"),
+            });
+            services.AddSingleton<IScheduledJobRegistry>(registry);
+
+            var provider = services.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+            var logger = Substitute.For<ILogger<ScheduledJobRunner>>();
+            var runner = new ScheduledJobRunner(scopeFactory, logger);
+
+            var jobCt = Substitute.For<Hangfire.IJobCancellationToken>();
+            jobCt.ShutdownToken.Returns(CancellationToken.None);
+            await runner.RunAsync("test:capturing", jobCt, performContext: null);
+
+            Assert.True(capturing.Ran);
+            Assert.NotNull(capturing.CapturedContext);
+            Assert.Equal(ScheduledJobContext.SchedulerActor, capturing.CapturedContext!.ModBy);
+        }
+
+        [Fact]
+        public async Task RunAsync_LogsAndSkipsWhenIdUnknown()
+        {
+            var services = new ServiceCollection();
+            var registry = new ScheduledJobRegistry(new Dictionary<string, ScheduledJobMetadata>());
+            services.AddSingleton<IScheduledJobRegistry>(registry);
+            var provider = services.BuildServiceProvider();
+            var logger = Substitute.For<ILogger<ScheduledJobRunner>>();
+            var runner = new ScheduledJobRunner(provider.GetRequiredService<IServiceScopeFactory>(), logger);
+
+            var jobCt = Substitute.For<Hangfire.IJobCancellationToken>();
+            jobCt.ShutdownToken.Returns(CancellationToken.None);
+            var ex = await Record.ExceptionAsync(() => runner.RunAsync("does-not-exist", jobCt, performContext: null));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/test/Viper.test.csproj
+++ b/test/Viper.test.csproj
@@ -36,6 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/web/Areas/RAPS/Jobs/RapsRoleRefreshScheduledJob.cs
+++ b/web/Areas/RAPS/Jobs/RapsRoleRefreshScheduledJob.cs
@@ -1,0 +1,45 @@
+using Viper.Areas.RAPS.Services;
+using Viper.Areas.Scheduler.Models;
+using Viper.Areas.Scheduler.Services;
+using Viper.Classes.SQLContext;
+using Viper.Classes.Utilities;
+
+namespace Viper.Areas.RAPS.Jobs;
+
+/// <summary>
+/// First consumer of the scheduled-job abstraction: nightly role membership
+/// refresh. Wraps <see cref="RoleViews.UpdateRoles"/> and threads the run's
+/// <see cref="ScheduledJobContext.ModBy"/> through so the audit log clearly
+/// distinguishes scheduler-driven changes (<c>"__sched"</c>) from
+/// admin-driven manual runs (a real LoginId).
+/// </summary>
+[ScheduledJob(id: "raps:role-refresh", cron: "0 0 * * *", TimeZoneId = "Pacific Standard Time")]
+public sealed class RapsRoleRefreshScheduledJob : IScheduledJob
+{
+    private readonly RAPSContext _rapsContext;
+    private readonly ILogger<RapsRoleRefreshScheduledJob> _logger;
+
+    public RapsRoleRefreshScheduledJob(
+        RAPSContext rapsContext,
+        ILogger<RapsRoleRefreshScheduledJob> logger)
+    {
+        _rapsContext = rapsContext;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(ScheduledJobContext context, CancellationToken ct)
+    {
+        context.WriteLine($"RAPS role refresh starting (modBy={context.ModBy})");
+        var roleViews = new RoleViews(_rapsContext);
+        var messages = await roleViews.UpdateRoles(modBy: context.ModBy, debugOnly: false, ct: ct);
+        foreach (var message in messages)
+        {
+            context.WriteLine(message);
+        }
+        context.WriteLine($"Done. {messages.Count} change message(s).");
+        _logger.LogInformation(
+            "RAPS role refresh (modBy={ModBy}) wrote {ChangeCount} change message(s)",
+            LogSanitizer.SanitizeString(context.ModBy),
+            messages.Count);
+    }
+}

--- a/web/Areas/RAPS/Services/RAPSAuditService.cs
+++ b/web/Areas/RAPS/Services/RAPSAuditService.cs
@@ -243,12 +243,14 @@ namespace Viper.Areas.RAPS.Services
         /// </summary>
         /// <param name="roleMember">The rolemember object</param>
         /// <param name="actionType">Create Update or Delete</param>
-        public void AuditRoleMemberChange(TblRoleMember roleMember, AuditActionType actionType, string? comment)
+        /// <param name="comment">Optional free-text reason recorded on the audit row.</param>
+        /// <param name="modBy">Audit actor; falls back to the current CAS user when null or blank.</param>
+        public void AuditRoleMemberChange(TblRoleMember roleMember, AuditActionType actionType, string? comment, string? modBy = null)
         {
             TblLog tblLog = new()
             {
                 ModTime = DateTime.Now,
-                ModBy = UserHelper.GetCurrentUser()?.LoginId,
+                ModBy = string.IsNullOrWhiteSpace(modBy) ? UserHelper.GetCurrentUser()?.LoginId : modBy,
                 RoleId = roleMember.RoleId,
                 MemberId = roleMember.MemberId,
                 Comment = comment

--- a/web/Areas/RAPS/Services/RoleViews.cs
+++ b/web/Areas/RAPS/Services/RoleViews.cs
@@ -6,9 +6,11 @@ namespace Viper.Areas.RAPS.Services
 {
     public class RoleViews
     {
+        /// <summary>Default audit actor when no caller-supplied value is given (e.g. legacy callers).</summary>
+        public const string DefaultModBy = "__system";
+
         private readonly RAPSContext _RAPSContext;
         private readonly RAPSAuditService _auditService;
-        private static readonly string _ModByName = "__system";
         private static readonly string _AddComment = "Adding to role based on view {0}";
         private static readonly string _DeleteComment = "Removing from role based on view {0}";
 
@@ -18,6 +20,9 @@ namespace Viper.Areas.RAPS.Services
             _auditService = new RAPSAuditService(RAPSContext);
         }
 
+        private static string ResolveActor(string? modBy)
+            => string.IsNullOrWhiteSpace(modBy) ? DefaultModBy : modBy;
+
         public async Task<List<string>> GetViewNames()
         {
             List<GetAllRapsViews> allViews = await _RAPSContext.GetAllRapsViews.FromSql($"dbo.usp_getAllRapsViews")
@@ -26,19 +31,27 @@ namespace Viper.Areas.RAPS.Services
         }
 
         /// <summary>
-        /// Update the membership of all roles defined by a view
+        /// Update the membership of all roles defined by a view.
         /// </summary>
-        /// <param name="debugOnly"></param>
-        /// <returns></returns>
-        public async Task<List<string>> UpdateRoles(bool debugOnly = false)
+        /// <param name="modBy">
+        /// Audit actor stamped on every <c>TblRoleMember</c> and <c>TblLog</c>
+        /// row written by this run. Pass <c>"__sched"</c> for nightly
+        /// recurring runs, the LoginId for manual admin runs, or rely on the
+        /// <see cref="DefaultModBy"/> for legacy callers.
+        /// </param>
+        /// <param name="debugOnly">If true, only write messages, don't change the DB.</param>
+        /// <param name="ct">Honored between roles so Hangfire-driven runs can be cancelled cleanly during deploys or shutdown.</param>
+        public async Task<List<string>> UpdateRoles(string? modBy = null, bool debugOnly = false, CancellationToken ct = default)
         {
+            var actor = ResolveActor(modBy);
             List<string> messages = new();
             var roles = await _RAPSContext.TblRoles
                     .Where(r => !string.IsNullOrEmpty(r.ViewName))
-                    .ToListAsync();
+                    .ToListAsync(ct);
             foreach (var role in roles)
             {
-                await UpdateRole(role, messages, debugOnly);
+                ct.ThrowIfCancellationRequested();
+                await UpdateRole(role, messages, debugOnly, actor);
             }
             return messages;
         }
@@ -49,7 +62,8 @@ namespace Viper.Areas.RAPS.Services
         /// <param name="role">The role</param>
         /// <param name="messages">If running as a routine for multiple roles, the messages will be appended to this list.</param>
         /// <param name="debugOnly">If true, only write messages, don't change the DB</param>
-        public async Task<List<string>> UpdateRole(TblRole role, List<string>? messages = null, bool debugOnly = false)
+        /// <param name="modBy">Audit actor; defaults to <see cref="DefaultModBy"/>.</param>
+        public async Task<List<string>> UpdateRole(TblRole role, List<string>? messages = null, bool debugOnly = false, string? modBy = null)
         {
             if (string.IsNullOrEmpty(role.ViewName))
             {
@@ -97,21 +111,22 @@ namespace Viper.Areas.RAPS.Services
                 messages.Add(string.Format("View {0} has 0 members", role.ViewName));
             }
 
+            var actor = ResolveActor(modBy);
             if (!debugOnly)
             {
                 foreach (string toAddMemberId in toAdd)
                 {
-                    AddRoleMember(role.RoleId, toAddMemberId, role.ViewName);
+                    AddRoleMember(role.RoleId, toAddMemberId, role.ViewName, actor);
                 }
                 foreach (TblRoleMember toDeleteMember in toDelete)
                 {
-                    DeleteRoleMember(toDeleteMember, role.ViewName);
+                    DeleteRoleMember(toDeleteMember, role.ViewName, actor);
                 }
             }
             return messages;
         }
 
-        private void AddRoleMember(int roleId, string memberId, string viewName)
+        private void AddRoleMember(int roleId, string memberId, string viewName, string modBy)
         {
             using var transaction = _RAPSContext.Database.BeginTransaction();
             TblRoleMember tblRoleMember = new()
@@ -120,19 +135,19 @@ namespace Viper.Areas.RAPS.Services
                 MemberId = memberId,
                 ViewName = viewName,
                 ModTime = DateTime.Now,
-                ModBy = _ModByName
+                ModBy = modBy
             };
             _RAPSContext.TblRoleMembers.Add(tblRoleMember);
             _RAPSContext.SaveChanges();
-            _auditService.AuditRoleMemberChange(tblRoleMember, RAPSAuditService.AuditActionType.Create, string.Format(_AddComment, viewName));
+            _auditService.AuditRoleMemberChange(tblRoleMember, RAPSAuditService.AuditActionType.Create, string.Format(_AddComment, viewName), modBy);
             _RAPSContext.SaveChanges();
             transaction.Commit();
         }
 
-        private void DeleteRoleMember(TblRoleMember deleteMember, string viewName)
+        private void DeleteRoleMember(TblRoleMember deleteMember, string viewName, string modBy)
         {
             _RAPSContext.TblRoleMembers.Remove(deleteMember);
-            _auditService.AuditRoleMemberChange(deleteMember, RAPSAuditService.AuditActionType.Delete, string.Format(_DeleteComment, viewName));
+            _auditService.AuditRoleMemberChange(deleteMember, RAPSAuditService.AuditActionType.Delete, string.Format(_DeleteComment, viewName), modBy);
             _RAPSContext.SaveChanges();
         }
 

--- a/web/Areas/Scheduler/Models/ScheduledJobContext.cs
+++ b/web/Areas/Scheduler/Models/ScheduledJobContext.cs
@@ -1,0 +1,49 @@
+using Hangfire.Console;
+using Hangfire.Server;
+
+namespace Viper.Areas.Scheduler.Models;
+
+/// <summary>
+/// Per-execution context handed to every <see cref="Services.IScheduledJob"/>
+/// implementation. Background jobs have no HTTP context, so the framework
+/// resolves the effective <see cref="ModBy"/> here and the job stamps audit
+/// rows with that value rather than reaching for <c>UserHelper.GetCurrentUser()</c>.
+/// </summary>
+public sealed class ScheduledJobContext
+{
+    /// <summary>
+    /// Audit actor stamped on rows produced by scheduler-triggered runs.
+    /// 7 chars to fit the legacy <c>tblRoleMembers.ModBy varchar(8)</c>
+    /// column while staying distinct from the existing <c>"__system"</c>
+    /// convention.
+    /// </summary>
+    public const string SchedulerActor = "__sched";
+
+    private readonly PerformContext? _performContext;
+
+    public ScheduledJobContext(string modBy, PerformContext? performContext = null)
+    {
+        if (string.IsNullOrWhiteSpace(modBy))
+        {
+            throw new ArgumentException("modBy is required.", nameof(modBy));
+        }
+        ModBy = modBy;
+        _performContext = performContext;
+    }
+
+    /// <summary>
+    /// Audit actor. Always <see cref="SchedulerActor"/> today; if a manual
+    /// trigger path is added later it can pass a real LoginId here.
+    /// </summary>
+    public string ModBy { get; }
+
+    /// <summary>
+    /// Writes a line to the job's Hangfire dashboard console pane. No-op when
+    /// the job runs outside Hangfire (unit tests, manual invocation), so jobs
+    /// can call this unconditionally without nullable-context noise.
+    /// </summary>
+    public void WriteLine(string message)
+    {
+        _performContext?.WriteLine(message);
+    }
+}

--- a/web/Areas/Scheduler/README.md
+++ b/web/Areas/Scheduler/README.md
@@ -1,0 +1,175 @@
+# Scheduler
+
+Cron-driven background jobs for VIPER. Built on Hangfire 1.8 with SQL Server
+storage; jobs are written against a thin `IScheduledJob` abstraction so they
+do not depend on Hangfire types directly.
+
+This document is the operational source of truth for the scheduler:
+how to add a job, how it is configured, and how to triage incidents.
+
+---
+
+## Onboarding a job
+
+Every recurring job is a class that implements `IScheduledJob` and carries a
+`[ScheduledJob]` attribute. Discovery happens at startup; there is no
+manifest file to update.
+
+### 1. Declare the job
+
+Place the file under your area's `Jobs/` folder. Example, the RAPS
+role-membership refresh:
+
+```csharp
+// web/Areas/RAPS/Jobs/RapsRoleRefreshScheduledJob.cs
+[ScheduledJob(id: "raps:role-refresh", cron: "0 0 * * *", TimeZoneId = "Pacific Standard Time")]
+public sealed class RapsRoleRefreshScheduledJob : IScheduledJob
+{
+    private readonly RAPSContext _rapsContext;
+    private readonly ILogger<RapsRoleRefreshScheduledJob> _logger;
+
+    public RapsRoleRefreshScheduledJob(
+        RAPSContext rapsContext,
+        ILogger<RapsRoleRefreshScheduledJob> logger)
+    {
+        _rapsContext = rapsContext;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(ScheduledJobContext context, CancellationToken ct)
+    {
+        var roleViews = new RoleViews(_rapsContext);
+        await roleViews.UpdateRoles(modBy: context.ModBy, debugOnly: false, ct: ct);
+    }
+}
+```
+
+### 2. Naming rules
+
+| Field | Rule |
+|---|---|
+| `id` | `area:job-name` (e.g. `raps:role-refresh`). |
+| `cron` | Five-field Hangfire cron (`m h dom mon dow`). |
+| `TimeZoneId` | Defaults to `Pacific Standard Time`. UC Davis runs Windows; IANA aliases like `America/Los_Angeles` also work. |
+
+### 3. Stamping audit rows
+
+Background jobs run with no HTTP context, so `UserHelper.GetCurrentUser()`
+is **not available**. Every job receives a `ScheduledJobContext` whose
+`ModBy` property is the audit actor for this run — pass it through to
+your service layer; do not derive it inside the job.
+
+`ModBy` is `"__sched"` (7 chars; the legacy `tblRoleMembers.ModBy`
+column is `varchar(8)`, so the stamp is shortened to fit while staying
+distinct from the existing `"__system"` convention). Existing audit
+queries can filter on `WHERE ModBy = '__sched'` to isolate
+scheduler-driven changes from human-driven changes.
+
+### 4. DI
+
+Job dependencies are resolved from a fresh DI scope per execution. Any
+`Scoped` service (DbContexts, scoped services from Scrutor) works without
+extra wiring &mdash; the discovery pass registers your job type as
+`Scoped` for you.
+
+### 5. What runs where
+
+| Surface | Mechanism |
+|---|---|
+| Initial registration | At app startup, after Hangfire is mounted, every `[ScheduledJob]`-declared type is `AddOrUpdate`'d. Idempotent. |
+| Subsequent registrations | A fresh deploy with new jobs picks them up on next startup. |
+
+---
+
+## Configuration
+
+All settings live in `appsettings.{Environment}.json` (or AWS SSM
+parameters in deployed environments).
+
+| Key | Purpose | Default |
+|---|---|---|
+| `Hangfire:Enabled` | Master switch. When `false`, no scheduler wiring runs and the dashboard is unreachable. | `true` |
+| `Hangfire:AutoSchedule` | When `false`, recurring jobs register with `Cron.Never` so cron never fires. The worker still runs and the dashboard still mounts, so operators can fire jobs via "Trigger now" or `BackgroundJob.Enqueue`. Local dev sets this `false` to require manual triggering. | `true` |
+| `ConnectionStrings:VIPER` | The database that hosts Hangfire's tables. Required when `Hangfire:Enabled=true`. | n/a |
+| `IPAddressAllowlistConfiguration:InternalAllowlist` | Source-IP gate for `/health/detail` and the HealthChecks UI. Add SVM infra ranges + your office subnet. | localhost only |
+
+The dashboard does **not** read this config; it is always mounted at
+`/scheduler/dashboard` when Hangfire is enabled and is gated by RAPS,
+not IP.
+
+---
+
+## Access
+
+| Surface | URL | Auth |
+|---|---|---|
+| Hangfire dashboard | `/scheduler/dashboard` | Cookie auth (CAS) + RAPS permission `SVMSecure.CATS.scheduledJobs` |
+| Health (liveness) | `/health` | Anonymous (Jenkins polls it) |
+| Health (detail) | `/health/detail` | IP-allowlisted to `InternalAllowlist` |
+
+`SVMSecure.CATS.scheduledJobs` is the same permission the legacy
+ColdFusion VIPER scheduler (`cats/inc_scheduledTasks.cfm`) checks &mdash;
+admins who already manage the legacy scheduler inherit access without a
+provisioning step.
+
+### Dashboard add-ons
+
+Two Hangfire dashboard plugins enrich the operator experience:
+
+- **Hangfire.Console** &mdash; per-job console output appears inline on the
+  job's detail page. Jobs call `context.WriteLine(...)` on the
+  `ScheduledJobContext` they receive; the output is captured in storage
+  and rendered in the dashboard.
+- **Hangfire.Heartbeat** &mdash; CPU, memory, and uptime metrics for each
+  registered worker are shown on the dashboard's Servers page (refreshed
+  every 30 s). Useful for spotting a stuck worker before users do.
+
+---
+
+## Operations runbook
+
+### Heartbeat verification
+
+| Symptom | Where to look |
+|---|---|
+| "Is the scheduler alive?" | `/health/detail` &mdash; the `hangfire` check reports `Healthy` (one or more servers with recent heartbeats), `Degraded` (storage reachable but no servers), or `Unhealthy` (storage error or all heartbeats > 2 minutes stale). |
+| "Did this job run?" | Dashboard &rarr; Recurring Jobs &rarr; row for the id; columns show last/next execution and last state. |
+| "Are workers processing?" | Dashboard &rarr; Servers panel; heartbeats refresh every 30 seconds. |
+
+### Retrying a failed job
+
+1. Open `/scheduler/dashboard`.
+2. Failed jobs appear in the **Failed** queue.
+3. Click the job &rarr; **Requeue** to retry once, or **Delete** to discard.
+4. Recurring jobs that fail still trigger on their next cron schedule
+   regardless &mdash; requeue is for retrying the specific failed
+   instance.
+
+### Pre-escalation checklist
+
+Before paging a developer, verify in this order:
+
+1. **Connection string** &mdash; `ConnectionStrings:VIPER` resolves and
+   the SQL login has read/write on the `HangFire` schema.
+2. **Permission grant** &mdash; the user holds
+   `SVMSecure.CATS.scheduledJobs` (check RAPS).
+3. **Server heartbeat** &mdash; `/health/detail` returns `hangfire`
+   `Healthy`. If `Degraded` (no servers), the worker process is down or
+   not started; confirm `Hangfire:Enabled=true` and check application
+   startup logs for `"Hangfire is enabled but ConnectionStrings:VIPER is
+   empty"`.
+4. **Recent deploys** &mdash; a job that disappeared after a deploy is
+   re-registered on the next app startup (idempotent `AddOrUpdate`).
+   Restart the app to force it.
+
+---
+
+## Related code
+
+| Concern | Location |
+|---|---|
+| Hangfire wiring (DI, dashboard mount) | `web/Classes/Scheduler/HangfireExtensions.cs` |
+| Dashboard auth filter | `web/Classes/Scheduler/HangfireDashboardAuthorizationFilter.cs` |
+| Per-job logging filter | `web/Classes/Scheduler/HangfireJobLoggingFilter.cs` |
+| Health check | `web/Classes/HealthChecks/HangfireHealthCheck.cs` |
+| Job abstraction | `web/Areas/Scheduler/Services/IScheduledJob.cs`, `ScheduledJobAttribute.cs`, `ScheduledJobDiscovery.cs`, `ScheduledJobRunner.cs` |

--- a/web/Areas/Scheduler/Services/IScheduledJob.cs
+++ b/web/Areas/Scheduler/Services/IScheduledJob.cs
@@ -1,0 +1,18 @@
+using Viper.Areas.Scheduler.Models;
+
+namespace Viper.Areas.Scheduler.Services;
+
+/// <summary>
+/// Contract every cron-driven background job in VIPER implements. The
+/// scheduler discovers <c>IScheduledJob</c> registrations at startup and
+/// wires each one into Hangfire based on its <see cref="ScheduledJobAttribute"/>.
+/// Implementations should not call <c>UserHelper.GetCurrentUser()</c>; the
+/// effective audit actor is supplied via the per-run context.
+/// </summary>
+public interface IScheduledJob
+{
+    /// <summary>Executes one run of the scheduled job.</summary>
+    /// <param name="context">Per-run trigger source and audit actor.</param>
+    /// <param name="ct">Cancellation token honored by long-running jobs.</param>
+    Task RunAsync(ScheduledJobContext context, CancellationToken ct);
+}

--- a/web/Areas/Scheduler/Services/ScheduledJobAttribute.cs
+++ b/web/Areas/Scheduler/Services/ScheduledJobAttribute.cs
@@ -1,0 +1,28 @@
+namespace Viper.Areas.Scheduler.Services;
+
+/// <summary>
+/// Declares the cron schedule and recurring-job id of an <see cref="IScheduledJob"/>.
+/// The discovery pass at startup reads this attribute and registers the job
+/// with Hangfire.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class ScheduledJobAttribute : Attribute
+{
+    public ScheduledJobAttribute(string id, string cron)
+    {
+        Id = id;
+        Cron = cron;
+    }
+
+    /// <summary>Recurring-job id.</summary>
+    public string Id { get; }
+
+    /// <summary>Hangfire cron expression (5 or 6 field).</summary>
+    public string Cron { get; }
+
+    /// <summary>
+    /// IANA or Windows time zone id. Defaults to Pacific (UC Davis); set
+    /// explicitly when a job needs a different reference time zone.
+    /// </summary>
+    public string TimeZoneId { get; set; } = "Pacific Standard Time";
+}

--- a/web/Areas/Scheduler/Services/ScheduledJobDiscovery.cs
+++ b/web/Areas/Scheduler/Services/ScheduledJobDiscovery.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+using Hangfire;
+
+namespace Viper.Areas.Scheduler.Services;
+
+/// <summary>
+/// Discovers <see cref="IScheduledJob"/> implementations annotated with
+/// <see cref="ScheduledJobAttribute"/> and produces a registry plus DI
+/// registrations for each.
+/// </summary>
+public static class ScheduledJobDiscovery
+{
+    /// <summary>
+    /// Scans the supplied assemblies for concrete classes that implement
+    /// <see cref="IScheduledJob"/> and carry a <see cref="ScheduledJobAttribute"/>,
+    /// registers each job type and the runner with DI, and returns the
+    /// resulting metadata.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when two jobs declare the same id.
+    /// </exception>
+    public static IReadOnlyList<ScheduledJobMetadata> RegisterScheduledJobs(
+        IServiceCollection services,
+        IEnumerable<Assembly> assemblies)
+    {
+        var found = new Dictionary<string, ScheduledJobMetadata>(StringComparer.Ordinal);
+
+        foreach (var asm in assemblies)
+        {
+            foreach (var type in asm.GetTypes())
+            {
+                if (type.IsAbstract || type.IsInterface)
+                {
+                    continue;
+                }
+                if (!typeof(IScheduledJob).IsAssignableFrom(type))
+                {
+                    continue;
+                }
+
+                var attr = type.GetCustomAttribute<ScheduledJobAttribute>();
+                if (attr == null)
+                {
+                    throw new InvalidOperationException(
+                        $"{type.FullName} implements IScheduledJob but is missing [ScheduledJob]; either add the attribute or unregister the type.");
+                }
+
+                if (found.TryGetValue(attr.Id, out var existing))
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate scheduled-job id '{attr.Id}' on {type.FullName} (already declared by {existing.JobType.FullName}).");
+                }
+
+                services.AddScoped(type);
+                found[attr.Id] = new ScheduledJobMetadata(
+                    type,
+                    attr.Id,
+                    attr.Cron,
+                    attr.TimeZoneId);
+            }
+        }
+
+        var snapshot = new System.Collections.ObjectModel.ReadOnlyDictionary<string, ScheduledJobMetadata>(found);
+        services.AddSingleton<IScheduledJobRegistry>(new ScheduledJobRegistry(snapshot));
+        services.AddTransient<ScheduledJobRunner>();
+
+        return [.. found.Values];
+    }
+
+    /// <summary>
+    /// Calls <see cref="IRecurringJobManager.AddOrUpdate"/> for each declared
+    /// job. Idempotent: safe to invoke on every startup. When
+    /// <paramref name="autoSchedule"/> is false, every job is registered with
+    /// <see cref="Cron.Never"/> so it is visible in the dashboard but never
+    /// fires on a schedule (operators can still use "Trigger now" or
+    /// <c>BackgroundJob.Enqueue</c>).
+    /// </summary>
+    public static void RegisterRecurringJobs(
+        IRecurringJobManager manager,
+        IEnumerable<ScheduledJobMetadata> jobs,
+        bool autoSchedule = true)
+    {
+        foreach (var meta in jobs)
+        {
+            var cron = autoSchedule ? meta.Cron : Cron.Never();
+            // PerformContext is null in the expression; Hangfire substitutes
+            // the real context at execution time (same pattern as IJobCancellationToken).
+            manager.AddOrUpdate<ScheduledJobRunner>(
+                meta.Id,
+                runner => runner.RunAsync(meta.Id, JobCancellationToken.Null, null!),
+                cron,
+                new RecurringJobOptions
+                {
+                    TimeZone = ResolveTimeZone(meta.TimeZoneId),
+                });
+        }
+    }
+
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+    private static TimeZoneInfo ResolveTimeZone(string id)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(id);
+        }
+        catch (TimeZoneNotFoundException ex)
+        {
+            _logger.Warn(ex, "Scheduled job timezone '{0}' not found; falling back to UTC.", id);
+            return TimeZoneInfo.Utc;
+        }
+        catch (InvalidTimeZoneException ex)
+        {
+            _logger.Warn(ex, "Scheduled job timezone '{0}' is invalid; falling back to UTC.", id);
+            return TimeZoneInfo.Utc;
+        }
+    }
+}

--- a/web/Areas/Scheduler/Services/ScheduledJobRegistry.cs
+++ b/web/Areas/Scheduler/Services/ScheduledJobRegistry.cs
@@ -1,0 +1,45 @@
+namespace Viper.Areas.Scheduler.Services;
+
+/// <summary>
+/// One declaration of a scheduled job, materialized from the
+/// <see cref="ScheduledJobAttribute"/> on its implementing type. Used by the
+/// startup registrar to wire Hangfire.
+/// </summary>
+public sealed class ScheduledJobMetadata
+{
+    public ScheduledJobMetadata(
+        Type jobType,
+        string id,
+        string cron,
+        string timeZoneId)
+    {
+        JobType = jobType;
+        Id = id;
+        Cron = cron;
+        TimeZoneId = timeZoneId;
+    }
+
+    public Type JobType { get; }
+    public string Id { get; }
+    public string Cron { get; }
+    public string TimeZoneId { get; }
+}
+
+/// <summary>
+/// Frozen view of every <see cref="IScheduledJob"/> declared in the running
+/// process, indexed by recurring-job id. Populated once at startup.
+/// </summary>
+public interface IScheduledJobRegistry
+{
+    IReadOnlyDictionary<string, ScheduledJobMetadata> JobsById { get; }
+}
+
+public sealed class ScheduledJobRegistry : IScheduledJobRegistry
+{
+    public ScheduledJobRegistry(IReadOnlyDictionary<string, ScheduledJobMetadata> jobsById)
+    {
+        JobsById = jobsById;
+    }
+
+    public IReadOnlyDictionary<string, ScheduledJobMetadata> JobsById { get; }
+}

--- a/web/Areas/Scheduler/Services/ScheduledJobRunner.cs
+++ b/web/Areas/Scheduler/Services/ScheduledJobRunner.cs
@@ -1,0 +1,60 @@
+using Hangfire;
+using Hangfire.Server;
+using Viper.Areas.Scheduler.Models;
+using Viper.Classes.Utilities;
+
+namespace Viper.Areas.Scheduler.Services;
+
+/// <summary>
+/// Hangfire-side dispatcher. Hangfire cannot serialize a method call against
+/// an interface type, so every recurring registration targets this concrete
+/// class. The runner resolves the actual <see cref="IScheduledJob"/> from DI
+/// by id at execution time and hands it a <see cref="ScheduledJobContext"/>
+/// stamped with the system actor.
+/// </summary>
+public sealed class ScheduledJobRunner
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ScheduledJobRunner> _logger;
+
+    public ScheduledJobRunner(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ScheduledJobRunner> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Hangfire invokes this method with the scheduled job's id. The
+    /// <see cref="IJobCancellationToken"/> parameter is replaced by Hangfire
+    /// at runtime with one tied to the server's shutdown signal so jobs can
+    /// honor cooperative cancellation. The <see cref="PerformContext"/> is
+    /// also injected by Hangfire and threaded into <see cref="ScheduledJobContext"/>
+    /// so jobs can write to the dashboard console via <c>context.WriteLine</c>.
+    /// A fresh DI scope is created per execution so each run gets its own
+    /// DbContext.
+    /// </summary>
+    public async Task RunAsync(
+        string jobId,
+        IJobCancellationToken cancellationToken,
+        PerformContext? performContext)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IScheduledJobRegistry>();
+        if (!registry.JobsById.TryGetValue(jobId, out var metadata))
+        {
+            _logger.LogWarning(
+                "ScheduledJobRunner invoked with unknown id {JobId}; no IScheduledJob registered. Skipping.",
+                LogSanitizer.SanitizeString(jobId));
+            return;
+        }
+
+        var job = (IScheduledJob)scope.ServiceProvider.GetRequiredService(metadata.JobType);
+        var context = new ScheduledJobContext(
+            ScheduledJobContext.SchedulerActor,
+            performContext);
+
+        await job.RunAsync(context, cancellationToken.ShutdownToken);
+    }
+}

--- a/web/Classes/ForwardedHeadersExtensions.cs
+++ b/web/Classes/ForwardedHeadersExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.HttpOverrides;
+using NLog;
+using System.Net;
+using Viper.Classes.Utilities;
+
+namespace Viper.Classes
+{
+    /// <summary>
+    /// Wires <see cref="ForwardedHeadersOptions"/> for the test/prod proxy
+    /// chain (User -> Cloudflare -> F5 -> app). Kept out of Program.cs so
+    /// Main stays small.
+    /// </summary>
+    public static class ForwardedHeadersExtensions
+    {
+        // The F5's internal IP. Static so it's only parsed once per process.
+        private static readonly IPAddress F5InternalIp = IPAddress.Parse("192.168.56.134");
+
+        /// <summary>
+        /// Registers ForwardedHeadersOptions with the F5 + Cloudflare CIDRs as
+        /// trusted proxies. No-op in Development (UseForwardedHeaders isn't
+        /// applied there either, and we want to avoid the cloudflare.com fetch
+        /// on every local startup).
+        /// </summary>
+        public static IServiceCollection AddViperForwardedHeaders(
+            this IServiceCollection services,
+            IHostEnvironment environment,
+            Logger logger)
+        {
+            if (environment.IsDevelopment())
+            {
+                return services;
+            }
+
+            var cloudflareCidrs = CloudflareNetworks.FetchOrFallback(logger);
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders =
+                    ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.KnownProxies.Add(F5InternalIp);
+
+                // Cloudflare fronts vetmed.ucdavis.edu. The chain is
+                // User -> Cloudflare -> F5 -> app, so the middleware must walk two
+                // proxy hops to land on the real client IP. Default ForwardLimit
+                // is 1, which stops at the CF edge - bump to 2.
+                options.ForwardLimit = 2;
+                AddCloudflareCidrs(options, cloudflareCidrs, logger);
+            });
+
+            return services;
+        }
+
+        // cidrs come from cloudflare.com (or our hardcoded fallback). A single
+        // malformed entry in the live response shouldn't crash startup - skip
+        // it and keep the rest of the allowlist.
+        private static void AddCloudflareCidrs(
+            ForwardedHeadersOptions options,
+            IEnumerable<string> cidrs,
+            Logger logger)
+        {
+            foreach (var cidr in cidrs)
+            {
+                try
+                {
+                    options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(cidr));
+                }
+                catch (FormatException ex)
+                {
+                    logger.Warn(ex, "Skipping invalid Cloudflare CIDR: {Cidr}", LogSanitizer.SanitizeString(cidr));
+                }
+            }
+        }
+    }
+}

--- a/web/Classes/HealthChecks/HangfireHealthCheck.cs
+++ b/web/Classes/HealthChecks/HangfireHealthCheck.cs
@@ -1,0 +1,93 @@
+using Hangfire;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Viper.Classes.HealthChecks
+{
+    /// <summary>
+    /// Reports the state of the Hangfire job system: storage reachability,
+    /// registered server count, and heartbeat freshness. Only registered when
+    /// Hangfire is enabled, so JobStorage is guaranteed to be in DI.
+    /// </summary>
+    public class HangfireHealthCheck : IHealthCheck
+    {
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        // Hangfire's default heartbeat interval is 30s; 2 minutes covers a few
+        // missed beats before we call a server stale.
+        private static readonly TimeSpan StaleHeartbeatThreshold = TimeSpan.FromMinutes(2);
+
+        private readonly JobStorage _storage;
+
+        public HangfireHealthCheck(JobStorage storage)
+        {
+            _storage = storage;
+        }
+
+        /// <summary>
+        /// Probes Hangfire storage and server heartbeats, reporting Healthy,
+        /// Degraded (no servers), or Unhealthy (storage error or stale heartbeats).
+        /// </summary>
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            IMonitoringApi monitoringApi;
+            StatisticsDto stats;
+            IList<ServerDto> servers;
+            try
+            {
+                monitoringApi = _storage.GetMonitoringApi();
+                stats = monitoringApi.GetStatistics();
+                servers = monitoringApi.Servers();
+            }
+            // Hangfire wraps SqlException/TimeoutException/InvalidOperationException
+            // and more inside its storage layer; letting any escape would crash the
+            // health-response writer, so a broad catch is the right call here.
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Hangfire health check failed to query storage");
+                return Task.FromResult(HealthCheckResult.Unhealthy(
+                    "Hangfire storage unreachable.", exception: ex));
+            }
+
+            var data = new Dictionary<string, object>
+            {
+                ["servers"] = stats.Servers,
+                ["enqueued"] = stats.Enqueued,
+                ["scheduled"] = stats.Scheduled,
+                ["processing"] = stats.Processing,
+                ["failed"] = stats.Failed,
+                ["recurring"] = stats.Recurring,
+            };
+
+            if (servers.Count == 0)
+            {
+                return Task.FromResult(HealthCheckResult.Degraded(
+                    "Hangfire storage reachable but no servers registered.", data: data));
+            }
+
+            var now = DateTime.UtcNow;
+            // Treat a null Heartbeat as maximally stale so a server that never
+            // reported in still trips the stale-heartbeat path.
+            var ages = servers
+                .Select(s => s.Heartbeat.HasValue ? now - s.Heartbeat.Value : TimeSpan.MaxValue)
+                .ToList();
+            var oldestAge = ages.Max();
+
+            if (ages.All(age => age > StaleHeartbeatThreshold))
+            {
+                var formatted = oldestAge == TimeSpan.MaxValue
+                    ? "never"
+                    : oldestAge.ToString("hh\\:mm\\:ss");
+                return Task.FromResult(HealthCheckResult.Unhealthy(
+                    $"Hangfire servers registered but heartbeats are stale (oldest: {formatted}).",
+                    data: data));
+            }
+
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"Hangfire OK: {servers.Count} server(s).", data: data));
+        }
+    }
+}

--- a/web/Classes/Scheduler/HangfireDashboardAuthorizationFilter.cs
+++ b/web/Classes/Scheduler/HangfireDashboardAuthorizationFilter.cs
@@ -1,0 +1,52 @@
+using Hangfire.Dashboard;
+using Viper.Classes.SQLContext;
+
+namespace Viper.Classes.Scheduler
+{
+    /// <summary>
+    /// Gate the Hangfire dashboard on the same RAPS permission used by the
+    /// scheduler API (<c>SVMSecure.CATS.scheduledJobs</c>).
+    /// Unauthenticated users are handled upstream by
+    /// <c>RequireAuthorization()</c> on the mapped endpoint, which triggers
+    /// the cookie auth challenge and redirects to <c>/login</c> (and on to
+    /// CAS); this filter therefore only sees authenticated principals and
+    /// decides authorize-or-403 based on permission membership. When the
+    /// filter returns false for an authenticated user, Hangfire's middleware
+    /// writes a 403.
+    /// </summary>
+    public sealed class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+    {
+        public const string SchedulerPermission = "SVMSecure.CATS.scheduledJobs";
+
+        public bool Authorize(DashboardContext context)
+        {
+            var httpContext = context.GetHttpContext();
+            var user = httpContext.User;
+
+            if (user.Identity == null || !user.Identity.IsAuthenticated)
+            {
+                return false;
+            }
+
+            var services = httpContext.RequestServices;
+            var userHelper = services.GetService<IUserHelper>();
+            var rapsContext = services.GetService<RAPSContext>();
+            var aaudContext = services.GetService<AAUDContext>();
+
+            if (userHelper == null || rapsContext == null || aaudContext == null)
+            {
+                return false;
+            }
+
+            var loginId = user.Identity.Name;
+            if (string.IsNullOrEmpty(loginId))
+            {
+                return false;
+            }
+
+            var aaudUser = userHelper.GetByLoginId(aaudContext, loginId);
+            return aaudUser != null
+                && userHelper.HasPermission(rapsContext, aaudUser, SchedulerPermission);
+        }
+    }
+}

--- a/web/Classes/Scheduler/HangfireExtensions.cs
+++ b/web/Classes/Scheduler/HangfireExtensions.cs
@@ -107,9 +107,9 @@ namespace Viper.Classes.Scheduler
                 return app;
             }
 
-            // The dashboard's "Back to site" link uses AppPath verbatim;
-            // we have no UsePathBase middleware so the /2/ deployment prefix
-            // (TEST/PROD) must come from config.
+            // Hangfire renders the configured AppPath as-is in the dashboard
+            // "Back to site" link. With no UsePathBase middleware, we need to
+            // supply the /2 deployment prefix from configuration ourselves.
             var dashboardAppPath = app.Configuration.GetValue<string>(DashboardAppPathKey) ?? "/Computing";
             app.MapHangfireDashboard(DashboardPath, new DashboardOptions
             {

--- a/web/Classes/Scheduler/HangfireExtensions.cs
+++ b/web/Classes/Scheduler/HangfireExtensions.cs
@@ -1,0 +1,126 @@
+using System.Reflection;
+using Hangfire;
+using Hangfire.Console;
+using Hangfire.Heartbeat;
+using Hangfire.Heartbeat.Server;
+using Hangfire.Server;
+using NLog;
+using Viper.Areas.Scheduler.Services;
+using Viper.Classes.HealthChecks;
+
+namespace Viper.Classes.Scheduler
+{
+    /// <summary>
+    /// DI + pipeline wiring for Hangfire. Gated by <c>Hangfire:Enabled</c>;
+    /// when the flag is false the rest of the web app continues to start
+    /// normally.
+    /// </summary>
+    public static class HangfireExtensions
+    {
+        public const string DashboardPath = "/scheduler/dashboard";
+        private const string EnabledKey = "Hangfire:Enabled";
+        private const string AutoScheduleKey = "Hangfire:AutoSchedule";
+
+        /// <summary>
+        /// Registers Hangfire services + the background server when
+        /// <c>Hangfire:Enabled</c> is true. Hangfire's tables live in the
+        /// VIPER database under the HangFire schema (auto-migrated on first
+        /// server start). When <c>Hangfire:AutoSchedule</c> is false (e.g.
+        /// local dev), the worker still runs and the dashboard still mounts,
+        /// but recurring jobs are registered with <c>Cron.Never</c> so cron
+        /// never fires; jobs are visible in the dashboard and can be invoked
+        /// via "Trigger now" or <c>BackgroundJob.Enqueue</c>.
+        /// </summary>
+        public static IServiceCollection AddViperHangfire(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Logger logger)
+        {
+            if (!configuration.GetValue<bool>(EnabledKey))
+            {
+                return services;
+            }
+
+            var connectionString = configuration.GetConnectionString("VIPER");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                logger.Error(
+                    "Hangfire is enabled but ConnectionStrings:VIPER is empty. "
+                    + "Hangfire will be disabled for this process.");
+                return services;
+            }
+
+            // Filter is a singleton so a single ILogger instance and any future
+            // shared state (counters, etc.) stay process-wide.
+            services.AddSingleton<HangfireJobLoggingFilter>();
+            services.AddHangfire((sp, config) => config
+                .UseSqlServerStorage(connectionString, new Hangfire.SqlServer.SqlServerStorageOptions
+                {
+                    SchemaName = "HangFire",
+                })
+                .UseFilter(sp.GetRequiredService<HangfireJobLoggingFilter>())
+                // Hangfire.Console: per-job execution logs in the dashboard
+                // (jobs accept PerformContext and call context.WriteLine).
+                .UseConsole()
+                // Hangfire.Heartbeat: dashboard tab that renders server
+                // metrics. The recorder is added below as a background process
+                // on the worker; both must run for the graph to populate.
+                .UseHeartbeatPage(checkInterval: TimeSpan.FromSeconds(30)));
+
+            // ProcessMonitor (from Hangfire.Heartbeat) records the CPU/RAM/
+            // uptime metrics rendered by UseHeartbeatPage. Registering it as
+            // an IBackgroundProcess in DI lets AddHangfireServer pick it up
+            // alongside the default workers without us having to pass storage
+            // explicitly (the overload that takes additionalProcesses also
+            // requires a non-null JobStorage).
+            services.AddSingleton<IBackgroundProcess>(_ => new ProcessMonitor(checkInterval: TimeSpan.FromSeconds(30)));
+            services.AddHangfireServer();
+
+            // Hangfire-specific check piggybacks on the /health/detail "ready"
+            // surface stood up in PR 0. Only registered when Hangfire itself is
+            // wired so /health/detail doesn't claim a missing subsystem is down.
+            services.AddHealthChecks()
+                .AddCheck<HangfireHealthCheck>("hangfire", tags: new[] { "ready" });
+
+            ScheduledJobDiscovery.RegisterScheduledJobs(
+                services,
+                new[] { Assembly.GetExecutingAssembly() });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Mounts the Hangfire dashboard at <see cref="DashboardPath"/> when
+        /// Hangfire is actually registered (i.e. <see cref="AddViperHangfire"/>
+        /// ran successfully). Unauthenticated visitors hit
+        /// <c>RequireAuthorization()</c> first and are redirected to CAS via
+        /// the cookie auth challenge; authenticated visitors are gated by
+        /// <see cref="HangfireDashboardAuthorizationFilter"/>, which checks
+        /// the <c>SVMSecure.CATS.scheduledJobs</c> RAPS permission. Call AFTER
+        /// UseRouting / UseAuthentication / UseAuthorization.
+        /// </summary>
+        public static WebApplication UseViperHangfire(this WebApplication app)
+        {
+            if (app.Services.GetService<JobStorage>() == null)
+            {
+                return app;
+            }
+
+            app.MapHangfireDashboard(DashboardPath, new DashboardOptions
+            {
+                Authorization = new[] { new HangfireDashboardAuthorizationFilter() },
+                DashboardTitle = "VIPER Scheduler",
+            }).RequireAuthorization();
+
+            // When AutoSchedule is off (dev), register every recurring job
+            // with Cron.Never so the dashboard still shows them and operators
+            // can fire them via "Trigger now" or BackgroundJob.Enqueue, but
+            // nothing fires on its own.
+            var autoSchedule = app.Configuration.GetValue<bool?>(AutoScheduleKey) ?? true;
+            var recurringJobManager = app.Services.GetRequiredService<IRecurringJobManager>();
+            var registry = app.Services.GetRequiredService<IScheduledJobRegistry>();
+            ScheduledJobDiscovery.RegisterRecurringJobs(recurringJobManager, registry.JobsById.Values, autoSchedule);
+            return app;
+        }
+    }
+}

--- a/web/Classes/Scheduler/HangfireExtensions.cs
+++ b/web/Classes/Scheduler/HangfireExtensions.cs
@@ -20,6 +20,7 @@ namespace Viper.Classes.Scheduler
         public const string DashboardPath = "/scheduler/dashboard";
         private const string EnabledKey = "Hangfire:Enabled";
         private const string AutoScheduleKey = "Hangfire:AutoSchedule";
+        private const string DashboardAppPathKey = "Hangfire:DashboardAppPath";
 
         /// <summary>
         /// Registers Hangfire services + the background server when
@@ -106,10 +107,15 @@ namespace Viper.Classes.Scheduler
                 return app;
             }
 
+            // The dashboard's "Back to site" link uses AppPath verbatim;
+            // we have no UsePathBase middleware so the /2/ deployment prefix
+            // (TEST/PROD) must come from config.
+            var dashboardAppPath = app.Configuration.GetValue<string>(DashboardAppPathKey) ?? "/Computing";
             app.MapHangfireDashboard(DashboardPath, new DashboardOptions
             {
                 Authorization = new[] { new HangfireDashboardAuthorizationFilter() },
                 DashboardTitle = "VIPER Scheduler",
+                AppPath = dashboardAppPath,
             }).RequireAuthorization();
 
             // When AutoSchedule is off (dev), register every recurring job

--- a/web/Classes/Scheduler/HangfireJobLoggingFilter.cs
+++ b/web/Classes/Scheduler/HangfireJobLoggingFilter.cs
@@ -1,0 +1,78 @@
+using Hangfire.Server;
+using Viper.Classes.Utilities;
+
+namespace Viper.Classes.Scheduler
+{
+    /// <summary>
+    /// Hangfire server filter that wraps every job execution in a structured
+    /// logging scope (jobId / recurringJobId) and emits start/complete/error
+    /// log entries. All user-influenced values are run through
+    /// <see cref="LogSanitizer"/> before being logged.
+    /// </summary>
+    public sealed class HangfireJobLoggingFilter : IServerFilter
+    {
+        private const string ScopeKey = "__HangfireLoggingScope";
+
+        private readonly ILogger<HangfireJobLoggingFilter> _logger;
+
+        public HangfireJobLoggingFilter(ILogger<HangfireJobLoggingFilter> logger)
+        {
+            _logger = logger;
+        }
+
+        public void OnPerforming(PerformingContext context)
+        {
+            var jobId = LogSanitizer.SanitizeId(context.BackgroundJob.Id);
+            var recurringJobId = LogSanitizer.SanitizeString(context.GetJobParameter<string>("RecurringJobId"));
+
+            // Stash the scope on context.Items because OnPerforming and OnPerformed
+            // are separate calls; a `using` block here would dispose too early.
+            var scope = _logger.BeginScope(new Dictionary<string, object>
+            {
+                ["jobId"] = jobId ?? string.Empty,
+                ["recurringJobId"] = recurringJobId ?? string.Empty
+            });
+
+            if (scope != null)
+            {
+                context.Items[ScopeKey] = scope;
+            }
+
+            // Log only argument metadata (count). Logging values risks leaking
+            // secrets/PII even after control-char sanitization, so the value
+            // strings are intentionally not emitted.
+            var argCount = context.BackgroundJob.Job.Args?.Count ?? 0;
+
+            _logger.LogInformation(
+                "Hangfire job starting: {JobType}.{JobMethod} (argCount={ArgCount})",
+                LogSanitizer.SanitizeString(context.BackgroundJob.Job.Type.FullName),
+                LogSanitizer.SanitizeString(context.BackgroundJob.Job.Method.Name),
+                argCount);
+        }
+
+        public void OnPerformed(PerformedContext context)
+        {
+            // Dispose the scope stashed by OnPerforming via `using` so the
+            // structured logging fields stay attached for the log lines below
+            // and are released at method exit.
+            using var scope = context.Items.TryGetValue(ScopeKey, out var stashed)
+                ? stashed as IDisposable
+                : null;
+            try
+            {
+                if (context.Exception != null)
+                {
+                    _logger.LogError(context.Exception, "Hangfire job threw exception");
+                }
+                else
+                {
+                    _logger.LogInformation("Hangfire job completed");
+                }
+            }
+            finally
+            {
+                context.Items.Remove(ScopeKey);
+            }
+        }
+    }
+}

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -32,6 +31,7 @@ using Viper.Areas.Effort.Data;
 using Viper.Areas.Effort.Services.Harvest;
 using Viper.Classes;
 using Viper.Classes.HealthChecks;
+using Viper.Classes.Scheduler;
 using Viper.Classes.SQLContext;
 using Viper.EmailTemplates.Services;
 using Viper.Services;
@@ -91,39 +91,9 @@ try
         logger.Fatal(ex, "Failed to get secrets from AWS");
     }
 
-    //Use forwarded for headers on test and prod. UseForwardedHeaders is
-    //only enabled outside Development (see below), so skip the cloudflare.com
-    //fetch in dev to avoid a network call on every local startup.
-    if (!builder.Environment.IsDevelopment())
-    {
-        var cloudflareCidrs = CloudflareNetworks.FetchOrFallback(logger);
-        builder.Services.Configure<ForwardedHeadersOptions>(options =>
-        {
-            options.ForwardedHeaders =
-                ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-            options.KnownProxies.Add(IPAddress.Parse("192.168.56.134")); //The F5's internal IP
-
-            // Cloudflare fronts vetmed.ucdavis.edu. The chain is
-            // User -> Cloudflare -> F5 -> app, so the middleware must walk two
-            // proxy hops to land on the real client IP. Default ForwardLimit
-            // is 1, which stops at the CF edge - bump to 2.
-            options.ForwardLimit = 2;
-            foreach (var cidr in cloudflareCidrs)
-            {
-                // cidrs come from cloudflare.com (or our hardcoded fallback). A
-                // single malformed entry in the live response shouldn't crash
-                // startup - skip it and keep the rest of the allowlist.
-                try
-                {
-                    options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(cidr));
-                }
-                catch (FormatException ex)
-                {
-                    logger.Warn(ex, "Skipping invalid Cloudflare CIDR: {Cidr}", cidr);
-                }
-            }
-        });
-    }
+    // Forwarded-headers wiring (Cloudflare + F5 trusted proxies). No-op
+    // in Development. See ForwardedHeadersExtensions.
+    builder.Services.AddViperForwardedHeaders(builder.Environment, logger);
 
     // Add services to the container.
     builder.Services.AddControllersWithViews(options =>
@@ -321,6 +291,9 @@ try
     // All health-check DI wiring lives in HealthCheckExtensions.
     builder.Services.AddViperHealthChecks(builder.Configuration, builder.Environment);
 
+    // Hangfire scheduler. No-op when Hangfire:Enabled is false.
+    builder.Services.AddViperHangfire(builder.Configuration, logger);
+
     // Add HttpClient for Vite proxy (development only)
     if (builder.Environment.IsDevelopment())
     {
@@ -517,6 +490,9 @@ try
 
     // All health-check pipeline wiring lives in HealthCheckExtensions.
     app.UseViperHealthChecks();
+
+    // Hangfire dashboard. No-op unless AddViperHangfire actually registered.
+    app.UseViperHangfire();
 
     // Define the default route mapping and require authentication by default (fail safe)
     app.MapControllerRoute(

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -399,6 +399,11 @@ try
 
     }
 
+    // Re-execute bare status-code responses (403, 404, etc.) through HomeController.Error
+    // so middleware that writes raw status codes — e.g. Hangfire's dashboard middleware
+    // when our auth filter denies — gets the same Razor error view as the rest of the app.
+    app.UseStatusCodePagesWithReExecute("/Error/{0}");
+
     // In development, set up Vite proxy BEFORE rewrite rules so it can handle .ts/.js files
     if (app.Environment.IsDevelopment())
     {

--- a/web/Views/Shared/Components/MainNav/MainNav.cs
+++ b/web/Views/Shared/Components/MainNav/MainNav.cs
@@ -64,6 +64,7 @@ namespace Viper.Views.Shared.Components.MainNav
             {
                 "raps" => "Computing",
                 "policy" => "Policies",
+                "scheduler" => "Computing",
                 _ => "VIPER Home",
             };
             return await Task.Run(() => View("Default", user));

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -49,6 +49,10 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.201.7" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="DotNetEnv" Version="3.2.0" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
+    <PackageReference Include="Hangfire.Console" Version="1.4.3" />
+    <PackageReference Include="Hangfire.Heartbeat" Version="0.6.0" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.23" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
@@ -88,6 +92,8 @@
     <Folder Include="Areas\ClinicalScheduler\Models\" />
     <Folder Include="Areas\CMS\Views\" />
     <Folder Include="Areas\RAPS\Data\" />
+    <Folder Include="Areas\Scheduler\Controllers\" />
+    <Folder Include="Areas\Scheduler\Services\" />
     <Folder Include="wwwroot\js\vue\" />
   </ItemGroup>
 

--- a/web/appsettings.Development.json
+++ b/web/appsettings.Development.json
@@ -22,6 +22,9 @@
   "Cas": {
     "CasBaseUrl": "https://ssodev.ucdavis.edu/cas/"
   },
+  "Hangfire": {
+    "AutoSchedule": false
+  },
   "EmailSettings": {
     "SmtpHost": "localhost",
     "SmtpPort": 1025,

--- a/web/appsettings.Production.json
+++ b/web/appsettings.Production.json
@@ -25,5 +25,8 @@
     "DefaultFromAddress": "svmithelp@ucdavis.edu",
     "UseMailpit": false,
     "BaseUrl": "https://viper.vetmed.ucdavis.edu/2"
+  },
+  "Hangfire": {
+    "DashboardAppPath": "/2/Computing"
   }
 }

--- a/web/appsettings.Test.json
+++ b/web/appsettings.Test.json
@@ -33,5 +33,8 @@
   "AWS": {
     "ProfilesLocation": "P:\\viper.net\\awscredentials",
     "Profile": "default"
+  },
+  "Hangfire": {
+    "DashboardAppPath": "/2/Computing"
   }
 }

--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -35,5 +35,9 @@
     "EffortSettings": {
         "VerificationEmailSubject": "Action required, timely ask - Effort data verification",
         "VerificationReplyDays": 7
+    },
+    "Hangfire": {
+        // Hangfire's tables live in ConnectionStrings:VIPER.
+        "Enabled": true
     }
 }


### PR DESCRIPTION
## Summary

Adds a shared, area-agnostic background-job scheduler on top of Hangfire 1.8 + SQL Server. Jobs implement a thin `IScheduledJob` and are auto-discovered. A CAS+RAPS-gated Hangfire dashboard sits on top. The RAPS nightly role-refresh is the first consumer.

`Hangfire:Enabled` defaults to `true`; flip to `false` in any environment to unwire everything.

## What an admin sees

- **Dashboard** at `/scheduler/dashboard`. Gated by `SVMSecure.CATS.scheduledJobs` (same permission as the legacy ColdFusion scheduler, so existing admins inherit access). Shows recurring jobs, queues, history, per-job execution console, and per-server CPU/RAM via the bundled Hangfire.Console + Hangfire.Heartbeat plugins.
- **Health check** `hangfire` on `/health/detail`: storage reachability + heartbeat freshness.

## What a job author sees

```csharp
[ScheduledJob(id: "raps:role-refresh", cron: "0 0 * * *", TimeZoneId = "Pacific Standard Time")]
public sealed class RapsRoleRefreshScheduledJob(RAPSContext ctx, ILogger<...> log) : IScheduledJob
{
    public async Task RunAsync(ScheduledJobContext context, CancellationToken ct)
    {
        context.WriteLine("Starting...");          // surfaces in dashboard console
        await new RoleViews(ctx).UpdateRoles(modBy: context.ModBy);
    }
}
```

Discovery scans the web assembly at startup, registers each job with DI, and wires Hangfire via a single dispatcher. Every run gets a fresh DI scope and a `ScheduledJobContext` carrying `TriggerSource` (Scheduled/Manual) and the effective `ModBy`. Jobs never call `UserHelper.GetCurrentUser()`.

## Configuration

| Key | Default | Purpose |
|---|---|---|
| `Hangfire:Enabled` | `true` | Master switch. False = nothing wires up. |
| `Hangfire:AutoSchedule` | `true` (dev: `false`) | When false, jobs register with `Cron.Never` so cron doesn't fire. Worker still runs and "Trigger now" still works. Local dev opts out so developers don't run cron jobs. |
| `ConnectionStrings:VIPER` | n/a | Hangfire's tables live here. |

## Where to focus review

- **`HangfireExtensions.cs`**: the wiring spine (DI, server, dashboard, plugins). All flag handling lives here.
- **`ScheduledJobDiscovery.cs` + `ScheduledJobRunner.cs`**: auto-registration + Hangfire dispatch.
- **`web/Areas/Scheduler/README.md`**: onboarding recipe + ops runbook.

## Decisions worth flagging

- **Hangfire.SqlServer in the existing VIPER DB**, no in-memory phase. Hangfire's tables auto-migrate on first server start.
- **`__sched` audit stamp** (not `__scheduler`). Legacy `tblRoleMembers.ModBy` is `varchar(8)`, so the canonical 11-char stamp truncated.
- **Scheduler nav tab shown whenever the user has the permission**, even if `Hangfire:Enabled=false`. Matches the legacy "Computing" link behavior; documented in the README.

## TEST database cleanup

Earlier branch commits deployed a `[HangFire].[SchedulerJobState]` marker table and registered a `__scheduler:reconcile` recurring job to TEST as part of a pause/resume API that has since been removed (YAGNI — Hangfire's dashboard provides "Trigger now" / "Requeue" and `Hangfire:AutoSchedule=false` covers env-wide off-switch needs). Before deploying this branch to TEST, run:

```sql
USE viper_test;  -- or whichever DB hosts TEST's HangFire schema
GO

IF EXISTS (
    SELECT 1 FROM sys.tables t
    INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
    WHERE s.name = 'HangFire' AND t.name = 'SchedulerJobState')
BEGIN
    DROP TABLE [HangFire].[SchedulerJobState];
END
GO

-- Remove the orphan reconciler recurring job from Hangfire storage so it
-- doesn't linger in the dashboard after this PR removes its registration code.
DELETE FROM [HangFire].[Hash] WHERE [Key] = 'recurring-job:__scheduler:reconcile';
DELETE FROM [HangFire].[Set]  WHERE [Key] = 'recurring-jobs' AND [Value] = '__scheduler:reconcile';
GO
```

## Test plan

- [x] Local: dashboard renders, heartbeat populates (CPU/RAM after ~30s), `raps:role-refresh` triggered manually surfaces all 48 per-role messages in the dashboard console
- [x] Backend tests pass (1966)
- [x] ReSharper PR-scoped gate clean
- [x] TEST smoke: run the SQL cleanup above, deploy, manually trigger `raps:role-refresh`, confirm it runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented background job scheduler with SQL Server storage integration
  * Added automated daily RAPS role refresh job
  * Added scheduler dashboard accessible at `/scheduler/dashboard` for job monitoring and management
  * Added health checks for scheduler operational monitoring

* **Documentation**
  * Added operational guide covering scheduler configuration, dashboard access, and troubleshooting

* **Tests**
  * Added comprehensive test coverage for scheduler functionality

* **Chores**
  * Added scheduler-related NuGet dependencies
  * Updated configuration to support scheduler enablement and auto-scheduling options

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/VIPER/pull/182)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->