### PR TITLE
fix: release Biorender semaphore permit on invalid email

### DIFF
--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -23,29 +23,30 @@ namespace Viper.Areas.Computing.Services
             var throttler = new SemaphoreSlim(initialCount: 20);
             foreach (var email in emails)
             {
-                await throttler.WaitAsync();
-
                 var emailTrimmed = email.Trim();
                 if (!emailTrimmed.Contains('@'))
                 {
                     emailTrimmed += "@ucdavis.edu";
                 }
-                if (IsValidEmail(emailTrimmed))
+                if (!IsValidEmail(emailTrimmed))
                 {
-                    resultList.Add(
-                        Task.Run(async () =>
-                        {
-                            try
-                            {
-                                return await GetSingleStudent(emailTrimmed);
-                            }
-                            finally
-                            {
-                                throttler.Release();
-                            }
-                        })
-                    );
+                    continue;
                 }
+
+                await throttler.WaitAsync();
+                resultList.Add(
+                    Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await GetSingleStudent(emailTrimmed);
+                        }
+                        finally
+                        {
+                            throttler.Release();
+                        }
+                    })
+                );
             }
 
             var taskResults = await Task.WhenAll(resultList);


### PR DESCRIPTION
## Summary

`BiorenderStudentLookup.GetBiorenderStudentInfo` acquires a semaphore permit via `throttler.WaitAsync()` **before** checking `IsValidEmail`, but `Release()` only runs inside the scheduled `Task.Run`. Each invalid email permanently consumes a permit, so 20 invalid entries in a row deadlock the loop at `WaitAsync()` waiting for permits that will never be returned.

### Fix

Reorder: trim and validate first, `continue` on invalid, then `WaitAsync` only when work is actually being scheduled.

## Context

Split from #192 (CodeQL dispose hygiene). CodeRabbit surfaced this during the #192 review, but it is a control-flow correction rather than a dispose annotation, so it lives here for cleaner `git log`/bisect.

Independent of #192 — either can merge first. Touches adjacent lines on `var throttler = new SemaphoreSlim(...)` so a trivial merge resolution may be needed for whichever lands second (keep the `using` from #192, keep the reorder from here).

## Test plan

- [x] `npm run test:backend` — 1946 tests passing
- [x] `npm run lint web/Areas/Computing/Services/BiorenderStudentLookup.cs` — clean
- [x] `npm run verify:build` — clean
- [ ] Manual: call `GetBiorenderStudentInfo` with >20 invalid emails, confirm it returns (currently hangs)