### PR TITLE
fix(clinical): detect duplicate schedules by SQL error number

### DIFF
--- a/test/ClinicalScheduler/ScheduleEditServiceTest.cs
+++ b/test/ClinicalScheduler/ScheduleEditServiceTest.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,7 +24,7 @@ namespace Viper.test.ClinicalScheduler
         private readonly IPermissionValidator _mockPermissionValidator;
         private readonly IUserHelper _mockUserHelper;
         private readonly IEmailTemplateRenderer _mockEmailTemplateRenderer;
-        private readonly ClinicalSchedulerContext _context;
+        private readonly ToggleThrowContext _context;
         private readonly TestableScheduleEditService _service;
         private bool _disposed;
 
@@ -33,7 +34,7 @@ namespace Viper.test.ClinicalScheduler
             var options = new DbContextOptionsBuilder<ClinicalSchedulerContext>()
                 .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
                 .Options;
-            _context = new ClinicalSchedulerContext(options);
+            _context = new ToggleThrowContext(options);
 
             _mockPermissionService = Substitute.For<ISchedulePermissionService>();
             _mockAuditService = Substitute.For<IScheduleAuditService>();
@@ -425,6 +426,56 @@ namespace Viper.test.ClinicalScheduler
                 ex.Message.Contains("Failed to add instructor") ||
                 (ex.InnerException != null && ex.InnerException.Message.Contains("already scheduled")),
                 $"Expected duplicate schedule error but got: {ex.Message}");
+        }
+
+        [Theory]
+        [InlineData(2627, false)] // bare unique-constraint violation
+        [InlineData(2601, true)]  // duplicate key in a unique index, wrapped in DbUpdateException (EF's real path)
+        public async Task AddInstructorAsync_DbSaveThrowsDuplicateKey_ThrowsAlreadyScheduled(int errorNumber, bool wrapInDbUpdate)
+        {
+            // Arrange - a save that fails with a SQL Server duplicate/unique-key error (2627 or 2601) must be
+            // classified as a duplicate, whether raised bare or wrapped by EF in a DbUpdateException.
+            var sqlFailure = SqlExceptionFactory.Create(errorNumber);
+            Exception saveFailure = wrapInDbUpdate ? new DbUpdateException("save failed", sqlFailure) : sqlFailure;
+            _context.SaveException = saveFailure;
+            var testYear = DateTime.Now.Year + 1;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _service.AddInstructorAsync("test123", 1, new[] { 1 }, testYear, false, TestContext.Current.CancellationToken));
+            Assert.Contains("already be scheduled", ex.Message);
+            Assert.Same(saveFailure, ex.InnerException); // original failure is preserved as the inner exception
+        }
+
+        [Fact]
+        public async Task AddInstructorAsync_DbSaveThrowsNonDuplicateSqlError_ThrowsGenericDatabaseError()
+        {
+            // Arrange - a non-duplicate database error (547 = constraint/foreign-key violation) must NOT be
+            // treated as a duplicate; it falls through to the generic "database operation failed" message.
+            _context.SaveException = SqlExceptionFactory.Create(547);
+            var testYear = DateTime.Now.Year + 1;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _service.AddInstructorAsync("test123", 1, new[] { 1 }, testYear, false, TestContext.Current.CancellationToken));
+            Assert.Contains("Database operation failed", ex.Message);
+            Assert.IsType<SqlException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task ToggleThrowContext_SaveException_IsOneShot()
+        {
+            // The helper documents that only the *next* save throws. Verify it consumes the exception so a
+            // subsequent save persists normally, guarding against brittle multi-save tests.
+            _context.SaveException = new InvalidOperationException("boom");
+
+            // First save consumes the exception and throws...
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+            // ...the next save persists normally instead of throwing again.
+            var affected = await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(0, affected);
         }
 
         [Fact]

--- a/test/ClinicalScheduler/SqlExceptionFactory.cs
+++ b/test/ClinicalScheduler/SqlExceptionFactory.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using Microsoft.Data.SqlClient;
+
+namespace Viper.test.ClinicalScheduler
+{
+    /// <summary>
+    /// Builds <see cref="SqlException"/> instances carrying a specific SQL Server error number.
+    /// SqlException/SqlError/SqlErrorCollection have no public constructors, so this reaches the
+    /// library's internal members via reflection.
+    /// </summary>
+    internal static class SqlExceptionFactory
+    {
+        private const BindingFlags Members = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        public static SqlException Create(int errorNumber)
+        {
+            var errors = (SqlErrorCollection)Activator.CreateInstance(typeof(SqlErrorCollection), nonPublic: true)!;
+            typeof(SqlErrorCollection).GetMethod("Add", Members)!.Invoke(errors, new object[] { NewError(errorNumber) });
+
+            var createException = typeof(SqlException).GetMethod(
+                "CreateException",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(SqlErrorCollection), typeof(string) },
+                modifiers: null)!;
+            return (SqlException)createException.Invoke(null, new object[] { errors, "11.0.0" })!;
+        }
+
+        // Every SqlError constructor starts with the error number (int infoNumber); pick the shortest
+        // and fill the remaining parameters (only int/byte/string/Exception occur) with type defaults.
+        private static SqlError NewError(int number)
+        {
+            var ctor = typeof(SqlError).GetConstructors(Members)
+                .Where(c => c.GetParameters().FirstOrDefault()?.ParameterType == typeof(int))
+                .OrderBy(c => c.GetParameters().Length)
+                .First();
+
+            var args = ctor.GetParameters()
+                .Select((p, i) => i == 0 ? number : Default(p.ParameterType))
+                .ToArray();
+            return (SqlError)ctor.Invoke(args);
+        }
+
+        private static object? Default(Type type)
+        {
+            if (type == typeof(string))
+            {
+                return string.Empty;
+            }
+            return type.IsValueType ? Activator.CreateInstance(type) : null;
+        }
+    }
+}

--- a/test/ClinicalScheduler/ToggleThrowContext.cs
+++ b/test/ClinicalScheduler/ToggleThrowContext.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Viper.Classes.SQLContext;
+
+namespace Viper.test.ClinicalScheduler
+{
+    /// <summary>
+    /// In-memory <see cref="ClinicalSchedulerContext"/> that can be told to throw a specific exception
+    /// from SaveChanges, so tests can exercise the database-failure handling in
+    /// <see cref="Viper.Areas.ClinicalScheduler.Services.ScheduleEditService"/>. Leave
+    /// <see cref="SaveException"/> null for normal behavior (e.g. seeding test data).
+    /// </summary>
+    internal sealed class ToggleThrowContext : ClinicalSchedulerContext
+    {
+        public ToggleThrowContext(DbContextOptions<ClinicalSchedulerContext> options) : base(options)
+        {
+        }
+
+        /// <summary>When set, the next SaveChanges call throws this exception instead of persisting.</summary>
+        public Exception? SaveException { get; set; }
+
+        public override int SaveChanges()
+        {
+            if (TakePendingException() is { } ex)
+            {
+                throw ex;
+            }
+            return base.SaveChanges();
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (TakePendingException() is { } ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+            return base.SaveChangesAsync(cancellationToken);
+        }
+
+        // One-shot: consume the pending exception so only the next save fails, matching the
+        // documented behavior. Subsequent saves persist normally.
+        private Exception? TakePendingException()
+        {
+            var ex = SaveException;
+            SaveException = null;
+            return ex;
+        }
+    }
+}

--- a/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
@@ -247,12 +247,9 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogError(saveEx, "Database save failed for MothraId='{MothraId}', RotationId={RotationId}, WeekIds=[{WeekIds}]",
                     LogSanitizer.SanitizeId(mothraId), rotationId, string.Join(",", weekIds));
 
-                // Check if this is a database constraint violation (typically a duplicate key error)
-                var errorMessage = saveEx.Message?.ToLower();
-                var innerMessage = saveEx.InnerException?.Message?.ToLower();
-
-                if ((errorMessage != null && (errorMessage.Contains("duplicate") || errorMessage.Contains("unique") || errorMessage.Contains("constraint") || errorMessage.Contains("violation of primary key"))) ||
-                    (innerMessage != null && (innerMessage.Contains("duplicate") || innerMessage.Contains("unique") || innerMessage.Contains("constraint") || innerMessage.Contains("violation of primary key"))))
+                // Only a unique/duplicate-key violation means the instructor is already scheduled.
+                // Other DB errors (foreign-key, check constraints, etc.) fall through to the generic message.
+                if (IsDuplicateKeyViolation(saveEx))
                 {
                     throw new InvalidOperationException($"Instructor {mothraId} appears to already be scheduled for one or more of the specified weeks. Please refresh the page and try again.", saveEx);
                 }
@@ -260,6 +257,22 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 // For other database errors, wrap with context
                 throw new InvalidOperationException($"Database operation failed while adding instructor {mothraId} to rotation {rotationId}. Please try again or contact support if the problem persists.", saveEx);
             }
+        }
+
+        // SQL Server: 2627 = unique constraint violation, 2601 = duplicate key in a unique index.
+        // EF wraps the provider error in DbUpdateException, so walk the inner-exception chain to find
+        // the underlying SqlException (robust even if it is wrapped more than once).
+        private static bool IsDuplicateKeyViolation(Exception? ex)
+        {
+            for (; ex is not null; ex = ex.InnerException)
+            {
+                if (ex is SqlException sqlEx
+                    && sqlEx.Errors.Cast<SqlError>().Any(e => e.Number is 2627 or 2601))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public async Task<(bool success, bool wasPrimaryEvaluator, string? instructorName)> RemoveInstructorScheduleAsync(


### PR DESCRIPTION
## What

In `ScheduleEditService.AddInstructorAsync`, the post-`SaveChanges` catch decides whether a DB failure means "instructor already scheduled" by **SQL Server error number** (2627 unique-constraint, 2601 duplicate-key-in-unique-index) instead of substring-matching the exception message.

```csharp
private static bool IsDuplicateKeyViolation(Exception ex)
{
    var sqlEx = ex as SqlException ?? ex.InnerException as SqlException;
    return sqlEx is not null
        && sqlEx.Errors.Cast<SqlError>().Any(e => e.Number is 2627 or 2601);
}
```

## Why

The old check matched `"duplicate" / "unique" / "constraint" / "violation of primary key"` against `message.ToLower()`. Two problems:

1. **Latent bug:** other constraint failures — foreign-key or check-constraint violations (error 547, whose message contains "constraint") — were mis-reported as "already scheduled." Now only true duplicate/unique violations get that message; everything else falls through to the generic "database operation failed" message.
2. **Locale fragility:** `ToLower()` plus English error-text matching is culture-sensitive (Turkish-I) and breaks if SQL messages are localized. Error numbers are stable and locale-invariant.

## Notes

- Behavior-preserving for the real duplicate case; only re-routes non-duplicate constraint errors to the correct (generic) message.
- The duplicate **pre-check** (before SaveChanges) is unchanged; `AddInstructorAsync_WithScheduleConflicts` and all 2084 tests pass.
- Supersedes the message-matching helper currently on `Development` via #227; the overlap will be resolved (keeping this version) at the Development merge.