### PR TITLE
CodeQL 16: refactor: remove useless upcasts via record types and default(T)

### DIFF
--- a/test/CTS/AssessmentControllerTest.cs
+++ b/test/CTS/AssessmentControllerTest.cs
@@ -263,7 +263,7 @@ namespace Viper.test.CTS
                 Assert.True(result != null || forbidResult != null);
 
             }
-            catch (Exception)
+            catch (Xunit.Sdk.XunitException)
             {
                 return false;
             }
@@ -279,7 +279,7 @@ namespace Viper.test.CTS
                 var result = a.Result as NotFoundResult;
                 Assert.Equal((int)HttpStatusCode.NotFound, result?.StatusCode);
             }
-            catch (Exception)
+            catch (Xunit.Sdk.XunitException)
             {
                 return false;
             }

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -281,7 +281,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");
@@ -463,7 +463,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -281,7 +282,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
+            catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");
@@ -463,7 +464,7 @@ namespace Viper.test.ClinicalScheduler
             {
                 result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or Microsoft.EntityFrameworkCore.DbUpdateException or Microsoft.Data.SqlClient.SqlException or OperationCanceledException)
+            catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
                 caughtException = ex;
                 Console.WriteLine($"Exception caught: {ex.GetType().Name}: {ex.Message}");

--- a/test/ClinicalScheduler/RotationServiceTest.cs
+++ b/test/ClinicalScheduler/RotationServiceTest.cs
@@ -96,7 +96,7 @@ namespace Viper.test.ClinicalScheduler
                 }
                 _context.SaveChanges();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or InvalidOperationException)
             {
                 // Log the exception and provide a clear error message for debugging
                 Console.WriteLine($"Error seeding test data: {ex.Message}");

--- a/test/ClinicalScheduler/RotationServiceTest.cs
+++ b/test/ClinicalScheduler/RotationServiceTest.cs
@@ -96,7 +96,7 @@ namespace Viper.test.ClinicalScheduler
                 }
                 _context.SaveChanges();
             }
-            catch (Exception ex) when (ex is Microsoft.EntityFrameworkCore.DbUpdateException or InvalidOperationException)
+            catch (Exception ex) when (ex is DbUpdateException or InvalidOperationException)
             {
                 // Log the exception and provide a clear error message for debugging
                 Console.WriteLine($"Error seeding test data: {ex.Message}");

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -201,7 +201,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                             fullName = $"Clinician {mothraId}",
                             firstName = "",
                             lastName = "",
-                            role = (string?)null
+                            role = default(string)
                         };
                     }
                     else

--- a/web/Areas/Effort/Services/VerificationService.cs
+++ b/web/Areas/Effort/Services/VerificationService.cs
@@ -233,7 +233,7 @@ public class VerificationService : IVerificationService
 
         // Set verification timestamp
         var verifiedDate = DateTime.Now;
-        var oldValues = new { EffortVerified = (DateTime?)null };
+        var oldValues = new { EffortVerified = default(DateTime?) };
 
         instructor.EffortVerified = verifiedDate;
 

--- a/web/EmailTemplates/Views/Shared/_EmailLayout.cshtml
+++ b/web/EmailTemplates/Views/Shared/_EmailLayout.cshtml
@@ -41,11 +41,14 @@
                 @* Use width attribute for Outlook, max-width for modern clients. Class for responsive override. *@
                 <table class="email-container" cellpadding="0" cellspacing="0" border="0" width="650" bgcolor="#ffffff" style="background-color: #ffffff; border: 1px solid #dee2e6; max-width: 650px; width: 100%;">
                     @* UC Davis Weill Header Image *@
+                    @{
+                        var baseUrl = ViewBag.BaseUrl as string;
+                    }
                     <tr>
                         <td class="email-header" style="padding: 0; line-height: 0; font-size: 0;">
-                            @if (!string.IsNullOrWhiteSpace((string?)ViewBag.BaseUrl))
+                            @if (!string.IsNullOrWhiteSpace(baseUrl))
                             {
-                                <img src="@(((string)ViewBag.BaseUrl).TrimEnd('/'))/images/email/email-header-weill.jpg"
+                                <img src="@(baseUrl.TrimEnd('/'))/images/email/email-header-weill.jpg"
                                      alt="UC Davis Weill School of Veterinary Medicine"
                                      width="650"
                                      style="display: block; width: 100%; max-width: 650px; height: auto; border: 0;" />


### PR DESCRIPTION
## Summary

Closes 6 of the 7 non-test `cs/useless-upcast` alerts by either extracting a named record or replacing `(T?)null` with `default(T?)`:

- **`PhotoExportService.BatchLoadPhotosAsync`** (PhotoExportService.cs:906, 911, 916, 921) - replaces the 4 anonymous types with a private `PhotoLookupResult(string MailId, byte[]? PhotoBytes)` record. The catch branches now return `new PhotoLookupResult(s.MailId, null)` - no cast needed because the parameter is typed.
- **`VerificationService.cs:235`** - `(DateTime?)null` → `default(DateTime?)`. Same value, no cast.
- **`CliniciansController.cs:204`** - `(string?)null` → `default(string)`. The two anonymous types in the if/else assign to an `object` variable, so they don't need to match.
- **`_EmailLayout.cshtml:46,48`** - extracted `var baseUrl = ViewBag.BaseUrl as string;` into a Razor block; the `(string?)`/`(string)` casts on every reference go away.

## Not addressed

The 1 remaining non-test useless-upcast alert is essentially the same site as above - they collapse together once CodeQL re-scans.

## Context

Sixteenth in the `CodeQL N:` cleanup series.

## Test plan

- [x] `npm run test:backend` - 1946 tests passing
- [x] `npm run verify:build` - clean
- [x] Pre-commit lint+test+verify all passed
