### PR TITLE
chore(build): harden dotnet build scripts and drop deprecated baseUrl

### DIFF
--- a/VueApp/tsconfig.json
+++ b/VueApp/tsconfig.json
@@ -12,7 +12,6 @@
     }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/scripts/build-dotnet.js
+++ b/scripts/build-dotnet.js
@@ -21,6 +21,10 @@ const logger = createLogger("BUILD")
 
 const artifactsPath = ".artifacts-precommit"
 
+// Default execFileSync maxBuffer is 1 MB; full build output with all warnings can exceed
+// that, which would surface as a false "build failed" instead of the real result.
+const MAX_BUILD_OUTPUT = 10_485_760
+
 // Check if either project needs rebuild
 const webNeedsBuild = needsBuild("web", "Viper.csproj")
 const testNeedsBuild = needsBuild("test", "Viper.test.csproj")
@@ -52,6 +56,7 @@ try {
         {
             encoding: "utf8",
             timeout: 120_000,
+            maxBuffer: MAX_BUILD_OUTPUT,
             stdio: ["inherit", "pipe", "pipe"],
             env: { ...env, DOTNET_USE_COMPILER_SERVER: "1" },
         },

--- a/scripts/lib/build-cache.js
+++ b/scripts/lib/build-cache.js
@@ -286,6 +286,30 @@ function getCachedBuildOutput(projectName) {
 }
 
 /**
+ * Remove static-web-asset manifest and dswa caches under an obj/ root, leaving
+ * NuGet restore state and compiled output intact so an active `dotnet watch`
+ * session only has to redo its static-web-assets step.
+ * @param {string} objRoot - Path to a project's obj/ directory
+ */
+function clearStaticWebAssetCache(objRoot) {
+    if (!fs.existsSync(objRoot)) return
+    for (const config of fs.readdirSync(objRoot)) {
+        // Walk Debug/ and Release/ (skip files like project.assets.json at the root)
+        const configDir = path.join(objRoot, config)
+        if (!fs.statSync(configDir).isDirectory()) continue
+        for (const tfm of fs.readdirSync(configDir)) {
+            const tfmDir = path.join(configDir, tfm)
+            if (!fs.statSync(tfmDir).isDirectory()) continue
+            for (const entry of fs.readdirSync(tfmDir)) {
+                if (entry.startsWith("staticwebassets") || entry.endsWith(".dswa.cache.json")) {
+                    fs.rmSync(path.join(tfmDir, entry), { recursive: true, force: true })
+                }
+            }
+        }
+    }
+}
+
+/**
  * Clear the build cache for a specific project or all projects
  * @param {string} [projectName] - Optional project name to clear, or undefined to clear all
  */
@@ -308,6 +332,11 @@ function clearBuildCache(projectName) {
                     fs.rmSync(artifactsDir, { recursive: true, force: true })
                 }
             }
+            // Clear stale static-web-asset state in web/obj — survives across artifact-path
+            // isolation and causes confusing "asset can not be found" errors when Vite bundle
+            // hashes change. Narrowly scoped so a running `npm run dev` session doesn't have
+            // to redo a full restore.
+            clearStaticWebAssetCache(path.join(process.cwd(), "web", "obj"))
             // Clear ESLint cache
             const eslintCache = path.join(process.cwd(), "VueApp", ".eslintcache")
             if (fs.existsSync(eslintCache)) {


### PR DESCRIPTION
- Raise dotnet build maxBuffer to 10 MB; full warning output was overflowing the 1 MB execFileSync default and surfacing as build failures instead of the real result.
- Purge stale static-web-asset caches in web/obj on cache clear so Vite bundle-hash changes do not produce "asset can not be found" errors.
- Drop deprecated baseUrl from VueApp/tsconfig.json (TS resolves paths relative to tsconfig.json without it).