### PR TITLE
CodeQL 7: refactor: tighten foreach-to-LINQ where it improves the call site

### DIFF
--- a/web/Areas/CTS/Controllers/AssessmentController.cs
+++ b/web/Areas/CTS/Controllers/AssessmentController.cs
@@ -126,15 +126,12 @@ namespace Viper.Areas.CTS.Controllers
             var assessmentsList = await assessments
                 .ToListAsync();
 
-            List<StudentAssessment> studentAssessments = new();
-            foreach (var a in assessmentsList)
+            return assessmentsList.Select(a =>
             {
                 var sa = CreateStudentAssessment(a);
                 sa.Editable = ctsSecurityService.CanEditStudentAssessment(sa.EnteredBy, sa.EnteredOn);
-                studentAssessments.Add(sa);
-            }
-
-            return studentAssessments;
+                return sa;
+            }).ToList();
         }
 
         [HttpGet("assessors")]

--- a/web/Areas/CTS/Services/CrestCourseService.cs
+++ b/web/Areas/CTS/Services/CrestCourseService.cs
@@ -60,16 +60,16 @@ namespace Viper.Areas.CTS.Services
         /// </summary>
         static private List<Course> CourseSessionOfferingsToCourses(List<CourseSessionOffering> csos)
         {
-            List<Course> courses = new();
-            foreach (var cso in csos.GroupBy(c => c.CourseId))
-            {
-                var rows = cso.ToList();
-                courses.Add(new Course(rows[0])
+            return csos.GroupBy(c => c.CourseId)
+                .Select(g =>
                 {
-                    Sessions = CourseSessionOfferingsToSessions(rows)
-                });
-            }
-            return courses;
+                    var rows = g.ToList();
+                    return new Course(rows[0])
+                    {
+                        Sessions = CourseSessionOfferingsToSessions(rows)
+                    };
+                })
+                .ToList();
         }
 
         /// <summary>
@@ -77,16 +77,16 @@ namespace Viper.Areas.CTS.Services
         /// </summary>
         static private List<Session> CourseSessionOfferingsToSessions(List<CourseSessionOffering> csos)
         {
-            List<Session> sessions = new();
-            foreach (var cso in csos.GroupBy(c => c.SessionId))
-            {
-                var rows = cso.ToList();
-                sessions.Add(new Session(rows[0])
+            return csos.GroupBy(c => c.SessionId)
+                .Select(g =>
                 {
-                    Offerings = CourseSessionOfferingsToOfferings(rows)
-                });
-            }
-            return sessions;
+                    var rows = g.ToList();
+                    return new Session(rows[0])
+                    {
+                        Offerings = CourseSessionOfferingsToOfferings(rows)
+                    };
+                })
+                .ToList();
         }
 
         /// <summary>

--- a/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
+++ b/web/Areas/RAPS/Controllers/RoleTemplatesController.cs
@@ -125,12 +125,9 @@ namespace Viper.Areas.RAPS.Controllers
             }
 
             RoleMemberService roleMemberService = new(_context);
-            foreach (RoleApplyPreview role in preview.Roles)
+            foreach (RoleApplyPreview role in preview.Roles.Where(r => !r.UserHasRole))
             {
-                if (!role.UserHasRole)
-                {
-                    await roleMemberService.AddMemberToRole(role.RoleId, memberId, null, null, string.Format("Added via role template {0}", roleTemplate.TemplateName));
-                }
+                await roleMemberService.AddMemberToRole(role.RoleId, memberId, null, null, string.Format("Added via role template {0}", roleTemplate.TemplateName));
             }
 
             _rapsCacheService.ClearCachedRolesAndPermissionsForUser(memberId);

--- a/web/Areas/RAPS/Services/RoleViews.cs
+++ b/web/Areas/RAPS/Services/RoleViews.cs
@@ -84,14 +84,12 @@ namespace Viper.Areas.RAPS.Services
             //Remove members that were added via this view if they are no longer in the view. Check first that the view is not empty.
             if (members.Count > 0)
             {
-                foreach (TblRoleMember roleMember in roleMembers)
+                foreach (TblRoleMember roleMember in roleMembers.Where(rm => !string.IsNullOrEmpty(rm.MemberId.Trim())
+                    && !members.Contains(rm.MemberId)
+                    && rm.ViewName == role.ViewName))
                 {
-                    if (!string.IsNullOrEmpty(roleMember.MemberId.Trim()) && !members.Contains(roleMember.MemberId)
-                        && roleMember.ViewName == role.ViewName)
-                    {
-                        messages.Add(string.Format("Removing {0}", roleMember.MemberId));
-                        toDelete.Add(roleMember);
-                    }
+                    messages.Add(string.Format("Removing {0}", roleMember.MemberId));
+                    toDelete.Add(roleMember);
                 }
             }
             else
@@ -210,7 +208,7 @@ namespace Viper.Areas.RAPS.Services
                 "vw_vmdo_sp" => await _RAPSContext.VwVmdoSps.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
                 "vw_vmdo_svm_it" => await _RAPSContext.VwVmdoSvmIts.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
                 "vw_vmthadmissions" => await _RAPSContext.VwVmthadmissions.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
-				"vw_vmth_chiefs" => await _RAPSContext.VwVmthChiefs.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
+                "vw_vmth_chiefs" => await _RAPSContext.VwVmthChiefs.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
                 "vw_vmth_clinicians" => await _RAPSContext.VwVmthClinicians.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
                 "vw_vmth_constituents" => await _RAPSContext.VwVmthConstituents.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
                 "vw_vmthinternsmanual" => await _RAPSContext.VwVmthinternsManuals.AsNoTracking().Select(v => v.MemberId).ToListAsync(),
@@ -223,5 +221,5 @@ namespace Viper.Areas.RAPS.Services
                 _ => new List<string?>(),
             };
         }
-	}
+    }
 }

--- a/web/Classes/UserHelper.cs
+++ b/web/Classes/UserHelper.cs
@@ -92,22 +92,7 @@ namespace Viper
             if (user.LoginId == HttpHelper.HttpContext?.User?.Identity?.Name)
             {
                 var claims = HttpHelper.HttpContext?.User?.Claims;
-
-                if (claims != null)
-                {
-
-                    foreach (var claim in claims)
-                    {
-                        if (claim.Type == ClaimTypes.Role && claim.Value == roleName)
-                        {
-                            return true;
-                        }
-
-                    }
-
-                }
-
-                return false;
+                return claims?.Any(c => c.Type == ClaimTypes.Role && c.Value == roleName) == true;
             }
 
             var roles = GetRoles(rapsContext, user);


### PR DESCRIPTION
## Summary

Closes 6 of 34 `cs/linq/missed-*` alerts where the `foreach`-to-LINQ conversion makes the intent clearer:

- `UserHelper.IsInRole` - claim-search loop → `claims.Any(c => c.Type == ClaimTypes.Role && c.Value == roleName)` (also collapses the surrounding null guard).
- `CrestCourseService.CourseSessionOfferingsToCourses` / `…Sessions` - staging-list + foreach-Add pattern → `csos.GroupBy(...).Select(g => new Course/Session(...)).ToList()`.
- `AssessmentController.GetAssessmentsForStudent` - build-and-mutate loop → `assessmentsList.Select(a => { … }).ToList()`.
- `RoleTemplatesController.Apply` - `foreach (... in preview.Roles) { if (!UserHasRole) … }` → `foreach (... in preview.Roles.Where(r => !r.UserHasRole))`.
- `RoleViews` delete loop - compound `if` filter hoisted into the `foreach … in roleMembers.Where(...)`.

Also fixed two stray tab-indented lines in `RoleViews.cs` that `dotnet format` flagged.

## Why 28 alerts are not addressed

The remaining 28 `cs/linq/missed-select` alerts all live in PDF/Excel cell-generation loops in the Effort report services - `TeachingActivityService`, `MeritReportService`, `SchoolSummaryService`, `DeptSummaryService`, `MeritMultiYearService`, `EvaluationReportService`, `MeritSummaryService`. Pattern is:

```csharp
foreach (var type in orderedTypes)
{
    var val = course.EffortByType.GetValueOrDefault(type, 0);
    table.Cell().PaddingVertical(cellPadV).Text(val > 0 ? val.ToString() : "0");
}
```

The `var val = …` is what CodeQL identifies as a "mapping", but the surrounding body is `QuestPDF.table.Cell()…` / `ClosedXML.ws.Cell()…` side effects, not collection-building. Forcing a `Select` here would just add a tuple-deconstruction `foreach` over a `.Select(t => (Type: t, Val: …))` with the same side-effectful body - more code, same behavior, lower readability. These are dismissible as wontfix-by-design on the CodeQL dashboard.

## Context

Seventh in the `CodeQL N:` cleanup series (after #189, #190, #191, #192, #193, #194).

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] `npm run verify:build` - clean (0 errors)
- [x] Pre-commit lint+test+verify all passed
- [ ] CodeQL workflow on this PR shows 6 of the 34 LINQ alerts closed
