### PR TITLE
CodeQL 6: refactor: catch specific exceptions across CTS/RAPS/shared

### DIFF
--- a/test/ClinicalScheduler/CliniciansControllerTest.cs
+++ b/test/ClinicalScheduler/CliniciansControllerTest.cs
@@ -3,10 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Viper.Areas.ClinicalScheduler.Controllers;
 using Viper.Areas.ClinicalScheduler.Models.DTOs.Responses;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Classes.SQLContext;
+using Viper.Models.AAUD;
 
 namespace Viper.test.ClinicalScheduler
 {
@@ -268,6 +270,38 @@ namespace Viper.test.ClinicalScheduler
             var okResult = Assert.IsType<OkObjectResult>(result);
             var clinicians = Assert.IsAssignableFrom<IEnumerable<dynamic>>(okResult.Value);
             Assert.Equal(2, clinicians.Count()); // Should see all clinicians to assign to rotations
+        }
+
+        [Fact]
+        public async Task GetClinicians_WhenPermissionCheckThrows_ReturnsEmptyList()
+        {
+            // Fail closed: if evaluating permissions throws, the endpoint must return no
+            // clinicians rather than leak the unfiltered roster. Admin would normally see all.
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.Admin });
+            MockUserHelper.HasPermission(Arg.Any<RAPSContext>(), Arg.Any<AaudUser>(), Arg.Any<string>())
+                .Throws(new InvalidOperationException("Simulated permission store failure"));
+            RecreateController();
+
+            var result = await _controller.GetClinicians();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var clinicians = Assert.IsAssignableFrom<IEnumerable<dynamic>>(okResult.Value);
+            Assert.Empty(clinicians);
+        }
+
+        [Fact]
+        public async Task GetClinicianSchedule_WhenPermissionCheckThrows_ReturnsForbid()
+        {
+            // Deny on error: if evaluating permissions throws, access must be denied even for a
+            // user (Admin) who would otherwise be allowed to view any clinician's schedule.
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.Admin });
+            MockUserHelper.HasPermission(Arg.Any<RAPSContext>(), Arg.Any<AaudUser>(), Arg.Any<string>())
+                .Throws(new InvalidOperationException("Simulated permission store failure"));
+            RecreateController();
+
+            var result = await _controller.GetClinicianSchedule("67890"); // Requesting other user's schedule
+
+            Assert.IsType<ForbidResult>(result);
         }
 
         protected override void Dispose(bool disposing)

--- a/web/Areas/CTS/Controllers/BundleCompetencyController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyController.cs
@@ -5,6 +5,7 @@ using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.CTS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -158,7 +159,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustBundleCompetencyOrders(bundleComp);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Cannot delete this bundle competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleCompetencyController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyController.cs
@@ -158,7 +158,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustBundleCompetencyOrders(bundleComp);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Cannot delete this bundle competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleCompetencyController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyController.cs
@@ -159,7 +159,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustBundleCompetencyOrders(bundleComp);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Cannot delete this bundle competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
@@ -5,6 +5,7 @@ using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.CTS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -116,7 +117,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustGroupOrders(group);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Cannot delete group. Competencies must be removed from the group, and the group cannot have been used to document a student competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
@@ -116,7 +116,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustGroupOrders(group);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Cannot delete group. Competencies must be removed from the group, and the group cannot have been used to document a student competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
@@ -117,7 +117,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 AdjustGroupOrders(group);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Cannot delete group. Competencies must be removed from the group, and the group cannot have been used to document a student competency.");
             }

--- a/web/Areas/CTS/Controllers/BundleController.cs
+++ b/web/Areas/CTS/Controllers/BundleController.cs
@@ -140,7 +140,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not delete bundle. If this bundle has been used, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/BundleController.cs
+++ b/web/Areas/CTS/Controllers/BundleController.cs
@@ -5,6 +5,7 @@ using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.CTS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -139,7 +140,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not delete bundle. If this bundle has been used, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/BundleController.cs
+++ b/web/Areas/CTS/Controllers/BundleController.cs
@@ -139,7 +139,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not delete bundle. If this bundle has been used, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/CompetencyController.cs
+++ b/web/Areas/CTS/Controllers/CompetencyController.cs
@@ -177,9 +177,9 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                return BadRequest("Could not remove domain. It may be linked to other objects.");
+                return BadRequest("Could not remove competency. It may be linked to other objects.");
             }
             await UpdateCompetencyOrders();
             return new CompetencyDto(c);

--- a/web/Areas/CTS/Controllers/CompetencyController.cs
+++ b/web/Areas/CTS/Controllers/CompetencyController.cs
@@ -176,7 +176,7 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not remove domain. It may be linked to other objects.");
             }

--- a/web/Areas/CTS/Controllers/CompetencyController.cs
+++ b/web/Areas/CTS/Controllers/CompetencyController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.CTS.Models;
 using Viper.Classes;
@@ -176,7 +177,7 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not remove domain. It may be linked to other objects.");
             }

--- a/web/Areas/CTS/Controllers/CourseController.cs
+++ b/web/Areas/CTS/Controllers/CourseController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.CTS.Models;
 using Viper.Classes;
@@ -105,7 +106,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not set roles.");
             }
@@ -279,7 +280,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not update levels.");
             }

--- a/web/Areas/CTS/Controllers/CourseController.cs
+++ b/web/Areas/CTS/Controllers/CourseController.cs
@@ -106,7 +106,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not set roles.");
             }
@@ -280,7 +280,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not update levels.");
             }

--- a/web/Areas/CTS/Controllers/CourseController.cs
+++ b/web/Areas/CTS/Controllers/CourseController.cs
@@ -105,7 +105,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not set roles.");
             }
@@ -279,7 +279,7 @@ namespace Viper.Areas.CTS.Controllers
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not update levels.");
             }

--- a/web/Areas/CTS/Controllers/DomainController.cs
+++ b/web/Areas/CTS/Controllers/DomainController.cs
@@ -5,6 +5,7 @@ using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.CTS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -91,7 +92,7 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not remove domain. It may be linked to other objects.");
             }

--- a/web/Areas/CTS/Controllers/DomainController.cs
+++ b/web/Areas/CTS/Controllers/DomainController.cs
@@ -92,7 +92,7 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not remove domain. It may be linked to other objects.");
             }

--- a/web/Areas/CTS/Controllers/DomainController.cs
+++ b/web/Areas/CTS/Controllers/DomainController.cs
@@ -91,7 +91,7 @@ namespace Viper.Areas.CTS.Controllers
             {
                 await context.SaveChangesAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not remove domain. It may be linked to other objects.");
             }

--- a/web/Areas/CTS/Controllers/EpaController.cs
+++ b/web/Areas/CTS/Controllers/EpaController.cs
@@ -105,7 +105,7 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(epa).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest(ex.Message);
             }

--- a/web/Areas/CTS/Controllers/EpaController.cs
+++ b/web/Areas/CTS/Controllers/EpaController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
@@ -105,7 +106,7 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(epa).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest(ex.Message);
             }

--- a/web/Areas/CTS/Controllers/EpaController.cs
+++ b/web/Areas/CTS/Controllers/EpaController.cs
@@ -106,9 +106,9 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(epa).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                return BadRequest(ex.Message);
+                return BadRequest("Could not delete EPA. It may be linked to other objects.");
             }
 
             return epa;

--- a/web/Areas/CTS/Controllers/LevelsController.cs
+++ b/web/Areas/CTS/Controllers/LevelsController.cs
@@ -5,6 +5,7 @@ using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.CTS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -151,7 +152,7 @@ namespace Viper.Areas.CTS.Controllers
                 AdjustLevelOrders(existing);
                 await trans.CommitAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not delete level. If this level has been used in an assessment, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/LevelsController.cs
+++ b/web/Areas/CTS/Controllers/LevelsController.cs
@@ -151,7 +151,7 @@ namespace Viper.Areas.CTS.Controllers
                 AdjustLevelOrders(existing);
                 await trans.CommitAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not delete level. If this level has been used in an assessment, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/LevelsController.cs
+++ b/web/Areas/CTS/Controllers/LevelsController.cs
@@ -152,7 +152,7 @@ namespace Viper.Areas.CTS.Controllers
                 AdjustLevelOrders(existing);
                 await trans.CommitAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not delete level. If this level has been used in an assessment, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/RoleController.cs
+++ b/web/Areas/CTS/Controllers/RoleController.cs
@@ -4,6 +4,7 @@ using Viper.Areas.CTS.Models;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.CTS.Controllers
 {
@@ -84,7 +85,7 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(role).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return BadRequest("Could not delete role. If this role has been added to a bundle, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/RoleController.cs
+++ b/web/Areas/CTS/Controllers/RoleController.cs
@@ -84,7 +84,7 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(role).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 return BadRequest("Could not delete role. If this role has been added to a bundle, it cannot be deleted.");
             }

--- a/web/Areas/CTS/Controllers/RoleController.cs
+++ b/web/Areas/CTS/Controllers/RoleController.cs
@@ -85,7 +85,7 @@ namespace Viper.Areas.CTS.Controllers
                 context.Entry(role).State = EntityState.Deleted;
                 await context.SaveChangesAsync();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 return BadRequest("Could not delete role. If this role has been added to a bundle, it cannot be deleted.");
             }

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -334,7 +334,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     schedules.Count, LogSanitizer.SanitizeId(mothraId), LogSanitizer.SanitizeYear(targetYear));
                 return Ok(result);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -381,7 +381,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogDebug("Found {RotationCount} unique rotations for clinician {MothraId}", rotations.Count, LogSanitizer.SanitizeId(mothraId));
                 return Ok(rotations);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -575,7 +575,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 // All other cases (Admin, Manage, EditClnSchedules, rotation view, or service-specific permissions) see all clinicians
                 return clinicians;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error filtering clinicians by permissions. Returning unfiltered list.");
                 return clinicians; // Return unfiltered list on error to avoid breaking functionality
@@ -653,7 +653,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     LogSanitizer.SanitizeId(currentUser.MothraId), LogSanitizer.SanitizeId(targetMothraId));
                 return false;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking clinician schedule view permission for target {TargetMothraId}", LogSanitizer.SanitizeId(targetMothraId));
                 return false; // Deny access on error

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Areas.Curriculum.Services;
@@ -334,7 +335,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     schedules.Count, LogSanitizer.SanitizeId(mothraId), LogSanitizer.SanitizeYear(targetYear));
                 return Ok(result);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -381,7 +382,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogDebug("Found {RotationCount} unique rotations for clinician {MothraId}", rotations.Count, LogSanitizer.SanitizeId(mothraId));
                 return Ok(rotations);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -575,7 +576,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 // All other cases (Admin, Manage, EditClnSchedules, rotation view, or service-specific permissions) see all clinicians
                 return clinicians;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error filtering clinicians by permissions. Returning unfiltered list.");
                 return clinicians; // Return unfiltered list on error to avoid breaking functionality
@@ -653,7 +654,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     LogSanitizer.SanitizeId(currentUser.MothraId), LogSanitizer.SanitizeId(targetMothraId));
                 return false;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking clinician schedule view permission for target {TargetMothraId}", LogSanitizer.SanitizeId(targetMothraId));
                 return false; // Deny access on error

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -578,8 +578,8 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             }
             catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                _logger.LogError(ex, "Error filtering clinicians by permissions. Returning unfiltered list.");
-                return clinicians; // Return unfiltered list on error to avoid breaking functionality
+                _logger.LogError(ex, "Error filtering clinicians by permissions. Returning empty list.");
+                return new List<ClinicianSummary>(); // Fail closed: don't expose unfiltered data when permission checks fail
             }
         }
 

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -335,7 +335,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     schedules.Count, LogSanitizer.SanitizeId(mothraId), LogSanitizer.SanitizeYear(targetYear));
                 return Ok(result);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -382,7 +382,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogDebug("Found {RotationCount} unique rotations for clinician {MothraId}", rotations.Count, LogSanitizer.SanitizeId(mothraId));
                 return Ok(rotations);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("MothraId", mothraId);
@@ -576,7 +576,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 // All other cases (Admin, Manage, EditClnSchedules, rotation view, or service-specific permissions) see all clinicians
                 return clinicians;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error filtering clinicians by permissions. Returning unfiltered list.");
                 return clinicians; // Return unfiltered list on error to avoid breaking functionality
@@ -654,7 +654,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     LogSanitizer.SanitizeId(currentUser.MothraId), LogSanitizer.SanitizeId(targetMothraId));
                 return false;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking clinician schedule view permission for target {TargetMothraId}", LogSanitizer.SanitizeId(targetMothraId));
                 return false; // Deny access on error

--- a/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
@@ -106,7 +106,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             {
                 return HandleInvalidOperation(ex, correlationId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return HandleSystemError(ex, request.RotationId!.Value, correlationId);
             }
@@ -335,7 +335,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     userMessage,
                     correlationId));
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -414,7 +414,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     instructorScheduleId, correlationId);
                 return Forbid();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -507,7 +507,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(response);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking schedule conflicts for {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 return StatusCode(500, "An error occurred while checking for schedule conflicts");
@@ -532,7 +532,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 var auditHistory = await _auditService.GetInstructorScheduleAuditHistoryAsync(instructorScheduleId, cancellationToken);
                 return Ok(auditHistory);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 return StatusCode(500, "An error occurred while retrieving audit history");

--- a/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Constants;
 using Viper.Areas.ClinicalScheduler.Extensions;
 using Viper.Areas.ClinicalScheduler.Models;
@@ -106,7 +108,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             {
                 return HandleInvalidOperation(ex, correlationId);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return HandleSystemError(ex, request.RotationId!.Value, correlationId);
             }
@@ -335,7 +337,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     userMessage,
                     correlationId));
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -414,7 +416,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     instructorScheduleId, correlationId);
                 return Forbid();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -507,7 +509,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(response);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking schedule conflicts for {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 return StatusCode(500, "An error occurred while checking for schedule conflicts");
@@ -532,7 +534,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 var auditHistory = await _auditService.GetInstructorScheduleAuditHistoryAsync(instructorScheduleId, cancellationToken);
                 return Ok(auditHistory);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 return StatusCode(500, "An error occurred while retrieving audit history");

--- a/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
@@ -108,7 +108,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             {
                 return HandleInvalidOperation(ex, correlationId);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException)
             {
                 return HandleSystemError(ex, request.RotationId!.Value, correlationId);
             }
@@ -337,7 +337,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     userMessage,
                     correlationId));
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException)
             {
                 _logger.LogError(ex, "Error removing instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -416,7 +416,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     instructorScheduleId, correlationId);
                 return Forbid();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error setting primary evaluator for instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     instructorScheduleId, correlationId);
@@ -509,7 +509,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(response);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking schedule conflicts for {MothraId}", LogSanitizer.SanitizeId(mothraId));
                 return StatusCode(500, "An error occurred while checking for schedule conflicts");
@@ -534,7 +534,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 var auditHistory = await _auditService.GetInstructorScheduleAuditHistoryAsync(instructorScheduleId, cancellationToken);
                 return Ok(auditHistory);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error retrieving audit history for instructor schedule {ScheduleId}", instructorScheduleId);
                 return StatusCode(500, "An error occurred while retrieving audit history");

--- a/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
@@ -153,7 +153,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("ServiceId", serviceId);
@@ -215,7 +215,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", rotationId);
@@ -277,7 +277,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEditOwn });
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("InstructorScheduleId", instructorScheduleId);

--- a/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Classes.SQLContext;
@@ -153,7 +154,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("ServiceId", serviceId);
@@ -215,7 +216,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", rotationId);
@@ -277,7 +278,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEditOwn });
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("InstructorScheduleId", instructorScheduleId);

--- a/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/PermissionsController.cs
@@ -154,7 +154,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("ServiceId", serviceId);
@@ -216,7 +216,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEdit });
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", rotationId);
@@ -278,7 +278,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(new { canEditOwn });
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("InstructorScheduleId", instructorScheduleId);

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -71,7 +71,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     rotations.Count, filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext(new Dictionary<string, object>
@@ -132,7 +132,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved rotation via RotationService: {RotationName}", rotation.Name);
                 return Ok(response);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -234,7 +234,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(BuildRotationScheduleResponse(rotation, targetYear, groupedSchedules, recentCliniciansList));
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -299,7 +299,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved {Count} rotations with scheduled weeks for year {Year} (filtered to {FilteredCount})", rotationsWithSchedules.Count, LogSanitizer.SanitizeYear(targetYear), filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("Year", year?.ToString() ?? "null");

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -8,6 +8,7 @@ using Viper.Classes.Utilities;
 using Viper.Models.ClinicalScheduler;
 using Web.Authorization;
 using Person = Viper.Models.ClinicalScheduler.Person;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.ClinicalScheduler.Controllers
 {
@@ -70,7 +71,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     rotations.Count, filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext(new Dictionary<string, object>
@@ -131,7 +132,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved rotation via RotationService: {RotationName}", rotation.Name);
                 return Ok(response);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -233,7 +234,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(BuildRotationScheduleResponse(rotation, targetYear, groupedSchedules, recentCliniciansList));
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -298,7 +299,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved {Count} rotations with scheduled weeks for year {Year} (filtered to {FilteredCount})", rotationsWithSchedules.Count, LogSanitizer.SanitizeYear(targetYear), filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("Year", year?.ToString() ?? "null");

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -70,7 +70,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     rotations.Count, filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext(new Dictionary<string, object>
@@ -131,7 +131,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved rotation via RotationService: {RotationName}", rotation.Name);
                 return Ok(response);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -233,7 +233,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
                 return Ok(BuildRotationScheduleResponse(rotation, targetYear, groupedSchedules, recentCliniciansList));
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("RotationId", id);
@@ -298,7 +298,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Retrieved {Count} rotations with scheduled weeks for year {Year} (filtered to {FilteredCount})", rotationsWithSchedules.Count, LogSanitizer.SanitizeYear(targetYear), filteredRotations.Count);
                 return Ok(filteredRotations);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 // Store context for ApiExceptionFilter to use in logging
                 SetExceptionContext("Year", year?.ToString() ?? "null");

--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -23,29 +23,37 @@ namespace Viper.Areas.Computing.Services
             using var throttler = new SemaphoreSlim(initialCount: 20);
             foreach (var email in emails)
             {
-                await throttler.WaitAsync();
-
+                if (string.IsNullOrWhiteSpace(email))
+                {
+                    continue;
+                }
                 var emailTrimmed = email.Trim();
                 if (!emailTrimmed.Contains('@'))
                 {
                     emailTrimmed += "@ucdavis.edu";
                 }
-                if (IsValidEmail(emailTrimmed))
+                if (!IsValidEmail(emailTrimmed))
                 {
-                    resultList.Add(
-                        Task.Run(async () =>
-                        {
-                            try
-                            {
-                                return await GetSingleStudent(emailTrimmed);
-                            }
-                            finally
-                            {
-                                throttler.Release();
-                            }
-                        })
-                    );
+                    continue;
                 }
+
+                // Acquire only after validation so skipped emails can't leak permits and stall the loop
+                await throttler.WaitAsync();
+                resultList.Add(
+                    Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await GetSingleStudent(emailTrimmed);
+                        }
+                        finally
+                        {
+                            // Safe: Task.WhenAll below awaits every task before the using-scope disposes the throttler
+                            // ReSharper disable once AccessToDisposedClosure
+                            throttler.Release();
+                        }
+                    })
+                );
             }
 
             var taskResults = await Task.WhenAll(resultList);

--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -95,7 +95,7 @@ namespace Viper.Areas.Computing.Services
                 var addr = new MailAddress(email);
                 return addr.Address == trimmed;
             }
-            catch
+            catch (Exception ex) when (ex is FormatException or ArgumentException)
             {
                 return false;
             }

--- a/web/Areas/RAPS/Controllers/AdGroupsController.cs
+++ b/web/Areas/RAPS/Controllers/AdGroupsController.cs
@@ -114,10 +114,10 @@ namespace Viper.Areas.RAPS.Controllers
                 OuGroup newOuGroup = await _ouGroupService.CreateRapsGroup(group.Name, group.Description);
                 return CreatedAtAction("CreateGroup", new { id = newOuGroup.OugroupId }, newOuGroup);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                //Exception message could be indication user is trying to create a group that exists or is invalid.
-                return ValidationProblem(ex.Message);
+                // Return a generic message; the raw exception may reveal internal details.
+                return ValidationProblem("Unable to create or update the group. Verify the request and try again.");
             }
         }
 

--- a/web/Areas/RAPS/Controllers/AdGroupsController.cs
+++ b/web/Areas/RAPS/Controllers/AdGroupsController.cs
@@ -10,6 +10,7 @@ using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
 using Viper.Models.RAPS;
 using Web.Authorization;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.RAPS.Controllers
 {
@@ -113,7 +114,7 @@ namespace Viper.Areas.RAPS.Controllers
                 OuGroup newOuGroup = await _ouGroupService.CreateRapsGroup(group.Name, group.Description);
                 return CreatedAtAction("CreateGroup", new { id = newOuGroup.OugroupId }, newOuGroup);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 //Exception message could be indication user is trying to create a group that exists or is invalid.
                 return ValidationProblem(ex.Message);

--- a/web/Areas/RAPS/Controllers/AdGroupsController.cs
+++ b/web/Areas/RAPS/Controllers/AdGroupsController.cs
@@ -113,7 +113,7 @@ namespace Viper.Areas.RAPS.Controllers
                 OuGroup newOuGroup = await _ouGroupService.CreateRapsGroup(group.Name, group.Description);
                 return CreatedAtAction("CreateGroup", new { id = newOuGroup.OugroupId }, newOuGroup);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 //Exception message could be indication user is trying to create a group that exists or is invalid.
                 return ValidationProblem(ex.Message);

--- a/web/Areas/RAPS/Controllers/RoleMembersController.cs
+++ b/web/Areas/RAPS/Controllers/RoleMembersController.cs
@@ -267,7 +267,7 @@ namespace Viper.Areas.RAPS.Controllers
                         return vmacsResponse;
                     }
                 }
-                catch
+                catch (System.Text.Json.JsonException)
                 {
                     return new VmacsResponse
                     {

--- a/web/Areas/RAPS/Controllers/RoleMembersController.cs
+++ b/web/Areas/RAPS/Controllers/RoleMembersController.cs
@@ -267,7 +267,7 @@ namespace Viper.Areas.RAPS.Controllers
                         return vmacsResponse;
                     }
                 }
-                catch (System.Text.Json.JsonException)
+                catch (JsonException)
                 {
                     return new VmacsResponse
                     {

--- a/web/Areas/RAPS/Controllers/RolesController.cs
+++ b/web/Areas/RAPS/Controllers/RolesController.cs
@@ -222,7 +222,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return Problem("The record was not updated because it was locked. " + ex.InnerException?.Message);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return Problem("There was a problem updating the database. " + ex.InnerException?.Message);
             }

--- a/web/Areas/RAPS/Controllers/RolesController.cs
+++ b/web/Areas/RAPS/Controllers/RolesController.cs
@@ -219,13 +219,13 @@ namespace Viper.Areas.RAPS.Controllers
 
                 return CreatedAtAction("GetTblRole", new { id = tblRole.RoleId }, tblRole);
             }
-            catch (DbUpdateConcurrencyException ex)
+            catch (DbUpdateConcurrencyException)
             {
-                return Problem("The record was not updated because it was locked. " + ex.InnerException?.Message);
+                return Problem("The record was not updated because it was locked.");
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                return Problem("There was a problem updating the database. " + ex.InnerException?.Message);
+                return Problem("There was a problem updating the database.");
             }
 
         }

--- a/web/Areas/RAPS/Controllers/RolesController.cs
+++ b/web/Areas/RAPS/Controllers/RolesController.cs
@@ -6,6 +6,7 @@ using Viper.Areas.RAPS.Services;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.RAPS;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.RAPS.Controllers
 {
@@ -222,7 +223,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return Problem("The record was not updated because it was locked. " + ex.InnerException?.Message);
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 return Problem("There was a problem updating the database. " + ex.InnerException?.Message);
             }

--- a/web/Areas/RAPS/Services/OuGroupService.cs
+++ b/web/Areas/RAPS/Services/OuGroupService.cs
@@ -45,7 +45,7 @@ namespace Viper.Areas.RAPS.Services
             {
                 ActiveDirectoryService.GetGroups();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 Logger logger = LogManager.GetCurrentClassLogger();
                 logger.Error(ex);

--- a/web/Areas/RAPS/Services/OuGroupService.cs
+++ b/web/Areas/RAPS/Services/OuGroupService.cs
@@ -1,3 +1,4 @@
+using System.DirectoryServices.Protocols;
 using System.Runtime.Versioning;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -8,7 +9,6 @@ using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
 using Viper.Models.RAPS;
 using static Viper.Areas.RAPS.Services.RAPSAuditService;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.RAPS.Services
 {
@@ -44,9 +44,9 @@ namespace Viper.Areas.RAPS.Services
             List<LdapGroup> ldapGroups = new();
             try
             {
-                ActiveDirectoryService.GetGroups();
+                ldapGroups = ActiveDirectoryService.GetGroups();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is LdapException or DirectoryOperationException)
             {
                 Logger logger = LogManager.GetCurrentClassLogger();
                 logger.Error(ex);
@@ -54,14 +54,23 @@ namespace Viper.Areas.RAPS.Services
 
             List<ManagedGroup> managedGroups = await _uInformService.GetManagedGroups();
 
+            HashSet<string> boxSyncGroupDns = ldapGroups
+                .Where(lg => string.Equals(lg.ExtensionAttribute3, "ucdboxsync", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(lg.DistinguishedName))
+                .Select(lg => lg.DistinguishedName)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string?> displayNamesByDn = managedGroups
+                .Where(mg => !string.IsNullOrEmpty(mg.DistinguishedName))
+                .GroupBy(mg => mg.DistinguishedName, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First().DisplayName, StringComparer.OrdinalIgnoreCase);
+
             List<Group> groups = new();
             foreach (OuGroup group in result)
             {
                 //for OU groups, look up the box sync attribute
-                bool BoxSync = ldapGroups.FirstOrDefault(lg => lg.DistinguishedName.ToLower() == group.Name.ToLower())
-                    ?.ExtensionAttribute3?.ToLower() == "ucdboxsync";
+                bool BoxSync = boxSyncGroupDns.Contains(group.Name);
                 //for AD3 groups, look up display name
-                string? displayName = managedGroups.FirstOrDefault(mg => mg.DistinguishedName.ToLower() == group.Name.ToLower())?.DisplayName;
+                string? displayName = displayNamesByDn.GetValueOrDefault(group.Name);
                 Group g = new(group)
                 {
                     BoxSyncEnabled = BoxSync,

--- a/web/Areas/RAPS/Services/OuGroupService.cs
+++ b/web/Areas/RAPS/Services/OuGroupService.cs
@@ -8,6 +8,7 @@ using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
 using Viper.Models.RAPS;
 using static Viper.Areas.RAPS.Services.RAPSAuditService;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Areas.RAPS.Services
 {
@@ -45,7 +46,7 @@ namespace Viper.Areas.RAPS.Services
             {
                 ActiveDirectoryService.GetGroups();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 Logger logger = LogManager.GetCurrentClassLogger();
                 logger.Error(ex);

--- a/web/Areas/RAPS/Services/VMACSExport.cs
+++ b/web/Areas/RAPS/Services/VMACSExport.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.RAPS.Models;
 using Viper.Classes.SQLContext;
@@ -132,7 +133,7 @@ namespace Viper.Areas.RAPS.Services
                         VmacsResponse vmacsResponse = await ParseResponse(response);
                         RecordMessage(messages, JsonSerializer.Serialize(vmacsResponse));
                     }
-                    catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                    catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                     {
                         HttpHelper.Logger.Log(LogLevel.Warn, ex);
                         RecordMessage(messages, "Error: " + ex.Message + " " + ex.StackTrace);
@@ -167,7 +168,7 @@ namespace Viper.Areas.RAPS.Services
 
                 vmacsResponse.Success = response.IsSuccessStatusCode;
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 vmacsResponse = new()
                 {

--- a/web/Areas/RAPS/Services/VMACSExport.cs
+++ b/web/Areas/RAPS/Services/VMACSExport.cs
@@ -132,7 +132,7 @@ namespace Viper.Areas.RAPS.Services
                         VmacsResponse vmacsResponse = await ParseResponse(response);
                         RecordMessage(messages, JsonSerializer.Serialize(vmacsResponse));
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                     {
                         HttpHelper.Logger.Log(LogLevel.Warn, ex);
                         RecordMessage(messages, "Error: " + ex.Message + " " + ex.StackTrace);
@@ -167,7 +167,7 @@ namespace Viper.Areas.RAPS.Services
 
                 vmacsResponse.Success = response.IsSuccessStatusCode;
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 vmacsResponse = new()
                 {

--- a/web/Areas/RAPS/Services/VMACSExport.cs
+++ b/web/Areas/RAPS/Services/VMACSExport.cs
@@ -2,7 +2,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.RAPS.Models;
 using Viper.Classes.SQLContext;
@@ -133,7 +132,7 @@ namespace Viper.Areas.RAPS.Services
                         VmacsResponse vmacsResponse = await ParseResponse(response);
                         RecordMessage(messages, JsonSerializer.Serialize(vmacsResponse));
                     }
-                    catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                    catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or TaskCanceledException)
                     {
                         HttpHelper.Logger.Log(LogLevel.Warn, ex);
                         RecordMessage(messages, "Error: " + ex.Message + " " + ex.StackTrace);
@@ -168,7 +167,7 @@ namespace Viper.Areas.RAPS.Services
 
                 vmacsResponse.Success = response.IsSuccessStatusCode;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
             {
                 vmacsResponse = new()
                 {

--- a/web/Classes/ClaimsTransformer.cs
+++ b/web/Classes/ClaimsTransformer.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Viper;
 using Viper.Classes;
@@ -90,7 +92,7 @@ namespace Web.Authorization
 
 
                 }
-                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     bool isProd = false;
 

--- a/web/Classes/ClaimsTransformer.cs
+++ b/web/Classes/ClaimsTransformer.cs
@@ -90,7 +90,7 @@ namespace Web.Authorization
 
 
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     bool isProd = false;
 

--- a/web/Classes/ClaimsTransformer.cs
+++ b/web/Classes/ClaimsTransformer.cs
@@ -92,7 +92,7 @@ namespace Web.Authorization
 
 
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or RecordNotFoundException)
                 {
                     bool isProd = false;
 

--- a/web/Classes/SitemapMiddleware.cs
+++ b/web/Classes/SitemapMiddleware.cs
@@ -5,8 +5,6 @@ using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Web.Authorization;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes
 {
@@ -87,7 +85,12 @@ namespace Viper.Classes
                         await memoryStream.CopyToAsync(stream, bytes.Length);
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                // Middleware boundary: any sitemap-generation failure (DB, IO,
+                // reflection, etc.) must fall through to the pipeline rather than
+                // break the request.
+#pragma warning disable CA1031
+                catch (Exception)
+#pragma warning restore CA1031
                 {
                     await _next(context);
                 }

--- a/web/Classes/SitemapMiddleware.cs
+++ b/web/Classes/SitemapMiddleware.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Web.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes
 {
@@ -85,7 +87,7 @@ namespace Viper.Classes
                         await memoryStream.CopyToAsync(stream, bytes.Length);
                     }
                 }
-                catch (Exception) when (true /* placeholder */)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     await _next(context);
                 }

--- a/web/Classes/SitemapMiddleware.cs
+++ b/web/Classes/SitemapMiddleware.cs
@@ -85,7 +85,7 @@ namespace Viper.Classes
                         await memoryStream.CopyToAsync(stream, bytes.Length);
                     }
                 }
-                catch (Exception)
+                catch (Exception) when (true /* placeholder */)
                 {
                     await _next(context);
                 }

--- a/web/Classes/UserHelper.cs
+++ b/web/Classes/UserHelper.cs
@@ -5,6 +5,8 @@ using Viper.Models;
 using Viper.Models.AAUD;
 using Viper.Models.RAPS;
 using Web.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper
 {
@@ -255,7 +257,7 @@ namespace Viper
                         return user;
                     }
                 }
-                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     HttpHelper.Logger.Error(ex);
                     return null;
@@ -282,7 +284,7 @@ namespace Viper
 
                 return currentUser;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;
@@ -314,7 +316,7 @@ namespace Viper
 
                 return GetCurrentUser();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;

--- a/web/Classes/UserHelper.cs
+++ b/web/Classes/UserHelper.cs
@@ -257,7 +257,7 @@ namespace Viper
                         return user;
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
                 {
                     HttpHelper.Logger.Error(ex);
                     return null;
@@ -284,7 +284,7 @@ namespace Viper
 
                 return currentUser;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;
@@ -316,7 +316,7 @@ namespace Viper
 
                 return GetCurrentUser();
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;

--- a/web/Classes/UserHelper.cs
+++ b/web/Classes/UserHelper.cs
@@ -255,7 +255,7 @@ namespace Viper
                         return user;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
                 {
                     HttpHelper.Logger.Error(ex);
                     return null;
@@ -282,7 +282,7 @@ namespace Viper
 
                 return currentUser;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;
@@ -314,7 +314,7 @@ namespace Viper
 
                 return GetCurrentUser();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
                 return null;

--- a/web/Classes/Utilities/ActiveDirectoryService.cs
+++ b/web/Classes/Utilities/ActiveDirectoryService.cs
@@ -219,7 +219,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
             }
@@ -245,7 +245,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
             }

--- a/web/Classes/Utilities/ActiveDirectoryService.cs
+++ b/web/Classes/Utilities/ActiveDirectoryService.cs
@@ -3,6 +3,8 @@ using System.DirectoryServices.Protocols;
 using System.Net;
 using System.Runtime.Versioning;
 using Viper.Areas.RAPS.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -219,7 +221,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
             }
@@ -245,7 +247,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 HttpHelper.Logger.Error(ex);
             }

--- a/web/Classes/Utilities/ActiveDirectoryService.cs
+++ b/web/Classes/Utilities/ActiveDirectoryService.cs
@@ -3,8 +3,6 @@ using System.DirectoryServices.Protocols;
 using System.Net;
 using System.Runtime.Versioning;
 using Viper.Areas.RAPS.Models;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -221,7 +219,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is PrincipalException or System.DirectoryServices.DirectoryServicesCOMException)
             {
                 HttpHelper.Logger.Error(ex);
             }
@@ -247,7 +245,7 @@ namespace Viper.Classes.Utilities
                     group.Save();
                 }
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is PrincipalException or System.DirectoryServices.DirectoryServicesCOMException)
             {
                 HttpHelper.Logger.Error(ex);
             }

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Text.Json;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -24,7 +22,7 @@ namespace Viper.Classes.Utilities
             {
                 response = await _httpClient.SendAsync(request);
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
             {
                 response = await HandleConnectionFail(request, attemptNumber);
             }

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -22,7 +24,7 @@ namespace Viper.Classes.Utilities
             {
                 response = await _httpClient.SendAsync(request);
             }
-            catch (Exception) when (true /* placeholder */)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 response = await HandleConnectionFail(request, attemptNumber);
             }

--- a/web/Classes/Utilities/F5HttpRequest.cs
+++ b/web/Classes/Utilities/F5HttpRequest.cs
@@ -22,7 +22,7 @@ namespace Viper.Classes.Utilities
             {
                 response = await _httpClient.SendAsync(request);
             }
-            catch (Exception)
+            catch (Exception) when (true /* placeholder */)
             {
                 response = await HandleConnectionFail(request, attemptNumber);
             }

--- a/web/Classes/Utilities/IamApi.cs
+++ b/web/Classes/Utilities/IamApi.cs
@@ -398,7 +398,7 @@ namespace Viper.Classes.Utilities
 
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 r.ErrorMessage = "Invalid response: " + ex.Message + ".";
             }

--- a/web/Classes/Utilities/IamApi.cs
+++ b/web/Classes/Utilities/IamApi.cs
@@ -4,6 +4,8 @@ using System.Text.Json;
 using System.Web;
 using NLog;
 using Viper.Models.IAM;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -398,7 +400,7 @@ namespace Viper.Classes.Utilities
 
                 }
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 r.ErrorMessage = "Invalid response: " + ex.Message + ".";
             }

--- a/web/Classes/Utilities/IamApi.cs
+++ b/web/Classes/Utilities/IamApi.cs
@@ -4,8 +4,6 @@ using System.Text.Json;
 using System.Web;
 using NLog;
 using Viper.Models.IAM;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Classes.Utilities
 {
@@ -400,9 +398,10 @@ namespace Viper.Classes.Utilities
 
                 }
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
             {
-                r.ErrorMessage = "Invalid response: " + ex.Message + ".";
+                LogManager.GetLogger("IAM").Warn(ex, "Failed to parse IAM response.");
+                r.ErrorMessage = "Invalid response.";
             }
 
             return r;

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
@@ -86,7 +87,7 @@ try
             .AddSystemsManager("/" + builder.Environment.EnvironmentName, awsOptions)
             .AddSystemsManager("/Shared", awsOptions);
     }
-    catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+    catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
     {
         logger.Fatal(ex, "Failed to get secrets from AWS");
     }
@@ -567,7 +568,7 @@ void SetAwsCredentials(Logger logger)
         {
             File.Delete(awsCredentialsFilePath);
         }
-        catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+        catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
         {
             logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");
             logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Amazon;
 using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
 using DotNetEnv;
 using Joonasw.AspNetCore.SecurityHeaders;
@@ -14,7 +15,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Rewrite;
-using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
@@ -87,7 +87,7 @@ try
             .AddSystemsManager("/" + builder.Environment.EnvironmentName, awsOptions)
             .AddSystemsManager("/Shared", awsOptions);
     }
-    catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+    catch (Exception ex) when (ex is AmazonServiceException or AmazonClientException)
     {
         logger.Fatal(ex, "Failed to get secrets from AWS");
     }
@@ -568,9 +568,8 @@ void SetAwsCredentials(Logger logger)
         {
             File.Delete(awsCredentialsFilePath);
         }
-        catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");
             logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");
         }
     }

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -86,7 +86,7 @@ try
             .AddSystemsManager("/" + builder.Environment.EnvironmentName, awsOptions)
             .AddSystemsManager("/Shared", awsOptions);
     }
-    catch (Exception ex)
+    catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
     {
         logger.Fatal(ex, "Failed to get secrets from AWS");
     }
@@ -519,7 +519,9 @@ try
     app.Run();
 #pragma warning restore S6966
 }
+#pragma warning disable CA1031 // Top-level app startup must catch any exception to log fatal and rethrow as InvalidOperationException with context for hosting platform.
 catch (Exception exception)
+#pragma warning restore CA1031
 {
     // NLog: catch setup errors
     logger.Fatal(exception, "Stopped program because of exception");
@@ -565,7 +567,7 @@ void SetAwsCredentials(Logger logger)
         {
             File.Delete(awsCredentialsFilePath);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
         {
             logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");
             logger.Error(ex, $"COULD NOT DELETE THE AWS CREDENTIALS XML FILE (\"{awsCredentialsFilePath}\").  The file will need to be deleted manually.");

--- a/web/Services/EmailService.cs
+++ b/web/Services/EmailService.cs
@@ -5,8 +5,6 @@ using MailKit.Security;
 using Microsoft.Extensions.Options;
 using MimeKit;
 using Viper.Classes.Utilities;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.SqlClient;
 
 namespace Viper.Services
 {
@@ -221,7 +219,7 @@ namespace Viper.Services
                 // For production, assume the SMTP server is available
                 return true;
             }
-            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is SocketException or ArgumentException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking email service availability");
                 return false;

--- a/web/Services/EmailService.cs
+++ b/web/Services/EmailService.cs
@@ -219,7 +219,7 @@ namespace Viper.Services
                 // For production, assume the SMTP server is available
                 return true;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking email service availability");
                 return false;

--- a/web/Services/EmailService.cs
+++ b/web/Services/EmailService.cs
@@ -5,6 +5,8 @@ using MailKit.Security;
 using Microsoft.Extensions.Options;
 using MimeKit;
 using Viper.Classes.Utilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
 
 namespace Viper.Services
 {
@@ -219,7 +221,7 @@ namespace Viper.Services
                 // For production, assume the SMTP server is available
                 return true;
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
                 _logger.LogError(ex, "Error checking email service availability");
                 return false;

--- a/web/Services/EmailService.cs
+++ b/web/Services/EmailService.cs
@@ -248,7 +248,7 @@ namespace Viper.Services
                 await tcpClient.ConnectAsync(_emailSettings.SmtpHost, _emailSettings.SmtpPort);
                 return tcpClient.Connected;
             }
-            catch
+            catch (SocketException)
             {
                 return false;
             }

--- a/web/ViteProxyHelpers.cs
+++ b/web/ViteProxyHelpers.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore;
 
 namespace Web;
 
@@ -286,7 +284,7 @@ internal static class ViteProxyHelpers
                 {
                     context.Response.Headers[header.Key] = header.Value.ToArray();
                 }
-                catch (Exception headerEx) when (headerEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException or IOException)
+                catch (Exception headerEx) when (headerEx is ArgumentException or InvalidOperationException)
                 {
                     // Use structured logging for header errors
                     var safeHeaderKey = WebUtility.HtmlEncode(header.Key);
@@ -369,7 +367,7 @@ internal static class ViteProxyHelpers
                     return;
                 }
             }
-            catch (Exception fileEx) when (fileEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException or IOException)
+            catch (Exception fileEx) when (fileEx is IOException or UnauthorizedAccessException or InvalidOperationException or ArgumentException or NotSupportedException)
             {
                 var safePath = context.Request.Path.ToString().Replace("\r", "").Replace("\n", "");
                 logger.LogWarning(fileEx, "Failed to serve static file fallback for {Path}", safePath);

--- a/web/ViteProxyHelpers.cs
+++ b/web/ViteProxyHelpers.cs
@@ -284,7 +284,7 @@ internal static class ViteProxyHelpers
                 {
                     context.Response.Headers[header.Key] = header.Value.ToArray();
                 }
-                catch (Exception headerEx)
+                catch (Exception headerEx) when (headerEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException or System.IO.IOException)
                 {
                     // Use structured logging for header errors
                     var safeHeaderKey = WebUtility.HtmlEncode(header.Key);
@@ -367,7 +367,7 @@ internal static class ViteProxyHelpers
                     return;
                 }
             }
-            catch (Exception fileEx)
+            catch (Exception fileEx) when (fileEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException or System.IO.IOException)
             {
                 var safePath = context.Request.Path.ToString().Replace("\r", "").Replace("\n", "");
                 logger.LogWarning(fileEx, "Failed to serve static file fallback for {Path}", safePath);

--- a/web/ViteProxyHelpers.cs
+++ b/web/ViteProxyHelpers.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 
 namespace Web;
 
@@ -284,7 +286,7 @@ internal static class ViteProxyHelpers
                 {
                     context.Response.Headers[header.Key] = header.Value.ToArray();
                 }
-                catch (Exception headerEx) when (headerEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException or System.IO.IOException)
+                catch (Exception headerEx) when (headerEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException or IOException)
                 {
                     // Use structured logging for header errors
                     var safeHeaderKey = WebUtility.HtmlEncode(header.Key);
@@ -367,7 +369,7 @@ internal static class ViteProxyHelpers
                     return;
                 }
             }
-            catch (Exception fileEx) when (fileEx is Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or InvalidOperationException or OperationCanceledException or System.IO.IOException)
+            catch (Exception fileEx) when (fileEx is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException or IOException)
             {
                 var safePath = context.Request.Path.ToString().Replace("\r", "").Replace("\n", "");
                 logger.LogWarning(fileEx, "Failed to serve static file fallback for {Path}", safePath);


### PR DESCRIPTION
## Summary

Closes 38 of 46 remaining `cs/catch-of-all-exceptions` alerts. Same when-filter pattern as #193, applied across the rest of the codebase.

Rebased onto latest `main` (post #184). The earlier `Program.cs` Vite-proxy narrowing was dropped in the rebase: `main`'s SPA-shell refactor already scopes that catch to `HttpRequestException`/`TaskCanceledException`.

## Files changed (28)

- **CTS controllers** (9): BundleCompetencyController, BundleCompetencyGroupController, BundleController, CompetencyController, CourseController, DomainController, EpaController, LevelsController, RoleController
- **ClinicalScheduler controllers** (4): CliniciansController, InstructorScheduleController, PermissionsController, RotationsController
- **RAPS** (5): AdGroupsController, RoleMembersController, RolesController, OuGroupService, VMACSExport
- **Shared** (7): BiorenderStudentLookup, ClaimsTransformer, SitemapMiddleware, UserHelper, ActiveDirectoryService, F5HttpRequest, IamApi
- **Top-level web** (3): EmailService, Program.cs, ViteProxyHelpers

## Filter choices (matched to what each call site actually throws)

- **DB-backed paths** (controllers, UserHelper, ClaimsTransformer): `DbUpdateException` / `SqlException` / `InvalidOperationException`
- **HTTP** (F5HttpRequest): `HttpRequestException` / `TaskCanceledException`
- **JSON parsing** (IamApi, VMACSExport, RoleMembersController): `JsonException` / `NotSupportedException`
- **AD/LDAP**: ActiveDirectoryService `PrincipalException` / `DirectoryServicesCOMException`; OuGroupService `LdapException` / `DirectoryOperationException`
- **AWS Parameter Store** (Program.cs): `AmazonServiceException` / `AmazonClientException`
- **Email availability probes** (EmailService): `SocketException` plus config-argument failures
- **MailAddress validation** (BiorenderStudentLookup): `FormatException` / `ArgumentException`

Raw exception messages are no longer returned to clients (EpaController, AdGroupsController); responses use fixed messages with details kept in server logs.

Drive-by fix surfaced by review: `OuGroupService.GetAllGroups` discarded the `ActiveDirectoryService.GetGroups()` result, so `BoxSyncEnabled` was always false. Now wired up (own commit).

## Intentional broad catches kept (the 8 alerts left open)

- `Program.cs` top-level startup catch: must log fatal on any exception before rethrowing (`#pragma warning disable CA1031`)
- `SitemapMiddleware`: middleware boundary; any generation failure must fall through to `_next(context)` (restored to broad per review, with CA1031 pragma and rationale)
- `EmailService.GetRequestContext`: defensive log-context builder
- `HangfireHealthCheck`: must not crash the health response on any storage error (documented in-code)
- The 4 `ScheduleEditService` post-transaction catches kept broad in #193

Test files (test/CTS/AssessmentControllerTest.cs helpers, test/ClinicalScheduler/EmailNotificationTest.cs diagnostic catches) are intentionally left as broad catches: they are test infrastructure, not production code.

## Context

Sixth in the `CodeQL N:` cleanup series (after #189, #190, #191, #192, #193).

## Test plan

- [x] `npm run test:backend` - all tests passing
- [x] Pre-commit lint + test + verify:build all passed
- [ ] CodeQL workflow on this PR shows 38 of the 46 listed alerts closed
