### PR TITLE
CodeQL 11: chore(tests): replace Returns((T?)null) casts with ReturnsNull()

### DIFF
--- a/test/ClinicalScheduler/ClinicalSchedulerTestBase.cs
+++ b/test/ClinicalScheduler/ClinicalSchedulerTestBase.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using MockQueryable.NSubstitute;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
@@ -227,7 +228,7 @@ namespace Viper.test.ClinicalScheduler
         /// </summary>
         protected void SetupNullUser()
         {
-            MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+            MockUserHelper.GetCurrentUser().ReturnsNull();
         }
 
         /// <summary>
@@ -239,7 +240,7 @@ namespace Viper.test.ClinicalScheduler
         {
             if (userMothraId == null)
             {
-                MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+                MockUserHelper.GetCurrentUser().ReturnsNull();
                 return;
             }
 

--- a/test/ClinicalScheduler/IntegrationTestBase.cs
+++ b/test/ClinicalScheduler/IntegrationTestBase.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
@@ -131,7 +132,7 @@ namespace Viper.test.ClinicalScheduler
         {
             if (userMothraId == null)
             {
-                MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+                MockUserHelper.GetCurrentUser().ReturnsNull();
                 return;
             }
 
@@ -239,7 +240,7 @@ namespace Viper.test.ClinicalScheduler
         /// </summary>
         protected void SetupNullUser()
         {
-            MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+            MockUserHelper.GetCurrentUser().ReturnsNull();
         }
 
         public void Dispose()

--- a/test/Effort/CourseRelationshipsControllerTests.cs
+++ b/test/Effort/CourseRelationshipsControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
 using Viper.Areas.Effort.Models.DTOs.Responses;
@@ -102,7 +103,7 @@ public sealed class CourseRelationshipsControllerTests
     public async Task GetRelationships_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var actionResult = await _controller.GetRelationships(999);
@@ -439,7 +440,7 @@ public sealed class CourseRelationshipsControllerTests
     public async Task DeleteRelationship_ReturnsNotFound_WhenRelationshipNotFound()
     {
         // Arrange
-        _relationshipServiceMock.GetRelationshipAsync(999, Arg.Any<CancellationToken>()).Returns((CourseRelationshipDto?)null);
+        _relationshipServiceMock.GetRelationshipAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var actionResult = await _controller.DeleteRelationship(1, 999);

--- a/test/Effort/CoursesControllerTests.cs
+++ b/test/Effort/CoursesControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -149,7 +150,7 @@ public sealed class CoursesControllerTests
     public async Task GetCourse_ReturnsNotFound_WhenCourseDoesNotExist()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetCourse(999);
@@ -402,7 +403,7 @@ public sealed class CoursesControllerTests
             CustDept = "VME"
         };
 
-        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateCourse(999, request);
@@ -493,7 +494,7 @@ public sealed class CoursesControllerTests
         // Arrange
         var request = new UpdateEnrollmentRequest { Enrollment = 50 };
 
-        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateCourseEnrollment(999, request);
@@ -546,7 +547,7 @@ public sealed class CoursesControllerTests
     public async Task DeleteCourse_ReturnsNotFound_WhenCourseDoesNotExist()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeleteCourse(999);
@@ -712,7 +713,7 @@ public sealed class CoursesControllerTests
             Crn = "99999"
         };
 
-        _courseServiceMock.GetBannerCourseAsync(202410, "99999", Arg.Any<CancellationToken>()).Returns((BannerCourseDto?)null);
+        _courseServiceMock.GetBannerCourseAsync(202410, "99999", Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.ImportCourse(request);
@@ -852,7 +853,7 @@ public sealed class CoursesControllerTests
     public async Task GetCourseEffort_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetCourseEffort(TestCourseId);
@@ -940,7 +941,7 @@ public sealed class CoursesControllerTests
     public async Task GetPossibleInstructors_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetPossibleInstructors(TestCourseId);
@@ -995,7 +996,7 @@ public sealed class CoursesControllerTests
     public async Task GetCourseEvaluations_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetCourseEvaluations(TestCourseId);
@@ -1090,7 +1091,7 @@ public sealed class CoursesControllerTests
     public async Task CreateEvaluation_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         var request = new CreateAdHocEvalRequest
         {
@@ -1201,7 +1202,7 @@ public sealed class CoursesControllerTests
     public async Task UpdateEvaluation_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         var request = new UpdateAdHocEvalRequest
         {
@@ -1294,7 +1295,7 @@ public sealed class CoursesControllerTests
     public async Task DeleteEvaluation_ReturnsNotFound_WhenCourseNotFound()
     {
         // Arrange
-        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns((CourseDto?)null);
+        _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId);

--- a/test/Effort/EffortIntegrationTestBase.cs
+++ b/test/Effort/EffortIntegrationTestBase.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort;
 using Viper.Areas.Effort.Constants;
 using Viper.Areas.Effort.Models.Entities;
@@ -341,7 +342,7 @@ public abstract class EffortIntegrationTestBase : IDisposable
     /// </summary>
     protected void SetupNullUser()
     {
-        MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+        MockUserHelper.GetCurrentUser().ReturnsNull();
     }
 
     /// <summary>
@@ -351,7 +352,7 @@ public abstract class EffortIntegrationTestBase : IDisposable
     {
         if (userMothraId == null)
         {
-            MockUserHelper.GetCurrentUser().Returns((AaudUser?)null);
+            MockUserHelper.GetCurrentUser().ReturnsNull();
             return;
         }
 

--- a/test/Effort/EffortRecordsControllerTests.cs
+++ b/test/Effort/EffortRecordsControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Exceptions;
@@ -100,7 +101,7 @@ public sealed class EffortRecordsControllerTests
     public async Task GetRecord_ReturnsNotFound_WhenRecordDoesNotExist()
     {
         // Arrange
-        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).Returns((InstructorEffortRecordDto?)null);
+        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetRecord(999);
@@ -270,7 +271,7 @@ public sealed class EffortRecordsControllerTests
             EffortValue = 30
         };
 
-        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).Returns((InstructorEffortRecordDto?)null);
+        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateRecord(999, request);
@@ -353,7 +354,7 @@ public sealed class EffortRecordsControllerTests
     public async Task DeleteRecord_ReturnsNotFound_WhenRecordDoesNotExist()
     {
         // Arrange
-        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).Returns((InstructorEffortRecordDto?)null);
+        _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeleteRecord(999, null);

--- a/test/Effort/EffortTypesControllerTests.cs
+++ b/test/Effort/EffortTypesControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -111,7 +112,7 @@ public sealed class EffortTypesControllerTests
     public async Task GetEffortType_ReturnsNotFound_WhenMissing()
     {
         // Arrange
-        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).Returns((EffortTypeDto?)null);
+        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetEffortType("XXX", CancellationToken.None);
@@ -217,7 +218,7 @@ public sealed class EffortTypesControllerTests
             AllowedOn199299 = false,
             AllowedOnRCourses = false
         };
-        _effortTypeServiceMock.UpdateEffortTypeAsync("XXX", request, Arg.Any<CancellationToken>()).Returns((EffortTypeDto?)null);
+        _effortTypeServiceMock.UpdateEffortTypeAsync("XXX", request, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateEffortType("XXX", request, CancellationToken.None);
@@ -297,7 +298,7 @@ public sealed class EffortTypesControllerTests
     public async Task DeleteEffortType_ReturnsNotFound_WhenMissing()
     {
         // Arrange
-        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).Returns((EffortTypeDto?)null);
+        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeleteEffortType("XXX", CancellationToken.None);
@@ -397,7 +398,7 @@ public sealed class EffortTypesControllerTests
     public async Task CanDeleteEffortType_ReturnsNotFound_WhenMissing()
     {
         // Arrange
-        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).Returns((EffortTypeDto?)null);
+        _effortTypeServiceMock.GetEffortTypeAsync("XXX", Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.CanDeleteEffortType("XXX", CancellationToken.None);

--- a/test/Effort/InstructorsControllerTests.cs
+++ b/test/Effort/InstructorsControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -132,7 +133,7 @@ public sealed class InstructorsControllerTests
     public async Task GetInstructor_ReturnsNotFound_WhenInstructorDoesNotExist()
     {
         // Arrange
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetInstructor(999, 202410);
@@ -318,7 +319,7 @@ public sealed class InstructorsControllerTests
             VolunteerWos = false
         };
 
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateInstructor(999, 202410, request);
@@ -377,7 +378,7 @@ public sealed class InstructorsControllerTests
     public async Task DeleteInstructor_ReturnsNotFound_WhenInstructorDoesNotExist()
     {
         // Arrange
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeleteInstructor(999, 202410);
@@ -529,7 +530,7 @@ public sealed class InstructorsControllerTests
     public async Task GetInstructorEffortRecords_ReturnsNotFound_WhenInstructorDoesNotExist()
     {
         // Arrange
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetInstructorEffortRecords(999, 202410);

--- a/test/Effort/PercentAssignTypesControllerTests.cs
+++ b/test/Effort/PercentAssignTypesControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Services;
@@ -122,7 +123,7 @@ public sealed class PercentAssignTypesControllerTests
     public async Task GetPercentAssignType_ReturnsNotFound_WhenMissing()
     {
         // Arrange
-        _typeServiceMock.GetPercentAssignTypeAsync(999, Arg.Any<CancellationToken>()).Returns((PercentAssignTypeDto?)null);
+        _typeServiceMock.GetPercentAssignTypeAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetPercentAssignType(999, CancellationToken.None);
@@ -201,7 +202,7 @@ public sealed class PercentAssignTypesControllerTests
     public async Task GetInstructorsByType_ReturnsNotFound_WhenTypeMissing()
     {
         // Arrange
-        _typeServiceMock.GetInstructorsByTypeAsync(999, Arg.Any<CancellationToken>()).Returns((InstructorsByPercentAssignTypeResponseDto?)null);
+        _typeServiceMock.GetInstructorsByTypeAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetInstructorsByType(999, CancellationToken.None);

--- a/test/Effort/PercentagesControllerTests.cs
+++ b/test/Effort/PercentagesControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -153,7 +154,7 @@ public sealed class PercentagesControllerTests
     public async Task GetPercentage_ReturnsNotFound_WhenPercentageDoesNotExist()
     {
         // Arrange
-        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).Returns((PercentageDto?)null);
+        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetPercentage(999);
@@ -398,7 +399,7 @@ public sealed class PercentagesControllerTests
         // Arrange
         var request = CreateTestUpdateRequest();
 
-        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).Returns((PercentageDto?)null);
+        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdatePercentage(999, request);
@@ -525,7 +526,7 @@ public sealed class PercentagesControllerTests
     public async Task DeletePercentage_ReturnsNotFound_WhenPercentageDoesNotExist()
     {
         // Arrange
-        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).Returns((PercentageDto?)null);
+        _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.DeletePercentage(999);

--- a/test/Effort/ReportsControllerTests.cs
+++ b/test/Effort/ReportsControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Services;
@@ -2731,7 +2732,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(true);
         _sabbaticalServiceMock
-            .GetByPersonIdAsync(456, Arg.Any<CancellationToken>()).Returns((SabbaticalDto?)null);
+            .GetByPersonIdAsync(456, Arg.Any<CancellationToken>()).ReturnsNull();
 
         var result = await _controller.GetSabbatical(456);
 

--- a/test/Effort/UnitsControllerTests.cs
+++ b/test/Effort/UnitsControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -111,7 +112,7 @@ public sealed class UnitsControllerTests
     public async Task GetUnit_ReturnsNotFound_WhenMissing()
     {
         // Arrange
-        _unitServiceMock.GetUnitAsync(999, Arg.Any<CancellationToken>()).Returns((UnitDto?)null);
+        _unitServiceMock.GetUnitAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetUnit(999, CancellationToken.None);
@@ -199,7 +200,7 @@ public sealed class UnitsControllerTests
     {
         // Arrange
         var request = new UpdateUnitRequest { Name = "Updated Unit", IsActive = true };
-        _unitServiceMock.UpdateUnitAsync(999, request, Arg.Any<CancellationToken>()).Returns((UnitDto?)null);
+        _unitServiceMock.UpdateUnitAsync(999, request, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.UpdateUnit(999, request, CancellationToken.None);

--- a/test/Effort/VerificationControllerTests.cs
+++ b/test/Effort/VerificationControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort;
 using Viper.Areas.Effort.Controllers;
 using Viper.Areas.Effort.Models.DTOs.Requests;
@@ -90,7 +91,7 @@ public sealed class VerificationControllerTests
     public async Task GetMyEffort_ReturnsEmptyDto_WhenNoInstructorRecord()
     {
         // Arrange
-        _verificationServiceMock.GetMyEffortAsync(202410, Arg.Any<CancellationToken>()).Returns((MyEffortDto?)null);
+        _verificationServiceMock.GetMyEffortAsync(202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetMyEffort(202410);
@@ -171,7 +172,7 @@ public sealed class VerificationControllerTests
         // Arrange
         var request = new SendVerificationEmailRequest { PersonId = 999, TermCode = 202410 };
 
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.SendVerificationEmail(request);
@@ -286,7 +287,7 @@ public sealed class VerificationControllerTests
     public async Task GetEmailHistory_ReturnsNotFound_WhenInstructorNotFound()
     {
         // Arrange
-        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.GetEmailHistory(999, 202410);
@@ -360,7 +361,7 @@ public sealed class VerificationControllerTests
     {
         // Arrange
         _permissionServiceMock.GetCurrentPersonId().Returns(123); // Different person
-        _instructorServiceMock.GetInstructorAsync(456, 202410, Arg.Any<CancellationToken>()).Returns((PersonDto?)null);
+        _instructorServiceMock.GetInstructorAsync(456, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
         var result = await _controller.CanVerify(456, 202410);

--- a/test/Effort/VerificationServiceTests.cs
+++ b/test/Effort/VerificationServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Effort;
 using Viper.Areas.Effort.Constants;
 using Viper.Areas.Effort.EmailTemplates.Models;
@@ -628,7 +629,7 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendVerificationEmailAsync_ReturnsError_WhenNoSenderEmail()
     {
         // Arrange: Current user has no email
-        _permissionServiceMock.GetCurrentUserEmail().Returns((string?)null);
+        _permissionServiceMock.GetCurrentUserEmail().ReturnsNull();
 
         // Act
         var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);

--- a/test/RAPS/RolesTests.cs
+++ b/test/RAPS/RolesTests.cs
@@ -180,7 +180,7 @@ namespace Viper.test.RAPS
             // arrange
             int RoleId = -1;
             var mockSet = GetTestRoles().BuildMockDbSet();
-            mockSet.FindAsync(Arg.Any<object?[]?>()).ReturnsNull();
+            mockSet.FindAsync(Arg.Any<object?[]?>(), Arg.Any<CancellationToken>()).ReturnsNull();
             rapsContext.TblRoles.Returns(mockSet);
 
             var rolesController = new RolesController(rapsContext);

--- a/test/RAPS/RolesTests.cs
+++ b/test/RAPS/RolesTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using MockQueryable.NSubstitute;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.RAPS.Controllers;
 using Viper.Areas.RAPS.Models;
 using Viper.Areas.RAPS.Services;
@@ -55,7 +56,7 @@ namespace Viper.test.RAPS
         public async Task ReturnNotFound_WhenNoRolesInTable()
         {
             // arrange
-            rapsContext.TblRoles.Returns((DbSet<TblRole>?)null);
+            rapsContext.TblRoles.ReturnsNull();
             var rolesController = new RolesController(rapsContext);
 
             // act
@@ -179,7 +180,7 @@ namespace Viper.test.RAPS
             // arrange
             int RoleId = -1;
             var mockSet = GetTestRoles().BuildMockDbSet();
-            mockSet.FindAsync(Arg.Any<object?[]?>()).Returns((TblRole?)null);
+            mockSet.FindAsync(Arg.Any<object?[]?>()).ReturnsNull();
             rapsContext.TblRoles.Returns(mockSet);
 
             var rolesController = new RolesController(rapsContext);

--- a/test/Services/EmailServiceTests.cs
+++ b/test/Services/EmailServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Models.AAUD;
 using Viper.Services;
 
@@ -122,7 +123,7 @@ public class EmailServiceTests
             UseMailpit = true,
             RedirectToCurrentUser = true
         };
-        _userHelperMock.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelperMock.GetCurrentUser().ReturnsNull();
         var service = CreateService(settings);
 
         // Act - should not throw, email is silently suppressed
@@ -208,7 +209,7 @@ public class EmailServiceTests
             UseMailpit = false,
             RedirectToCurrentUser = true
         };
-        _userHelperMock.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelperMock.GetCurrentUser().ReturnsNull();
         var service = CreateService(settings);
 
         // Act - no exception should be thrown; email is suppressed before SMTP attempt

--- a/test/Students/EmergencyContactControllerTests.cs
+++ b/test/Students/EmergencyContactControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Students.Constants;
 using Viper.Areas.Students.Controllers;
@@ -65,7 +66,7 @@ public class EmergencyContactControllerTests
     [Fact]
     public async Task GetStudentContactDetail_NoUser_ReturnsUnauthorized()
     {
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var result = await _controller.GetStudentContactDetail(1);
 
@@ -226,7 +227,7 @@ public class EmergencyContactControllerTests
         _userHelper.HasPermission(_rapsContext, adminUser, EmergencyContactPermissions.SISAllStudents).Returns(false);
 
         _service.CanEditAsync(999, adminUser.LoginId).Returns(true);
-        _service.GetStudentContactDetailAsync(999, true).Returns((StudentContactDetailDto?)null);
+        _service.GetStudentContactDetailAsync(999, true).ReturnsNull();
 
         var result = await _controller.GetStudentContactDetail(999);
 
@@ -240,7 +241,7 @@ public class EmergencyContactControllerTests
     [Fact]
     public async Task UpdateStudentContact_NoUser_ReturnsUnauthorized()
     {
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var result = await _controller.UpdateStudentContact(1, new UpdateStudentContactRequest { ContactPermanent = false });
 
@@ -451,7 +452,7 @@ public class EmergencyContactControllerTests
     [Fact]
     public async Task CanEdit_NoUser_ReturnsUnauthorized()
     {
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var result = await _controller.CanEdit(1);
 

--- a/test/Students/PhotoGalleryControllerTest.cs
+++ b/test/Students/PhotoGalleryControllerTest.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.Curriculum.Services;
 using Viper.Areas.Students.Controllers;
 using Viper.Areas.Students.Models;
@@ -159,7 +160,7 @@ namespace Viper.test.Students
             _mockStudentGroupService.GetStudentsByCourseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<string>())
                 .Returns(new List<StudentPhoto>());
             _mockCourseService.GetCourseInfoAsync(Arg.Any<string>(), Arg.Any<string>())
-                .Returns((CourseInfo?)null);
+                .ReturnsNull();
 
             // Act
             var result = await _controller.GetCourseGallery("202409", "12345");


### PR DESCRIPTION
## Summary

Closes ~19 `cs/useless-upcast` alerts in `test/**` by replacing the NSubstitute pattern `.Returns((SomeType?)null)` with the dedicated `.ReturnsNull()` extension from `NSubstitute.ReturnsExtensions`.

## Why

The explicit `(T?)null` cast existed because the bare `.Returns(null)` call is ambiguous between NSubstitute's `Returns<T>(T)` and `Returns<T>(Func<CallInfo, T>)` overloads, but the cast itself trips the `cs/useless-upcast` rule (CodeQL sees the receiver's return type, so the cast is "redundant from the type system's POV"). `.ReturnsNull()` is the canonical NSubstitute idiom for this case - it disambiguates without a cast and makes the test intent clearer.

## Files (18)

- ClinicalSchedulerTestBase, IntegrationTestBase
- CourseRelationshipsControllerTests, CoursesControllerTests, EffortIntegrationTestBase, EffortRecordsControllerTests, EffortTypesControllerTests, InstructorsControllerTests, PercentagesControllerTests, PercentAssignTypesControllerTests, ReportsControllerTests, UnitsControllerTests, VerificationControllerTests, VerificationServiceTests
- RolesTests
- EmailServiceTests
- EmergencyContactControllerTests, PhotoGalleryControllerTest

Each file got a `using NSubstitute.ReturnsExtensions;` added.

## Context

Eleventh in the `CodeQL N:` cleanup series. Earlier task #9 had marked these as wontfix-by-design - that was wrong. `ReturnsNull()` is the correct fix.

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] Pre-commit lint+test+verify all passed
- [ ] CodeQL workflow on this PR shows the test/Effort/cs/useless-upcast alerts closed
