### PR TITLE
chore(codeql): simplify redundant null-conditionals in StudentList

### DIFF
--- a/web/Areas/Students/Services/StudentList.cs
+++ b/web/Areas/Students/Services/StudentList.cs
@@ -223,10 +223,10 @@ namespace Viper.Areas.Students.Services
                         LastName = std.Student.LastName,
                         MiddleName = std.Student.MiddleName,
                         FullName = std.Student.FullName,
-                        ClassLevel = std.Student?.StudentInfo?.ClassLevel,
-                        TermCode = std.Student?.StudentInfo?.TermCode,
+                        ClassLevel = std.Student.StudentInfo?.ClassLevel,
+                        TermCode = std.Student.StudentInfo?.TermCode,
                         ClassYear = std.ClassYear,
-                        Active = std?.Student?.Current == 1 || std?.Student?.Future == 1
+                        Active = std.Student.Current == 1 || std.Student.Future == 1
                     };
 
                     var classYears = activeYearOnly


### PR DESCRIPTION
## What

`StudentList.CreateStudentListFromStudentGradYears` builds a `Student` inside an `if (std.Student != null)` guard, but three members still used `std.Student?.` / `std?.Student?.`:

```csharp
ClassLevel = std.Student.StudentInfo?.ClassLevel,   // was std.Student?.StudentInfo?...
TermCode   = std.Student.StudentInfo?.TermCode,      // was std.Student?.StudentInfo?...
Active     = std.Student.Current == 1 || std.Student.Future == 1  // was std?.Student?...
```

The genuinely-nullable `StudentInfo?` is kept.

## Why

CodeQL flagged these as `cs/constant-condition` (#634, #635, #636, #637) — always-non-null because the `std.Student != null` guard already holds and `std` comes from `.First()`. The `?.` operators were dead. This is a behavior-neutral simplification, not a null-safety change.

## Notes

- No behavior change; build/lint/tests green.
- A pre-existing nullable warning (CS8601) on the unrelated `MailId` line is out of scope for this PR.