### PR TITLE
chore(test): migrate test project from xUnit v2 to v3

### DIFF
--- a/test/Viper.test.csproj
+++ b/test/Viper.test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -22,13 +23,14 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="2.0.2" />
     <PackageReference Include="MockQueryable.NSubstitute" Version="10.0.5" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Pin Microsoft.Testing.Platform to 2.0.2 to resolve a transitive conflict between xunit.v3 (brings 1.9.1) and JunitXml.TestLogger 8.0 (compiled against 2.0.2); remove once xunit.v3 ships with MTP 2.0+