### PR TITLE
CodeQL 1: chore(codeql): exclude generated build artifacts from scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "VIPER CodeQL config"
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - "**/obj/**"
+  - "**/bin/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       uses: github/codeql-action/init@v4.35.2
       with:
         languages: ${{ matrix.language }}
-        queries: security-and-quality
+        config-file: ./.github/codeql/codeql-config.yml
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
## Summary

- Move CodeQL query config from inline (`queries: security-and-quality`) into a new `.github/codeql/codeql-config.yml` and reference it via `config-file:` in the workflow.
- Add `paths-ignore` for `**/obj/**` and `**/bin/**` so CodeQL stops reporting alerts on Roslyn-generated `.g.cs` files (Razor source generator output, xUnit auto-entry-point).

## Why

The Razor source generator and xUnit auto-entrypoint generator emit real C# files into `obj/` during `autobuild`. CodeQL traces the build and ingests those generated files, producing noise we cannot act on:

- 50× `cs/missed-readonly-modifier` in `web/obj/.../RazorSourceGenerator/Areas/**`
- 1× `cs/missed-ternary-operator` in `test/obj/.../XunitAutoGeneratedEntryPoint.cs`

Filtering these out at the config level gives a clean alert list that reflects code we own.

## Context

First in a planned `CodeQL N:` series of cleanup PRs separate from the existing stacked-refactor series (#176–#179). See repo discussion for the full grouping.

## Test plan

- [x] CodeQL workflow runs successfully on this PR.
- [ ] After merge, the ~50 `cs/missed-readonly-modifier` alerts and the auto-generated `cs/missed-ternary-operator` alert close automatically on the next scan.
- [ ] No previously visible alert in non-generated code disappears from the dashboard.