### PR TITLE
CodeQL 4: fix: dispose disposables on exception paths

### DIFF
--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -628,7 +628,7 @@ namespace Viper.Areas.CMS.Data
         {
             byte[] secretkey = GetSecretKey(keystring);
 
-            Aes aes = Aes.Create();
+            using Aes aes = Aes.Create();
             aes.Mode = CipherMode.ECB;
 
             using var ms = new MemoryStream();
@@ -653,13 +653,13 @@ namespace Viper.Areas.CMS.Data
         public string DecryptAES(string encryptedString, string Key)
         {
             //First write to memory
-            MemoryStream mmsStream = new();
-            StreamWriter srwTemp = new(mmsStream);
+            using MemoryStream mmsStream = new();
+            using StreamWriter srwTemp = new(mmsStream);
             srwTemp.Write(encryptedString);
             srwTemp.Flush();
             mmsStream.Position = 0;
 
-            MemoryStream outstream = new();
+            using MemoryStream outstream = new();
 
             //CallingUUDecode
             Codecs.UUDecode(mmsStream, outstream);

--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -19,7 +19,7 @@ namespace Viper.Areas.Computing.Services
         public async Task<List<BiorenderStudent>> GetBiorenderStudentInfo(List<string> emails)
         {
             List<Task<BiorenderStudent>> resultList = new();
-            var throttler = new SemaphoreSlim(initialCount: 20);
+            using var throttler = new SemaphoreSlim(initialCount: 20);
             foreach (var email in emails)
             {
                 await throttler.WaitAsync();

--- a/web/Areas/Effort/Services/DeptSummaryService.cs
+++ b/web/Areas/Effort/Services/DeptSummaryService.cs
@@ -310,7 +310,7 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
 
     public MemoryStream GenerateReportExcel(DeptSummaryReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Department Summary Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -428,7 +428,6 @@ public class DeptSummaryService : BaseReportService, IDeptSummaryService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/EvaluationReportService.cs
+++ b/web/Areas/Effort/Services/EvaluationReportService.cs
@@ -681,7 +681,7 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
     public MemoryStream GenerateEvalSummaryExcel(EvalSummaryReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Eval Summary Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -735,14 +735,13 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }
 
     public MemoryStream GenerateEvalDetailExcel(EvalDetailReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Eval Detail Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -819,7 +818,6 @@ public class EvaluationReportService : BaseReportService, IEvaluationReportServi
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/MeritMultiYearService.cs
+++ b/web/Areas/Effort/Services/MeritMultiYearService.cs
@@ -1261,7 +1261,7 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
     public MemoryStream GenerateReportExcel(MultiYearReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Merit & Promotion Report - Multi-Year";
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
             subject: $"Multi-year merit and evaluation summary for {report.Instructor}");
@@ -1494,7 +1494,6 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/MeritReportService.cs
+++ b/web/Areas/Effort/Services/MeritReportService.cs
@@ -918,7 +918,7 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
     public MemoryStream GenerateMeritDetailExcel(MeritDetailReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Merit & Promotion Detail Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -1017,14 +1017,13 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }
 
     public MemoryStream GenerateMeritAverageExcel(MeritAverageReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Merit & Promotion Average Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -1163,7 +1162,6 @@ public class MeritReportService : BaseReportService, IMeritReportService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/MeritSummaryService.cs
+++ b/web/Areas/Effort/Services/MeritSummaryService.cs
@@ -368,7 +368,7 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
 
     public MemoryStream GenerateReportExcel(MeritSummaryReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Merit & Promotion Summary Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -456,7 +456,6 @@ public class MeritSummaryService : BaseReportService, IMeritSummaryService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/SchoolSummaryService.cs
+++ b/web/Areas/Effort/Services/SchoolSummaryService.cs
@@ -339,7 +339,7 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
 
     public MemoryStream GenerateReportExcel(SchoolSummaryReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "School Summary Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -480,7 +480,6 @@ public class SchoolSummaryService : BaseReportService, ISchoolSummaryService
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Areas/Effort/Services/TeachingActivityService.cs
+++ b/web/Areas/Effort/Services/TeachingActivityService.cs
@@ -485,7 +485,7 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
     public MemoryStream GenerateReportExcel(TeachingActivityReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Teaching Activity Report";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -596,14 +596,13 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }
 
     public MemoryStream GenerateIndividualReportExcel(TeachingActivityReport report)
     {
-        var wb = new XLWorkbook();
+        using var wb = new XLWorkbook();
         const string reportTitle = "Teaching Activity Report (Individual)";
         var termName = report.AcademicYear ?? report.TermName;
         ExcelAccessibilityHelper.SetCoreProperties(wb, reportTitle,
@@ -694,7 +693,6 @@ public class TeachingActivityService : BaseReportService, ITeachingActivityServi
 
         var stream = new MemoryStream();
         wb.SaveAs(stream);
-        wb.Dispose();
         stream.Position = 0;
         return stream;
     }

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -41,7 +41,7 @@ namespace Viper.Classes.Utilities
             if (request.Method != HttpMethod.Get && attemptNumber == 0)
             {
                 //Try a send to the original url, with a get and empty body.
-                HttpRequestMessage newRequest = new()
+                using HttpRequestMessage newRequest = new()
                 {
                     RequestUri = request.RequestUri,
                     Method = HttpMethod.Get

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -41,11 +41,9 @@ namespace Viper.Classes.Utilities
             if (request.Method != HttpMethod.Get && attemptNumber == 0)
             {
                 //Try a send to the original url, with a get and empty body.
-                using HttpRequestMessage newRequest = new()
-                {
-                    RequestUri = request.RequestUri,
-                    Method = HttpMethod.Get
-                };
+                using HttpRequestMessage newRequest = new();
+                newRequest.RequestUri = request.RequestUri;
+                newRequest.Method = HttpMethod.Get;
 
                 //don't care about the response
                 await Send(newRequest);

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -45,8 +45,8 @@ namespace Viper.Classes.Utilities
                 newRequest.RequestUri = request.RequestUri;
                 newRequest.Method = HttpMethod.Get;
 
-                //don't care about the response
-                await Send(newRequest);
+                //don't care about the response, but dispose it to free resources
+                using var warmupResponse = await Send(newRequest);
                 return await Send(await CopyHttpRequest(request), 1);
             }
 


### PR DESCRIPTION
## Summary

Closes ~17 CodeQL alerts in two related rule families: `cs/dispose-not-called-on-throw` (10) and `cs/local-not-disposed` (6 + 1 reviewer-found). All same fix shape - wrap IDisposable locals with `using`.

### Effort Excel-generation services (10 alerts)
Seven files have the pattern `var wb = new XLWorkbook(); ...; wb.Dispose();` where the explicit Dispose at the bottom is bypassed if `SaveAs` or any of the intermediate `ExcelHelper`/`ExcelAccessibilityHelper` calls throw. Converted to `using var wb = new XLWorkbook();` and removed the now-redundant Dispose:

- `web/Areas/Effort/Services/TeachingActivityService.cs` (2 sites)
- `web/Areas/Effort/Services/SchoolSummaryService.cs` (1 site)
- `web/Areas/Effort/Services/MeritSummaryService.cs` (1 site)
- `web/Areas/Effort/Services/MeritMultiYearService.cs` (1 site)
- `web/Areas/Effort/Services/MeritReportService.cs` (2 sites)
- `web/Areas/Effort/Services/DeptSummaryService.cs` (1 site)
- `web/Areas/Effort/Services/EvaluationReportService.cs` (2 sites)

### Other leaked disposables (7 alerts)
- `web/Areas/CMS/Data/CMS.cs::DecryptFile` - `Aes` local was never disposed.
- `web/Areas/CMS/Data/CMS.cs::DecryptAES` - `MemoryStream mmsStream`, `StreamWriter srwTemp`, `MemoryStream outstream` all leaked.
- `web/Areas/Computing/Services/BiorenderStudentLookup.cs::GetBiorenderStudentInfo` - `SemaphoreSlim throttler` leaked.
- `web/Classes/Utilities/F5HttpRequest.cs::HandleConnectionFail` - probe `HttpRequestMessage newRequest` leaked.
- `web/Classes/Utilities/F5HttpRequest.cs::HandleConnectionFail` - warm-up `Send(newRequest)` response was discarded undisposed (added per CodeRabbit review).

CMS.cs touch is outside the range PR #184 modifies (#184 covers lines 469-516 in DownloadZip; these edits are lines 631+).

## Context

Fourth in the `CodeQL N:` cleanup series (after #189, #190, #191).

### Related — out of scope

CodeRabbit's review of this PR also surfaced a pre-existing semaphore permit leak in `BiorenderStudentLookup` (invalid emails consume permits without releasing, deadlocking the loop after 20 bad entries). That's a control-flow bug rather than a dispose-hygiene change, so it lives in **#209** for cleaner history.

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] `npm run verify:build` - clean (0 errors)
- [x] Pre-commit lint+test+verify all passed
- [ ] CodeQL workflow on this PR shows the listed alerts closed