### PR TITLE
CodeQL 16: refactor: drop redundant casts on null and ViewBag

### DIFF
--- a/web/Areas/Effort/Services/VerificationService.cs
+++ b/web/Areas/Effort/Services/VerificationService.cs
@@ -233,7 +233,7 @@ public class VerificationService : IVerificationService
 
         // Set verification timestamp
         var verifiedDate = DateTime.Now;
-        var oldValues = new { EffortVerified = (DateTime?)null };
+        var oldValues = new { EffortVerified = default(DateTime?) };
 
         instructor.EffortVerified = verifiedDate;
 

--- a/web/EmailTemplates/Views/Shared/_EmailLayout.cshtml
+++ b/web/EmailTemplates/Views/Shared/_EmailLayout.cshtml
@@ -41,11 +41,14 @@
                 @* Use width attribute for Outlook, max-width for modern clients. Class for responsive override. *@
                 <table class="email-container" cellpadding="0" cellspacing="0" border="0" width="650" bgcolor="#ffffff" style="background-color: #ffffff; border: 1px solid #dee2e6; max-width: 650px; width: 100%;">
                     @* UC Davis Weill Header Image *@
+                    @{
+                        var baseUrl = ViewBag.BaseUrl as string;
+                    }
                     <tr>
                         <td class="email-header" style="padding: 0; line-height: 0; font-size: 0;">
-                            @if (!string.IsNullOrWhiteSpace((string?)ViewBag.BaseUrl))
+                            @if (!string.IsNullOrWhiteSpace(baseUrl))
                             {
-                                <img src="@(((string)ViewBag.BaseUrl).TrimEnd('/'))/images/email/email-header-weill.jpg"
+                                <img src="@(baseUrl.TrimEnd('/'))/images/email/email-header-weill.jpg"
                                      alt="UC Davis Weill School of Veterinary Medicine"
                                      width="650"
                                      style="display: block; width: 100%; max-width: 650px; height: auto; border: 0;" />


### PR DESCRIPTION
## Summary

Closes 2 of the `cs/useless-upcast` alerts in production code by dropping unnecessary type casts:

- **`VerificationService.cs:236`**: `(DateTime?)null` becomes `default(DateTime?)`. Same value, same inferred field type, no cast.
- **`_EmailLayout.cshtml:41-50`**: extracted `var baseUrl = ViewBag.BaseUrl as string;` into a Razor block. The `(string?)` and `(string)` casts at the two use sites collapse into the single `as string` coercion at the top.

## What was dropped from earlier draft

This branch supersedes #202 (now closed):

- **Two duplicate test-file commits** (catch-narrowing): those are already shipping in #207.
- **`CliniciansController.cs:204`**: the prior draft changed `role = (string?)null` to `role = default(string)` inside an anonymous type. Under `<Nullable>enable</Nullable>`, `default(string)` is `null` typed as non-nullable `string` (CS8625), and would change the inferred field type. Reverted. Kept as `(string?)null` because the cast is conveying nullability intent, not a useless upcast.
- **`PhotoExportService.cs` `PhotoLookupResult` record extraction**: the #202 description mentioned this, but it was never actually committed to the branch. Not included here either; can be done in a follow-up if desired.

## Context

Sixteenth in the `CodeQL N:` cleanup series.

## Test plan

- [x] `npm run test:backend`: passing (pre-commit hooks ran lint+test+verify on the commit)
- [x] Pre-commit lint+test+verify all passed