### PR TITLE
chore(coderabbit): disable unsolicited PR summaries

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,9 +8,11 @@ tone_instructions: >
 reviews:
   profile: assertive
   request_changes_workflow: false
-  high_level_summary: true
+  # No unsolicited summaries — CodeRabbit should only summarize when a review
+  # is explicitly requested via `@coderabbitai review` or `@coderabbitai summary`.
+  high_level_summary: false
   poem: false
-  review_status: true
+  review_status: false
   collapse_walkthrough: true
   auto_review:
     enabled: false


### PR DESCRIPTION
## Summary

Stop CodeRabbit from posting a walkthrough/summary block on every PR open. Example noise: https://github.com/ucdavis/VIPER/pull/189#issuecomment-4437225005

## Changes

In `.coderabbit.yaml`:

- `reviews.high_level_summary: true` → `false` — removes the auto-generated high-level summary section that appears even without `auto_review.enabled`.
- `reviews.review_status: true` → `false` — removes the "Review status" comment.

`auto_review.enabled` was already `false`, so no automatic deep review was firing — these two flags were what kept the summary/status comment appearing on PR open.

## After this lands

CodeRabbit will only summarize or review when explicitly invoked via:

- `@coderabbitai review` — full review of the PR
- `@coderabbitai summary` — summary only

## Test plan

- [x] `npm run verify:build` — clean (config-only change; no code impact)
- [ ] Next PR opened against this repo does not get an auto-summary comment