### PR TITLE
CodeQL 13: chore: additional style fixes (ternary, complex-block, implicit-conversion)

### DIFF
--- a/VueApp/src/Effort/__tests__/course-import-dialog.test.ts
+++ b/VueApp/src/Effort/__tests__/course-import-dialog.test.ts
@@ -69,7 +69,8 @@ describe("CourseImportDialog - Error Handling", () => {
 
             // Simulate handling a non-Error value (e.g., from external code)
             const nonErrorValue: unknown = "string error"
-            importError.value = nonErrorValue instanceof Error ? nonErrorValue.message : "Failed to import course"
+            const isError = typeof nonErrorValue === "object" && nonErrorValue instanceof Error
+            importError.value = isError ? (nonErrorValue as Error).message : "Failed to import course"
 
             expect(importError.value).toBe("Failed to import course")
         })
@@ -93,7 +94,8 @@ describe("CourseImportDialog - Error Handling", () => {
 
             // Simulate handling a non-Error value (e.g., from external code)
             const nonErrorValue: unknown = "unknown error"
-            searchError.value = nonErrorValue instanceof Error ? nonErrorValue.message : "Error searching for courses"
+            const isError = typeof nonErrorValue === "object" && nonErrorValue instanceof Error
+            searchError.value = isError ? (nonErrorValue as Error).message : "Error searching for courses"
 
             expect(searchError.value).toBe("Error searching for courses")
         })

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -58,16 +58,9 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 _logger.LogInformation("Getting rotations. ServiceId: {ServiceId}", serviceId);
 
                 // Get rotations through service layer
-                List<RotationDto> rotations;
-
-                if (serviceId.HasValue)
-                {
-                    rotations = await _rotationService.GetRotationsByServiceAsync(serviceId.Value, HttpContext.RequestAborted);
-                }
-                else
-                {
-                    rotations = await _rotationService.GetRotationsAsync(HttpContext.RequestAborted);
-                }
+                List<RotationDto> rotations = serviceId.HasValue
+                    ? await _rotationService.GetRotationsByServiceAsync(serviceId.Value, HttpContext.RequestAborted)
+                    : await _rotationService.GetRotationsAsync(HttpContext.RequestAborted);
 
                 // Filter rotations based on user permissions
                 var allowedServiceIds = await GetAllowedServiceIdsAsync(HttpContext.RequestAborted);

--- a/web/Areas/Effort/Services/EffortAuditService.cs
+++ b/web/Areas/Effort/Services/EffortAuditService.cs
@@ -600,26 +600,19 @@ public class EffortAuditService : IEffortAuditService
 
         var auditRecordIds = auditQuery.Select(a => a.RecordId);
 
-        IQueryable<int> courseIds;
-
-        if (termCode.HasValue)
-        {
-            // When filtering by term, start from Records (very selective on TermCode)
-            // and use a semi-join for audit existence instead of a full Audits→Records join
-            courseIds = _context.Records
+        // When filtering by term, start from Records (very selective on TermCode)
+        // and use a semi-join for audit existence instead of a full Audits→Records join
+        IQueryable<int> courseIds = termCode.HasValue
+            ? _context.Records
                 .AsNoTracking()
                 .Where(r => r.TermCode == termCode.Value)
                 .Where(r => auditRecordIds.Contains(r.Id))
                 .Select(r => r.CourseId)
-                .Distinct();
-        }
-        else
-        {
-            courseIds = auditQuery
+                .Distinct()
+            : auditQuery
                 .Join(_context.Records, a => a.RecordId, r => r.Id, (a, r) => r)
                 .Select(r => r.CourseId)
                 .Distinct();
-        }
 
         return _context.Courses
             .AsNoTracking()

--- a/web/Areas/Effort/Services/MeritMultiYearService.cs
+++ b/web/Areas/Effort/Services/MeritMultiYearService.cs
@@ -866,16 +866,22 @@ public class MeritMultiYearService : BaseReportService, IMeritMultiYearService
     /// </summary>
     private static decimal? CalculateMedian(int n1, int n2, int n3, int n4, int n5)
     {
-        var total = n1 + n2 + n3 + n4 + n5;
-        if (total == 0) return null;
+        // Clamp negative counts; Enumerable.Repeat throws on negative counts whereas
+        // the prior for-loop silently ignored them.
+        n1 = Math.Max(0, n1);
+        n2 = Math.Max(0, n2);
+        n3 = Math.Max(0, n3);
+        n4 = Math.Max(0, n4);
+        n5 = Math.Max(0, n5);
 
-        // Build sorted response list
-        var responses = new List<decimal>();
-        for (var i = 0; i < n1; i++) responses.Add(1);
-        for (var i = 0; i < n2; i++) responses.Add(2);
-        for (var i = 0; i < n3; i++) responses.Add(3);
-        for (var i = 0; i < n4; i++) responses.Add(4);
-        for (var i = 0; i < n5; i++) responses.Add(5);
+        if (n1 + n2 + n3 + n4 + n5 == 0) return null;
+
+        var responses = Enumerable.Repeat(1m, n1)
+            .Concat(Enumerable.Repeat(2m, n2))
+            .Concat(Enumerable.Repeat(3m, n3))
+            .Concat(Enumerable.Repeat(4m, n4))
+            .Concat(Enumerable.Repeat(5m, n5))
+            .ToList();
 
         return CalculateListMedian(responses);
     }


### PR DESCRIPTION
## Summary

Final sweep of CodeQL style alerts that earlier PRs left as wontfix:

- **js/implicit-operand-conversion (2)**: `course-import-dialog.test.ts:72,96` - narrow the union check by combining `typeof === 'object'` with `instanceof Error`, then explicit `as Error` cast on the truthy branch.
- **cs/complex-block (1)**: `MeritMultiYearService.CalculateMedian` - five for-loops appending to a List<decimal> collapsed into chained `Enumerable.Repeat(...).Concat(...)`.
- **cs/missed-ternary-operator (5)** that were deferred:
  - `GradYearClassLevel.cs:63` - case-4 if-else assignment
  - `RotationsController.cs:63` - `serviceId.HasValue ? GetRotationsByServiceAsync : GetRotationsAsync`
  - `UinformService.cs:247` - `response.IsSuccessStatusCode ? Deserialize : new ErrorResponse`
  - `EffortAuditService.cs:605` - termCode-keyed IQueryable selection
  - Also picks up the earlier `useless-tostring` fix on `GradYearClassLevel.cs:57,60,69` (no-op vs PR #198 which has the same change).

## Context

Thirteenth in the `CodeQL N:` cleanup series.

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] Pre-commit lint+test+verify all passed
