### PR TITLE
fix(directory): harden VMACS query construction

### DIFF
--- a/.github/workflows/development-merge-check.yml
+++ b/.github/workflows/development-merge-check.yml
@@ -1,25 +1,39 @@
 name: Development Merge Check
 
-# Advisory, NON-BLOCKING check for the team workflow that branches should merge
-# into Development before main. When a PR into main is opened whose branch is not
-# yet in Development, this surfaces a warning annotation. It never fails the check,
-# so it does not block merging — it is purely informational.
+# Advisory, NON-BLOCKING check for the team convention that branches merge into
+# Development before main.
 #
-# "Merged to Development" is detected by looking for a MERGED pull request whose
-# base is Development and whose head is this branch. This repo squash-merges, so
-# commit ancestry against Development would give false negatives after a squash.
+# It is a single check on the PR - this job's own pass/fail:
+#   green  when the PR head commit is already in Development
+#   red    when it is not (a reminder, not a hard failure; it does not block a
+#          merge unless someone marks it a required check)
+#
+# "In Development" is detected by ancestry, because the team merges into
+# Development with a direct `git merge` + push (`npm run merge`), not a PR, so the
+# PR head becomes an ancestor of Development. A merged-PR lookup is kept as a
+# squash-merge fallback.
+#
+# Triggers:
+#   pull_request      - evaluate this PR's head on every commit (this is the verdict).
+#   push: Development - a branch can land in Development without a new PR commit,
+#                       so re-run each still-red PR's check to flip it green.
+#   workflow_dispatch - manual refresh.
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
+  push:
+    branches: [Development]
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: read
+  actions: write
 
 concurrency:
-  group: dev-merge-check-${{ github.event.pull_request.number }}
+  group: dev-merge-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -27,42 +41,79 @@ jobs:
     name: Development merge check (advisory)
     runs-on: ubuntu-latest
     steps:
-      - name: Warn if not merged to Development first
+      - name: Check Development merge status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const DEV_BRANCH = 'Development';
-
-            const pr = context.payload.pull_request;
+            const WORKFLOW = 'development-merge-check.yml';
             const { owner, repo } = context.repo;
-            const headRef = pr.head.ref;
-            // Fork-safe: fall back to the base repo owner if the head repo is gone.
-            const headOwner = pr.head.repo ? pr.head.repo.owner.login : owner;
 
-            // Has this branch already been merged into Development?
-            // Robust to squash merges: find a merged PR with base=Development, head=this branch.
-            const devPulls = await github.paginate(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: 'closed',
-              base: DEV_BRANCH,
-              head: `${headOwner}:${headRef}`,
-              per_page: 100,
-            });
-            const mergedToDev = devPulls.find((p) => p.merged_at);
+            // Detail string if the head is in Development, else null.
+            async function mergedDetail(headRef, headSha, headOwner) {
+              // Direct merge: npm run merge makes a real merge commit, so the head
+              // is contained in Development ("behind" or "identical").
+              try {
+                const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                  owner, repo, basehead: `${DEV_BRANCH}...${headSha}`,
+                });
+                if (cmp.data.status === 'behind' || cmp.data.status === 'identical') {
+                  return `Branch "${headRef}" is on ${DEV_BRANCH}: its commits (through ${headSha.slice(0, 7)}) are already in ${DEV_BRANCH}.`;
+                }
+              } catch (e) {
+                core.info(`compare ${DEV_BRANCH}...${headSha} failed: ${e.message}`);
+              }
+              // Fallback: a PR/squash merge into Development.
+              const devPulls = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'closed', base: DEV_BRANCH,
+                head: `${headOwner}:${headRef}`, per_page: 100,
+              });
+              const mergedPr = devPulls.find((p) => p.merged_at);
+              return mergedPr
+                ? `Branch "${headRef}" is on ${DEV_BRANCH} (merged via PR #${mergedPr.number}).`
+                : null;
+            }
 
-            if (mergedToDev) {
-              core.info(
-                `Code reached ${DEV_BRANCH} via #${mergedToDev.number} ` +
-                  `(merged ${mergedToDev.merged_at}).`
-              );
+            // pull_request: this job's pass/fail IS the advisory check for the PR.
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              const headOwner = pr.head.repo ? pr.head.repo.owner.login : owner;
+              const detail = await mergedDetail(pr.head.ref, pr.head.sha, headOwner);
+              if (detail) {
+                core.info(detail);
+              } else {
+                core.setFailed(
+                  `Branch "${pr.head.ref}" is not on ${DEV_BRANCH} yet. Team workflow ` +
+                  `routes branches through ${DEV_BRANCH} before main. Advisory only; ` +
+                  `it does not block merging.`,
+                );
+              }
               return;
             }
 
-            // Not in Development yet: warn, but do not fail (advisory only).
-            core.warning(
-              `Branch "${headRef}" has not been merged into ${DEV_BRANCH} yet. Team workflow ` +
-                `routes branches through ${DEV_BRANCH} before main. This is advisory and does ` +
-                `not block merging.`,
-              { title: 'Not yet merged to Development' }
-            );
+            // push to Development / manual dispatch: a branch may have just landed
+            // in Development without a new PR commit. Re-run each still-red PR's
+            // check so its verdict refreshes against the updated Development.
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', base: 'main', per_page: 100,
+            });
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner, repo, workflow_id: WORKFLOW, event: 'pull_request', per_page: 100,
+            });
+            const latestBySha = new Map();
+            for (const r of runs) {
+              if (!latestBySha.has(r.head_sha)) latestBySha.set(r.head_sha, r);
+            }
+            for (const pr of prs) {
+              const run = latestBySha.get(pr.head.sha);
+              if (run?.conclusion === 'failure') {
+                try {
+                  await github.rest.actions.reRunWorkflowFailedJobs({
+                    owner, repo, run_id: run.id,
+                  });
+                  core.info(`PR #${pr.number}: re-running advisory check (was red).`);
+                } catch (e) {
+                  core.warning(`PR #${pr.number}: re-run failed: ${e.message}`);
+                }
+              }
+            }

--- a/test/Areas/Directory/VMACSServiceTest.cs
+++ b/test/Areas/Directory/VMACSServiceTest.cs
@@ -1,0 +1,32 @@
+using Viper.Areas.Directory.Services;
+
+namespace Viper.test.Areas.Directory
+{
+    public class VMACSServiceTest
+    {
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("jdoe", "jdoe")]
+        [InlineData("john doe", "john%20doe")]
+        [InlineData("a+b", "a%2Bb")]
+        [InlineData("a&b", "a%26b")]
+        [InlineData("a=b", "a%3Db")]
+        public void BuildSearchPath_UrlEncodesLoginId(string? loginID, string expectedFind)
+        {
+            string path = VMACSService.BuildSearchPath(loginID, "TESTAUTH");
+
+            Assert.Equal(
+                $"/trust/query.xml?dbfile=3&index=CampusLoginId&find={expectedFind}&format=CHRIS4&AUTH=TESTAUTH",
+                path);
+        }
+
+        [Fact]
+        public void BuildSearchPath_IncludesAuthToken()
+        {
+            string path = VMACSService.BuildSearchPath("jdoe", "SECRET123");
+
+            Assert.Contains("&AUTH=SECRET123", path);
+        }
+    }
+}

--- a/web/Areas/Directory/Services/VMACSService.cs
+++ b/web/Areas/Directory/Services/VMACSService.cs
@@ -7,6 +7,9 @@ namespace Viper.Areas.Directory.Services
 {
     public class VMACSService
     {
+        // Fixed token required by the internal VMACS trust endpoint (not a rotating secret).
+        private const string VmacsAuthToken = "06232005";
+
         private static HttpClient sharedClient = new()
         {
             BaseAddress = new Uri("https://vmacs-vmth.vetmed.ucdavis.edu"),
@@ -21,7 +24,8 @@ namespace Viper.Areas.Directory.Services
         public static async Task<VMACSQuery?> Search(String? loginID)
         {
 
-            string request = $"/trust/query.xml?dbfile=3&index=CampusLoginId&find={loginID}&format=CHRIS4&AUTH=06232005".ToString();
+            string encodedLoginId = Uri.EscapeDataString(loginID ?? string.Empty);
+            string request = $"/trust/query.xml?dbfile=3&index=CampusLoginId&find={encodedLoginId}&format=CHRIS4&AUTH={VmacsAuthToken}";
             using HttpResponseMessage response = await sharedClient.GetAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/web/Areas/Directory/Services/VMACSService.cs
+++ b/web/Areas/Directory/Services/VMACSService.cs
@@ -10,7 +10,7 @@ namespace Viper.Areas.Directory.Services
         private static string VmacsAuthToken =>
             HttpHelper.GetSetting<string>("Credentials", "VmacsAuthToken") ?? string.Empty;
 
-        private static HttpClient sharedClient = new()
+        private static readonly HttpClient sharedClient = new()
         {
             BaseAddress = new Uri("https://vmacs-vmth.vetmed.ucdavis.edu"),
         };
@@ -23,9 +23,7 @@ namespace Viper.Areas.Directory.Services
         /// <returns></returns>
         public static async Task<VMACSQuery?> Search(String? loginID)
         {
-
-            string encodedLoginId = Uri.EscapeDataString(loginID ?? string.Empty);
-            string request = $"/trust/query.xml?dbfile=3&index=CampusLoginId&find={encodedLoginId}&format=CHRIS4&AUTH={VmacsAuthToken}";
+            string request = BuildSearchPath(loginID, VmacsAuthToken);
             using HttpResponseMessage response = await sharedClient.GetAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -53,6 +51,12 @@ namespace Viper.Areas.Directory.Services
                 }
             }
             return null;
+        }
+
+        internal static string BuildSearchPath(string? loginID, string authToken)
+        {
+            string encodedLoginId = Uri.EscapeDataString(loginID ?? string.Empty);
+            return $"/trust/query.xml?dbfile=3&index=CampusLoginId&find={encodedLoginId}&format=CHRIS4&AUTH={authToken}";
         }
     }
 }

--- a/web/Areas/Directory/Services/VMACSService.cs
+++ b/web/Areas/Directory/Services/VMACSService.cs
@@ -7,8 +7,8 @@ namespace Viper.Areas.Directory.Services
 {
     public class VMACSService
     {
-        // Fixed token required by the internal VMACS trust endpoint (not a rotating secret).
-        private const string VmacsAuthToken = "06232005";
+        private static string VmacsAuthToken =>
+            HttpHelper.GetSetting<string>("Credentials", "VmacsAuthToken") ?? string.Empty;
 
         private static HttpClient sharedClient = new()
         {


### PR DESCRIPTION
## What

Hardening changes to `VMACSService.Search`, plus a rewrite of the advisory Development-merge CI check carried on this branch.

**`VMACSService`:**

1. **URL-encode the login ID.** `Uri.EscapeDataString(loginID ?? string.Empty)` before interpolating into the query URL, so reserved characters can't alter the request. Also drops a no-op `.ToString()`.
2. **Source the `AUTH` token from config.** Read from the `Credentials:VmacsAuthToken` config section (AWS SSM Parameter Store) instead of a hardcoded constant in source, matching how DB and other secrets are sourced.
3. **Extract a testable query builder.** Request-path construction moved into `BuildSearchPath`, covered by unit tests for the `null`, space, `+`, `&`, and `=` encoding cases.

## Why

Both hardening items surfaced during the CodeQL/agy review work. `loginID` is a DB-sourced campus login (`AaudUser.LoginId`, passed by both `DirectoryController` call sites), so exploitability is low. Moving the `AUTH` token out of source removes a hardcoded credential from version control and brings it in line with the rest of the app's secret handling.

## Deploy note

Requires the `Credentials:VmacsAuthToken` parameter to exist in AWS SSM Parameter Store (under `/Shared/Credentials/`) before this deploys. Until it does, VMACS phone/pager/unit enrichment in the Directory search returns empty (the endpoint still returns results). Verified on dev: a Directory search now shows the VMACS-sourced "M: ... (VMACS)" line, confirming the token loads from SSM and the lookup succeeds.

## CI: Development merge check

Unrelated to VMACS, but carried on this branch: a rewrite of the advisory `Development merge check` workflow so it actually works for our flow.

**Why it was needed:** we merge into Development with a direct `git merge` + push (`npm run merge`), not through a PR, so the old "find a merged PR into Development" detection never matched and the check was meaningless.

**Now:** a single check per PR, green when the head commit is in Development (detected by ancestry, with a merged-PR squash fallback), red when it isn't. It re-evaluates on every PR commit, and because merging into Development adds no PR commit, a push-on-Development run re-runs any still-red PR so its check flips green once the branch lands there. Advisory only; it never blocks merging.

## Scope note

The agy review also suggested reading the response stream directly instead of string→bytes→`MemoryStream`, and a full static→DI refactor of `VMACSService`. Those remain out of scope here; recommend a separate ticket for the static→DI refactor.
