### PR TITLE
chore(deps): remove unused devDependencies

### DIFF
--- a/VueApp/package-lock.json
+++ b/VueApp/package-lock.json
@@ -47,7 +47,6 @@
                 "npm-run-all2": "^8.0.4",
                 "oxfmt": "^0.46.0",
                 "oxlint-tsgolint": "^0.21.1",
-                "sass": "^1.99.0",
                 "tree-kill": "^1.2.2",
                 "typescript": "^6.0.3",
                 "vite": "^8.0.10",
@@ -2151,6 +2150,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2168,6 +2170,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2185,6 +2190,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2202,6 +2210,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2219,6 +2230,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2236,6 +2250,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2253,6 +2270,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2270,6 +2290,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -9470,27 +9493,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/sass": {
-            "version": "1.99.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
-            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chokidar": "^4.0.0",
-                "immutable": "^5.1.5",
-                "source-map-js": ">=0.6.2 <2.0.0"
-            },
-            "bin": {
-                "sass": "sass.js"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "optionalDependencies": {
-                "@parcel/watcher": "^2.4.1"
-            }
-        },
         "node_modules/sass-embedded": {
             "version": "1.98.0",
             "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.98.0.tgz",
@@ -9961,36 +9963,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/sass/node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14.16.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/sass/node_modules/readdirp": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.18.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/sax": {

--- a/VueApp/package.json
+++ b/VueApp/package.json
@@ -64,7 +64,6 @@
         "npm-run-all2": "^8.0.4",
         "oxfmt": "^0.46.0",
         "oxlint-tsgolint": "^0.21.1",
-        "sass": "^1.99.0",
         "tree-kill": "^1.2.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",

--- a/VueApp/vite-watch.js
+++ b/VueApp/vite-watch.js
@@ -62,7 +62,7 @@ function startBuild() {
 let watcher = null
 try {
     // For chokidar v4, expand globs first
-    const filesToWatch = await glob("./src/**/*.{vue,ts,js,css,scss,sass}", {
+    const filesToWatch = await glob("./src/**/*.{vue,ts,js,css}", {
         ignore: ["**/node_modules/**"],
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@eslint/js": "^10.0.0",
                 "concurrently": "^9.0.1",
                 "cross-env": "^10.0.0",
-                "dotenv": "^17.4.2",
                 "eslint": "^10.2.1",
                 "eslint-plugin-html": "^8.1.4",
                 "eslint-plugin-security": "^4.0.0",
@@ -23,10 +22,8 @@
                 "oxlint": "^1.61.0",
                 "oxlint-tsgolint": "^0.21.1",
                 "postcss-html": "^1.8.0",
-                "recursive-last-modified": "^1.0.6",
                 "stylelint": "^17.9.0",
                 "stylelint-config-standard": "^40.0.0",
-                "tsgolint": "^0.0.1",
                 "yauzl": "^3.2.0"
             },
             "engines": {
@@ -891,6 +888,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -908,6 +908,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -925,6 +928,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -942,6 +948,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -959,6 +968,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -976,6 +988,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -993,6 +1008,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1010,6 +1028,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1298,6 +1319,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1315,6 +1339,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1332,6 +1359,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1349,6 +1379,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1366,6 +1399,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1383,6 +1419,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1400,6 +1439,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1417,6 +1459,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2229,19 +2274,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "17.4.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {
@@ -4292,13 +4324,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/recursive-last-modified": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/recursive-last-modified/-/recursive-last-modified-1.0.6.tgz",
-            "integrity": "sha512-5zIxmcHbPSxGFKEbTIPVntDYx0u7+nuiw1eEzbqrc6XIZlseYM3pVLb6nCoAWVtsIworbiBRJXPGotv8Eh+e2Q==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/regexp-tree": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -4938,13 +4963,6 @@
             "bin": {
                 "tree-kill": "cli.js"
             }
-        },
-        "node_modules/tsgolint": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/tsgolint/-/tsgolint-0.0.1.tgz",
-            "integrity": "sha512-cSh6jgqMsVrzaRipcTBDcfiUo3iTK92gukInY0eeFP14ICe1pZjBC+yL1rVfQSBR72ZaBizmwsqEI4g1eqx1Eg==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/tslib": {
             "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
         "@eslint/js": "^10.0.0",
         "concurrently": "^9.0.1",
         "cross-env": "^10.0.0",
-        "dotenv": "^17.4.2",
         "eslint": "^10.2.1",
         "eslint-plugin-html": "^8.1.4",
         "eslint-plugin-security": "^4.0.0",
@@ -52,10 +51,8 @@
         "oxlint": "^1.61.0",
         "oxlint-tsgolint": "^0.21.1",
         "postcss-html": "^1.8.0",
-        "recursive-last-modified": "^1.0.6",
         "stylelint": "^17.9.0",
         "stylelint-config-standard": "^40.0.0",
-        "tsgolint": "^0.0.1",
         "yauzl": "^3.2.0"
     },
     "volta": {


### PR DESCRIPTION
- Drop `tsgolint@0.0.1`: npm squatter placeholder, not the real oxc tool (which ships as `oxlint-tsgolint`)
- Drop `dotenv`: scripts use Node's built-in `--env-file-if-exists` flag instead
- Drop `sass` from VueApp: no .scss/.sass sources, Quasar configured with `sassVariables: false`; also trim `scss,sass` from the vite-watch glob to match
- Drop `recursive-last-modified`: no source references