### PR TITLE
CodeQL 15: chore(tests): narrow catch(Exception) to specific types in test helpers

### DIFF
--- a/test/CTS/AssessmentControllerTest.cs
+++ b/test/CTS/AssessmentControllerTest.cs
@@ -263,7 +263,7 @@ namespace Viper.test.CTS
                 Assert.True(result != null || forbidResult != null);
 
             }
-            catch (Exception)
+            catch (Xunit.Sdk.XunitException)
             {
                 return false;
             }
@@ -279,7 +279,7 @@ namespace Viper.test.CTS
                 var result = a.Result as NotFoundResult;
                 Assert.Equal((int)HttpStatusCode.NotFound, result?.StatusCode);
             }
-            catch (Exception)
+            catch (Xunit.Sdk.XunitException)
             {
                 return false;
             }

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -281,7 +281,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");
@@ -463,7 +463,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -281,7 +282,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
+            catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");
@@ -463,7 +464,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
+            catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");

--- a/test/ClinicalScheduler/RotationServiceTest.cs
+++ b/test/ClinicalScheduler/RotationServiceTest.cs
@@ -96,7 +96,7 @@ namespace Viper.test.ClinicalScheduler
                 }
                 _context.SaveChanges();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or InvalidOperationException)
             {
                 // Log the exception and provide a clear error message for debugging
                 Console.WriteLine($"Error seeding test data: {ex.Message}");

--- a/test/ClinicalScheduler/RotationServiceTest.cs
+++ b/test/ClinicalScheduler/RotationServiceTest.cs
@@ -96,7 +96,7 @@ namespace Viper.test.ClinicalScheduler
                 }
                 _context.SaveChanges();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or InvalidOperationException)
+            catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
             {
                 // Log the exception and provide a clear error message for debugging
                 Console.WriteLine($"Error seeding test data: {ex.Message}");


### PR DESCRIPTION
## Summary

Closes 5 of the remaining `cs/catch-of-all-exceptions` alerts in test code by narrowing the catch to the specific types each test helper is actually expecting:

- `test/CTS/AssessmentControllerTest.cs:266,282` - `IsForbidResult` / `IsNotFoundResult` helpers convert xUnit assertion failures to `false`. Narrowed from `catch (Exception)` to `catch (Xunit.Sdk.XunitException)`, which is exactly what `Assert.X(...)` throws.
- `test/ClinicalScheduler/EmailNotificationTest.cs:284,466` - diagnostic try/catch around `RemoveInstructorScheduleAsync`. Narrowed to `when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)` - the actual exception families that production code throws (matches the service's `when` filter from #193).
- `test/ClinicalScheduler/RotationServiceTest.cs:98` - test-data-seeding try/catch around `SaveChanges`. Narrowed to `when (ex is DbUpdateException or InvalidOperationException)`.

## Context

Fifteenth in the `CodeQL N:` cleanup series. (The PDF/Excel `cs/linq/missed-select` Select-conversion attempted on this branch was reverted - the script over-matched loops where the iter var is also used in headers/totals/spacers, breaking compilation. Those remaining 19 alerts genuinely require the iter var and can't be cleanly converted.)

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] Pre-commit lint+test+verify all passed
