### PR TITLE
CodeQL 5: refactor(ClinicalScheduler): catch specific exceptions in services

### DIFF
--- a/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
@@ -105,7 +105,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} instructor schedules", schedules.Count);
                 return schedules;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules");
                 throw new InvalidOperationException("Failed to retrieve instructor schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
@@ -104,7 +104,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} instructor schedules", schedules.Count);
                 return schedules;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules");
                 throw new InvalidOperationException("Failed to retrieve instructor schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/InstructorScheduleService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
@@ -104,7 +105,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} instructor schedules", schedules.Count);
                 return schedules;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules");
                 throw new InvalidOperationException("Failed to retrieve instructor schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/PersonService.cs
+++ b/web/Areas/ClinicalScheduler/Services/PersonService.cs
@@ -81,7 +81,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return person;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving person data for MothraId: {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve person data for MothraId {LogSanitizer.SanitizeId(mothraId)}", ex);
@@ -139,7 +139,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {ClinicianCount} clinicians for year {Year} with person names from vPerson view", clinicians.Count, year);
                 return clinicians;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for year: {Year}", year);
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year {year}. Check database connectivity and view permissions.", ex);
@@ -209,7 +209,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogError(ex, "Database error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Database error retrieving clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
@@ -240,7 +240,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} unique MothraIds in Clinical Scheduler data", mothraIds.Count);
                 return mothraIds;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving unique MothraIds");
                 throw new InvalidOperationException("Failed to retrieve unique MothraIds from database", ex);
@@ -277,7 +277,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Found {Count} active employee affiliates from AAUD", allAffiliates.Count);
                 return allAffiliates;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving active employee affiliates from AAUD");
                 throw new InvalidOperationException("Failed to retrieve active employee affiliates from AAUD database", ex);
@@ -325,7 +325,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return clinician;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinician data for MothraId: {MothraId} from AAUD", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve clinician data for MothraId {LogSanitizer.SanitizeId(mothraId)} from AAUD", ex);

--- a/web/Areas/ClinicalScheduler/Services/PersonService.cs
+++ b/web/Areas/ClinicalScheduler/Services/PersonService.cs
@@ -81,7 +81,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return person;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving person data for MothraId: {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve person data for MothraId {LogSanitizer.SanitizeId(mothraId)}", ex);
@@ -139,7 +139,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {ClinicianCount} clinicians for year {Year} with person names from vPerson view", clinicians.Count, year);
                 return clinicians;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for year: {Year}", year);
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year {year}. Check database connectivity and view permissions.", ex);
@@ -209,7 +209,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogError(ex, "Database error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Database error retrieving clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
@@ -240,7 +240,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} unique MothraIds in Clinical Scheduler data", mothraIds.Count);
                 return mothraIds;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving unique MothraIds");
                 throw new InvalidOperationException("Failed to retrieve unique MothraIds from database", ex);
@@ -277,7 +277,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Found {Count} active employee affiliates from AAUD", allAffiliates.Count);
                 return allAffiliates;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving active employee affiliates from AAUD");
                 throw new InvalidOperationException("Failed to retrieve active employee affiliates from AAUD database", ex);
@@ -325,7 +325,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return clinician;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving clinician data for MothraId: {MothraId} from AAUD", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve clinician data for MothraId {LogSanitizer.SanitizeId(mothraId)} from AAUD", ex);

--- a/web/Areas/ClinicalScheduler/Services/PersonService.cs
+++ b/web/Areas/ClinicalScheduler/Services/PersonService.cs
@@ -81,7 +81,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return person;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving person data for MothraId: {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve person data for MothraId {LogSanitizer.SanitizeId(mothraId)}", ex);
@@ -139,7 +139,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {ClinicianCount} clinicians for year {Year} with person names from vPerson view", clinicians.Count, year);
                 return clinicians;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for year: {Year}", year);
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year {year}. Check database connectivity and view permissions.", ex);
@@ -209,7 +209,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogError(ex, "Database error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Database error retrieving clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving clinicians for grad year range {StartYear}-{EndYear}", LogSanitizer.SanitizeYear(startGradYear), LogSanitizer.SanitizeYear(endGradYear));
                 throw new InvalidOperationException($"Failed to retrieve clinicians for grad year range {LogSanitizer.SanitizeYear(startGradYear)}-{LogSanitizer.SanitizeYear(endGradYear)}", ex);
@@ -240,7 +240,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} unique MothraIds in Clinical Scheduler data", mothraIds.Count);
                 return mothraIds;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving unique MothraIds");
                 throw new InvalidOperationException("Failed to retrieve unique MothraIds from database", ex);
@@ -277,7 +277,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Found {Count} active employee affiliates from AAUD", allAffiliates.Count);
                 return allAffiliates;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving active employee affiliates from AAUD");
                 throw new InvalidOperationException("Failed to retrieve active employee affiliates from AAUD database", ex);
@@ -325,7 +325,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return clinician;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving clinician data for MothraId: {MothraId} from AAUD", LogSanitizer.SanitizeId(mothraId));
                 throw new InvalidOperationException($"Failed to retrieve clinician data for MothraId {LogSanitizer.SanitizeId(mothraId)} from AAUD", ex);

--- a/web/Areas/ClinicalScheduler/Services/RotationService.cs
+++ b/web/Areas/ClinicalScheduler/Services/RotationService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Extensions;
 using Viper.Areas.ClinicalScheduler.Models.DTOs.Responses;
@@ -45,7 +46,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     rotations.Count);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve rotations from Clinical Scheduler database", ex);
@@ -82,7 +83,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotation?.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotation by ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve rotation with ID {rotationId}", ex);
@@ -124,7 +125,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotations;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by course - CourseNumber: {CourseNumber}, SubjectCode: {SubjectCode}",
                     courseNumber, subjectCode);
@@ -154,7 +155,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} rotations for service ID: {ServiceId}", rotations.Count, serviceId);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by service ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve rotations for service ID {serviceId}", ex);
@@ -180,7 +181,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} services from Clinical Scheduler", services.Count);
                 return services.Select(s => s.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving services from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve services from Clinical Scheduler database", ex);
@@ -215,7 +216,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return service?.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving service by ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve service with ID {serviceId}", ex);
@@ -265,7 +266,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return schedules;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules for rotation ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve instructor schedules for rotation ID {rotationId}", ex);

--- a/web/Areas/ClinicalScheduler/Services/RotationService.cs
+++ b/web/Areas/ClinicalScheduler/Services/RotationService.cs
@@ -45,7 +45,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     rotations.Count);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve rotations from Clinical Scheduler database", ex);
@@ -82,7 +82,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotation?.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotation by ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve rotation with ID {rotationId}", ex);
@@ -124,7 +124,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotations;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by course - CourseNumber: {CourseNumber}, SubjectCode: {SubjectCode}",
                     courseNumber, subjectCode);
@@ -154,7 +154,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} rotations for service ID: {ServiceId}", rotations.Count, serviceId);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by service ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve rotations for service ID {serviceId}", ex);
@@ -180,7 +180,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} services from Clinical Scheduler", services.Count);
                 return services.Select(s => s.ToDto()).ToList();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving services from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve services from Clinical Scheduler database", ex);
@@ -215,7 +215,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return service?.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving service by ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve service with ID {serviceId}", ex);
@@ -265,7 +265,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return schedules;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules for rotation ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve instructor schedules for rotation ID {rotationId}", ex);

--- a/web/Areas/ClinicalScheduler/Services/RotationService.cs
+++ b/web/Areas/ClinicalScheduler/Services/RotationService.cs
@@ -46,7 +46,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     rotations.Count);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving rotations from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve rotations from Clinical Scheduler database", ex);
@@ -83,7 +83,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotation?.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving rotation by ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve rotation with ID {rotationId}", ex);
@@ -125,7 +125,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return rotations;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by course - CourseNumber: {CourseNumber}, SubjectCode: {SubjectCode}",
                     courseNumber, subjectCode);
@@ -155,7 +155,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} rotations for service ID: {ServiceId}", rotations.Count, serviceId);
                 return rotations.Select(r => r.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving rotations by service ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve rotations for service ID {serviceId}", ex);
@@ -181,7 +181,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Retrieved {Count} services from Clinical Scheduler", services.Count);
                 return services.Select(s => s.ToDto()).ToList();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving services from Clinical Scheduler");
                 throw new InvalidOperationException("Failed to retrieve services from Clinical Scheduler database", ex);
@@ -216,7 +216,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return service?.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving service by ID: {ServiceId}", serviceId);
                 throw new InvalidOperationException($"Failed to retrieve service with ID {serviceId}", ex);
@@ -266,7 +266,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return schedules;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving instructor schedules for rotation ID: {RotationId}", rotationId);
                 throw new InvalidOperationException($"Failed to retrieve instructor schedules for rotation ID {rotationId}", ex);

--- a/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
@@ -114,7 +114,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for instructor schedule {instructorScheduleId}. Please try again or contact support if the problem persists.", ex);
@@ -134,7 +134,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for rotation {RotationId}, week {WeekId}", rotationId, weekId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for rotation {rotationId}, week {weekId}. Please try again or contact support if the problem persists.", ex);
@@ -179,7 +179,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return auditEntry;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error creating audit entry for action {Action}, {MothraId} on rotation {RotationId}, week {WeekId}",
                     action, LogSanitizer.SanitizeId(mothraId), rotationId, weekId);

--- a/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
@@ -115,7 +115,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for instructor schedule {instructorScheduleId}. Please try again or contact support if the problem persists.", ex);
@@ -135,7 +135,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for rotation {RotationId}, week {WeekId}", rotationId, weekId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for rotation {rotationId}, week {weekId}. Please try again or contact support if the problem persists.", ex);
@@ -180,7 +180,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return auditEntry;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error creating audit entry for action {Action}, {MothraId} on rotation {RotationId}, week {WeekId}",
                     action, LogSanitizer.SanitizeId(mothraId), rotationId, weekId);

--- a/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleAuditService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Constants;
 using Viper.Classes.SQLContext;
@@ -114,7 +115,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for instructor schedule {instructorScheduleId}. Please try again or contact support if the problem persists.", ex);
@@ -134,7 +135,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .OrderByDescending(a => a.TimeStamp)
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for rotation {RotationId}, week {WeekId}", rotationId, weekId);
                 throw new InvalidOperationException($"Failed to retrieve audit history for rotation {rotationId}, week {weekId}. Please try again or contact support if the problem persists.", ex);
@@ -179,7 +180,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return auditEntry;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error creating audit entry for action {Action}, {MothraId} on rotation {RotationId}, week {WeekId}",
                     action, LogSanitizer.SanitizeId(mothraId), rotationId, weekId);

--- a/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Viper.Areas.ClinicalScheduler.EmailTemplates.Models;
@@ -241,7 +242,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "already scheduled" messages)
                 throw;
             }
-            catch (Exception saveEx) when (saveEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception saveEx) when (saveEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(saveEx, "Database save failed for MothraId='{MothraId}', RotationId={RotationId}, WeekIds=[{WeekIds}]",
                     LogSanitizer.SanitizeId(mothraId), rotationId, string.Join(",", weekIds));
@@ -359,7 +360,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "Cannot remove primary evaluator" message)
                 throw;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException("Failed to remove instructor schedule. Please try again or contact support if the problem persists.", ex);
@@ -470,7 +471,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return (true, previousPrimaryName);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} to {IsPrimary}", instructorScheduleId, isPrimary);
                 throw new InvalidOperationException("Failed to update primary evaluator status. Please try again or contact support if the problem persists.", ex);
@@ -495,7 +496,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // All instructors can now be removed, including primary evaluators
                 return true;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking if instructor schedule {ScheduleId} can be removed", instructorScheduleId);
                 return false;
@@ -537,7 +538,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await query.ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking other rotation schedules for {MothraId} on weeks {WeekIds} for grad year {GradYear}",
                     LogSanitizer.SanitizeId(mothraId), string.Join(",", weekIds), LogSanitizer.SanitizeYear(gradYear));
@@ -565,7 +566,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .Where(s => s.RotationId == rotationId && weekIds.Contains(s.WeekId))
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error getting scheduled instructors for rotation {RotationId} on weeks {WeekIds}", rotationId, string.Join(",", weekIds));
                 throw new InvalidOperationException("Failed to retrieve scheduled instructors. Please try again or contact support if the problem persists.", ex);
@@ -668,7 +669,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         }
                     }
                 }
-                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve instructor name for {MothraId} in email notification", LogSanitizer.SanitizeId(schedule.MothraId));
                 }
@@ -701,7 +702,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         weekNumber = weekGradYear.WeekNum.ToString();
                     }
                 }
-                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve week number for {WeekId} in email notification", schedule.WeekId);
                 }
@@ -726,7 +727,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                             : "";
                     }
                 }
-                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve modifier information for {MothraId} in email notification", modifiedByMothraId);
                 }

--- a/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
@@ -242,7 +242,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "already scheduled" messages)
                 throw;
             }
-            catch (Exception saveEx) when (saveEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception saveEx) when (saveEx is DbUpdateException or SqlException)
             {
                 _logger.LogError(saveEx, "Database save failed for MothraId='{MothraId}', RotationId={RotationId}, WeekIds=[{WeekIds}]",
                     LogSanitizer.SanitizeId(mothraId), rotationId, string.Join(",", weekIds));
@@ -360,7 +360,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "Cannot remove primary evaluator" message)
                 throw;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException("Failed to remove instructor schedule. Please try again or contact support if the problem persists.", ex);
@@ -471,7 +471,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return (true, previousPrimaryName);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} to {IsPrimary}", instructorScheduleId, isPrimary);
                 throw new InvalidOperationException("Failed to update primary evaluator status. Please try again or contact support if the problem persists.", ex);
@@ -496,7 +496,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // All instructors can now be removed, including primary evaluators
                 return true;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking if instructor schedule {ScheduleId} can be removed", instructorScheduleId);
                 return false;
@@ -538,7 +538,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await query.ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking other rotation schedules for {MothraId} on weeks {WeekIds} for grad year {GradYear}",
                     LogSanitizer.SanitizeId(mothraId), string.Join(",", weekIds), LogSanitizer.SanitizeYear(gradYear));
@@ -566,7 +566,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .Where(s => s.RotationId == rotationId && weekIds.Contains(s.WeekId))
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error getting scheduled instructors for rotation {RotationId} on weeks {WeekIds}", rotationId, string.Join(",", weekIds));
                 throw new InvalidOperationException("Failed to retrieve scheduled instructors. Please try again or contact support if the problem persists.", ex);
@@ -669,7 +669,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         }
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve instructor name for {MothraId} in email notification", LogSanitizer.SanitizeId(schedule.MothraId));
                 }
@@ -702,7 +702,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         weekNumber = weekGradYear.WeekNum.ToString();
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve week number for {WeekId} in email notification", schedule.WeekId);
                 }
@@ -727,7 +727,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                             : "";
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve modifier information for {MothraId} in email notification", modifiedByMothraId);
                 }

--- a/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
@@ -217,7 +217,9 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     }
 #pragma warning restore S3267
                 }
+#pragma warning disable CA1031 // Intentional broad catch: post-transaction work (email/audit notifications) must not roll back the successful database changes above.
                 catch (Exception postTransactionEx)
+#pragma warning restore CA1031
                 {
                     // Log warning but don't fail the operation - the database changes were successful
                     _logger.LogWarning(postTransactionEx, "Post-transaction operations failed for instructor {MothraId} in rotation {RotationId}, but database changes were successful",
@@ -239,7 +241,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "already scheduled" messages)
                 throw;
             }
-            catch (Exception saveEx)
+            catch (Exception saveEx) when (saveEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(saveEx, "Database save failed for MothraId='{MothraId}', RotationId={RotationId}, WeekIds=[{WeekIds}]",
                     LogSanitizer.SanitizeId(mothraId), rotationId, string.Join(",", weekIds));
@@ -333,7 +335,9 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         await HandlePrimaryEvaluatorRemovalAsync(schedule, currentUser.MothraId, cancellationToken);
                     }
                 }
+#pragma warning disable CA1031 // Intentional broad catch: post-transaction work (email/audit notifications) must not roll back the successful database changes above.
                 catch (Exception postTransactionEx)
+#pragma warning restore CA1031
                 {
                     // Log warning but don't fail the operation - the database changes were successful
                     _logger.LogWarning(postTransactionEx, "Post-transaction operations failed for instructor removal {ScheduleId}, but database changes were successful",
@@ -355,7 +359,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // Re-throw InvalidOperationException without wrapping (includes "Cannot remove primary evaluator" message)
                 throw;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId}", instructorScheduleId);
                 throw new InvalidOperationException("Failed to remove instructor schedule. Please try again or contact support if the problem persists.", ex);
@@ -452,7 +456,9 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         await HandlePrimaryEvaluatorRemovalAsync(schedule, currentUser.MothraId, cancellationToken, null, requiresPrimaryEvaluator);
                     }
                 }
+#pragma warning disable CA1031 // Intentional broad catch: post-transaction work (email/audit notifications) must not roll back the successful database changes above.
                 catch (Exception postTransactionEx)
+#pragma warning restore CA1031
                 {
                     // Log warning but don't fail the operation - the database changes were successful
                     _logger.LogWarning(postTransactionEx, "Post-transaction operations failed for primary evaluator update {ScheduleId}, but database changes were successful",
@@ -464,7 +470,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return (true, previousPrimaryName);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} to {IsPrimary}", instructorScheduleId, isPrimary);
                 throw new InvalidOperationException("Failed to update primary evaluator status. Please try again or contact support if the problem persists.", ex);
@@ -489,7 +495,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // All instructors can now be removed, including primary evaluators
                 return true;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking if instructor schedule {ScheduleId} can be removed", instructorScheduleId);
                 return false;
@@ -531,7 +537,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await query.ToListAsync(cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking other rotation schedules for {MothraId} on weeks {WeekIds} for grad year {GradYear}",
                     LogSanitizer.SanitizeId(mothraId), string.Join(",", weekIds), LogSanitizer.SanitizeYear(gradYear));
@@ -559,7 +565,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .Where(s => s.RotationId == rotationId && weekIds.Contains(s.WeekId))
                     .ToListAsync(cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error getting scheduled instructors for rotation {RotationId} on weeks {WeekIds}", rotationId, string.Join(",", weekIds));
                 throw new InvalidOperationException("Failed to retrieve scheduled instructors. Please try again or contact support if the problem persists.", ex);
@@ -662,7 +668,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         }
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve instructor name for {MothraId} in email notification", LogSanitizer.SanitizeId(schedule.MothraId));
                 }
@@ -695,7 +701,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                         weekNumber = weekGradYear.WeekNum.ToString();
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve week number for {WeekId} in email notification", schedule.WeekId);
                 }
@@ -720,7 +726,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                             : "";
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Could not retrieve modifier information for {MothraId} in email notification", modifiedByMothraId);
                 }
@@ -771,9 +777,10 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     _logger.LogInformation("No notification recipients configured for Primary Evaluator Removal; skipped email. Rotation={RotationName}, Week={WeekNumber}", rotationName, weekNumber);
                 }
             }
+#pragma warning disable CA1031 // Intentional broad catch: email notification is secondary to the schedule removal; any failure must be logged but not propagated.
             catch (Exception ex)
+#pragma warning restore CA1031
             {
-                // Log error but don't fail the transaction - email is secondary to the schedule removal
                 _logger.LogError(ex, "Failed to send primary evaluator removal notification for {MothraId} from rotation {RotationId} week {WeekId} (rotation: {RotationName})",
                     LogSanitizer.SanitizeId(schedule.MothraId), schedule.RotationId, schedule.WeekId, schedule.Rotation?.Name ?? "Unknown");
             }

--- a/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
+++ b/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
@@ -87,7 +87,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return hasPermission;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var currentUser = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and service {ServiceId}", LogSanitizer.SanitizeId(currentUser?.MothraId), serviceId);
@@ -114,7 +114,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await HasEditPermissionForServiceAsync(rotation.ServiceId, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and rotation {RotationId}", LogSanitizer.SanitizeId(user?.MothraId), rotationId);
@@ -150,7 +150,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return editableServices;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting editable services for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -183,7 +183,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return permissions;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting service permissions for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -212,7 +212,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Required permission for service {ServiceId}: {RequiredPermission}", serviceId, requiredPermission);
                 return requiredPermission;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error getting required permission for service {ServiceId}", serviceId);
                 return ClinicalSchedulePermissions.Manage;
@@ -258,7 +258,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return canEdit;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking own schedule permissions for user {MothraId} and instructor schedule {InstructorScheduleId}",
@@ -304,7 +304,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to student schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking student schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -346,7 +346,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to instructor schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking instructor schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));

--- a/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
+++ b/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
@@ -88,7 +88,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return hasPermission;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var currentUser = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and service {ServiceId}", LogSanitizer.SanitizeId(currentUser?.MothraId), serviceId);
@@ -115,7 +115,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await HasEditPermissionForServiceAsync(rotation.ServiceId, cancellationToken);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and rotation {RotationId}", LogSanitizer.SanitizeId(user?.MothraId), rotationId);
@@ -151,7 +151,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return editableServices;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting editable services for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -184,7 +184,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return permissions;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting service permissions for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -213,7 +213,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Required permission for service {ServiceId}: {RequiredPermission}", serviceId, requiredPermission);
                 return requiredPermission;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error getting required permission for service {ServiceId}", serviceId);
                 return ClinicalSchedulePermissions.Manage;
@@ -259,7 +259,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return canEdit;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking own schedule permissions for user {MothraId} and instructor schedule {InstructorScheduleId}",
@@ -305,7 +305,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to student schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking student schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -347,7 +347,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to instructor schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking instructor schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));

--- a/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
+++ b/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
@@ -87,7 +88,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return hasPermission;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var currentUser = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and service {ServiceId}", LogSanitizer.SanitizeId(currentUser?.MothraId), serviceId);
@@ -114,7 +115,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return await HasEditPermissionForServiceAsync(rotation.ServiceId, cancellationToken);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking edit permissions for user {MothraId} and rotation {RotationId}", LogSanitizer.SanitizeId(user?.MothraId), rotationId);
@@ -150,7 +151,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return editableServices;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting editable services for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -183,7 +184,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return permissions;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error getting service permissions for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -212,7 +213,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("Required permission for service {ServiceId}: {RequiredPermission}", serviceId, requiredPermission);
                 return requiredPermission;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error getting required permission for service {ServiceId}", serviceId);
                 return ClinicalSchedulePermissions.Manage;
@@ -258,7 +259,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
 
                 return canEdit;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking own schedule permissions for user {MothraId} and instructor schedule {InstructorScheduleId}",
@@ -304,7 +305,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to student schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking student schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
@@ -346,7 +347,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogDebug("User {MothraId} denied access to instructor schedules", LogSanitizer.SanitizeId(user.MothraId));
                 return Task.FromResult(false);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 var user = _userHelper.GetCurrentUser();
                 _logger.LogError(ex, "Error checking instructor schedule access for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));

--- a/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
@@ -111,7 +111,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} student schedules", result.Count);
                 return result;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving student schedules");
                 throw new InvalidOperationException("Failed to retrieve student schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.CTS.Models;
 using Viper.Classes.SQLContext;
@@ -110,7 +111,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} student schedules", result.Count);
                 return result;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving student schedules");
                 throw new InvalidOperationException("Failed to retrieve student schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
+++ b/web/Areas/ClinicalScheduler/Services/StudentScheduleService.cs
@@ -110,7 +110,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Found {Count} student schedules", result.Count);
                 return result;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving student schedules");
                 throw new InvalidOperationException("Failed to retrieve student schedules", ex);

--- a/web/Areas/ClinicalScheduler/Services/WeekService.cs
+++ b/web/Areas/ClinicalScheduler/Services/WeekService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Extensions;
 using Viper.Areas.ClinicalScheduler.Models.DTOs.Responses;
@@ -48,7 +49,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, gradYear, includeExtendedRotation);
                 return weeks.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for grad year {GradYear}: {ErrorMessage}", gradYear, ex.Message);
                 throw new InvalidOperationException($"Failed to retrieve weeks for graduation year {gradYear}", ex);
@@ -89,7 +90,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weekId, week.GradYear, week.WeekNum);
                 return week.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving week {WeekId} for grad year {GradYear}", weekId, gradYear);
                 throw new InvalidOperationException($"Failed to retrieve week {weekId} for graduation year {gradYear}", ex);
@@ -130,7 +131,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Current week is {WeekNum} for grad year {GradYear}", week.WeekNum, week.GradYear);
                 return week.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving current week for grad year {GradYear}", gradYear);
                 throw new InvalidOperationException($"Failed to retrieve current week for graduation year {gradYear}", ex);
@@ -174,7 +175,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");
                 return weeks.ToDto();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for date range {StartDate} to {EndDate}",
                     startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");

--- a/web/Areas/ClinicalScheduler/Services/WeekService.cs
+++ b/web/Areas/ClinicalScheduler/Services/WeekService.cs
@@ -49,7 +49,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, gradYear, includeExtendedRotation);
                 return weeks.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for grad year {GradYear}: {ErrorMessage}", gradYear, ex.Message);
                 throw new InvalidOperationException($"Failed to retrieve weeks for graduation year {gradYear}", ex);
@@ -90,7 +90,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weekId, week.GradYear, week.WeekNum);
                 return week.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving week {WeekId} for grad year {GradYear}", weekId, gradYear);
                 throw new InvalidOperationException($"Failed to retrieve week {weekId} for graduation year {gradYear}", ex);
@@ -131,7 +131,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Current week is {WeekNum} for grad year {GradYear}", week.WeekNum, week.GradYear);
                 return week.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving current week for grad year {GradYear}", gradYear);
                 throw new InvalidOperationException($"Failed to retrieve current week for graduation year {gradYear}", ex);
@@ -175,7 +175,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");
                 return weeks.ToDto();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for date range {StartDate} to {EndDate}",
                     startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");

--- a/web/Areas/ClinicalScheduler/Services/WeekService.cs
+++ b/web/Areas/ClinicalScheduler/Services/WeekService.cs
@@ -48,7 +48,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, gradYear, includeExtendedRotation);
                 return weeks.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for grad year {GradYear}: {ErrorMessage}", gradYear, ex.Message);
                 throw new InvalidOperationException($"Failed to retrieve weeks for graduation year {gradYear}", ex);
@@ -89,7 +89,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weekId, week.GradYear, week.WeekNum);
                 return week.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving week {WeekId} for grad year {GradYear}", weekId, gradYear);
                 throw new InvalidOperationException($"Failed to retrieve week {weekId} for graduation year {gradYear}", ex);
@@ -130,7 +130,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogInformation("Current week is {WeekNum} for grad year {GradYear}", week.WeekNum, week.GradYear);
                 return week.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving current week for grad year {GradYear}", gradYear);
                 throw new InvalidOperationException($"Failed to retrieve current week for graduation year {gradYear}", ex);
@@ -174,7 +174,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     weeks.Count, startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");
                 return weeks.ToDto();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving weeks for date range {StartDate} to {EndDate}",
                     startDate?.ToString("yyyy-MM-dd") ?? "none", endDate?.ToString("yyyy-MM-dd") ?? "none");


### PR DESCRIPTION
## Summary

Closes ~39 of 43 `cs/catch-of-all-exceptions` alerts in `web/Areas/ClinicalScheduler/Services/**`. Replaces blanket `catch (Exception)` with a `when` filter that restricts to the exception families these service methods actually need to wrap (`DbUpdateException`, `SqlException`, `InvalidOperationException`) per the CLAUDE.md convention.

## Why 4 broad catches are kept

Four catches wrap fire-and-forget post-transaction work - email notifications and audit logging that must run *after* a successful DB change and **must not** roll the change back. The `EmailNotificationTest.RemoveInstructorScheduleAsync_EmailServiceFails_StillCompletesRemoval` test enforces this resilience contract by throwing a raw `Exception` from the mocked email service and asserting that the schedule removal still succeeds. These four sites are kept broad and explicitly annotated:

```csharp
#pragma warning disable CA1031 // Intentional broad catch: post-transaction work (email/audit notifications) must not roll back the successful database changes above.
catch (Exception postTransactionEx)
#pragma warning restore CA1031
```

CodeQL will still flag these four; they're known-intentional and can be dismissed in the dashboard.

## Cancellation handling

The `when` filters originally included `OperationCanceledException`, which caused cancellation to be wrapped as `InvalidOperationException` (or, in `SchedulePermissionService`, silently returned `false`/empty). Removed from all filters so cooperative cancellation now propagates naturally to callers — a behavior change addressing review feedback.

## Files changed

- `InstructorScheduleService.cs` - 1 catch narrowed
- `PersonService.cs` - 6 catches narrowed
- `RotationService.cs` - 7 catches narrowed
- `ScheduleAuditService.cs` - 3 catches narrowed
- `ScheduleEditService.cs` - 9 narrowed, 4 kept broad with pragma
- `SchedulePermissionService.cs` - 8 catches narrowed
- `StudentScheduleService.cs` - 1 catch narrowed
- `WeekService.cs` - 4 catches narrowed

## Context

Fifth in the `CodeQL N:` cleanup series (after #189, #190, #191, #192).

## Test plan

- [x] `npm run test:backend` - 1946 tests passing (including the email-failure resilience test)
- [x] `npm run verify:build` - clean (0 errors)
- [x] Pre-commit lint+test+verify all passed
- [ ] CodeQL workflow on this PR shows ~39 of the 43 ClinicalScheduler/Services catch-of-all alerts closed
