### PR TITLE
CodeQL 8: perf: replace ContainsKey+indexer with TryGetValue

### DIFF
--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -497,16 +497,18 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
         {
             var weekSchedules = allSchedules
                 .Where(s => s.WeekId == week.WeekId)
-                .Select(i => new
+                .Select(i =>
                 {
-                    instructorScheduleId = i.InstructorScheduleId,
-                    firstName = personData.ContainsKey(i.MothraId) ? personData[i.MothraId].PersonDisplayFirstName : "Unknown",
-                    lastName = personData.ContainsKey(i.MothraId) ? personData[i.MothraId].PersonDisplayLastName : "Unknown",
-                    fullName = personData.ContainsKey(i.MothraId)
-                        ? personData[i.MothraId].PersonDisplayFullName
-                        : $"Person {i.MothraId}",
-                    mothraId = i.MothraId,
-                    isPrimaryEvaluator = i.Evaluator
+                    personData.TryGetValue(i.MothraId, out var p);
+                    return new
+                    {
+                        instructorScheduleId = i.InstructorScheduleId,
+                        firstName = p?.PersonDisplayFirstName ?? "Unknown",
+                        lastName = p?.PersonDisplayLastName ?? "Unknown",
+                        fullName = p?.PersonDisplayFullName ?? $"Person {i.MothraId}",
+                        mothraId = i.MothraId,
+                        isPrimaryEvaluator = i.Evaluator
+                    };
                 })
                 .ToList();
 

--- a/web/Areas/RAPS/Services/RAPSAuditService.cs
+++ b/web/Areas/RAPS/Services/RAPSAuditService.cs
@@ -142,9 +142,8 @@ namespace Viper.Areas.RAPS.Services
                     string key = auditLog?.RoleId != null
                         ? "role-" + auditLog.RoleId
                         : "permission-" + auditLog!.PermissionId;
-                    if (actionsPerformedOnObject.ContainsKey(key))
+                    if (actionsPerformedOnObject.TryGetValue(key, out var moreRecentActions))
                     {
-                        List<string> moreRecentActions = actionsPerformedOnObject[key];
                         bool undone = false;
                         switch (auditLog.Audit)
                         {

--- a/web/Areas/RAPS/Services/VMACSExport.cs
+++ b/web/Areas/RAPS/Services/VMACSExport.cs
@@ -299,8 +299,8 @@ namespace Viper.Areas.RAPS.Services
                         exportUsers[^1].AccessCodes = accessCodesBuilder.ToString();
                     }
                     accessCodesBuilder.Clear();
-                    string permissionIdList = permissionsByMemberId.ContainsKey(user.MothraId.Trim())
-                        ? permissionsByMemberId[user.MothraId.Trim()]
+                    string permissionIdList = permissionsByMemberId.TryGetValue(user.MothraId.Trim(), out var permIds)
+                        ? permIds
                         : "";
                     exportUsers.Add(new VMACSExportUser
                     {
@@ -341,7 +341,7 @@ namespace Viper.Areas.RAPS.Services
         private string GetServerUrl(string instance, string server)
         {
             string key = instance.ToLower() + "-" + server.ToLower();
-            return _vmacsServers.ContainsKey(key) ? _vmacsServers[key] : "";
+            return _vmacsServers.TryGetValue(key, out var url) ? url : "";
         }
 
         private static void RecordMessage(List<string> messages, string message)

--- a/web/Areas/RAPS/Views/Members/List.cshtml
+++ b/web/Areas/RAPS/Views/Members/List.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Members";
 }
 <h1>Search for a user</h1>
@@ -34,19 +34,19 @@
     no-results-label="No results found">
     <template v-slot:body-cell-links="props">
         <q-td :props="props">
-            @if(ViewData.ContainsKey("CanRSOP") && (bool)(ViewData["CanRSOP"] ?? false))
+            @if((bool)(ViewData["CanRSOP"] ?? false))
             {
                 <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="policy" title="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
             }
-            @if (ViewData.ContainsKey("canEditRoleMembership") && (bool)(ViewData["canEditRoleMembership"] ?? false))
+            @if ((bool)(ViewData["canEditRoleMembership"] ?? false))
             {
                 <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="security" title="Show Roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
             }
-            @if (ViewData.ContainsKey("canEditMemberPermissions") && (bool)(ViewData["canEditMemberPermissions"] ?? false))
+            @if ((bool)(ViewData["canEditMemberPermissions"] ?? false))
             {
                 <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="lock" title="Show individual permissions for this user" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
             }
-            @if (ViewData.ContainsKey("canViewHistory") && (bool)(ViewData["canViewHistory"] ?? false))
+            @if ((bool)(ViewData["canViewHistory"] ?? false))
             {
                 <q-btn :props="props" size="sm" padding="xs" color="primary" square flat icon="history" title="Show History" :href="'MemberHistory?memberId=' + props.row.memberId"></q-btn>
             }            

--- a/web/Areas/RAPS/Views/Members/Roles.cshtml
+++ b/web/Areas/RAPS/Views/Members/Roles.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Member Roles";
 }
 <h1>Roles for {{member.displayFirstName}} {{member.displayLastName}}</h1>
@@ -74,7 +74,7 @@
         <template v-slot:body-cell-links="props">
             <q-td :props="props">
                 <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="View members of this role" aria-label="View members of this role" :href="'RoleMembers?roleId=' + props.row.roleId"></q-btn>
-                @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
+                @if ((bool)(ViewData["canEditPermissions"] ?? false))
                 {
                     <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="lock" title="Set permissions this role controls" aria-label="Set permissions this role controls" :href="'RolePermissions?roleId=' + props.row.roleId"></q-btn>
                 }

--- a/web/Areas/RAPS/Views/Roles/Members.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Members.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Role Members";
 }
 <h1>Members of {{ role.friendlyName }}</h1>
@@ -82,7 +82,7 @@
         <q-td :props="props">
             <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="policy" title="Combined permissions for user" aria-label="Combined permissions for user" :href="'RSOP?memberId=' + props.row.memberId"></q-btn>
             <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="View roles for this user" aria-label="View roles for this user" :href="'MemberRoles?memberId=' + props.row.memberId"></q-btn>
-            @if (ViewData.ContainsKey("canEditPermissions") && (bool)(ViewData["canEditPermissions"] ?? false))
+            @if ((bool)(ViewData["canEditPermissions"] ?? false))
             {
                 <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="lock" title="View individual permissions" aria-label="View individual permissions" :href="'MemberPermissions?memberId=' + props.row.memberId"></q-btn>
             }

--- a/web/Areas/RAPS/Views/Roles/Templates.cshtml
+++ b/web/Areas/RAPS/Views/Roles/Templates.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewData["Title"] = "Templates";
 }
 <h1>Role Templates</h1>
@@ -36,7 +36,7 @@
              :filter="templates.filter"
              :filter-method="filterTemplates"
              :pagination="templates.pagination">
-        @if (ViewData.ContainsKey("canEditRoleTemplates") && (bool)(ViewData["canEditRoleTemplates"] ?? false))
+        @if ((bool)(ViewData["canEditRoleTemplates"] ?? false))
         {
             <template v-slot:top-left="props">
                 <q-btn no-caps color="positive" label="Add Role Template" padding="xs md" @@click="templates.showForm = true"></q-btn>
@@ -51,11 +51,11 @@
         </template>
         <template v-slot:body-cell-links="props">
             <q-td :props="props">
-                @if (ViewData.ContainsKey("canApplyTemplates") && (bool)(ViewData["canApplyTemplates"] ?? false))
+                @if ((bool)(ViewData["canApplyTemplates"] ?? false))
                 {
                     <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="person" title="Apply Role Template to one or more users" aria-label="Apply Role Template to one or more users" :href="'RoleTemplateApply?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
                 }
-                @if (ViewData.ContainsKey("canEditRoleTemplates") && (bool)(ViewData["canEditRoleTemplates"] ?? false))
+                @if ((bool)(ViewData["canEditRoleTemplates"] ?? false))
                 {
                     <q-btn :props="props" size="sm" padding="sm" color="primary" square flat icon="security" title="View Roles for this Template" aria-label="View Roles for this Template" :href="'RoleTemplateRoles?roleTemplateId=' + props.row.roleTemplateId"></q-btn>
                 }
@@ -73,7 +73,7 @@
                 <br />
             </q-td>
         </template>
-        @if (ViewData.ContainsKey("canEditRoleTemplates") && (bool)(ViewData["canEditRoleTemplates"] ?? false))
+        @if ((bool)(ViewData["canEditRoleTemplates"] ?? false))
         {
             <template v-slot:body-cell-action="props">
                 <q-td :props="props">


### PR DESCRIPTION
## Summary

Closes ~14 of 18 `cs/inefficient-containskey` alerts. Two distinct cleanups bundled together:

1. **C# perf swap** — replace `ContainsKey + indexer` (two dictionary lookups) with `TryGetValue` (one lookup) at 4 call-sites.
2. **Razor dead-code removal** — drop the redundant `ContainsKey` guard in 4 views; `ViewData["X"] ?? false` already handles missing keys.

## What's actually a perf change

`dict.ContainsKey(k) + dict[k]` does two hash computations and two bucket walks. `TryGetValue` does one — roughly **2× cheaper per access**. String-key sites get the biggest gain because `string.GetHashCode()` walks every character.

| Site | Before | After |
|------|--------|-------|
| `RotationsController.cs:498-511` | **6 lookups per row** (3× `ContainsKey` + 3× indexer) inside a `.Select` projection | **1 `TryGetValue`** per row |
| `RAPSAuditService.cs:144` | 2 lookups per audit-log entry | 1 |
| `VMACSExport.cs:302` | 2 lookups per user + double `user.MothraId.Trim()` | 1 lookup + 1 `Trim()` |
| `VMACSExport.cs:344` (`GetServerUrl`) | 2 lookups per call | 1 |

The Rotations site is the headline: **6× reduction in dictionary operations per row** in the per-week projection. Absolute wall-clock impact is on the order of nanoseconds per lookup, so this is micro-optimization, not something a profiler will flag — but it's free given the alert is firing anyway.

**Secondary benefit:** `TryGetValue` is a single atomic lookup, so it's TOCTOU-safe against concurrent dictionary mutation. Not load-bearing for these specific callsites (the dicts aren't shared cross-thread), but it's a strictly safer pattern.

## What's NOT a perf change (despite the PR label)

The Razor changes are **simplification**, not perf:

- `ViewData.ContainsKey(\"X\") && (bool)(ViewData[\"X\"] ?? false)` → `(bool)(ViewData[\"X\"] ?? false)`
- `ViewData[\"missingKey\"]` returns `null`, not an exception, so the `ContainsKey` guard was always redundant once the `?? false` is there.

Touches `Areas/RAPS/Views/Members/List.cshtml` (×4), `Members/Roles.cshtml` (×1), `Roles/Members.cshtml` (×1), `Roles/Templates.cshtml` (×4). Also strips the UTF-8 BOM from those four files — encoding hygiene, zero runtime impact.

Not addressed: 1 site in `test/Students/EmergencyContactControllerTests.cs:319` (test infrastructure) and ~3 likely already covered or out-of-scope.

## Test plan

- [x] `npm run test:backend` — 1946 tests passing
- [x] Pre-commit lint+test+verify all passed
- [ ] CodeQL workflow on this PR shows ~14 of the 18 ContainsKey alerts closed