### PR TITLE
VPR-138 fix(cms): harden DownloadZip and unblock controller route

### DIFF
--- a/test/CMS/DownloadZipSecurityTests.cs
+++ b/test/CMS/DownloadZipSecurityTests.cs
@@ -1,0 +1,344 @@
+using CmsData = Viper.Areas.CMS.Services.CmsFilePathSafety;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Security tests for the helpers that back <c>CMS.DownloadZip</c>.
+/// Covers the filename sanitizer used for the Content-Disposition header
+/// and the per-request temp-archive path builder (VPR-138).
+/// </summary>
+public sealed class DownloadZipSecurityTests
+{
+    #region SanitizeDownloadName
+
+    [Theory]
+    [InlineData(@"\..\..\evil.zip")]
+    [InlineData("../../evil.zip")]
+    [InlineData(@"C:\Windows\Temp\evil.zip")]
+    [InlineData("../evil")]
+    public void SanitizeDownloadName_StripsPathSeparatorsAndTraversal(string input)
+    {
+        var result = CmsData.SanitizeDownloadName(input);
+
+        Assert.DoesNotContain('\\', result);
+        Assert.DoesNotContain('/', result);
+        Assert.DoesNotContain("..", result);
+        Assert.EndsWith(".zip", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    [InlineData("///")]
+    [InlineData(@"\\\")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("...")]
+    [InlineData(". .")]
+    public void SanitizeDownloadName_NullEmptyOrJunk_ReturnsDefault(string? input)
+    {
+        var result = CmsData.SanitizeDownloadName(input);
+
+        Assert.Equal("FileDownload.zip", result);
+    }
+
+    [Fact]
+    public void SanitizeDownloadName_NameWithoutExtension_AppendsZip()
+    {
+        var result = CmsData.SanitizeDownloadName("export");
+
+        Assert.Equal("export.zip", result);
+    }
+
+    [Fact]
+    public void SanitizeDownloadName_NonZipExtension_ForcesZipSuffix()
+    {
+        // Documented choice: preserve the original name and append .zip so the
+        // response MIME (application/zip) always matches the filename.
+        var result = CmsData.SanitizeDownloadName("export.exe");
+
+        Assert.EndsWith(".zip", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("export.exe.zip", result);
+    }
+
+    [Fact]
+    public void SanitizeDownloadName_AlreadyZip_IsPreserved()
+    {
+        var result = CmsData.SanitizeDownloadName("monthly-report.zip");
+
+        Assert.Equal("monthly-report.zip", result);
+    }
+
+    [Fact]
+    public void SanitizeDownloadName_CaseInsensitiveZipExtension_IsPreserved()
+    {
+        var result = CmsData.SanitizeDownloadName("REPORT.ZIP");
+
+        Assert.Equal("REPORT.ZIP", result);
+    }
+
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("PRN")]
+    [InlineData("AUX")]
+    [InlineData("NUL")]
+    [InlineData("COM1")]
+    [InlineData("LPT1")]
+    [InlineData("con")]
+    [InlineData("CON.txt")]
+    public void SanitizeDownloadName_ReservedWindowsDeviceNames_ReturnsDefault(string input)
+    {
+        var result = CmsData.SanitizeDownloadName(input);
+
+        Assert.Equal("FileDownload.zip", result);
+    }
+
+    [Fact]
+    public void SanitizeDownloadName_AllowsSafeCharacters()
+    {
+        var result = CmsData.SanitizeDownloadName("My_File-01 v2.zip");
+
+        Assert.Equal("My_File-01 v2.zip", result);
+    }
+
+    #endregion
+
+    #region LooksLikeTraversalAttempt
+
+    [Theory]
+    [InlineData(@"\..\..\evil.zip")]
+    [InlineData("../../evil.zip")]
+    [InlineData(@"C:\Windows\Temp\evil.zip")]
+    [InlineData("../evil")]
+    [InlineData("..")]
+    [InlineData("nested/file.zip")]
+    [InlineData(@"nested\file.zip")]
+    public void LooksLikeTraversalAttempt_PathShapedInput_IsFlagged(string input)
+    {
+        Assert.True(CmsData.LooksLikeTraversalAttempt(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("export")]
+    [InlineData("monthly-report.zip")]
+    [InlineData("My_File-01 v2.zip")]
+    [InlineData("report.final.zip")]
+    [InlineData("report..final.zip")]
+    [InlineData("a..b")]
+    public void LooksLikeTraversalAttempt_PlainName_IsNotFlagged(string? input)
+    {
+        Assert.False(CmsData.LooksLikeTraversalAttempt(input));
+    }
+
+    #endregion
+
+    #region Regression guard (VPR-138)
+
+    // Before the fix, DownloadZip built the on-disk temp archive path by
+    // concatenating GetRootFileFolder() + ticks + user-supplied fileName.
+    // A traversal payload in fileName (e.g. \..\..\evil.zip) escaped the
+    // CMS root. The fix splits the flow: user input feeds only the
+    // Content-Disposition name (SanitizeDownloadName); the on-disk path
+    // is generated from a server-side GUID under a dedicated temp root
+    // (BuildTempArchivePath).
+    //
+    // This test exercises both helpers as DownloadZip wires them and
+    // asserts the traversal payload cannot influence the on-disk path,
+    // even if a future refactor reintroduces the old concatenation.
+    [Theory]
+    [InlineData(@"\..\..\evil.zip")]
+    [InlineData("../../evil.zip")]
+    [InlineData(@"C:\Windows\System32\evil.zip")]
+    [InlineData(@"..\..\..\..\Windows\evil.zip")]
+    [InlineData("../../../../etc/passwd")]
+    public void Regression_Vpr138_TraversalPayload_CannotEscapeTempRoot(string attackPayload)
+    {
+        var tempRoot = CreateIsolatedTempRoot();
+        try
+        {
+            var responseName = CmsData.SanitizeDownloadName(attackPayload);
+            var tempPath = CmsData.BuildTempArchivePath(tempRoot);
+
+            Assert.DoesNotContain('\\', responseName);
+            Assert.DoesNotContain('/', responseName);
+            Assert.DoesNotContain("..", responseName);
+            Assert.EndsWith(".zip", responseName, StringComparison.OrdinalIgnoreCase);
+
+            var resolvedRoot = Path.GetFullPath(tempRoot);
+            var resolvedPath = Path.GetFullPath(tempPath);
+            Assert.StartsWith(
+                resolvedRoot + Path.DirectorySeparatorChar,
+                resolvedPath,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("..", resolvedPath);
+        }
+        finally
+        {
+            Cleanup(tempRoot);
+        }
+    }
+
+    #endregion
+
+    #region SanitizeZipEntryName
+
+    [Theory]
+    [InlineData(@"..\..\evil.txt", "evil.txt")]
+    [InlineData("../../evil.txt", "evil.txt")]
+    [InlineData(@"nested\folder\file.pdf", "file.pdf")]
+    [InlineData("nested/folder/file.pdf", "file.pdf")]
+    [InlineData("Annual Report 2024.pdf", "Annual Report 2024.pdf")]
+    public void SanitizeZipEntryName_StripsPathComponents(string friendlyName, string expected)
+    {
+        var result = CmsData.SanitizeZipEntryName(friendlyName, fallback: "fallback.bin");
+
+        Assert.Equal(expected, result);
+        Assert.DoesNotContain('\\', result);
+        Assert.DoesNotContain('/', result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeZipEntryName_EmptyFriendlyName_FallsBackToFilePath(string? friendlyName)
+    {
+        var result = CmsData.SanitizeZipEntryName(friendlyName, fallback: @"C:\storage\real-file.bin");
+
+        Assert.Equal("real-file.bin", result);
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData("dir/..")]
+    [InlineData(@"nested\.")]
+    [InlineData(". .")]
+    public void SanitizeZipEntryName_DotsOnly_FallsBackToFilePath(string friendlyName)
+    {
+        var result = CmsData.SanitizeZipEntryName(friendlyName, fallback: @"C:\storage\real-file.bin");
+
+        Assert.Equal("real-file.bin", result);
+    }
+
+    #endregion
+
+    #region BuildTempArchivePath
+
+    [Fact]
+    public void BuildTempArchivePath_ReturnsPathUnderTempRoot()
+    {
+        var tempRoot = CreateIsolatedTempRoot();
+        try
+        {
+            var path = CmsData.BuildTempArchivePath(tempRoot);
+
+            var resolved = Path.GetFullPath(path);
+            var normalizedRoot = Path.GetFullPath(tempRoot);
+
+            Assert.StartsWith(
+                normalizedRoot + Path.DirectorySeparatorChar,
+                resolved,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith(".zip", resolved, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Cleanup(tempRoot);
+        }
+    }
+
+    [Fact]
+    public void BuildTempArchivePath_AcceptsRootWithTrailingSeparator()
+    {
+        var tempRoot = CreateIsolatedTempRoot();
+        var withTrailing = tempRoot + Path.DirectorySeparatorChar;
+        try
+        {
+            var path = CmsData.BuildTempArchivePath(withTrailing);
+
+            var resolved = Path.GetFullPath(path);
+            var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(withTrailing));
+
+            Assert.StartsWith(
+                normalizedRoot + Path.DirectorySeparatorChar,
+                resolved,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Cleanup(tempRoot);
+        }
+    }
+
+    [Fact]
+    public void BuildTempArchivePath_AcceptsFilesystemRoot()
+    {
+        // A filesystem root (e.g. "C:\" or "/") keeps its trailing separator after
+        // TrimEndingDirectorySeparator; the containment check must not double the
+        // separator and wrongly reject a path that is genuinely inside the root.
+        var root = Path.GetPathRoot(Path.GetTempPath())!;
+
+        var path = CmsData.BuildTempArchivePath(root);
+
+        Assert.StartsWith(Path.GetFullPath(root), Path.GetFullPath(path), StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(".zip", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildTempArchivePath_GeneratesUniquePaths_OnSuccessiveCalls()
+    {
+        var tempRoot = CreateIsolatedTempRoot();
+        try
+        {
+            var a = CmsData.BuildTempArchivePath(tempRoot);
+            var b = CmsData.BuildTempArchivePath(tempRoot);
+
+            Assert.NotEqual(a, b);
+        }
+        finally
+        {
+            Cleanup(tempRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildTempArchivePath_RejectsEmptyRoot(string tempRoot)
+    {
+        Assert.Throws<ArgumentException>(() => CmsData.BuildTempArchivePath(tempRoot));
+    }
+
+    [Fact]
+    public void BuildTempArchivePath_RejectsNullRoot()
+    {
+        Assert.Throws<ArgumentException>(() => CmsData.BuildTempArchivePath(null!));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string CreateIsolatedTempRoot()
+    {
+        var root = Path.Join(Path.GetTempPath(), "Viper-CMS-Test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void Cleanup(string root)
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    #endregion
+}

--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -5,7 +5,9 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
 using Viper.Areas.CMS.Models;
+using Viper.Areas.CMS.Services;
 using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
 using Viper.Models.AAUD;
@@ -402,18 +404,25 @@ namespace Viper.Areas.CMS.Data
         #region public IActionResult DownloadZip(Controller controller, string[] fileGUIDs, string fileName = "FileDownload.zip")
         public IActionResult DownloadZip(Controller controller, string[] fileGUIDs, string fileName = "FileDownload.zip")
         {
-            if (fileGUIDs.Length == 0 && fileName.Length == 0)
+            // Treat an empty array or one of only blank segments (e.g. "ids=,,") as a
+            // missing parameter, and drop blanks so the loop skips no-op GetFile lookups.
+            var guids = fileGUIDs.Where(g => !string.IsNullOrWhiteSpace(g)).ToArray();
+            if (guids.Length == 0)
             {
-                ArgumentNullException argumentNullException = new(nameof(fileGUIDs), "Missing fileGUIDs and file name parameters");
-                throw argumentNullException;
+                return controller.BadRequest("Missing fileGUIDs parameter.");
             }
 
-            //only allow good filename characters
-            fileName = fileName.Replace(@"[^a-zA-Z0-9\.\-_ ]", "");
+            var safeDownloadName = CmsFilePathSafety.SanitizeDownloadName(fileName);
+
             List<CMSFile> files = new();
             AaudUser? currentUser = UserHelper.GetCurrentUser();
 
-            foreach (var guid in fileGUIDs)
+            if (CmsFilePathSafety.LooksLikeTraversalAttempt(fileName))
+            {
+                LogSuspiciousDownloadName(controller, fileName, safeDownloadName, currentUser);
+            }
+
+            foreach (var guid in guids)
             {
                 CMSFile? file = GetFile(guid, null, null, null, null);
 
@@ -429,45 +438,59 @@ namespace Viper.Areas.CMS.Data
                 }
             }
 
-            // create a temp Zip file and populate it with the files
-            string tempFileName = GetRootFileFolder() + @"\" + DateTime.Now.Ticks + fileName;
-
-            using (FileStream fs = System.IO.File.Open(tempFileName, FileMode.OpenOrCreate))
+            if (files.Count == 0)
             {
-                using ZipArchive archive = new(fs, ZipArchiveMode.Update);
-                foreach (var file in files)
-                {
-                    if (file.Encrypted && !string.IsNullOrEmpty(file.Key))
-                    {
-                        ZipArchiveEntry fileEntry = archive.CreateEntry(file.FriendlyName);
-                        using StreamWriter writer = new(fileEntry.Open());
-                        byte[] filebytes = System.IO.File.ReadAllBytes(file.FilePath);
-                        filebytes = DecryptFile(filebytes, file.Key);
-
-                        if (filebytes != null)
-                        {
-                            writer.BaseStream.Write(filebytes, 0, filebytes.Length);
-                        }
-                    }
-                    else
-                    {
-                        archive.CreateEntryFromFile(file.FilePath, file.FriendlyName);
-                    }
-
-                }
+                return controller.NotFound();
             }
 
-            // read the temp zip file then delete it
-            byte[] bytes = System.IO.File.ReadAllBytes(tempFileName);
-            if (bytes == null)
-                return controller.NotFound();
+            var zipTempFolder = CmsFilePathSafety.GetZipTempFolder();
+            // Create on demand so a download survives the OS or an admin sweeping %TEMP%
+            // mid-run; otherwise File.Open below throws DirectoryNotFoundException.
+            System.IO.Directory.CreateDirectory(zipTempFolder);
+            string tempFileName = CmsFilePathSafety.BuildTempArchivePath(zipTempFolder);
 
-            System.IO.File.Delete(tempFileName);
+            try
+            {
+                using (FileStream fs = System.IO.File.Open(tempFileName, FileMode.Create))
+                using (ZipArchive archive = new(fs, ZipArchiveMode.Create))
+                {
+                    foreach (var file in files)
+                    {
+                        var entryName = CmsFilePathSafety.SanitizeZipEntryName(file.FriendlyName, file.FilePath);
 
-            string extension = "zip";
+                        if (file.Encrypted && !string.IsNullOrEmpty(file.Key))
+                        {
+                            ZipArchiveEntry fileEntry = archive.CreateEntry(entryName);
+                            using var entryStream = fileEntry.Open();
+                            byte[] filebytes = System.IO.File.ReadAllBytes(file.FilePath);
+                            filebytes = DecryptFile(filebytes, file.Key);
 
-            return controller.File(bytes, MimeTypes[extension.ToLower()], fileName);
+                            entryStream.Write(filebytes, 0, filebytes.Length);
+                        }
+                        else
+                        {
+                            archive.CreateEntryFromFile(file.FilePath, entryName);
+                        }
+                    }
+                }
 
+                byte[] bytes = System.IO.File.ReadAllBytes(tempFileName);
+                return controller.File(bytes, MimeTypes["zip"], safeDownloadName);
+            }
+            finally
+            {
+                // Best-effort cleanup: swallow filesystem exceptions so we don't
+                // mask an earlier exception from archive creation or the response.
+                try
+                {
+                    if (System.IO.File.Exists(tempFileName))
+                    {
+                        System.IO.File.Delete(tempFileName);
+                    }
+                }
+                catch (IOException) { /* ignored */ }
+                catch (UnauthorizedAccessException) { /* ignored */ }
+            }
         }
         #endregion
 
@@ -526,9 +549,22 @@ namespace Viper.Areas.CMS.Data
             }
 
             string extension = file.FilePath[(file.FilePath.LastIndexOf('.') + 1)..];
-            controller.Response.Headers["Content-Disposition"] = "inline; filename=" + friendlyName;
+            if (!MimeTypes.TryGetValue(extension.ToLowerInvariant(), out var contentType))
+            {
+                // Unknown/missing extension: fall back to a generic binary type so an
+                // unlisted file type downloads instead of throwing (was a 500 via the indexer).
+                contentType = "application/octet-stream";
+            }
 
-            return controller.File(bytes, MimeTypes[extension.ToLower()], true);
+            // Build Content-Disposition from the stored record's name, not the user-supplied
+            // friendlyName param, and let the framework encode it so a hostile fn cannot shape
+            // the header. Mirrors the DownloadZip download-name hardening.
+            var downloadName = CmsFilePathSafety.SanitizeZipEntryName(file.FriendlyName, file.FilePath);
+            var contentDisposition = new ContentDispositionHeaderValue("inline");
+            contentDisposition.SetHttpFileName(downloadName);
+            controller.Response.Headers.ContentDisposition = contentDisposition.ToString();
+
+            return controller.File(bytes, contentType, true);
 
         }
         #endregion
@@ -551,6 +587,30 @@ namespace Viper.Areas.CMS.Data
                 LogSanitizer.SanitizeString(id),
                 LogSanitizer.SanitizeString(friendlyName),
                 LogSanitizer.SanitizeString(oldURL),
+                LogSanitizer.SanitizeString(request.Headers.UserAgent.ToString()),
+                LogSanitizer.SanitizeString(request.Headers.Referer.ToString()),
+                LogSanitizer.SanitizeString(request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty));
+        }
+
+        // VPR-138: emits a warning when a DownloadZip request supplies a fileName that
+        // carries path structure (separators or ".." segments). The name only ever feeds
+        // the Content-Disposition header - the served files come from DB GUIDs and the
+        // temp path from a server-generated GUID - so this is detection signal for probing,
+        // not a block. Grep the tag to see who is poking at the download surface.
+        private void LogSuspiciousDownloadName(Controller controller, string rawFileName, string sanitizedName, AaudUser? currentUser)
+        {
+            if (_logger is null)
+            {
+                return;
+            }
+
+            var request = controller.Request;
+            _logger.LogWarning(
+                "[CMS-DOWNLOAD-NAME] traversal-shaped download name loginId={LoginId} rawFileName={RawFileName} " +
+                "servedAs={SanitizedName} userAgent={UserAgent} referer={Referer} remoteIp={RemoteIp}",
+                LogSanitizer.SanitizeString(currentUser?.LoginId ?? string.Empty),
+                LogSanitizer.SanitizeString(rawFileName),
+                LogSanitizer.SanitizeString(sanitizedName),
                 LogSanitizer.SanitizeString(request.Headers.UserAgent.ToString()),
                 LogSanitizer.SanitizeString(request.Headers.Referer.ToString()),
                 LogSanitizer.SanitizeString(request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty));

--- a/web/Areas/CMS/Services/CmsFilePathSafety.cs
+++ b/web/Areas/CMS/Services/CmsFilePathSafety.cs
@@ -1,0 +1,187 @@
+using System.Text.RegularExpressions;
+
+namespace Viper.Areas.CMS.Services
+{
+    /// <summary>
+    /// Path-safety primitives for CMS file download flows (VPR-138).
+    ///
+    /// Two surfaces: the static class is used by the legacy
+    /// <c>CMS.DownloadZip</c> call site (no DI plumbing); the
+    /// <see cref="ICmsFilePathSafetyService"/> interface is the contract the
+    /// PLAN-CMS migration's <c>IFileStorageService</c> / new download
+    /// controller depends on. See PLAN-CMS.md §11.7.
+    /// </summary>
+    public static class CmsFilePathSafety
+    {
+        private const string DefaultDownloadName = "FileDownload.zip";
+
+        private static readonly HashSet<string> ReservedWindowsNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        };
+
+        private static readonly Regex DisallowedFileNameChars = new(@"[^a-zA-Z0-9._\- ]", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns a filename safe to use in a Content-Disposition response header.
+        /// Strips path components, applies an allow-list, rejects reserved Windows
+        /// device names, and guarantees a <c>.zip</c> suffix so the name matches
+        /// the <c>application/zip</c> MIME type.
+        /// </summary>
+        public static string SanitizeDownloadName(string? userInput)
+        {
+            if (string.IsNullOrWhiteSpace(userInput))
+            {
+                return DefaultDownloadName;
+            }
+
+            var fileNamePart = StripPathComponents(userInput);
+            var filtered = DisallowedFileNameChars.Replace(fileNamePart, string.Empty).Trim();
+
+            // Reject names that collapse to only dots/spaces: ".", ".." etc. would
+            // become "..zip" after the suffix step, which is traversal-shaped.
+            if (filtered.Trim('.', ' ').Length == 0)
+            {
+                return DefaultDownloadName;
+            }
+
+            var stem = filtered;
+            var dotIndex = stem.IndexOf('.');
+            if (dotIndex >= 0)
+            {
+                stem = stem[..dotIndex];
+            }
+            if (ReservedWindowsNames.Contains(stem))
+            {
+                return DefaultDownloadName;
+            }
+
+            if (!filtered.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                filtered += ".zip";
+            }
+
+            return filtered;
+        }
+
+        /// <summary>
+        /// True when <paramref name="userInput"/> carried path structure: a path
+        /// separator, or ".." as a distinct segment. Used purely to log a
+        /// traversal-shaped download name; it never affects what is served (the file
+        /// set comes from DB GUIDs and the temp path from a server-generated GUID, so a
+        /// hostile name cannot reach the filesystem). A ".." inside a longer name
+        /// (e.g. "report..final.zip") is not treated as traversal.
+        /// </summary>
+        public static bool LooksLikeTraversalAttempt(string? userInput)
+        {
+            if (string.IsNullOrWhiteSpace(userInput))
+            {
+                return false;
+            }
+
+            // A download name should be a single segment: any separator, or a bare ".."
+            // segment, is traversal-shaped. ".." inside a name (e.g. "report..final") is not.
+            var normalized = userInput.Replace('\\', '/');
+            return normalized.Contains('/') || normalized == "..";
+        }
+
+        /// <summary>
+        /// Builds a per-request temp archive path under <paramref name="tempRoot"/>
+        /// using a server-generated GUID, and asserts the resolved path stays
+        /// inside that root.
+        /// </summary>
+        public static string BuildTempArchivePath(string tempRoot)
+        {
+            if (string.IsNullOrWhiteSpace(tempRoot))
+            {
+                throw new ArgumentException("Temp root must be provided.", nameof(tempRoot));
+            }
+
+            var resolvedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(tempRoot));
+            var candidate = Path.Join(resolvedRoot, Guid.NewGuid().ToString("N") + ".zip");
+            var resolved = Path.GetFullPath(candidate);
+
+            // TrimEndingDirectorySeparator leaves a filesystem root (e.g. "C:\" or "/")
+            // with its trailing separator, so append one only when it isn't already there
+            // to avoid a doubled separator that would break the containment check.
+            var rootPrefix = Path.EndsInDirectorySeparator(resolvedRoot)
+                ? resolvedRoot
+                : resolvedRoot + Path.DirectorySeparatorChar;
+
+            if (!resolved.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Generated temp path escaped the configured root.");
+            }
+
+            return resolved;
+        }
+
+        /// <summary>
+        /// Dedicated temp directory for ZIP archives. Kept separate from the
+        /// CMS content root so transient archives never mix with managed
+        /// content, and never get served through content URLs.
+        /// </summary>
+        public static string GetZipTempFolder()
+        {
+            return Path.Join(Path.GetTempPath(), "Viper-CMS");
+        }
+
+        /// <summary>
+        /// Returns a safe ZIP entry name from a stored file's friendly name.
+        /// Defense in depth against ZIP-slip when the archive is extracted.
+        /// </summary>
+        public static string SanitizeZipEntryName(string? friendlyName, string fallback)
+        {
+            if (!string.IsNullOrWhiteSpace(friendlyName))
+            {
+                var entry = StripPathComponents(friendlyName);
+                if (!string.IsNullOrWhiteSpace(entry) && entry.Trim('.', ' ').Length > 0)
+                {
+                    return entry;
+                }
+            }
+
+            return StripPathComponents(fallback);
+        }
+
+        // Path.GetFileName only honors the host OS separator, so "\..\evil"
+        // leaks through unchanged on Linux runners. Normalize first.
+        private static string StripPathComponents(string input)
+            => Path.GetFileName(input.Replace('\\', '/'));
+    }
+
+    /// <summary>
+    /// DI-injectable contract for <see cref="CmsFilePathSafety"/>. New code
+    /// (see PLAN-CMS.md §11.7) depends on this interface so the underlying
+    /// implementation can evolve without touching call sites.
+    /// </summary>
+    public interface ICmsFilePathSafetyService
+    {
+        string SanitizeDownloadName(string? userInput);
+        bool LooksLikeTraversalAttempt(string? userInput);
+        string BuildTempArchivePath(string tempRoot);
+        string GetZipTempFolder();
+        string SanitizeZipEntryName(string? friendlyName, string fallback);
+    }
+
+    /// <inheritdoc cref="ICmsFilePathSafetyService"/>
+    public sealed class CmsFilePathSafetyService : ICmsFilePathSafetyService
+    {
+        public string SanitizeDownloadName(string? userInput) =>
+            CmsFilePathSafety.SanitizeDownloadName(userInput);
+
+        public bool LooksLikeTraversalAttempt(string? userInput) =>
+            CmsFilePathSafety.LooksLikeTraversalAttempt(userInput);
+
+        public string BuildTempArchivePath(string tempRoot) =>
+            CmsFilePathSafety.BuildTempArchivePath(tempRoot);
+
+        public string GetZipTempFolder() =>
+            CmsFilePathSafety.GetZipTempFolder();
+
+        public string SanitizeZipEntryName(string? friendlyName, string fallback) =>
+            CmsFilePathSafety.SanitizeZipEntryName(friendlyName, fallback);
+    }
+}

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -258,7 +258,8 @@ try
                 "Viper.Areas.ClinicalScheduler.Validators",
                 "Viper.Areas.Students.Services",
                 "Viper.Areas.Curriculum.Services",
-                "Viper.Areas.Effort.Services"
+                "Viper.Areas.Effort.Services",
+                "Viper.Areas.CMS.Services"
             )
             .Where(type => type.Name.EndsWith("Service") || type.Name.EndsWith("Validator")))
         .UsingRegistrationStrategy(RegistrationStrategy.Skip)
@@ -404,44 +405,6 @@ try
     // when our auth filter denies — gets the same Razor error view as the rest of the app.
     app.UseStatusCodePagesWithReExecute("/Error/{0}");
 
-    // In development, set up Vite proxy BEFORE rewrite rules so it can handle .ts/.js files
-    if (app.Environment.IsDevelopment())
-    {
-        // Development: Proxy Vue.js assets to Vite dev server for hot module replacement (HMR)
-        // This middleware intercepts requests for Vue assets and forwards them to the Vite dev server
-        app.Use(async (context, next) =>
-        {
-            if (ViteProxyHelpers.ShouldProxyToVite(context, VueAppNames))
-            {
-                try
-                {
-                    // Use the registered HttpClient from dependency injection
-                    var httpClientFactory = context.RequestServices.GetRequiredService<IHttpClientFactory>();
-                    var httpClient = httpClientFactory.CreateClient("ViteProxy");
-
-                    // Build the Vite server URL and try to proxy directly
-                    var viteUrl = ViteProxyHelpers.BuildViteUrl(context.Request.Path, context.Request.QueryString, VueAppNames);
-                    var requestMessage = ViteProxyHelpers.CreateProxyRequest(context, viteUrl);
-                    using var response = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, context.RequestAborted);
-
-                    // Copy the response back to the client
-                    await ViteProxyHelpers.CopyProxyResponse(context, response);
-                    return; // Successfully proxied, don't continue to static files
-                }
-                catch (Exception ex)
-                {
-                    var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
-                    logger.LogDebug(ex, "Vite server not available, falling back to static files for {Path}",
-                        Uri.EscapeDataString(context.Request.Path.Value ?? "unknown"));
-                    // Fall through to static file serving
-                }
-            }
-
-            // Continue to static file serving (either Vite not needed or not available)
-            await next();
-        });
-    }
-
     var rewriteOptions = new RewriteOptions();
 
     // Add redirects and rewrites for each SPA using centralized app names
@@ -458,36 +421,77 @@ try
         rewriteOptions.AddRewrite($@"(?i)^{escapedAppName}", $"/2/vue/src/{lowerAppName}/index.html", true);
     }
 
-    app.UseRewriter(rewriteOptions);
-
-    //for the vue src files, use directories in the url but serve index.html
+    // Default-file convention for /vue (legacy path).
     app.UseDefaultFiles(new DefaultFilesOptions
     {
         DefaultFileNames = new List<string> { "index.html" },
         FileProvider = new PhysicalFileProvider(
-            Path.Join(builder.Environment.ContentRootPath, "wwwroot/vue")),
+            Path.Join(builder.Environment.WebRootPath, "vue")),
         RequestPath = "/vue",
         RedirectToAppendTrailingSlash = true
     });
 
-    // Static file serving configuration
-    // Serve built Vue files - in development proxy middleware runs first,
-    // in production these files are served directly
-    app.UseStaticFiles(new StaticFileOptions
-    {
-        FileProvider = new PhysicalFileProvider(
-            Path.Join(builder.Environment.ContentRootPath, "wwwroot/vue")),
-        RequestPath = "/2/vue"
-    });
-
-    // Serve other static files
+    // General static files (favicon, /css, /js, /images, etc.).
     app.UseStaticFiles();
 
-    // Add sitemap middleware after static file handling
     app.UseSitemapMiddleware();
 
-    // apply settings define earlier
+    // Routing first so subsequent middleware can defer to a matched MVC endpoint.
     app.UseRouting();
+
+    // SPA shell serving for Vue app prefixes like /CMS, /Effort, etc. Runs before
+    // auth/session so static Vue assets skip that per-request overhead.
+    // Only runs when no MVC controller endpoint claimed the path, so attribute-routed
+    // legacy endpoints (e.g. /CMS/Files → CMSController.Files) reach the controller
+    // instead of being rewritten to the SPA shell.
+    app.UseWhen(
+        ctx => ctx.GetEndpoint() is null,
+        branch =>
+        {
+            if (app.Environment.IsDevelopment())
+            {
+                // Dev: proxy Vue assets and SPA routes to the Vite dev server (HMR).
+                branch.Use(async (context, next) =>
+                {
+                    if (ViteProxyHelpers.ShouldProxyToVite(context, VueAppNames))
+                    {
+                        try
+                        {
+                            var httpClientFactory = context.RequestServices.GetRequiredService<IHttpClientFactory>();
+                            var httpClient = httpClientFactory.CreateClient("ViteProxy");
+
+                            var viteUrl = ViteProxyHelpers.BuildViteUrl(context.Request.Path, context.Request.QueryString, VueAppNames);
+                            var requestMessage = ViteProxyHelpers.CreateProxyRequest(context, viteUrl);
+                            using var response = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, context.RequestAborted);
+
+                            await ViteProxyHelpers.CopyProxyResponse(context, response);
+                            return;
+                        }
+                        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+                        {
+                            var viteLogger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+                            viteLogger.LogDebug(ex, "Vite server not available, falling back to static files for {Path}",
+                                Uri.EscapeDataString(context.Request.Path.Value ?? "unknown"));
+                        }
+                    }
+
+                    await next();
+                });
+            }
+
+            // Prod (and dev fallback): rewrite SPA routes to the built SPA shell,
+            // then serve the static file from wwwroot/vue.
+            branch.UseRewriter(rewriteOptions);
+            branch.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(
+                    Path.Join(builder.Environment.WebRootPath, "vue")),
+                RequestPath = "/2/vue"
+            });
+        });
+
+    // Auth/session run after the SPA shell block so built Vue assets skip them, but
+    // still before health checks, Hangfire, and controllers, which need an authenticated user.
     app.UseAuthentication();
     app.UseAuthorization();
     app.UseCookiePolicy();

--- a/web/Views/Home/StatusCode.cshtml
+++ b/web/Views/Home/StatusCode.cshtml
@@ -4,4 +4,4 @@
 	ViewData["Title"] = "Error";
 	ViewData["AllowAnonymousContent"] = true;
 }
-<h1 class="text-danger">Status Code: @((int)Model); @(Enum.GetName(typeof(HttpStatusCode), Model.ToString()))</h1>
+<h1 class="text-danger">Status Code: @((int)Model); @Model</h1>


### PR DESCRIPTION
## Summary

Hardens and enables the modernized CMS file-download surface (`CMSController.Files` → `CMS.DownloadZip` / `CMS.ProvideFile`) and fixes the routing that kept it unreachable. Three commits:

### `d9b1955` feat(cms): secure the CMS file download handlers
`CMS.DownloadZip`, `CMS.ProvideFile`, the new `CmsFilePathSafety` helpers, and tests.
- **Temp archive path** is generated from a server-side GUID under a dedicated `%TEMP%/Viper-CMS` folder, created on demand so a download survives the OS or an admin sweeping the temp dir, and written with `FileMode.Create` + `ZipArchiveMode.Create` plus a finally-cleanup. User input never forms an on-disk path.
- **`SanitizeDownloadName`** for the `Content-Disposition` name: strip path components (`\` normalized to `/` first), allow-list via the `DisallowedFileNameChars` regex, reject reserved Windows device names and dot/space-only names, force a `.zip` suffix.
- **`SanitizeZipEntryName`**: defense-in-depth ZIP-slip protection on each archive entry.
- **`BuildTempArchivePath`**: server-GUID path with a containment assertion that also handles filesystem-root temp roots (`C:\`, `/`) without doubling the separator.
- **`ProvideFile` (single-file path)** hardened the same way: the inline `Content-Disposition` name is derived from the stored record via `SetHttpFileName` (never the raw `fn` query param), and the content type uses a `TryGetValue` + `application/octet-stream` fallback (`ToLowerInvariant` lookup) instead of an indexer that 500s on an unmapped extension.
- **Blank-GUID handling**: `DownloadZip` filters blank/whitespace segments up front and returns `400` when none remain (so `ids=,,` is treated as a missing parameter), and skips blanks in the loop.
- **`[CMS-DOWNLOAD-NAME]` warning** (`LooksLikeTraversalAttempt`) when a requested `fileName` is traversal-shaped (a separator, or `..` as a distinct segment; `report..final.zip` is not flagged). Detection only: the name feeds `Content-Disposition`, never the filesystem.
- Helpers exposed via **`ICmsFilePathSafetyService`** (Scrutor-registered) for the PLAN-CMS migration. 68 security tests in `DownloadZipSecurityTests.cs`.

### `89d8737` fix(routing): let MVC controllers win over the Vue SPA shell
- The URL rewriter and Vite proxy claimed every `/CMS/*` path before MVC routing ran, so `CMSController.Files` never executed and the Vue SPA shell came back instead. Wrap the rewriter + Vite proxy + `/2/vue` static files in `UseWhen(ctx => ctx.GetEndpoint() is null, …)` so attribute-routed controllers claim their endpoint first.
- The `UseWhen` block runs immediately after `UseRouting`, before auth/session, so built Vue assets and SPA shells are served without per-request auth/session overhead.
- Register `Viper.Areas.CMS.Services` for Scrutor (DI for the safety service); static-file providers resolve via `WebRootPath`.

### `eb33c78` fix(error): stop StatusCode view from throwing on render
- `Views/Home/StatusCode.cshtml` passed `Model.ToString()` (a string) to `Enum.GetName(Type, object)`, which throws `ArgumentException`, so every non-403 status page (404, 500, ...) rendered as a 500. Render the `HttpStatusCode` model directly. Surfaced while verifying the download route on TEST (it was masking the route's 404s as 500s); a pre-existing error-view bug bundled here since it gated this PR's smoke tests.

## Test plan

- [x] `test/CMS/DownloadZipSecurityTests.cs` — 68 tests: sanitizer, ZIP-entry helper, temp-path builder (incl. trailing-separator and filesystem-root), traversal regression, and the `LooksLikeTraversalAttempt` predicate (path-shaped flagged; plain names incl. `report..final.zip` not).
- [x] Full backend test suite, CodeQL, and lint passing on CI.
- [x] Local dev smoke: `/CMS/Files?ids=<bogus>` → 404 from the controller; `/CMS` serves the SPA shell; `/Effort` and Vite/HMR assets unaffected.
- [x] **Verified on TEST** (`secure-test`, `/2` PathBase) after deploy:
  - `/2/CMS/Files?ids=<bogus-guid>` → **404** (clean; was 500 before the StatusCode fix).
  - `/2/CMS/Files?ids=,` → **400**.
  - generic non-existent route → **404** (StatusCode fix confirmed site-wide).
  - `/2/CMS` and `/2/Effort` SPA shells serve; login / SPA auth flow intact.

Authenticated happy path still to smoke with a logged-in session:
1. `/2/CMS/Files?ids=<real-guid>&fileName=Report.zip` → ZIP downloads as `Report.zip`.
2. `/2/CMS/Files?ids=<real-guid>&fileName=..%5C..%5Cevil.zip` → downloads, response filename sanitized to `evil.zip`, and a `[CMS-DOWNLOAD-NAME]` warning is logged.
3. `%TEMP%/Viper-CMS/` empty after each request (finally-cleanup intact).

## Notes

`CMSController.Files` carries no production traffic today; file downloads go through the legacy ColdFusion CMS at the root domain (`/cms/files/?id=...`). VIPER2's modernized handler exists as the migration target for PLAN-CMS.md. The routing fix and the `DownloadZip` hardening are load-bearing on each other: the routing fix without the hardening would expose path traversal; the hardening alone leaves it gated behind a still-broken route. The traversal-name logging, `ProvideFile` hardening, and `StatusCode` error-view fix are additive on the same surface.
