### PR TITLE
CodeQL 12: chore: style sweep for remaining CodeQL alerts

### DIFF
--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -120,8 +120,8 @@ namespace Viper.test.ClinicalScheduler
                 await _context.Weeks.AddAsync(new Week
                 {
                     WeekId = weekId,
-                    DateStart = DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId))),
-                    DateEnd = DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId) + 6)),
+                    DateStart = DateTime.UtcNow.AddDays(-7.0 * (10 - weekId)),
+                    DateEnd = DateTime.UtcNow.AddDays(-7.0 * (10 - weekId) + 6),
                     TermCode = 202501
                 });
             }

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -120,8 +120,8 @@ namespace Viper.test.ClinicalScheduler
                 await _context.Weeks.AddAsync(new Week
                 {
                     WeekId = weekId,
-                    DateStart = DateTime.UtcNow.AddDays(-7 * (10 - weekId)),
-                    DateEnd = DateTime.UtcNow.AddDays(-7 * (10 - weekId) + 6),
+                    DateStart = DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId))),
+                    DateEnd = DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId) + 6)),
                     TermCode = 202501
                 });
             }

--- a/test/ClinicalScheduler/TestDataBuilder.cs
+++ b/test/ClinicalScheduler/TestDataBuilder.cs
@@ -179,7 +179,7 @@ namespace Viper.test.ClinicalScheduler
         /// </summary>
         public static Week CreateWeek(int weekId, DateTime? startDate = null)
         {
-            var start = startDate ?? DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId)));
+            var start = startDate ?? DateTime.UtcNow.AddDays(-7.0 * (10 - weekId));
             return new Week
             {
                 WeekId = weekId,

--- a/test/ClinicalScheduler/TestDataBuilder.cs
+++ b/test/ClinicalScheduler/TestDataBuilder.cs
@@ -179,7 +179,7 @@ namespace Viper.test.ClinicalScheduler
         /// </summary>
         public static Week CreateWeek(int weekId, DateTime? startDate = null)
         {
-            var start = startDate ?? DateTime.UtcNow.AddDays(-7 * (10 - weekId));
+            var start = startDate ?? DateTime.UtcNow.AddDays((double)(-7 * (10 - weekId)));
             return new Week
             {
                 WeekId = weekId,

--- a/web/Areas/Curriculum/Services/TermCodeService.cs
+++ b/web/Areas/Curriculum/Services/TermCodeService.cs
@@ -36,7 +36,7 @@ namespace Viper.Areas.Curriculum.Services
                 default: desc = "Unknown Term"; break;
             }
 
-            return string.Format("{0} {1}", desc, year.ToString());
+            return string.Format("{0} {1}", desc, year);
         }
 
         public async Task<List<Term>> GetTerms(string? TermType = null, bool? current = null, bool? currentMulti = null)

--- a/web/Areas/Effort/Services/VerificationService.cs
+++ b/web/Areas/Effort/Services/VerificationService.cs
@@ -769,16 +769,10 @@ public class VerificationService : IVerificationService
     {
         var useWeeksForClinical = termCode >= EffortConstants.ClinicalAsWeeksStartTermCode;
 
-        // Due date: ExpectedCloseDate - 7 days if set, otherwise fallback to Now + 7
-        DateTime dueDate;
-        if (expectedCloseDate.HasValue)
-        {
-            dueDate = expectedCloseDate.Value.AddDays(-_settings.VerificationReplyDays);
-        }
-        else
-        {
-            dueDate = DateTime.Now.AddDays(_settings.VerificationReplyDays);
-        }
+        // Due date: ExpectedCloseDate - VerificationReplyDays if set, otherwise fallback to Now + VerificationReplyDays
+        DateTime dueDate = expectedCloseDate.HasValue
+            ? expectedCloseDate.Value.AddDays(-_settings.VerificationReplyDays)
+            : DateTime.Now.AddDays(_settings.VerificationReplyDays);
 
         var isPastDue = DateTime.Now.Date > dueDate.Date;
         var replyByDate = dueDate.ToString("M/d/yy");

--- a/web/Classes/HttpHelper.cs
+++ b/web/Classes/HttpHelper.cs
@@ -18,7 +18,7 @@ namespace Viper
         private static IDataProtectionProvider? dataProtectionProvider;
 
         /// <summary>
-        /// Helper functions constructor (gets injected with the memeory cache object)
+        /// Configures the helper with system-wide services (memory cache, configuration, environment, context accessor, authorization, data protection)
         /// </summary>
         public static void Configure(IMemoryCache? memoryCache, IConfiguration? configurationSettings, IWebHostEnvironment env, IHttpContextAccessor? httpContextAccessor, IAuthorizationService? authorizationService, IDataProtectionProvider? dataProtectionProvider)
         {

--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -309,11 +309,10 @@ namespace Viper.Controllers
                 var userNode = successNode?.Element(_ns + "user");
                 var validatedUserName = userNode?.Value;
 
-                // uncomment this line temporarily if you ever have issues with users getting unexpected 403(Access Denied) errors in the logs
-                // uncommenting this line will log what CAS is sending. When the user in question logs in while trying to access our site
+                // Log the sanitized CAS response when no username comes back, to help diagnose unexpected 403 (Access Denied) errors
                 if (string.IsNullOrEmpty(validatedUserName))
                 {
-                    HttpHelper.Logger.Log(LogLevel.Warn, "No username. CAS response: " + doc);
+                    HttpHelper.Logger.Log(LogLevel.Warn, "No username. CAS response: " + LogSanitizer.SanitizeString(doc.ToString()));
                 }
 
                 if (!string.IsNullOrEmpty(validatedUserName))


### PR DESCRIPTION
## Summary

Final slice of the CodeQL style sweep. Most alerts originally scoped here have since landed on `main` through other PRs in the series; this PR carries the remaining fixes plus a CAS log-injection hardening that surfaced while touching the same line.

## Closes

**cs/useless-tostring-call (2):**
- `TermCodeService.cs:39` - drop redundant `year.ToString()` inside `string.Format`
- `HomeController.cs:315` - redundant `doc.ToString()` in string concat; the log line now routes through `LogSanitizer` (see below)

**cs/missed-ternary-operator (1):**
- `VerificationService.cs:773` - `dueDate` if/else assignment collapsed to a ternary

**cs/loss-of-precision (3):**
- `test/ClinicalScheduler/EmailNotificationTest.cs:122-123` and `TestDataBuilder.cs:179` - `-7 * (...)` → `-7.0 * (...)` so the week-offset arithmetic flowing into `DateTime.AddDays(double)` is computed in `double`

## Also in this PR

- **fix(security)**: `HomeController` CAS auth-failure log now sanitizes the raw CAS XML via `LogSanitizer.SanitizeString()` before logging
- **Comment accuracy** (Copilot review feedback):
  - `HttpHelper.Configure` doc summary no longer calls the static configuration method a "constructor" (also fixes the "memeory" typo)
  - `HomeController` stale "uncomment this line" comment replaced with one describing the now-active, sanitized diagnostic log
  - `VerificationService` due-date comment now references the configurable `VerificationReplyDays` instead of hard-coding "7 days"

## Not addressed

`cs/complex-condition` and similar subjective-rewrite alerts remain open; converting them would hurt readability. Other items from the original sweep scope (multi-statement ternary candidates, complex-block, the test-file implicit conversions) were picked up by later PRs in the series and are no longer part of this branch.

## Context

Twelfth in the `CodeQL N:` cleanup series.

## Test plan

- [x] Pre-commit lint + backend tests + build verification all passed
- [x] Playwright smoke test (SMOKETEST-EFFORT-Verification): verification email due-date verified end-to-end for both branches of the refactored ternary - ExpectedCloseDate set (close - 7 days) and fallback (today + 7 days); login path, instructor list, and My Effort page load clean
- [ ] CodeQL workflow on this PR shows the listed style alerts closed


