### PR TITLE
CodeQL 14: refactor: convert foreach-add patterns to LINQ Select

### DIFF
--- a/web/Areas/CTS/Controllers/CourseController.cs
+++ b/web/Areas/CTS/Controllers/CourseController.cs
@@ -226,18 +226,14 @@ namespace Viper.Areas.CTS.Controllers
                 return checkResult;
             }
 
-            foreach (var levelId in sessionComp.LevelIds)
+            context.AddRange(sessionComp.LevelIds.Select(levelId => new SessionCompetency()
             {
-                var newSessionComp = new SessionCompetency
-                {
-                    CompetencyId = sessionComp.CompetencyId,
-                    SessionId = sessionComp.SessionId,
-                    LevelId = levelId,
-                    RoleId = sessionComp.RoleId,
-                    Order = sessionComp.Order ?? 0
-                };
-                context.Add(newSessionComp);
-            }
+                CompetencyId = sessionComp.CompetencyId,
+                SessionId = sessionComp.SessionId,
+                LevelId = levelId,
+                RoleId = sessionComp.RoleId,
+                Order = sessionComp.Order ?? 0
+            }));
             await context.SaveChangesAsync();
 
             var sessionComps = await context.SessionCompetencies
@@ -272,18 +268,14 @@ namespace Viper.Areas.CTS.Controllers
                 {
                     context.Remove(r);
                 }
-                foreach (var l in toAdd)
+                context.AddRange(toAdd.Select(l => new SessionCompetency()
                 {
-                    var newSessionComp = new SessionCompetency
-                    {
-                        CompetencyId = sessionComp.CompetencyId,
-                        SessionId = sessionComp.SessionId,
-                        LevelId = l,
-                        RoleId = sessionComp.RoleId,
-                        Order = sessionComp.Order ?? 0
-                    };
-                    context.Add(newSessionComp);
-                }
+                    CompetencyId = sessionComp.CompetencyId,
+                    SessionId = sessionComp.SessionId,
+                    LevelId = l,
+                    RoleId = sessionComp.RoleId,
+                    Order = sessionComp.Order ?? 0
+                }));
                 await context.SaveChangesAsync();
                 await trans.CommitAsync();
             }

--- a/web/Areas/Directory/Models/IndividualSearchResult.cs
+++ b/web/Areas/Directory/Models/IndividualSearchResult.cs
@@ -127,11 +127,13 @@ namespace Viper.Areas.Directory.Models
                 // Sanitize MailId to prevent SQL injection in OPENQUERY (which doesn't support parameters)
                 var safeMailId = MailId.Replace("'", "''");
                 var query = $"SELECT * FROM OPENQUERY(UCDMothra,'SELECT (USERPART || ''@'' || HOSTPART) AS USERATHOST FROM MOTHRA.MAILIDS WHERE MAILID = ''{safeMailId}'' AND MAILSTATUS = ''A'' AND MAILTYPE = ''P''')";
-                var results = context.Database.SqlQueryRaw<string>(query).ToList();
-                foreach (var r in results)
+                var hosts = context.Database.SqlQueryRaw<string>(query)
+                    .ToList()
+                    .Select(r => r.Split("@")[^1])
+                    .ToList();
+                if (hosts.Count > 0)
                 {
-                    var parts = r.Split("@");
-                    EmailHost = parts[^1];
+                    EmailHost = hosts[^1];
                 }
             }
         }

--- a/web/Areas/Directory/Models/IndividualSearchResult.cs
+++ b/web/Areas/Directory/Models/IndividualSearchResult.cs
@@ -127,13 +127,13 @@ namespace Viper.Areas.Directory.Models
                 // Sanitize MailId to prevent SQL injection in OPENQUERY (which doesn't support parameters)
                 var safeMailId = MailId.Replace("'", "''");
                 var query = $"SELECT * FROM OPENQUERY(UCDMothra,'SELECT (USERPART || ''@'' || HOSTPART) AS USERATHOST FROM MOTHRA.MAILIDS WHERE MAILID = ''{safeMailId}'' AND MAILSTATUS = ''A'' AND MAILTYPE = ''P''')";
-                var hosts = context.Database.SqlQueryRaw<string>(query)
-                    .ToList()
+                var lastHost = context.Database.SqlQueryRaw<string>(query)
+                    .AsEnumerable()
                     .Select(r => r.Split("@")[^1])
-                    .ToList();
-                if (hosts.Count > 0)
+                    .LastOrDefault();
+                if (lastHost != null)
                 {
-                    EmailHost = hosts[^1];
+                    EmailHost = lastHost;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes 3 of the 28 `cs/linq/missed-select` alerts where the foreach body is a simple build-and-add into a context/list:

- `CourseController.AddSessionCompetency` (line 227) - `foreach (var levelId in LevelIds) { var x = new SessionCompetency(...); context.Add(x); }` → `context.AddRange(LevelIds.Select(levelId => new SessionCompetency(...)))`.
- `CourseController.UpdateSessionCompetency` (line 273, same pattern).
- `IndividualSearchResult` (line 130) - `foreach (var r in results) { EmailHost = r.Split("@")[^1]; }` → `Select(...)` to materialize the list, then guard on count before assigning the last entry. Semantically identical.

## Not addressed (still open)

The remaining 25 `cs/linq/missed-select` alerts are all in PDF/Excel cell-generation loops in Effort report services where the foreach body calls side-effectful `QuestPDF.table.Cell()…Text(…)` or `ClosedXML.ws.Cell()…Value`. Forcing those into `Select` just renames a single local without removing the iteration or its side effects, so the resulting code is the same length with worse readability. Those should be dismissed at the dashboard.

## Context

Fourteenth in the `CodeQL N:` cleanup series.

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] Pre-commit lint+test+verify all passed
