### PR TITLE
chore(codeql): ignore generated source files in analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,11 @@ name: "VIPER CodeQL config"
 queries:
   - uses: security-and-quality
 
+# Generated and build-output code. The *.g.cs / *.Designer.cs globs catch
+# source-generator output that C# autobuild extracts despite obj/ being ignored.
 paths-ignore:
   - "**/obj/**"
   - "**/bin/**"
+  - "**/*.g.cs"
+  - "**/*.generated.cs"
+  - "**/*.Designer.cs"


### PR DESCRIPTION
## What

Adds explicit generated-source globs to the CodeQL `paths-ignore` list:

```yaml
- "**/*.g.cs"
- "**/*.generated.cs"
- "**/*.Designer.cs"
```

## Why

Of **169 open CodeQL alerts, 53 (31%) are in generated build artifacts** — Razor source-generator output (`*_cshtml.g.cs`), the Regex generator, etc. — all under `obj/`. These are not project code.

`#189` (merged May 13) already added `**/obj/**` and `**/bin/**`, but those alerts persist a month later. The reason: the C# job uses **autobuild**, and under that build mode CodeQL extracts and analyzes the generated sources that get compiled, so `paths-ignore` filters results unreliably for compiled languages. The explicit `*.g.cs` / `*.Designer.cs` globs target the generated output directly.

## Caveat / follow-up

Because of the same autobuild limitation, this config change may not retroactively dismiss the existing 53 alerts on its own. If a scan on `main` after merge does not clear them, the fallback is a one-time bulk-dismiss of those alerts as "Won't fix — generated code" in the Security tab. A more thorough (but heavier) alternative is switching the C# analysis to `build-mode: none`, where `paths-ignore` is honored fully — not done here to avoid changing analysis coverage.

This only affects scan scope; no application code changes.