### PR TITLE
CodeQL 3: fix: close CodeQL correctness alerts

### DIFF
--- a/test/RAPS/RoleTemplateSimplifiedTests.cs
+++ b/test/RAPS/RoleTemplateSimplifiedTests.cs
@@ -1,0 +1,59 @@
+using Viper.Areas.RAPS.Models;
+using Viper.Models.RAPS;
+
+namespace Viper.test.RAPS
+{
+    public class RoleTemplateSimplifiedTests
+    {
+        [Fact]
+        public void Constructor_MapsScalarsAndFlattensRoles()
+        {
+            // arrange
+            var rt = new RoleTemplate
+            {
+                RoleTemplateId = 42,
+                TemplateName = "Test Template",
+                Description = "Desc",
+                RoleTemplateRoles = new List<RoleTemplateRole>
+                {
+                    new() { Role = new TblRole { RoleId = 1, Role = "Alpha", DisplayName = "Alpha" } },
+                    new() { Role = new TblRole { RoleId = 2, Role = "Beta", DisplayName = "Beta" } }
+                }
+            };
+
+            // act
+            var dto = new RoleTemplateSimplified(rt);
+
+            // assert
+            Assert.Equal(42, dto.RoleTemplateId);
+            Assert.Equal("Test Template", dto.TemplateName);
+            Assert.Equal("Desc", dto.Description);
+            var roles = dto.Roles.ToList();
+            Assert.Equal(2, roles.Count);
+            Assert.Equal(1, roles[0].RoleId);
+            Assert.Equal("Alpha", roles[0].FriendlyName);
+            Assert.Equal(2, roles[1].RoleId);
+            Assert.Equal("Beta", roles[1].FriendlyName);
+        }
+
+        [Fact]
+        public void Constructor_EmptyRoles_ReturnsEmptyCollection()
+        {
+            // arrange
+            var rt = new RoleTemplate
+            {
+                RoleTemplateId = 7,
+                TemplateName = "No Roles",
+                Description = "",
+                RoleTemplateRoles = new List<RoleTemplateRole>()
+            };
+
+            // act
+            var dto = new RoleTemplateSimplified(rt);
+
+            // assert
+            Assert.Equal(7, dto.RoleTemplateId);
+            Assert.Empty(dto.Roles);
+        }
+    }
+}

--- a/test/Utilities/AcademicYearHelperTests.cs
+++ b/test/Utilities/AcademicYearHelperTests.cs
@@ -38,6 +38,14 @@ public class AcademicYearHelperTests
         Assert.Equal(new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Local), result);
     }
 
+    [Fact]
+    public void GetAcademicYearStart_DateBeforeJulyYearOne_Throws()
+    {
+        // date.Year == 1 && month < 7 would underflow to year 0 in AddYears(-1)
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AcademicYearHelper.GetAcademicYearStart(DateTime.MinValue));
+    }
+
     #endregion
 
     #region GetDateRange Tests

--- a/web/Areas/CTS/Models/AuditRow.cs
+++ b/web/Areas/CTS/Models/AuditRow.cs
@@ -22,10 +22,10 @@ namespace Viper.Areas.CTS.Models
             Timestamp = dbAudit.TimeStamp;
             ModifiedById = dbAudit.ModifiedBy;
             ModifiedByName = dbAudit.Modifier.LastName + ", " + dbAudit.Modifier.FirstName;
-            if (dbAudit?.Encounter?.Student != null)
+            if (dbAudit.Encounter?.Student != null)
             {
-                ModifiedPersonId = dbAudit.Encounter?.StudentUserId;
-                ModifiedPersonName = dbAudit.Encounter?.Student?.LastName + ", " + dbAudit.Encounter?.Student?.FirstName;
+                ModifiedPersonId = dbAudit.Encounter.StudentUserId;
+                ModifiedPersonName = dbAudit.Encounter.Student.LastName + ", " + dbAudit.Encounter.Student.FirstName;
             }
 
         }

--- a/web/Areas/Effort/Services/PercentRolloverService.cs
+++ b/web/Areas/Effort/Services/PercentRolloverService.cs
@@ -30,6 +30,10 @@ public class PercentRolloverService : IPercentRolloverService
 
     public async Task<PercentRolloverPreviewDto> GetRolloverPreviewAsync(int year, CancellationToken ct = default)
     {
+        // Bound year for DateTime constructions below (year and year+1 must be valid years).
+        ArgumentOutOfRangeException.ThrowIfLessThan(year, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(year, 9998);
+
         var result = new PercentRolloverPreviewDto();
 
         result.SourceAcademicYear = year;
@@ -42,7 +46,7 @@ public class PercentRolloverService : IPercentRolloverService
         var july1Start = new DateTime(year, 7, 1, 0, 0, 0, DateTimeKind.Local);
         result.OldEndDate = june30Start;
         result.NewStartDate = july1Start;
-        result.NewEndDate = new DateTime(year + 1, 6, 30, 0, 0, 0, DateTimeKind.Local);
+        result.NewEndDate = june30Start.AddYears(1);
 
         // Find assignments ending on June 30 of source year (any time on that day)
         var assignments = await _context.Percentages

--- a/web/Areas/Effort/Services/PercentageService.cs
+++ b/web/Areas/Effort/Services/PercentageService.cs
@@ -306,7 +306,8 @@ public class PercentageService : IPercentageService
             .Where(p => !string.Equals(p.PercentAssignType.Class, LeaveTypeClass, StringComparison.OrdinalIgnoreCase))
             .Sum(p => (decimal)EffortConstants.ToDisplayPercent(p.PercentageValue));
 
-        if (isNewActive && type != null && !string.Equals(type.Class, LeaveTypeClass, StringComparison.OrdinalIgnoreCase))
+        // type is guaranteed non-null here: early-return above when result.IsValid==false (set when type==null).
+        if (isNewActive && !string.Equals(type!.Class, LeaveTypeClass, StringComparison.OrdinalIgnoreCase))
         {
             var newTotal = activeNonLeaveTotal + Math.Round(request.PercentageValue, EffortConstants.PercentDisplayDecimals);
             if (newTotal > 100)

--- a/web/Areas/RAPS/Controllers/RAPSController.cs
+++ b/web/Areas/RAPS/Controllers/RAPSController.cs
@@ -46,14 +46,18 @@ namespace Viper.Areas.RAPS.Controllers
             List<string>? path = HttpContext?.Request?.Path.ToString().Split("/").ToList();
             int? rapsIdx = path?.FindIndex(p => p.Equals("raps", StringComparison.OrdinalIgnoreCase));
             string instance = "VIPER";
-            if (rapsIdx != null && rapsIdx > -1 && path?.Count > rapsIdx + 1)
-            {
-                instance = path[(int)rapsIdx + 1];
-            }
             string page = "";
-            if (rapsIdx != null && rapsIdx > -1 && path?.Count > rapsIdx + 2)
+            // rapsIdx is non-null iff path is non-null (it's derived from path?.FindIndex).
+            if (rapsIdx is int idx && idx > -1)
             {
-                page = path[(int)rapsIdx + 2];
+                if (path!.Count > idx + 1)
+                {
+                    instance = path[idx + 1];
+                }
+                if (path.Count > idx + 2)
+                {
+                    page = path[idx + 2];
+                }
             }
             ViewData["ViperLeftNav"] = await Nav(roleIdValid ? roleId : null,
                 permIdValid ? permissionId : null,

--- a/web/Areas/RAPS/Controllers/RAPSController.cs
+++ b/web/Areas/RAPS/Controllers/RAPSController.cs
@@ -47,10 +47,9 @@ namespace Viper.Areas.RAPS.Controllers
             int? rapsIdx = path?.FindIndex(p => p.Equals("raps", StringComparison.OrdinalIgnoreCase));
             string instance = "VIPER";
             string page = "";
-            // rapsIdx is non-null iff path is non-null (it's derived from path?.FindIndex).
-            if (rapsIdx is int idx && idx > -1)
+            if (path != null && rapsIdx is { } idx && idx > -1)
             {
-                if (path!.Count > idx + 1)
+                if (path.Count > idx + 1)
                 {
                     instance = path[idx + 1];
                 }

--- a/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
+++ b/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
@@ -185,8 +185,8 @@ namespace Viper.Areas.RAPS.Controllers
 
             return new RoleTemplateApplyPreview
             {
-                DisplayName = user?.DisplayFullName ?? "User not found",
-                MemberId = user?.MothraId ?? "",
+                DisplayName = user.DisplayFullName ?? "User not found",
+                MemberId = user.MothraId ?? "",
                 Roles = rolesToApply
             };
         }

--- a/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
+++ b/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
@@ -41,12 +41,9 @@ namespace Viper.Areas.RAPS.Controllers
                 .OrderBy(rt => rt.TemplateName)
                 .ToListAsync();
 
-            List<RoleTemplateSimplified> roleTemplates = new();
-            foreach (var rt in dbRoleTemplates)
-            {
-                roleTemplates.Add(new RoleTemplateSimplified(rt));
-            }
-            return roleTemplates;
+            return dbRoleTemplates
+                .Select(rt => new RoleTemplateSimplified(rt))
+                .ToList();
         }
 
         // GET: RoleTemplates/5
@@ -159,9 +156,6 @@ namespace Viper.Areas.RAPS.Controllers
                     : u.MothraId == memberId)
                 .FirstOrDefaultAsync();
 
-            List<RoleApplyPreview> rolesToApply = new();
-
-            //if user is not found, return the object with placeholder text
             if (user == null)
             {
                 return null;
@@ -172,21 +166,21 @@ namespace Viper.Areas.RAPS.Controllers
                 .Where(rm => rm.MemberId == user.MothraId)
                 .Select(rm => rm.Role)
                 .ToListAsync();
-            foreach (var role in roleTemplate.RoleTemplateRoles)
-            {
-                rolesToApply.Add(new RoleApplyPreview
+            HashSet<int> userRoleIds = userRoles.Select(r => r.RoleId).ToHashSet();
+            List<RoleApplyPreview> rolesToApply = roleTemplate.RoleTemplateRoles
+                .Select(role => new RoleApplyPreview
                 {
                     RoleId = role.Role.RoleId,
                     RoleName = role.Role.FriendlyName,
                     Description = role.Role.Description,
-                    UserHasRole = userRoles.Find(r => r.RoleId == role.RoleTemplateRoleRoleId) != null
-                });
-            }
+                    UserHasRole = userRoleIds.Contains(role.RoleTemplateRoleRoleId)
+                })
+                .ToList();
 
             return new RoleTemplateApplyPreview
             {
-                DisplayName = user.DisplayFullName ?? "User not found",
-                MemberId = user.MothraId ?? "",
+                DisplayName = user.DisplayFullName,
+                MemberId = user.MothraId,
                 Roles = rolesToApply
             };
         }

--- a/web/Areas/RAPS/Services/RAPSAuditService.cs
+++ b/web/Areas/RAPS/Services/RAPSAuditService.cs
@@ -137,11 +137,11 @@ namespace Viper.Areas.RAPS.Services
             Dictionary<string, List<string>> actionsPerformedOnObject = new();
             foreach (AuditLog auditLog in auditEntries)
             {
-                if (auditLog?.RoleId != null || auditLog?.PermissionId != null)
+                if (auditLog.RoleId != null || auditLog.PermissionId != null)
                 {
-                    string key = auditLog?.RoleId != null
+                    string key = auditLog.RoleId != null
                         ? "role-" + auditLog.RoleId
-                        : "permission-" + auditLog!.PermissionId;
+                        : "permission-" + auditLog.PermissionId;
                     if (actionsPerformedOnObject.TryGetValue(key, out var moreRecentActions))
                     {
                         bool undone = false;

--- a/web/Classes/Utilities/AcademicYearHelper.cs
+++ b/web/Classes/Utilities/AcademicYearHelper.cs
@@ -52,8 +52,8 @@ public static class AcademicYearHelper
     /// </summary>
     public static DateTime GetAcademicYearStart(DateTime date)
     {
-        var year = date.Month < 7 ? date.Year - 1 : date.Year;
-        return new DateTime(year, 7, 1, 0, 0, 0, DateTimeKind.Local);
+        var julyOfYear = new DateTime(date.Year, 7, 1, 0, 0, 0, DateTimeKind.Local);
+        return date.Month < 7 ? julyOfYear.AddYears(-1) : julyOfYear;
     }
 
     /// <summary>

--- a/web/Classes/Utilities/AcademicYearHelper.cs
+++ b/web/Classes/Utilities/AcademicYearHelper.cs
@@ -52,6 +52,12 @@ public static class AcademicYearHelper
     /// </summary>
     public static DateTime GetAcademicYearStart(DateTime date)
     {
+        // A date before July of year 1 has no representable academic-year start (year 0 is invalid).
+        if (date.Year == 1 && date.Month < 7)
+        {
+            throw new ArgumentOutOfRangeException(nameof(date),
+                "Date must be on or after July 1, year 1 for academic year calculation.");
+        }
         var julyOfYear = new DateTime(date.Year, 7, 1, 0, 0, 0, DateTimeKind.Local);
         return date.Month < 7 ? julyOfYear.AddYears(-1) : julyOfYear;
     }

--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -320,7 +320,8 @@ namespace Viper.Controllers
                 {
                     var claimsIdentity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, validatedUserName), new Claim(ClaimTypes.NameIdentifier, validatedUserName), new Claim(ClaimTypes.AuthenticationMethod, "CAS") }, CookieAuthenticationDefaults.AuthenticationScheme);
 
-                    XElement? attributesNode = successNode?.Element(_ns + "attributes");
+                    // successNode is guaranteed non-null here: validatedUserName is derived from successNode?.Element(user)?.Value.
+                    XElement? attributesNode = successNode!.Element(_ns + "attributes");
                     if (attributesNode != null)
                     {
                         foreach (string attributeName in _casAttributesToCapture)

--- a/web/Models/Students/StudentClassYear.cs
+++ b/web/Models/Students/StudentClassYear.cs
@@ -3,7 +3,7 @@ using Viper.Models.VIPER;
 
 namespace Viper.Models.Students
 {
-    public class StudentClassYear
+    public sealed class StudentClassYear
     {
 
         public int StudentClassYearId { get; set; }
@@ -20,10 +20,10 @@ namespace Viper.Models.Students
         public int? UpdatedBy { get; set; }
         public string? Comment { get; set; }
 
-        public virtual Person? Student { get; set; }
-        public virtual ClassYearLeftReason? ClassYearLeftReason { get; set; }
-        public virtual Person? AddedByPerson { get; set; }
-        public virtual Person? UpdatedByPerson { get; set; }
+        public Person? Student { get; set; }
+        public ClassYearLeftReason? ClassYearLeftReason { get; set; }
+        public Person? AddedByPerson { get; set; }
+        public Person? UpdatedByPerson { get; set; }
 
         [NotMapped]
         public string? LeftReasonText


### PR DESCRIPTION
## Summary

Closes ~15 CodeQL alerts across three correctness rule families. Each fix needs per-site judgment, so they're consolidated here rather than split — the reviewer mental model is the same throughout.

> Note: this PR was originally drafted with ~30 fixes; about half landed in main first via #176/#190 (b9266feb was an explicit pre-merge to keep the two branches from conflicting). The remaining fixes are described below.

### cs/virtual-call-in-constructor
- ``StudentClassYear`` ([web/Models/Students/StudentClassYear.cs](web/Models/Students/StudentClassYear.cs)) — ``class`` → ``sealed class``, drops ``virtual`` on the four navigation properties declared on the now-sealed class.

Safety check: not inherited from in C#, not ``Substitute.For<...>`` in tests, and there is no ``UseLazyLoadingProxies()`` call anywhere in the project so EF doesn't need it non-sealed.

A ``RoleTemplateSimplified`` alert in the same family is closed in commit 2dd08d8f by dropping ``virtual`` from the ``Roles`` property — a smaller change than sealing, which keeps the public constructor surface intact. New unit tests in [test/RAPS/RoleTemplateSimplifiedTests.cs](test/RAPS/RoleTemplateSimplifiedTests.cs) lock in the constructor mapping (``RoleTemplateId``, ``TemplateName``, ``Description``, and ``Roles`` projection) so future regressions surface.

### cs/unsafe-year-construction
- [web/Areas/Effort/Services/PercentRolloverService.cs](web/Areas/Effort/Services/PercentRolloverService.cs) — added ``ArgumentOutOfRangeException.ThrowIfLessThan(year, 1)`` / ``ThrowIfGreaterThan(year, 9998)`` at the top of ``GetRolloverPreviewAsync`` (year comes from HTTP). Replaced ``new DateTime(year + 1, 6, 30, ...)`` with ``june30Start.AddYears(1)``.
- [web/Classes/Utilities/AcademicYearHelper.cs](web/Classes/Utilities/AcademicYearHelper.cs) — ``GetAcademicYearStart`` now constructs July of ``date.Year`` first, then ``.AddYears(-1)`` if needed, instead of ``new DateTime(date.Year - 1, ...)``.

### cs/constant-condition
Removed redundant null-propagation that the analyzer can already prove dead:
- [web/Areas/Effort/Services/PercentageService.cs:309](web/Areas/Effort/Services/PercentageService.cs#L309) — dropped ``type != null &&`` after the ``IsValid`` guard already eliminated the null case.
- [web/Controllers/HomeController.cs:322](web/Controllers/HomeController.cs#L322) — ``successNode?.Element(...)`` → ``successNode!.Element(...)`` inside the guarded block (``validatedUserName`` is derived from ``successNode``, so it can only be non-null when ``successNode`` is non-null).
- [web/Areas/RAPS/Services/RAPSAuditService.cs:140-145](web/Areas/RAPS/Services/RAPSAuditService.cs#L140-L145) — dropped ``auditLog?.`` chains; the ``foreach`` variable is non-null by construction.
- [web/Areas/RAPS/Controllers/RoleTemplatesController.cs:185-186](web/Areas/RAPS/Controllers/RoleTemplatesController.cs#L185-L186) — dropped ``user?.`` after the ``if (user == null) return null;`` guard. Same controller also gets a small cleanup at [L41-45](web/Areas/RAPS/Controllers/RoleTemplatesController.cs#L41-L45): ``foreach`` + ``.Add`` rewritten as ``.Select().ToList()``.
- [web/Areas/RAPS/Controllers/RAPSController.cs:46-60](web/Areas/RAPS/Controllers/RAPSController.cs#L46-L60) — restructured the two ``if (rapsIdx != null && rapsIdx > -1 && path?.Count > ...)`` blocks into a single outer ``rapsIdx is { } idx && idx > -1`` check that lifts the ``path`` null check up and uses pattern matching for the cast.
- [web/Areas/CTS/Models/AuditRow.cs:25-28](web/Areas/CTS/Models/AuditRow.cs#L25-L28) — ``dbAudit?.Encounter?.`` / ``dbAudit.Encounter?.Student?.`` chains collapsed inside the surrounding non-null guard.

## Context

Third in the ``CodeQL N:`` cleanup series (after #189, #190).

## Test plan

- [x] ``npm run test`` — backend + frontend passing
- [x] ``npm run verify:build`` — clean (0 errors)
- [x] ``npm run lint`` — passing on changed files
- [ ] CodeQL workflow on this PR shows the listed alerts closed