### PR TITLE
test(effort): cover rollover year-bounds guard

### DIFF
--- a/test/Effort/PercentRolloverServiceTests.cs
+++ b/test/Effort/PercentRolloverServiceTests.cs
@@ -234,6 +234,17 @@ public sealed class PercentRolloverServiceTests : IDisposable
         Assert.Equal(new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Local), assignment.ProposedEndDate);
     }
 
+    [Theory]
+    [InlineData(0)]      // below DateTime's minimum year (1)
+    [InlineData(9999)]   // valid year, but year+1 (10000) exceeds DateTime's maximum year
+    public async Task GetRolloverPreviewAsync_ThrowsForYearOutsideSupportedRange(int year)
+    {
+        // Both year and year+1 are used to construct DateTime boundaries, so the service
+        // must reject years outside [1, 9998] before any date is built.
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => _rolloverService.GetRolloverPreviewAsync(year, TestContext.Current.CancellationToken));
+    }
+
     [Fact]
     public async Task GetRolloverPreviewAsync_ExcludesAlreadyRolledAssignments()
     {


### PR DESCRIPTION
## What

Adds a guard test to `PercentRolloverServiceTests` asserting that `GetRolloverPreviewAsync` throws `ArgumentOutOfRangeException` for years outside the constructable range (0 and 9999).

## Why

CodeQL flagged `cs/unsafe-year-construction` (#204, #205) on the `new DateTime(year, 6, 30)` / `new DateTime(year, 7, 1)` boundary construction. These are **false positives**: `year` is already validated to `[1, 9998]` at method entry, and the month/day are constants (6/30, 7/1) that exist in every year, so no `DateTime` can throw. The rule targets the `new DateTime(date.Year + N, date.Month, date.Day)` Feb-29 bug, which does not apply here.

The alerts are dismissed as false positives. This test locks in the bounds guard that makes the construction safe, so the mitigation can't silently regress.

## Notes

- Test-only change; no production code modified.
- Reviewed via the agy/antigravity review loop (verdict: good to go).