### PR TITLE
chore(deps): monthly npm + NuGet updates and Node 24.16 LTS

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -23,7 +23,7 @@ def copyOfflineOperations = [
 ]
 pipeline {
     agent any
-	tools { nodejs "NodeJS 24.14.1" }
+	tools { nodejs "NodeJS 24.16.0" }
     options {
         skipStagesAfterUnstable()
         skipDefaultCheckout()

--- a/VueApp/package-lock.json
+++ b/VueApp/package-lock.json
@@ -13,7 +13,7 @@
                 "inflection": "^3.0.2",
                 "pinia": "^3.0.3",
                 "quasar": "^2.19.3",
-                "vue": "^3.5.33",
+                "vue": "^3.5.35",
                 "vue-chartjs": "^5.3.1",
                 "vue-draggable-plus": "^0.6.1",
                 "vue-router": "^5.0.6"
@@ -24,12 +24,11 @@
                 "@quasar/app-vite": "^2.6.0",
                 "@quasar/vite-plugin": "^1.9.0",
                 "@tsconfig/node24": "^24.0.4",
-                "@types/inflection": "^2.0.0",
-                "@types/node": "~25.6.0",
+                "@types/node": "^24.12.4",
                 "@typescript-eslint/eslint-plugin": "^8.59.0",
                 "@typescript-eslint/parser": "^8.56.0",
                 "@vitejs/plugin-vue": "^6.0.6",
-                "@vitest/coverage-v8": "^4.1.5",
+                "@vitest/coverage-v8": "^4.1.7",
                 "@vue/test-utils": "^2.4.8",
                 "@vue/tsconfig": "^0.9.1",
                 "chokidar": "^5.0.0",
@@ -45,17 +44,17 @@
                 "happy-dom": "^20.9.0",
                 "lodash-es": "^4.17.21",
                 "npm-run-all2": "^8.0.4",
-                "oxfmt": "^0.46.0",
-                "oxlint-tsgolint": "^0.21.1",
+                "oxfmt": "^0.52.0",
+                "oxlint-tsgolint": "^0.23.0",
                 "tree-kill": "^1.2.2",
                 "typescript": "^6.0.3",
                 "vite": "^8.0.10",
-                "vite-plugin-vue-inspector": "^5.3.2",
-                "vitest": "^4.0.0",
+                "vite-plugin-vue-inspector": "^6.0.0",
+                "vitest": "^4.1.7",
                 "vue-tsc": "^3.2.7"
             },
             "engines": {
-                "node": "24.14.1"
+                "node": "24.16.0"
             }
         },
         "node_modules/@actions/core": {
@@ -201,6 +200,7 @@
             "version": "7.29.1",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -407,18 +407,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -449,12 +449,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -613,13 +613,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1205,9 +1205,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2014,9 +2014,9 @@
             "license": "MIT"
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.127.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+            "version": "0.132.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+            "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2024,9 +2024,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.46.0.tgz",
-            "integrity": "sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
+            "integrity": "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==",
             "cpu": [
                 "arm"
             ],
@@ -2041,9 +2041,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.46.0.tgz",
-            "integrity": "sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.52.0.tgz",
+            "integrity": "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2058,9 +2058,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.46.0.tgz",
-            "integrity": "sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.52.0.tgz",
+            "integrity": "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==",
             "cpu": [
                 "arm64"
             ],
@@ -2075,9 +2075,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.46.0.tgz",
-            "integrity": "sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.52.0.tgz",
+            "integrity": "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==",
             "cpu": [
                 "x64"
             ],
@@ -2092,9 +2092,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.46.0.tgz",
-            "integrity": "sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.52.0.tgz",
+            "integrity": "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==",
             "cpu": [
                 "x64"
             ],
@@ -2109,9 +2109,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.46.0.tgz",
-            "integrity": "sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.52.0.tgz",
+            "integrity": "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==",
             "cpu": [
                 "arm"
             ],
@@ -2126,9 +2126,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.46.0.tgz",
-            "integrity": "sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.52.0.tgz",
+            "integrity": "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==",
             "cpu": [
                 "arm"
             ],
@@ -2143,13 +2143,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.46.0.tgz",
-            "integrity": "sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.52.0.tgz",
+            "integrity": "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2160,13 +2163,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.46.0.tgz",
-            "integrity": "sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.52.0.tgz",
+            "integrity": "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2177,13 +2183,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.46.0.tgz",
-            "integrity": "sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.52.0.tgz",
+            "integrity": "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2194,13 +2203,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.46.0.tgz",
-            "integrity": "sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.52.0.tgz",
+            "integrity": "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2211,13 +2223,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.46.0.tgz",
-            "integrity": "sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.52.0.tgz",
+            "integrity": "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2228,13 +2243,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.46.0.tgz",
-            "integrity": "sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.52.0.tgz",
+            "integrity": "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2245,13 +2263,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.46.0.tgz",
-            "integrity": "sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.52.0.tgz",
+            "integrity": "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2262,13 +2283,16 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.46.0.tgz",
-            "integrity": "sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.52.0.tgz",
+            "integrity": "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2279,9 +2303,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.46.0.tgz",
-            "integrity": "sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.52.0.tgz",
+            "integrity": "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2296,9 +2320,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.46.0.tgz",
-            "integrity": "sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.52.0.tgz",
+            "integrity": "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2313,9 +2337,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.46.0.tgz",
-            "integrity": "sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.52.0.tgz",
+            "integrity": "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2330,9 +2354,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.46.0.tgz",
-            "integrity": "sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.52.0.tgz",
+            "integrity": "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==",
             "cpu": [
                 "x64"
             ],
@@ -2347,9 +2371,9 @@
             }
         },
         "node_modules/@oxlint-tsgolint/darwin-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.21.1.tgz",
-            "integrity": "sha512-7TLjyWe4wG9saJc992VWmaHq2hwKfOEEVTjheReXJXaDhavMZI4X9a6nKhbEng4IVkYtzjD2jw16vw2WFXLYLw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+            "integrity": "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==",
             "cpu": [
                 "arm64"
             ],
@@ -2361,9 +2385,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/darwin-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.21.1.tgz",
-            "integrity": "sha512-7wf9Wf75nTzA7zpL9myhFe2RKvfuqGUOADNvUooCjEWvh7hmPz3lSEqTMh5Z/VQhzsG04mM9ACyghxhRzq7zFw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.23.0.tgz",
+            "integrity": "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==",
             "cpu": [
                 "x64"
             ],
@@ -2375,9 +2399,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.21.1.tgz",
-            "integrity": "sha512-IPuQN/Vd0Rjklg/cCGBbQyUuRBp2f6LQXpZYwk5ivOR6V/+CgiYsv8pn/PVY7gjeyoNvPQrXB7xMjHUO2YZbdw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.23.0.tgz",
+            "integrity": "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==",
             "cpu": [
                 "arm64"
             ],
@@ -2389,9 +2413,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.21.1.tgz",
-            "integrity": "sha512-d1niGuTbh2qiv7dR7tqkbOcM5cIR63of0lMBFdEQavL1KrJV8zuRdwdi68K7MNGdgoR+J5A9ajpGGvsHwp1bPg==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.23.0.tgz",
+            "integrity": "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==",
             "cpu": [
                 "x64"
             ],
@@ -2403,9 +2427,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.21.1.tgz",
-            "integrity": "sha512-ICu9y2JLnFPvFqstnWPPNqBM8LK8BWw2OTeaR0UgEMm4hOSbrZAKv1/hwZYyiLqnCNjBL87AGSQIgTHCYlsipw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.23.0.tgz",
+            "integrity": "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==",
             "cpu": [
                 "arm64"
             ],
@@ -2417,9 +2441,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.21.1.tgz",
-            "integrity": "sha512-cTEFCFjCj6iXfrSHcvajSPNqhEA4TxSzU3gFxbdGSAUTNXGToU99IbdhWAPSbhcucoym0XE4Zl7E41NiSkNTug==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.23.0.tgz",
+            "integrity": "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==",
             "cpu": [
                 "x64"
             ],
@@ -3058,9 +3082,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+            "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3075,9 +3099,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+            "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
             "cpu": [
                 "arm64"
             ],
@@ -3092,9 +3116,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+            "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
             "cpu": [
                 "x64"
             ],
@@ -3109,9 +3133,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+            "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
             "cpu": [
                 "x64"
             ],
@@ -3126,9 +3150,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+            "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
             "cpu": [
                 "arm"
             ],
@@ -3143,13 +3167,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+            "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3160,13 +3187,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+            "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3177,13 +3207,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+            "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3194,13 +3227,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+            "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3211,13 +3247,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+            "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3228,13 +3267,16 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+            "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3245,9 +3287,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+            "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
             "cpu": [
                 "arm64"
             ],
@@ -3262,9 +3304,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+            "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -3281,9 +3323,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+            "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
             "cpu": [
                 "arm64"
             ],
@@ -3298,9 +3340,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+            "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
             "cpu": [
                 "x64"
             ],
@@ -3315,9 +3357,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
-            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -3336,9 +3378,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -3484,16 +3526,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/inflection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/inflection/-/inflection-2.0.0.tgz",
-            "integrity": "sha512-wvtAa0dRWFxn/Dw7w7+LySUmN6Yvndvbc87djXaSc0KwhcG2g33LwXdaHg6p2KOddj/1+172GPSeazgandPO2Q==",
-            "deprecated": "This is a stub types definition. inflection provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inflection": "*"
-            }
+        "node_modules/@types/jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -3503,13 +3540,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.19.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/qs": {
@@ -3577,17 +3614,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-            "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+            "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/type-utils": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/scope-manager": "8.60.0",
+                "@typescript-eslint/type-utils": "8.60.0",
+                "@typescript-eslint/utils": "8.60.0",
+                "@typescript-eslint/visitor-keys": "8.60.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3600,22 +3637,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.0",
+                "@typescript-eslint/parser": "^8.60.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-            "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+            "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.1",
-                "@typescript-eslint/types": "8.59.1",
-                "@typescript-eslint/typescript-estree": "8.59.1",
-                "@typescript-eslint/visitor-keys": "8.59.1",
+                "@typescript-eslint/scope-manager": "8.60.0",
+                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/typescript-estree": "8.60.0",
+                "@typescript-eslint/visitor-keys": "8.60.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3630,64 +3667,15 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-            "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.59.1",
-                "@typescript-eslint/visitor-keys": "8.59.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.59.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+            "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.1",
-                "@typescript-eslint/types": "^8.59.1",
+                "@typescript-eslint/tsconfig-utils": "^8.60.0",
+                "@typescript-eslint/types": "^8.60.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3702,29 +3690,15 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-            "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+            "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0"
+                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/visitor-keys": "8.60.0"
             },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -3734,9 +3708,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+            "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3751,15 +3725,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-            "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+            "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
+                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/typescript-estree": "8.60.0",
+                "@typescript-eslint/utils": "8.60.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -3775,91 +3749,10 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.0",
-                "@typescript-eslint/types": "^8.59.0",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.59.0",
-                "@typescript-eslint/tsconfig-utils": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+            "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3871,16 +3764,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+            "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.1",
-                "@typescript-eslint/tsconfig-utils": "8.59.1",
-                "@typescript-eslint/types": "8.59.1",
-                "@typescript-eslint/visitor-keys": "8.59.1",
+                "@typescript-eslint/project-service": "8.60.0",
+                "@typescript-eslint/tsconfig-utils": "8.60.0",
+                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/visitor-keys": "8.60.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3898,48 +3791,17 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.59.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-            "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+            "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0"
+                "@typescript-eslint/scope-manager": "8.60.0",
+                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/typescript-estree": "8.60.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3953,111 +3815,16 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.0",
-                "@typescript-eslint/types": "^8.59.0",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.59.0",
-                "@typescript-eslint/tsconfig-utils": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+            "version": "8.60.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+            "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/types": "8.60.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -4080,13 +3847,13 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
-            "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+            "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rolldown/pluginutils": "1.0.0-rc.13"
+                "@rolldown/pluginutils": "^1.0.1"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -4097,14 +3864,14 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+            "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.5",
+                "@vitest/utils": "4.1.7",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -4118,8 +3885,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.5",
-                "vitest": "4.1.5"
+                "@vitest/browser": "4.1.7",
+                "vitest": "4.1.7"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -4128,16 +3895,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+            "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4146,13 +3913,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+            "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.5",
+                "@vitest/spy": "4.1.7",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -4173,9 +3940,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+            "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4186,13 +3953,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+            "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.5",
+                "@vitest/utils": "4.1.7",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -4200,14 +3967,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+            "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -4216,9 +3983,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+            "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4226,13 +3993,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+            "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.5",
+                "@vitest/pretty-format": "4.1.7",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -4350,13 +4117,13 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-            "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
+            "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.2",
-                "@vue/shared": "3.5.33",
+                "@babel/parser": "^7.29.3",
+                "@vue/shared": "3.5.35",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
@@ -4369,29 +4136,29 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-            "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
+            "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-core": "3.5.35",
+                "@vue/shared": "3.5.35"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-            "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
+            "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.2",
-                "@vue/compiler-core": "3.5.33",
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/compiler-ssr": "3.5.33",
-                "@vue/shared": "3.5.33",
+                "@babel/parser": "^7.29.3",
+                "@vue/compiler-core": "3.5.35",
+                "@vue/compiler-dom": "3.5.35",
+                "@vue/compiler-ssr": "3.5.35",
+                "@vue/shared": "3.5.35",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.10",
+                "postcss": "^8.5.15",
                 "source-map-js": "^1.2.1"
             }
         },
@@ -4402,13 +4169,13 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-            "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
+            "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-dom": "3.5.35",
+                "@vue/shared": "3.5.35"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -4445,75 +4212,75 @@
             }
         },
         "node_modules/@vue/language-core": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.7.tgz",
-            "integrity": "sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.2.tgz",
+            "integrity": "sha512-CLwjSfHlPLhjd2qhuS3tTFtnOIWHXAM5u4X1DxmzlQ8j5bmOYlKCsSusOP7jCRJnlVg0mCTQtHU3vwFvopZGoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
                 "@vue/compiler-dom": "^3.5.0",
                 "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.1.2",
+                "alien-signals": "^3.2.0",
                 "muggle-string": "^0.4.1",
                 "path-browserify": "^1.0.1",
                 "picomatch": "^4.0.4"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-            "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.35.tgz",
+            "integrity": "sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.33"
+                "@vue/shared": "3.5.35"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-            "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz",
+            "integrity": "sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/reactivity": "3.5.35",
+                "@vue/shared": "3.5.35"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-            "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.35.tgz",
+            "integrity": "sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.33",
-                "@vue/runtime-core": "3.5.33",
-                "@vue/shared": "3.5.33",
+                "@vue/reactivity": "3.5.35",
+                "@vue/runtime-core": "3.5.35",
+                "@vue/shared": "3.5.35",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-            "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.35.tgz",
+            "integrity": "sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-ssr": "3.5.35",
+                "@vue/shared": "3.5.35"
             },
             "peerDependencies": {
-                "vue": "3.5.33"
+                "vue": "3.5.35"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-            "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
+            "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
             "license": "MIT"
         },
         "node_modules/@vue/test-utils": {
-            "version": "2.4.8",
-            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.8.tgz",
-            "integrity": "sha512-cjAKFbSXFhtZ9Cj+ug60b21lW/BN737e+Syu2LPACIW6R0zVtj65Fnfe649KjfHor3Etx3ZavDFFBrZ+p21YNw==",
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+            "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4551,14 +4318,14 @@
             }
         },
         "node_modules/@vueuse/core": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
-            "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+            "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
             "license": "MIT",
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.21",
-                "@vueuse/metadata": "14.2.1",
-                "@vueuse/shared": "14.2.1"
+                "@vueuse/metadata": "14.3.0",
+                "@vueuse/shared": "14.3.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -4568,18 +4335,18 @@
             }
         },
         "node_modules/@vueuse/metadata": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
-            "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+            "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "14.2.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
-            "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+            "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -4675,9 +4442,9 @@
             }
         },
         "node_modules/alien-signals": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-            "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
             "dev": true,
             "license": "MIT"
         },
@@ -6113,9 +5880,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -6205,16 +5972,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-            "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",
@@ -6277,9 +6044,9 @@
             }
         },
         "node_modules/eslint-plugin-harlanzw": {
-            "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-harlanzw/-/eslint-plugin-harlanzw-0.12.1.tgz",
-            "integrity": "sha512-0cbWCgRtiiAVadV+NBospUAg96RAHnuohEzcQCPhHtdfaBE8Tv33qEDNwEPqmCbDXxUfp8ZkE9fTWwgRQ4I6xA==",
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-harlanzw/-/eslint-plugin-harlanzw-0.12.3.tgz",
+            "integrity": "sha512-e0DsCTTnAjP6fwlXeE/5SJSVnwMqwj4Qx3xzVYJ1zpWRC5ALRraQv1r2qRCfXg8x68lS6yzyklbcr9vWPddMsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6293,9 +6060,9 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "10.9.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
-            "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+            "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6313,7 +6080,7 @@
                 "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
                 "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "vue-eslint-parser": "^10.0.0"
+                "vue-eslint-parser": "^10.3.0"
             },
             "peerDependenciesMeta": {
                 "@stylistic/eslint-plugin": {
@@ -6971,9 +6738,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-            "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8322,9 +8089,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "funding": [
                 {
                     "type": "github",
@@ -8584,9 +8351,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.46.0.tgz",
-            "integrity": "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.52.0.tgz",
+            "integrity": "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8602,43 +8369,55 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.46.0",
-                "@oxfmt/binding-android-arm64": "0.46.0",
-                "@oxfmt/binding-darwin-arm64": "0.46.0",
-                "@oxfmt/binding-darwin-x64": "0.46.0",
-                "@oxfmt/binding-freebsd-x64": "0.46.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.46.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.46.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.46.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.46.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-x64-musl": "0.46.0",
-                "@oxfmt/binding-openharmony-arm64": "0.46.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.46.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.46.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.46.0"
+                "@oxfmt/binding-android-arm-eabi": "0.52.0",
+                "@oxfmt/binding-android-arm64": "0.52.0",
+                "@oxfmt/binding-darwin-arm64": "0.52.0",
+                "@oxfmt/binding-darwin-x64": "0.52.0",
+                "@oxfmt/binding-freebsd-x64": "0.52.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.52.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.52.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.52.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.52.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-x64-musl": "0.52.0",
+                "@oxfmt/binding-openharmony-arm64": "0.52.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.52.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.52.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.52.0"
+            },
+            "peerDependencies": {
+                "svelte": "^5.0.0",
+                "vite-plus": "*"
+            },
+            "peerDependenciesMeta": {
+                "svelte": {
+                    "optional": true
+                },
+                "vite-plus": {
+                    "optional": true
+                }
             }
         },
         "node_modules/oxlint-tsgolint": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.21.1.tgz",
-            "integrity": "sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.23.0.tgz",
+            "integrity": "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "tsgolint": "bin/tsgolint.js"
             },
             "optionalDependencies": {
-                "@oxlint-tsgolint/darwin-arm64": "0.21.1",
-                "@oxlint-tsgolint/darwin-x64": "0.21.1",
-                "@oxlint-tsgolint/linux-arm64": "0.21.1",
-                "@oxlint-tsgolint/linux-x64": "0.21.1",
-                "@oxlint-tsgolint/win32-arm64": "0.21.1",
-                "@oxlint-tsgolint/win32-x64": "0.21.1"
+                "@oxlint-tsgolint/darwin-arm64": "0.23.0",
+                "@oxlint-tsgolint/darwin-x64": "0.23.0",
+                "@oxlint-tsgolint/linux-arm64": "0.23.0",
+                "@oxlint-tsgolint/linux-x64": "0.23.0",
+                "@oxlint-tsgolint/win32-arm64": "0.23.0",
+                "@oxlint-tsgolint/win32-x64": "0.23.0"
             }
         },
         "node_modules/p-limit": {
@@ -8863,9 +8642,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8882,7 +8661,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -9199,14 +8978,14 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+            "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.127.0",
-                "@rolldown/pluginutils": "1.0.0-rc.17"
+                "@oxc-project/types": "=0.132.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -9215,29 +8994,22 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+                "@rolldown/binding-android-arm64": "1.0.2",
+                "@rolldown/binding-darwin-arm64": "1.0.2",
+                "@rolldown/binding-darwin-x64": "1.0.2",
+                "@rolldown/binding-freebsd-x64": "1.0.2",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+                "@rolldown/binding-linux-arm64-musl": "1.0.2",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-musl": "1.0.2",
+                "@rolldown/binding-openharmony-arm64": "1.0.2",
+                "@rolldown/binding-wasm32-wasi": "1.0.2",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+                "@rolldown/binding-win32-x64-msvc": "1.0.2"
             }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.17",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/rollup-plugin-visualizer": {
             "version": "7.0.1",
@@ -10268,9 +10040,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -10482,9 +10254,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+            "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10686,9 +10458,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.19.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "dev": true,
             "license": "MIT"
         },
@@ -10825,16 +10597,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.10",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+            "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.17",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.2",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -10851,7 +10623,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
+                "@vitejs/devtools": "^0.1.18",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -10903,9 +10675,9 @@
             }
         },
         "node_modules/vite-plugin-vue-inspector": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-inspector/-/vite-plugin-vue-inspector-5.4.0.tgz",
-            "integrity": "sha512-Iq/024CydcE46FZqWPU4t4lw4uYOdLnFSO1RNxJVt2qY9zxIjmnkBqhHnYaReWM82kmNnaXs7OkfgRrV2GEjyw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-inspector/-/vite-plugin-vue-inspector-6.0.0.tgz",
+            "integrity": "sha512-OpyITJLgZNibxlrik1EmRtvXHDjLRxNPsWkGFTERZs2LgMEdG4W0WoFt5GIgp3a3jRou+eJR8U1zOBk/XQgEbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10924,19 +10696,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+            "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.5",
-                "@vitest/mocker": "4.1.5",
-                "@vitest/pretty-format": "4.1.5",
-                "@vitest/runner": "4.1.5",
-                "@vitest/snapshot": "4.1.5",
-                "@vitest/spy": "4.1.5",
-                "@vitest/utils": "4.1.5",
+                "@vitest/expect": "4.1.7",
+                "@vitest/mocker": "4.1.7",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/runner": "4.1.7",
+                "@vitest/snapshot": "4.1.7",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -10964,12 +10736,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.5",
-                "@vitest/browser-preview": "4.1.5",
-                "@vitest/browser-webdriverio": "4.1.5",
-                "@vitest/coverage-istanbul": "4.1.5",
-                "@vitest/coverage-v8": "4.1.5",
-                "@vitest/ui": "4.1.5",
+                "@vitest/browser-playwright": "4.1.7",
+                "@vitest/browser-preview": "4.1.7",
+                "@vitest/browser-webdriverio": "4.1.7",
+                "@vitest/coverage-istanbul": "4.1.7",
+                "@vitest/coverage-v8": "4.1.7",
+                "@vitest/ui": "4.1.7",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -11021,16 +10793,16 @@
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-            "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+            "version": "3.5.35",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.35.tgz",
+            "integrity": "sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/compiler-sfc": "3.5.33",
-                "@vue/runtime-dom": "3.5.33",
-                "@vue/server-renderer": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-dom": "3.5.35",
+                "@vue/compiler-sfc": "3.5.35",
+                "@vue/runtime-dom": "3.5.35",
+                "@vue/server-renderer": "3.5.35",
+                "@vue/shared": "3.5.35"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -11113,14 +10885,14 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
-            "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.7.tgz",
+            "integrity": "sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/generator": "^7.28.6",
+                "@babel/generator": "^8.0.0-rc.4",
                 "@vue-macros/common": "^3.1.1",
-                "@vue/devtools-api": "^8.0.6",
+                "@vue/devtools-api": "^8.1.1",
                 "ast-walker-scope": "^0.8.3",
                 "chokidar": "^5.0.0",
                 "json5": "^2.2.3",
@@ -11141,9 +10913,9 @@
             },
             "peerDependencies": {
                 "@pinia/colada": ">=0.21.2",
-                "@vue/compiler-sfc": "^3.5.17",
+                "@vue/compiler-sfc": "^3.5.34",
                 "pinia": "^3.0.4",
-                "vue": "^3.5.0"
+                "vue": "^3.5.34"
             },
             "peerDependenciesMeta": {
                 "@pinia/colada": {
@@ -11155,6 +10927,69 @@
                 "pinia": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue-router/node_modules/@babel/generator": {
+            "version": "8.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.6.tgz",
+            "integrity": "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^8.0.0-rc.6",
+                "@babel/types": "^8.0.0-rc.6",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "@types/jsesc": "^2.5.0",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/vue-router/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.6.tgz",
+            "integrity": "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==",
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/vue-router/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.6.tgz",
+            "integrity": "sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/vue-router/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.6.tgz",
+            "integrity": "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.6"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/vue-router/node_modules/@babel/types": {
+            "version": "8.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.6.tgz",
+            "integrity": "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.6",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.6"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/vue-router/node_modules/@vue/devtools-api": {
@@ -11205,14 +11040,14 @@
             }
         },
         "node_modules/vue-tsc": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.7.tgz",
-            "integrity": "sha512-zc1tL3HoQni1zGTGrwBVRQb7rGP5SWdu/m4rGB6JcnAC5MT5LFZIxF7Y+EJEnt4hGF23d60rXH7gRjHGb5KQQQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.2.tgz",
+            "integrity": "sha512-n7nQoA3YWW/eiDR8jMiv/uJvlg0uLGs+YgUrsTrf9EZaYSt3tuvMZb5V8+7Mvh/EH5pnY/hoVdgfjH+XcK+wwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.2.7"
+                "@vue/language-core": "3.3.2"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"

--- a/VueApp/package.json
+++ b/VueApp/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "engines": {
-        "node": "24.14.1"
+        "node": "24.16.0"
     },
     "scripts": {
         "dev": "vite",
@@ -30,7 +30,7 @@
         "inflection": "^3.0.2",
         "pinia": "^3.0.3",
         "quasar": "^2.19.3",
-        "vue": "^3.5.33",
+        "vue": "^3.5.35",
         "vue-chartjs": "^5.3.1",
         "vue-draggable-plus": "^0.6.1",
         "vue-router": "^5.0.6"
@@ -41,12 +41,11 @@
         "@quasar/app-vite": "^2.6.0",
         "@quasar/vite-plugin": "^1.9.0",
         "@tsconfig/node24": "^24.0.4",
-        "@types/inflection": "^2.0.0",
-        "@types/node": "~25.6.0",
+        "@types/node": "^24.12.4",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.56.0",
         "@vitejs/plugin-vue": "^6.0.6",
-        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/coverage-v8": "^4.1.7",
         "@vue/test-utils": "^2.4.8",
         "@vue/tsconfig": "^0.9.1",
         "chokidar": "^5.0.0",
@@ -62,13 +61,13 @@
         "happy-dom": "^20.9.0",
         "lodash-es": "^4.17.21",
         "npm-run-all2": "^8.0.4",
-        "oxfmt": "^0.46.0",
-        "oxlint-tsgolint": "^0.21.1",
+        "oxfmt": "^0.52.0",
+        "oxlint-tsgolint": "^0.23.0",
         "tree-kill": "^1.2.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
-        "vite-plugin-vue-inspector": "^5.3.2",
-        "vitest": "^4.0.0",
+        "vite-plugin-vue-inspector": "^6.0.0",
+        "vitest": "^4.1.7",
         "vue-tsc": "^3.2.7"
     },
     "overrides": {
@@ -77,7 +76,7 @@
         }
     },
     "volta": {
-        "node": "24.14.1",
-        "npm": "11.12.0"
+        "node": "24.16.0",
+        "npm": "11.13.0"
     }
 }

--- a/VueApp/src/CMS/components/ContentBlock.vue
+++ b/VueApp/src/CMS/components/ContentBlock.vue
@@ -1,5 +1,5 @@
 <template>
-    <!-- Content sanitized by CMS.cs using OWASP AntiSamy -->
+    <!-- Content sanitized by CMS.cs using HtmlSanitizerService -->
     <!-- eslint-disable vue/no-v-html -->
     <div
         v-html="contentBlock?.content"

--- a/VueApp/src/components/CmsContent.vue
+++ b/VueApp/src/components/CmsContent.vue
@@ -35,7 +35,7 @@ watch(props, () => {
 getContentBlock()
 </script>
 <template>
-    <!-- Content sanitized by CMS.cs using OWASP AntiSamy -->
+    <!-- Content sanitized by CMS.cs using HtmlSanitizerService -->
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="cb?.content" />
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
                 "fallow": "^2.38.0",
                 "husky": "^9.1.7",
                 "jscpd": "^4.0.9",
-                "oxfmt": "^0.46.0",
+                "oxfmt": "^0.52.0",
                 "oxlint": "^1.61.0",
-                "oxlint-tsgolint": "^0.21.1",
+                "oxlint-tsgolint": "^0.23.0",
                 "postcss-html": "^1.8.0",
                 "stylelint": "^17.9.0",
                 "stylelint-config-standard": "^40.0.0",
@@ -53,9 +53,9 @@
             "license": "MIT"
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -63,9 +63,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -73,13 +73,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -89,27 +89,27 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@cacheable/memory": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
-            "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+            "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/utils": "^2.4.0",
+                "@cacheable/utils": "^2.4.1",
                 "@keyv/bigmap": "^1.3.1",
                 "hookified": "^1.15.1",
                 "keyv": "^5.6.0"
@@ -337,13 +337,13 @@
             }
         },
         "node_modules/@double-great/stylelint-a11y": {
-            "version": "3.4.10",
-            "resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.4.10.tgz",
-            "integrity": "sha512-tftvJMegGlEN2XZyYOPHMTgE3pb2bkpcmGo/TSHgIW/L6U69cwQLcwbmJXuL+FcGVRyCcucd0xfwdece8dXu3A==",
+            "version": "3.4.14",
+            "resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.4.14.tgz",
+            "integrity": "sha512-yytlwspk4QCm9KcdlNtO+2zfZsThiciXEI+sAZrKV4OY35SLrvJHUWUkk1pVQ9FUY+xkQxXU6BD9gdbohmESlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "postcss": "^8.5.10"
+                "postcss": "^8.5.15"
             },
             "engines": {
                 "node": ">=18.12.0"
@@ -417,9 +417,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -488,9 +488,9 @@
             }
         },
         "node_modules/@fallow-cli/darwin-arm64": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.52.0.tgz",
-            "integrity": "sha512-pvWp2jn+LPfPqfKQOEd4PwC69Rb0g4gv95j38v6gkT8xXMEzrjgzZpijYojVPuWDeMYRSG1+01njghL72qJi+A==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.82.0.tgz",
+            "integrity": "sha512-qc9CFpQNHuSbbvbj4iSR215D7qEa1V0yq+pLhl1WTTMf9B2RjvXEzRrPqAYfQY4/8U1uvSl2KWY2uIkIhNZzww==",
             "cpu": [
                 "arm64"
             ],
@@ -502,9 +502,9 @@
             ]
         },
         "node_modules/@fallow-cli/darwin-x64": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.52.0.tgz",
-            "integrity": "sha512-Vo2xLC2EPcv+JervfbsP/Mzlhekjo1w3uMtryY+pULztHbH960srJscr8TFwRnoCYXdZjRtO2CXdZZ/7tuDbHA==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.82.0.tgz",
+            "integrity": "sha512-6ZAGvLLLIEWafRL0wxG6E+ixSfzDmYRF7i/7zDj9jTK6lN7tOjk1QSyTCjK14JpexCHY+XkaFiRObCBcFUP77g==",
             "cpu": [
                 "x64"
             ],
@@ -516,9 +516,9 @@
             ]
         },
         "node_modules/@fallow-cli/linux-arm64-gnu": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.52.0.tgz",
-            "integrity": "sha512-AIBLQqlq7hlCFeLj+LyFNhXPNiyfSKl8HrAtj8azfCW+9h4IR0vXi6apRvbHE9/VCoHlMlZpDE/6528qUpTUNg==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.82.0.tgz",
+            "integrity": "sha512-QrFhnpx3AOBSrFAIxF4Sn63qWltvT+Fz7rHmQD3ngkoEn6SuN7ZRLGiZIqYZFWPmx1+WB+1tMekjWoJo8my9mw==",
             "cpu": [
                 "arm64"
             ],
@@ -530,9 +530,9 @@
             ]
         },
         "node_modules/@fallow-cli/linux-arm64-musl": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.52.0.tgz",
-            "integrity": "sha512-x1a3LCFf+E9irw5Lkj1pT9GHRa6LfYg+w6SLqE8deZei6frtanqAeGKyD5d+24LzHF+TqlySlSQxnbBTMbl8AA==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.82.0.tgz",
+            "integrity": "sha512-K9iaJ324SOl7VMmWFaT1MdNmezQqpot5Mr8EpSqwD8qvFirVnzvvJBPKr3JGtLPJPvVQfY11PLzvABMEYQxmQQ==",
             "cpu": [
                 "arm64"
             ],
@@ -544,9 +544,9 @@
             ]
         },
         "node_modules/@fallow-cli/linux-x64-gnu": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.52.0.tgz",
-            "integrity": "sha512-JBezH1wC4CWrsnpkA5fdXwvbf6JIUKvZ9o9N855PVIwnmObj34KY+CvLZnlst4LassTAZk7NWy650OaJaiNWGg==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.82.0.tgz",
+            "integrity": "sha512-k1Srj22ITt65OBHr44MJ6Szn7za1PXFHQLUhk8t5haSvRKL2wunZAWe581C3epfgo3HpMALMxc87sylhNBV33g==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@fallow-cli/linux-x64-musl": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.52.0.tgz",
-            "integrity": "sha512-hv9Utb8oea+QJ526L7dl8qWexLYLwNsNLkSB8Ywb8+8q1oHXH3ORccEcxXEud/hjzHUHbjPcgqL36/CvLP02Xw==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.82.0.tgz",
+            "integrity": "sha512-rERHj2rWQgS6PAmrVS1E+5SFRTbPmwrSqjLeiVOoayVGN7gxaxI3Th+6jJDcpYY4f9iMv+7Cx/NEXkgrJDygvg==",
             "cpu": [
                 "x64"
             ],
@@ -572,9 +572,9 @@
             ]
         },
         "node_modules/@fallow-cli/win32-arm64-msvc": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.52.0.tgz",
-            "integrity": "sha512-uYT1WXu9lMIpBYfHqNNiULvTg+YgGxeCgfvMrRTO36LVrRXzdnKn5xeuYXx7CwjbQb9Zsu4PzHB++KC9ocGKiQ==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.82.0.tgz",
+            "integrity": "sha512-rYQi69+yEvdHQE8BKRqmbfaOF9/nKPoEP121DxvMTSvljq7Flruomx0+AKQFbLbcHOd7OrmwedYlOJWkRED8TA==",
             "cpu": [
                 "arm64"
             ],
@@ -586,9 +586,9 @@
             ]
         },
         "node_modules/@fallow-cli/win32-x64-msvc": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.52.0.tgz",
-            "integrity": "sha512-qJ2v+En5PLZidrsaapYUPuOUY2b1ZzbNlUbDg5Ly0Th8I2TaUpB8ZgKPWa3t+ISBfjbylmhrk1eLj0JFVEaEqw==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.82.0.tgz",
+            "integrity": "sha512-zFTJIsu+XcJ82ZBdSR+uHc5/GDfEpYdU1nGmxAoys73tFELfDljKHSmcAgruBaVqerDbCvmksXzcO95YzMPbiA==",
             "cpu": [
                 "x64"
             ],
@@ -652,9 +652,9 @@
             }
         },
         "node_modules/@jscpd/badge-reporter": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.0.5.tgz",
-            "integrity": "sha512-SLVhP00R9lkQ//Ivaanfm7k0L9sewpBven670kk1uGec2SWUOa7MVQcuad/TV59KEZ73UIC1lXvi6O9hAnbpUw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.2.4.tgz",
+            "integrity": "sha512-g5vu05u0lX9rcHA0k3CptLfpOiuMzxh5+mUe2iYRAznTwH3ks6JAVAf9aPi5mBFttMCRiJh2zSt3xnSadHtMGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -664,9 +664,9 @@
             }
         },
         "node_modules/@jscpd/core": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.0.5.tgz",
-            "integrity": "sha512-Udvym21nWzxjYRVXwwpYNBqZ6b50QV2zHN3fFNzOPPg4cfQVYOZerILB7xNDUsXHC1PCr/N52Tq3q7AElvjWWA==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.2.4.tgz",
+            "integrity": "sha512-9V9YzmmhYg9682kFqi+n0KGOhXNSoqxHbuIP3i/l/oSd6upBOnnSeBWDZMGOenQRQnyKEtCIbnS9YFz+3B+siQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -674,14 +674,14 @@
             }
         },
         "node_modules/@jscpd/finder": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.0.5.tgz",
-            "integrity": "sha512-/2VkRoVrrfya+51sitZo5I9MdwsRaPKB8X3L3khAYoHFXk4L/mUuG81RmGazDHjUIGg22ItlkQtwzorNZ2+aPw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.2.4.tgz",
+            "integrity": "sha512-4LLEuAAmAraud/TAAlB5BByVdWfy7SYiPKacj5yEggpkNs0qsw2kiZ5EyU3LonB+/vntJJEDDpJMmvOeS58e0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jscpd/core": "4.0.5",
-                "@jscpd/tokenizer": "4.0.5",
+                "@jscpd/core": "4.2.4",
+                "@jscpd/tokenizer": "4.2.4",
                 "blamer": "^1.0.6",
                 "bytes": "^3.1.2",
                 "cli-table3": "^0.6.5",
@@ -693,9 +693,9 @@
             }
         },
         "node_modules/@jscpd/html-reporter": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.0.5.tgz",
-            "integrity": "sha512-drK2J8KyPIW9wvaElSIobZFp4dBO9GA++JW4gx3oihvLdDSp8qSo/CNqH47Dw0XkjQTxND3j/+Wz5JWvYRBgFQ==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.2.4.tgz",
+            "integrity": "sha512-6UljCTVGf7O+o6D6fs1zNBG+vR1PTn47W2mSgb5hzSrvNw60rLrVoAMZMnr/TeIEdd/OEgAu+icbdvvVBfnvJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -705,14 +705,13 @@
             }
         },
         "node_modules/@jscpd/tokenizer": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.0.5.tgz",
-            "integrity": "sha512-WzRujQtN5WedxZVDKuoanxmKAFrxcLrHpcA6kaM4z8AhGtWXZ325yseqgL5TZ8OK7Auwu7kQLlqhfk05fGYG7A==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.2.4.tgz",
+            "integrity": "sha512-nM4kGyDvpcevt8t0zOsMQ82ShSc65c3LIQUHClTYwraiOGOmWgUQyen+JIiFCNF8eDCGR2Qa5iI5XBfGWYQzIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jscpd/core": "4.0.5",
-                "reprism": "^0.0.11",
+                "@jscpd/core": "4.2.4",
                 "spark-md5": "^3.0.2"
             }
         },
@@ -762,9 +761,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.46.0.tgz",
-            "integrity": "sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
+            "integrity": "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==",
             "cpu": [
                 "arm"
             ],
@@ -779,9 +778,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.46.0.tgz",
-            "integrity": "sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.52.0.tgz",
+            "integrity": "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==",
             "cpu": [
                 "arm64"
             ],
@@ -796,9 +795,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.46.0.tgz",
-            "integrity": "sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.52.0.tgz",
+            "integrity": "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==",
             "cpu": [
                 "arm64"
             ],
@@ -813,9 +812,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.46.0.tgz",
-            "integrity": "sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.52.0.tgz",
+            "integrity": "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==",
             "cpu": [
                 "x64"
             ],
@@ -830,9 +829,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.46.0.tgz",
-            "integrity": "sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.52.0.tgz",
+            "integrity": "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==",
             "cpu": [
                 "x64"
             ],
@@ -847,9 +846,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.46.0.tgz",
-            "integrity": "sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.52.0.tgz",
+            "integrity": "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==",
             "cpu": [
                 "arm"
             ],
@@ -864,9 +863,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.46.0.tgz",
-            "integrity": "sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.52.0.tgz",
+            "integrity": "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==",
             "cpu": [
                 "arm"
             ],
@@ -881,9 +880,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.46.0.tgz",
-            "integrity": "sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.52.0.tgz",
+            "integrity": "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==",
             "cpu": [
                 "arm64"
             ],
@@ -901,9 +900,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.46.0.tgz",
-            "integrity": "sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.52.0.tgz",
+            "integrity": "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==",
             "cpu": [
                 "arm64"
             ],
@@ -921,9 +920,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.46.0.tgz",
-            "integrity": "sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.52.0.tgz",
+            "integrity": "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==",
             "cpu": [
                 "ppc64"
             ],
@@ -941,9 +940,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.46.0.tgz",
-            "integrity": "sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.52.0.tgz",
+            "integrity": "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==",
             "cpu": [
                 "riscv64"
             ],
@@ -961,9 +960,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.46.0.tgz",
-            "integrity": "sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.52.0.tgz",
+            "integrity": "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==",
             "cpu": [
                 "riscv64"
             ],
@@ -981,9 +980,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.46.0.tgz",
-            "integrity": "sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.52.0.tgz",
+            "integrity": "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==",
             "cpu": [
                 "s390x"
             ],
@@ -1001,9 +1000,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.46.0.tgz",
-            "integrity": "sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.52.0.tgz",
+            "integrity": "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==",
             "cpu": [
                 "x64"
             ],
@@ -1021,9 +1020,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.46.0.tgz",
-            "integrity": "sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.52.0.tgz",
+            "integrity": "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==",
             "cpu": [
                 "x64"
             ],
@@ -1041,9 +1040,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.46.0.tgz",
-            "integrity": "sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.52.0.tgz",
+            "integrity": "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1058,9 +1057,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.46.0.tgz",
-            "integrity": "sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.52.0.tgz",
+            "integrity": "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1075,9 +1074,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.46.0.tgz",
-            "integrity": "sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.52.0.tgz",
+            "integrity": "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==",
             "cpu": [
                 "ia32"
             ],
@@ -1092,9 +1091,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.46.0.tgz",
-            "integrity": "sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.52.0.tgz",
+            "integrity": "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==",
             "cpu": [
                 "x64"
             ],
@@ -1109,9 +1108,9 @@
             }
         },
         "node_modules/@oxlint-tsgolint/darwin-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.21.1.tgz",
-            "integrity": "sha512-7TLjyWe4wG9saJc992VWmaHq2hwKfOEEVTjheReXJXaDhavMZI4X9a6nKhbEng4IVkYtzjD2jw16vw2WFXLYLw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+            "integrity": "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==",
             "cpu": [
                 "arm64"
             ],
@@ -1123,9 +1122,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/darwin-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.21.1.tgz",
-            "integrity": "sha512-7wf9Wf75nTzA7zpL9myhFe2RKvfuqGUOADNvUooCjEWvh7hmPz3lSEqTMh5Z/VQhzsG04mM9ACyghxhRzq7zFw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.23.0.tgz",
+            "integrity": "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==",
             "cpu": [
                 "x64"
             ],
@@ -1137,9 +1136,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.21.1.tgz",
-            "integrity": "sha512-IPuQN/Vd0Rjklg/cCGBbQyUuRBp2f6LQXpZYwk5ivOR6V/+CgiYsv8pn/PVY7gjeyoNvPQrXB7xMjHUO2YZbdw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.23.0.tgz",
+            "integrity": "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==",
             "cpu": [
                 "arm64"
             ],
@@ -1151,9 +1150,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.21.1.tgz",
-            "integrity": "sha512-d1niGuTbh2qiv7dR7tqkbOcM5cIR63of0lMBFdEQavL1KrJV8zuRdwdi68K7MNGdgoR+J5A9ajpGGvsHwp1bPg==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.23.0.tgz",
+            "integrity": "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==",
             "cpu": [
                 "x64"
             ],
@@ -1165,9 +1164,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-arm64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.21.1.tgz",
-            "integrity": "sha512-ICu9y2JLnFPvFqstnWPPNqBM8LK8BWw2OTeaR0UgEMm4hOSbrZAKv1/hwZYyiLqnCNjBL87AGSQIgTHCYlsipw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.23.0.tgz",
+            "integrity": "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==",
             "cpu": [
                 "arm64"
             ],
@@ -1179,9 +1178,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-x64": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.21.1.tgz",
-            "integrity": "sha512-cTEFCFjCj6iXfrSHcvajSPNqhEA4TxSzU3gFxbdGSAUTNXGToU99IbdhWAPSbhcucoym0XE4Zl7E41NiSkNTug==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.23.0.tgz",
+            "integrity": "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==",
             "cpu": [
                 "x64"
             ],
@@ -1193,9 +1192,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.61.0.tgz",
-            "integrity": "sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
+            "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
             "cpu": [
                 "arm"
             ],
@@ -1210,9 +1209,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.61.0.tgz",
-            "integrity": "sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
+            "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1227,9 +1226,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.61.0.tgz",
-            "integrity": "sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
+            "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
             "cpu": [
                 "arm64"
             ],
@@ -1244,9 +1243,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.61.0.tgz",
-            "integrity": "sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
+            "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
             "cpu": [
                 "x64"
             ],
@@ -1261,9 +1260,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.61.0.tgz",
-            "integrity": "sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
+            "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
             "cpu": [
                 "x64"
             ],
@@ -1278,9 +1277,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.61.0.tgz",
-            "integrity": "sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
+            "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
             "cpu": [
                 "arm"
             ],
@@ -1295,9 +1294,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.61.0.tgz",
-            "integrity": "sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
+            "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
             "cpu": [
                 "arm"
             ],
@@ -1312,9 +1311,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.61.0.tgz",
-            "integrity": "sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
+            "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
             "cpu": [
                 "arm64"
             ],
@@ -1332,9 +1331,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.61.0.tgz",
-            "integrity": "sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
+            "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
             "cpu": [
                 "arm64"
             ],
@@ -1352,9 +1351,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.61.0.tgz",
-            "integrity": "sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
+            "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
             "cpu": [
                 "ppc64"
             ],
@@ -1372,9 +1371,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.61.0.tgz",
-            "integrity": "sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
+            "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1392,9 +1391,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.61.0.tgz",
-            "integrity": "sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
+            "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1412,9 +1411,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.61.0.tgz",
-            "integrity": "sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
+            "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
             "cpu": [
                 "s390x"
             ],
@@ -1432,9 +1431,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.61.0.tgz",
-            "integrity": "sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
+            "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
             "cpu": [
                 "x64"
             ],
@@ -1452,9 +1451,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.61.0.tgz",
-            "integrity": "sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
+            "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
             "cpu": [
                 "x64"
             ],
@@ -1472,9 +1471,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.61.0.tgz",
-            "integrity": "sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
+            "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
             "cpu": [
                 "arm64"
             ],
@@ -1489,9 +1488,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.61.0.tgz",
-            "integrity": "sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
+            "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
             "cpu": [
                 "arm64"
             ],
@@ -1506,9 +1505,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.61.0.tgz",
-            "integrity": "sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
+            "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
             "cpu": [
                 "ia32"
             ],
@@ -1523,9 +1522,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.61.0.tgz",
-            "integrity": "sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
+            "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
             "cpu": [
                 "x64"
             ],
@@ -1621,16 +1620,13 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
@@ -1694,9 +1690,9 @@
             }
         },
         "node_modules/badgen": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.3.tgz",
-            "integrity": "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/badgen/-/badgen-3.3.2.tgz",
+            "integrity": "sha512-fbQwK9norfdzbdsoPwbLIAmgBXDGEme3jeIyqPAH7o6vp9lmuLHS7uXULvOiQ6XnMLkYNG4gDjILf74hgtTAug==",
             "dev": true,
             "license": "MIT"
         },
@@ -1771,17 +1767,17 @@
             }
         },
         "node_modules/cacheable": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
-            "integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+            "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@cacheable/memory": "^2.0.8",
-                "@cacheable/utils": "^2.4.0",
+                "@cacheable/utils": "^2.4.1",
                 "hookified": "^1.15.0",
                 "keyv": "^5.6.0",
-                "qified": "^0.9.0"
+                "qified": "^0.10.1"
             }
         },
         "node_modules/cacheable/node_modules/keyv": {
@@ -1891,44 +1887,6 @@
                 "@colors/colors": "1.5.0"
             }
         },
-        "node_modules/cli-table3/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1942,44 +1900,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/color-convert": {
@@ -2362,9 +2282,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2398,16 +2318,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-            "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",
@@ -2617,11 +2537,10 @@
             "license": "ISC"
         },
         "node_modules/fallow": {
-            "version": "2.52.0",
-            "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.52.0.tgz",
-            "integrity": "sha512-yZNFqRODW42mnGKYz6RosZR2CNhNwdYkXKIGBARKWNMRGwn9E9jonXFZDB+czjPL6rDnthNRheIJpRhDvzAaUw==",
+            "version": "2.82.0",
+            "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.82.0.tgz",
+            "integrity": "sha512-W0rwzQrOtr8/6T0Z4r0U0rc8V8w2QmiUiTB7RJVWwCP+pLKF4pjJSWz3rFSKvkg8SrSJMLGKcdWCa6tIjSE+6w==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -2635,14 +2554,14 @@
                 "node": ">=16"
             },
             "optionalDependencies": {
-                "@fallow-cli/darwin-arm64": "2.52.0",
-                "@fallow-cli/darwin-x64": "2.52.0",
-                "@fallow-cli/linux-arm64-gnu": "2.52.0",
-                "@fallow-cli/linux-arm64-musl": "2.52.0",
-                "@fallow-cli/linux-x64-gnu": "2.52.0",
-                "@fallow-cli/linux-x64-musl": "2.52.0",
-                "@fallow-cli/win32-arm64-msvc": "2.52.0",
-                "@fallow-cli/win32-x64-msvc": "2.52.0"
+                "@fallow-cli/darwin-arm64": "2.82.0",
+                "@fallow-cli/darwin-x64": "2.82.0",
+                "@fallow-cli/linux-arm64-gnu": "2.82.0",
+                "@fallow-cli/linux-arm64-musl": "2.82.0",
+                "@fallow-cli/linux-x64-gnu": "2.82.0",
+                "@fallow-cli/linux-x64-musl": "2.82.0",
+                "@fallow-cli/win32-arm64-msvc": "2.82.0",
+                "@fallow-cli/win32-x64-msvc": "2.82.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -2798,9 +2717,9 @@
             "license": "ISC"
         },
         "node_modules/fs-extra": {
-            "version": "11.3.4",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-            "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2833,9 +2752,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3206,13 +3125,13 @@
             "license": "MIT"
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3301,16 +3220,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-promise": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -3385,30 +3294,30 @@
             }
         },
         "node_modules/jscpd": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.0.9.tgz",
-            "integrity": "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.2.4.tgz",
+            "integrity": "sha512-PSo2U0G8OxULayGyQMv7T/0ZQ+c3PPltdMOz/57v9Xnmq5xSIhh4cnZ0oYZPKqejy10aFwAbMVxqAlo24+PQ3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jscpd/badge-reporter": "4.0.5",
-                "@jscpd/core": "4.0.5",
-                "@jscpd/finder": "4.0.5",
-                "@jscpd/html-reporter": "4.0.5",
-                "@jscpd/tokenizer": "4.0.5",
+                "@jscpd/badge-reporter": "4.2.4",
+                "@jscpd/core": "4.2.4",
+                "@jscpd/finder": "4.2.4",
+                "@jscpd/html-reporter": "4.2.4",
+                "@jscpd/tokenizer": "4.2.4",
                 "colors": "^1.4.0",
                 "commander": "^5.0.0",
                 "fs-extra": "^11.2.0",
-                "jscpd-sarif-reporter": "4.0.7"
+                "jscpd-sarif-reporter": "4.2.4"
             },
             "bin": {
                 "jscpd": "bin/jscpd"
             }
         },
         "node_modules/jscpd-sarif-reporter": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.0.7.tgz",
-            "integrity": "sha512-Q/VlfTI/Nbjc8dZ/2pDVIf1aRi2bM2CTYujcAoeYr7brRnS4o5ZeW86W8q7MM7cQu40gezlNckl+E9wKFSMFiA==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.2.4.tgz",
+            "integrity": "sha512-JtX79kFSyAhqJh5TdLUcvtYJtJd1F8UW8b4Miaga+EIgUn2/nR0N2zWL9mH5cRXgbzLuQbbsw9kReUVIECApwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3653,9 +3562,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -3770,9 +3679,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.46.0.tgz",
-            "integrity": "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==",
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.52.0.tgz",
+            "integrity": "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3788,31 +3697,43 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.46.0",
-                "@oxfmt/binding-android-arm64": "0.46.0",
-                "@oxfmt/binding-darwin-arm64": "0.46.0",
-                "@oxfmt/binding-darwin-x64": "0.46.0",
-                "@oxfmt/binding-freebsd-x64": "0.46.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.46.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.46.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.46.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.46.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.46.0",
-                "@oxfmt/binding-linux-x64-musl": "0.46.0",
-                "@oxfmt/binding-openharmony-arm64": "0.46.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.46.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.46.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.46.0"
+                "@oxfmt/binding-android-arm-eabi": "0.52.0",
+                "@oxfmt/binding-android-arm64": "0.52.0",
+                "@oxfmt/binding-darwin-arm64": "0.52.0",
+                "@oxfmt/binding-darwin-x64": "0.52.0",
+                "@oxfmt/binding-freebsd-x64": "0.52.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.52.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.52.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.52.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.52.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.52.0",
+                "@oxfmt/binding-linux-x64-musl": "0.52.0",
+                "@oxfmt/binding-openharmony-arm64": "0.52.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.52.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.52.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.52.0"
+            },
+            "peerDependencies": {
+                "svelte": "^5.0.0",
+                "vite-plus": "*"
+            },
+            "peerDependenciesMeta": {
+                "svelte": {
+                    "optional": true
+                },
+                "vite-plus": {
+                    "optional": true
+                }
             }
         },
         "node_modules/oxlint": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.61.0.tgz",
-            "integrity": "sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==",
+            "version": "1.67.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
+            "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3825,51 +3746,55 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.61.0",
-                "@oxlint/binding-android-arm64": "1.61.0",
-                "@oxlint/binding-darwin-arm64": "1.61.0",
-                "@oxlint/binding-darwin-x64": "1.61.0",
-                "@oxlint/binding-freebsd-x64": "1.61.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.61.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.61.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.61.0",
-                "@oxlint/binding-linux-arm64-musl": "1.61.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.61.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.61.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.61.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.61.0",
-                "@oxlint/binding-linux-x64-gnu": "1.61.0",
-                "@oxlint/binding-linux-x64-musl": "1.61.0",
-                "@oxlint/binding-openharmony-arm64": "1.61.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.61.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.61.0",
-                "@oxlint/binding-win32-x64-msvc": "1.61.0"
+                "@oxlint/binding-android-arm-eabi": "1.67.0",
+                "@oxlint/binding-android-arm64": "1.67.0",
+                "@oxlint/binding-darwin-arm64": "1.67.0",
+                "@oxlint/binding-darwin-x64": "1.67.0",
+                "@oxlint/binding-freebsd-x64": "1.67.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.67.0",
+                "@oxlint/binding-linux-arm64-musl": "1.67.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.67.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.67.0",
+                "@oxlint/binding-linux-x64-gnu": "1.67.0",
+                "@oxlint/binding-linux-x64-musl": "1.67.0",
+                "@oxlint/binding-openharmony-arm64": "1.67.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.67.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.67.0",
+                "@oxlint/binding-win32-x64-msvc": "1.67.0"
             },
             "peerDependencies": {
-                "oxlint-tsgolint": ">=0.18.0"
+                "oxlint-tsgolint": ">=0.22.1",
+                "vite-plus": "*"
             },
             "peerDependenciesMeta": {
                 "oxlint-tsgolint": {
+                    "optional": true
+                },
+                "vite-plus": {
                     "optional": true
                 }
             }
         },
         "node_modules/oxlint-tsgolint": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.21.1.tgz",
-            "integrity": "sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.23.0.tgz",
+            "integrity": "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "tsgolint": "bin/tsgolint.js"
             },
             "optionalDependencies": {
-                "@oxlint-tsgolint/darwin-arm64": "0.21.1",
-                "@oxlint-tsgolint/darwin-x64": "0.21.1",
-                "@oxlint-tsgolint/linux-arm64": "0.21.1",
-                "@oxlint-tsgolint/linux-x64": "0.21.1",
-                "@oxlint-tsgolint/win32-arm64": "0.21.1",
-                "@oxlint-tsgolint/win32-x64": "0.21.1"
+                "@oxlint-tsgolint/darwin-arm64": "0.23.0",
+                "@oxlint-tsgolint/darwin-x64": "0.23.0",
+                "@oxlint-tsgolint/linux-arm64": "0.23.0",
+                "@oxlint-tsgolint/linux-x64": "0.23.0",
+                "@oxlint-tsgolint/win32-arm64": "0.23.0",
+                "@oxlint-tsgolint/win32-x64": "0.23.0"
             }
         },
         "node_modules/p-limit": {
@@ -3991,9 +3916,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.13",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -4011,7 +3936,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -4284,9 +4209,9 @@
             }
         },
         "node_modules/qified": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
-            "integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+            "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4297,9 +4222,9 @@
             }
         },
         "node_modules/qified/node_modules/hookified": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
-            "integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+            "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
             "dev": true,
             "license": "MIT"
         },
@@ -4343,13 +4268,6 @@
             "engines": {
                 "node": ">=0.10"
             }
-        },
-        "node_modules/reprism": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/reprism/-/reprism-0.0.11.tgz",
-            "integrity": "sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -4556,36 +4474,31 @@
             "license": "(WTFPL OR MIT)"
         },
         "node_modules/string-width": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-            "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.2.2"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
@@ -4599,9 +4512,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "17.9.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.9.0.tgz",
-            "integrity": "sha512-xO0jeY6z1/urFL5L/BZLmB1yYlbRiRMQnYH6ArZIDWJ+SZXGssOY7XoYb1JIv/L220+EBnwwJXJS4Mt/F96SvA==",
+            "version": "17.12.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.12.0.tgz",
+            "integrity": "sha512-KIlzWXMHUvgfPUR0R7TK3H80yCIi0uoivUwf+6Az4yrHJD1Q3c1qIkh/H5Z0i/K3QXgtq/UMEkWyBUSUwnpnOg==",
             "dev": true,
             "funding": [
                 {
@@ -4629,24 +4542,23 @@
                 "debug": "^4.4.3",
                 "fast-glob": "^3.3.3",
                 "fastest-levenshtein": "^1.0.16",
-                "file-entry-cache": "^11.1.2",
+                "file-entry-cache": "^11.1.3",
                 "global-modules": "^2.0.0",
                 "globby": "^16.2.0",
                 "globjoin": "^0.1.4",
                 "html-tags": "^5.1.0",
                 "ignore": "^7.0.5",
                 "import-meta-resolve": "^4.2.0",
-                "is-plain-object": "^5.0.0",
                 "mathml-tag-names": "^4.0.0",
                 "meow": "^14.1.0",
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.1.1",
-                "postcss": "^8.5.9",
+                "postcss": "^8.5.14",
                 "postcss-safe-parser": "^7.0.1",
                 "postcss-selector-parser": "^7.1.1",
                 "postcss-value-parser": "^4.2.0",
-                "string-width": "^8.2.0",
+                "string-width": "^8.2.1",
                 "supports-hyperlinks": "^4.4.0",
                 "svg-tags": "^1.0.0",
                 "table": "^6.9.0",
@@ -4708,14 +4620,27 @@
                 "stylelint": "^17.0.0"
             }
         },
+        "node_modules/stylelint/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
         "node_modules/stylelint/node_modules/file-entry-cache": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
-            "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
+            "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "flat-cache": "^6.1.20"
+                "flat-cache": "^6.1.22"
             }
         },
         "node_modules/stylelint/node_modules/flat-cache": {
@@ -4765,6 +4690,39 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4.31"
+            }
+        },
+        "node_modules/stylelint/node_modules/string-width": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/supports-color": {
@@ -4879,50 +4837,12 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/table/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/table/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/table/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/table/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/tinypool": {
             "version": "2.1.0",
@@ -5094,44 +5014,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5191,48 +5073,10 @@
                 "node": ">=12"
             }
         },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+            "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
         "fallow": "^2.38.0",
         "husky": "^9.1.7",
         "jscpd": "^4.0.9",
-        "oxfmt": "^0.46.0",
+        "oxfmt": "^0.52.0",
         "oxlint": "^1.61.0",
-        "oxlint-tsgolint": "^0.21.1",
+        "oxlint-tsgolint": "^0.23.0",
         "postcss-html": "^1.8.0",
         "stylelint": "^17.9.0",
         "stylelint-config-standard": "^40.0.0",
         "yauzl": "^3.2.0"
     },
     "volta": {
-        "node": "24.14.1",
-        "npm": "11.12.0"
+        "node": "24.16.0",
+        "npm": "11.13.0"
     }
 }

--- a/test/Viper.test.csproj
+++ b/test/Viper.test.csproj
@@ -22,11 +22,11 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Microsoft.Testing.Platform" Version="2.0.2" />
-    <PackageReference Include="MockQueryable.NSubstitute" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+    <PackageReference Include="MockQueryable.NSubstitute" Version="10.0.8" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -79,7 +79,6 @@
     <PackageReference Include="System.DirectoryServices" Version="10.0.8" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.8" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageReference Include="OWASP.AntiSamy" Version="1.2.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
     <PackageReference Include="Razor.Templating.Core" Version="3.1.0" />

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -48,7 +48,7 @@
 
     <PackageReference Include="AWSSDK.Core" Version="3.7.201.7" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="DotNetEnv" Version="3.2.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
@@ -67,12 +67,12 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NLog.MailKit" Version="6.1.3" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
-    <PackageReference Include="QuestPDF" Version="2026.2.4" />
+    <PackageReference Include="NLog.MailKit" Version="6.1.4" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
+    <PackageReference Include="QuestPDF" Version="2026.5.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
     <PackageReference Include="Scrutor" Version="7.0.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -80,8 +80,8 @@
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.8" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="OWASP.AntiSamy" Version="1.2.0" />
-    <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="MimeKit" Version="4.16.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
     <PackageReference Include="Razor.Templating.Core" Version="3.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Monthly dependency refresh covering both npm trees (root tooling + `VueApp`), the .NET solution (`web` + `test`), and a Node.js LTS runtime bump. Every update was gated on a **7-day publish cooldown** (matching `.github/dependabot.yml`) and **excludes breaking/major changes**. Verified green by the full frontend and backend suites.

- **Frontend:** build OK + **765 tests** pass
- **Backend:** build OK (0 errors) + **1946 tests** pass
- Pre-commit hook (build + lint + test + verify) passed before commit.

> :warning: **CI action required:** the Jenkins pipeline pins the runtime by tool name (`tools { nodejs "NodeJS 24.16.0" }`). A matching **"NodeJS 24.16.0"** tool installation must exist under *Manage Jenkins -> Tools*, or the build fails with "No tool named NodeJS 24.16.0 found."

## :lock: Security

- **No new advisories introduced.** `npm audit` and the NuGet restore report zero new advisories attributable to these bumps. Pre-existing transitive advisories are unchanged (see "Deferred" below).
- **OWASP.AntiSamy removed entirely.** It turned out to be an orphaned dependency: VPR-142 (#158) consolidated HTML sanitization into `HtmlSanitizerService` and deleted `antisamy-cms.xml`, but the `<PackageReference>` was never removed from `main`. Verified unused on this branch (no `using`, types, or API calls; only stale comments, since refreshed to credit `HtmlSanitizerService`), so it has been dropped, shrinking the dependency / supply-chain surface. This also resolves the old pin: we had kept it at 1.2.0 because 1.2.1's transitive `AngleSharp >= 1.0.2` conflicts with `HtmlSanitizer`'s pinned `AngleSharp = 0.17.1` (NU1107).
- **MimeKit 4.17.0** marks `HtmlToHtml.FilterHtml` **obsolete**, explicitly warning it cannot adequately protect against XSS. We sanitize via `HtmlSanitizer` (unchanged), so no action is required, but the deprecation is a useful signal not to rely on that API.
- **MailKit 4.17.0** pulls `System.Formats.Asn1` 10.0.0 (cryptographic ASN.1 parsing aligned to .NET 10) and hardens IMAP response parsing.
- **Node.js 24.16.0** bundles **OpenSSL 3.5.6** plus HTTP `ClientRequest` hardening (defense-in-depth; no CVE in this span, since neither 24.15.0 nor 24.16.0 was a security release).
- **SonarAnalyzer.CSharp 10.24 -> 10.27** improves C# 14 analysis accuracy (false-positive/negative fixes) in the build-time security/quality analyzer. Measured on this codebase: no change in findings (44 warnings across 6 rules, identical before and after).
- **jscpd 4.2** fixes a ReDoS in its Lisp/Elisp tokenizer and rolls up roughly 50 transitive dependency vulnerability fixes.

### Deliberately held back (safety)
- **AWS SDK v4** (`AWSSDK.Core` 3->4, `Amazon.Extensions.Configuration.SystemsManager` 5->7): documented breaking migration, out of scope for a no-breaking-changes refresh.
- **Pre-existing transitive advisories** (`brace-expansion`, `qs`/`express`, `ws` on npm; `NuGet.Packaging`/`NuGet.Protocol` low severity): left for a dedicated pass, since `npm audit fix` may pull versions inside cooldown or force majors.

## :sparkles: Notable features

- **@vueuse/core 14.3.0:** new `onLongPress` pointer event, `useTextareaAutosize` `maxHeight`, `useElementVisibility` `controls` option, `createReusableTemplate` component names.
- **vite-plugin-vue-inspector 6.0.0:** adds **Vue Vapor** app support. Major version, but verified non-breaking for our dev-only usage (the `vite` peer range and our options are unchanged).
- **MimeKit 4.17.0:** new `Received` header parser; TnefPart default MIME aligned to `application/ms-tnef` for O365.
- **Node.js 24.16.0:** `crypto.randomUUIDv7()`, test-runner order randomization + `AbortSignal.timeout` mocks, `util.styleText()` hex colors, runtime probes in `node inspect`.
- **ESLint 10.4.0:** `for-direction` now checks sequence expressions; new `includeIgnoreFile()` config helper.
- **QuestPDF 2026.5.0:** fixes multi-page table rendering and large-paragraph artifacts (Skia m146).

## :package: Changes by area

### Runtime / CI
| Package | From | To |
|---|---|---|
| Node.js (Volta + engines + Jenkins tool) | 24.14.1 | **24.16.0** |
| npm (Volta) | 11.12.0 | **11.13.0** |

Node 24.14 -> 24.16 is a within-LTS ("Krypton") minor bump with no breaking changes. `engine-strict` is not set, so anyone still on 24.14.1 sees a warning, not a hard failure.

### Frontend runtime (`VueApp`)
| Package | From | To | Notes |
|---|---|---|---|
| vue | 3.5.33 | 3.5.35 | bug + perf fixes: v-for/v-memo keys, hydration dedup, SSR suspense errors, teleport unmount, out-in transition DOM leak |
| vue-router | 5.0.6 | 5.0.7 | patch |
| @vueuse/core | 14.2.1 | 14.3.0 | new composable features (see above) |

### Frontend tooling
| Package | From | To | Notes |
|---|---|---|---|
| vite | 8.0.10 | 8.0.14 | patch fixes: glob HMR matcher (8.0.11), module-runner re-export race (8.0.12), public-dir copy + CSS worker disposal (8.0.13), `transformIndexHtml` trailing slash + oxc JSX dep-scan (8.0.14) |
| vitest | 4.1.5 | 4.1.7 | screenshot path fix + `sequential` API deprecation (4.1.6), per-task-branch concurrency fix (4.1.7) |
| @vitest/coverage-v8 | 4.1.5 | 4.1.7 | moves in lockstep with vitest (exact peer) |
| @vitejs/plugin-vue | 6.0.6 | 6.0.7 | dependency maintenance; caret range for `@rolldown/pluginutils` |
| @vue/test-utils | 2.4.8 | 2.4.10 | tolerate duplicate `attachTo` cleanup (2.4.9); restore `text()`/`html()` for single-root components (2.4.10) |
| vue-tsc | 3.2.7 | 3.3.2 | fallthrough-attribute checking (3.3.0), conditional-slot fix (3.3.1), literal types for inline `v-for` (3.3.2), plus language-service/vscode fixes |
| @typescript-eslint/eslint-plugin | 8.59.0 | 8.60.0 | RuleTester synced from upstream ESLint; playground fix |
| @typescript-eslint/parser | 8.59.1 | 8.60.0 | coordinated release with the plugin |
| eslint-plugin-vue | 10.9.0 | 10.9.1 | bumps `vue-eslint-parser` peer to fix SFC parsing errors |
| eslint-plugin-harlanzw | 0.12.1 | 0.12.3 | rule fixes: `vue-no-faux-composables` now catches `provide`/`inject`; fewer `vue-require-composable-prefix` false positives |
| globals | 17.5.0 | 17.6.0 | refreshed global-identifier definitions |
| vite-plugin-vue-inspector | 5.4.0 | 6.0.0 | adds Vue Vapor app support (see Features); dev-only, verified non-breaking |

The shared linters `eslint`, `oxlint`, `oxfmt`, and `oxlint-tsgolint` are devDeps in both trees; their notes are in the Root tooling table above.

**Removed:** `@types/inflection` (deprecated stub; `inflection` 3.x ships its own type definitions, so the separate types package is no longer needed).

**Aligned:** `@types/node` 25.6.0 -> 24.12.4 to match the Node 24 LTS runtime (the types were a major ahead of the runtime; the project's TS base is already `@tsconfig/node24`). Verified with `vue-tsc`.

### Root tooling
| Package | From | To | Notes |
|---|---|---|---|
| stylelint | 17.9.0 | 17.12.0 | new layout/logical-property rules (17.10), `referenceFiles` `loader` option (17.11), false-positive fixes for `block-no-empty` and custom properties (17.12) |
| @double-great/stylelint-a11y | 3.4.10 | 3.4.14 | patch: accessibility rule fixes |
| jscpd | 4.0.9 | 4.2.4 | per-block Vue SFC tokenization, +71 language formats, ~11.5% faster tokenizer (reprism), **ReDoS fix** in Lisp patterns, hardened against malformed `package.json` |
| fallow | 2.52.0 | 2.82.0 | codebase-intelligence tool behind `audit:fallow`; this range adds the `health` complexity/coverage gate, more framework plugins, and better Vue/Svelte detection (note: the standalone `security` scan ships in a later 2.8x release, not 2.82) |
| yauzl | 3.3.0 | 3.3.1 | patch: unzip library fix |
| eslint (shared) | 10.2.1 | 10.4.0 | `for-direction` now checks sequence expressions; new `includeIgnoreFile()` config helper |
| oxlint (shared) | 1.61.0 | 1.67.0 | many new rules (`prefer-arrow-callback`, `prefer-regex-literals`, `no-implied-eval`, `id-match`, plus Vue/JSDoc/JSX-a11y/node rules) |
| oxfmt (shared) | 0.46.0 | 0.52.0 | JSON formatting support, import-phase preservation, improved comment handling |
| oxlint-tsgolint (shared) | 0.21.1 | 0.23.0 | type-aware lint plugin for oxlint; bumped alongside it |

### Backend `web/Viper.csproj`
| Package | From | To | Notes |
|---|---|---|---|
| MailKit | 4.16.0 | 4.17.0 | IMAP ACL/QUOTA/METADATA parser fixes for folder names containing brackets; pulls `System.Formats.Asn1` 10.0.0 for .NET 10 |
| MimeKit | 4.16.0 | 4.17.0 | new `Received` header parser; `HtmlToHtml.FilterHtml` marked obsolete (cannot adequately prevent XSS); TnefPart default MIME set to `application/ms-tnef` for O365 |
| QuestPDF | 2026.2.4 | 2026.5.0 | fixes multi-page table rendering and large-paragraph visual artifacts; Skia native dep advanced to m146 |
| DotNetEnv | 3.1.1 | 3.2.0 | parser switched to Superpower, UTF-8 encoding fixes, adds interpolated-variable parsing |
| NLog.Web.AspNetCore | 6.1.2 | 6.1.3 | patch: ASP.NET Core integration fixes |
| NLog.MailKit | 6.1.3 | 6.1.4 | patch: MailKit target bump and fixes |
| SonarAnalyzer.CSharp | 10.24.0.138807 | 10.27.0.140913 | C# 14 analysis accuracy (false-positive/negative fixes for extension members, primary constructors, partial types); build-time analyzer only |

**Removed:** `OWASP.AntiSamy` 1.2.0: orphaned dependency left over from VPR-142 (#158). HTML sanitization is now handled by `HtmlSanitizerService` and the package was unused, so it has been dropped (this also retires the 1.2.1 transitive `AngleSharp` conflict that had kept it pinned). Two stale CMS template comments that credited AntiSamy were refreshed to name `HtmlSanitizerService`.

### Backend `test/Viper.test.csproj`
| Package | From | To | Notes |
|---|---|---|---|
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.6.0 | restored video recorder, new `CreateNoWindow` run setting, faster blame dump collection, bundled runtimes updated (10.0.4) |
| Microsoft.Testing.Platform | 2.0.2 | 2.2.3 | MTP test runtime; minor bumps with platform features and fixes |
| MockQueryable.NSubstitute | 10.0.5 | 10.0.8 | transitive dependency and CI updates only (EF Core, Test.Sdk, NUnit); no public API change |
| coverlet.collector | 10.0.0 | 10.0.1 | patch: coverage collector fix |
| SonarAnalyzer.CSharp | 10.24.0.138807 | 10.27.0.140913 | same as web (build-time analyzer) |

## Methodology
- **Cooldown:** every target version was published at least 7 days before review (matches the dependabot 7-day default). `oxfmt` was held at 0.52.0 (within cooldown) rather than the newest 0.53.0 (1.9 days old).
- **No breaking changes:** majors and out-of-range bumps were checked against changelog/diff, not assumed from the version number. `vite-plugin-vue-inspector` 6.0 was adopted after confirming its major bump was additive (Vapor support). `OWASP.AntiSamy` was found to be unused (an orphaned VPR-142 leftover) and removed outright, which also moots the 1.2.1 transitive conflict that had kept it pinned at 1.2.0.
- **Verification:** frontend `npm run build` + vitest (765), backend `dotnet build` + xUnit (1946), plus the pre-commit gate.
