### PR TITLE
fix(effort): correct harvest custodial dept and exclude emeritus faculty

### DIFF
--- a/test/Effort/ClinicalImportServiceTests.cs
+++ b/test/Effort/ClinicalImportServiceTests.cs
@@ -73,6 +73,10 @@ public sealed class ClinicalImportServiceTests : IDisposable
             .BatchResolveDepartmentsAsync(Arg.Any<List<string>>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(ci => ci.Arg<List<string>>().ToDictionary(id => id, _ => "VME"));
 
+        _instructorServiceMock
+            .GetExcludedTitleCodesAsync(Arg.Any<CancellationToken>())
+            .Returns(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
         _service = new ClinicalImportService(
             _context,
             _viperContext,

--- a/test/Effort/CourseServiceTests.cs
+++ b/test/Effort/CourseServiceTests.cs
@@ -7,6 +7,7 @@ using Viper.Areas.Effort.Models.DTOs.Requests;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Models.Entities;
 using Viper.Areas.Effort.Services;
+using Viper.Classes.SQLContext;
 
 namespace Viper.test.Effort;
 
@@ -18,6 +19,7 @@ namespace Viper.test.Effort;
 public sealed class CourseServiceTests : IDisposable
 {
     private readonly EffortDbContext _context;
+    private readonly CoursesContext _coursesContext;
     private readonly IEffortAuditService _auditServiceMock;
     private readonly ICourseClassificationService _classificationService;
     private readonly ILogger<CourseService> _loggerMock;
@@ -31,6 +33,12 @@ public sealed class CourseServiceTests : IDisposable
             .Options;
 
         _context = new EffortDbContext(effortOptions);
+
+        var coursesOptions = new DbContextOptionsBuilder<CoursesContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _coursesContext = new CoursesContext(coursesOptions);
+
         _auditServiceMock = Substitute.For<IEffortAuditService>();
         _classificationService = new CourseClassificationService();
         _loggerMock = Substitute.For<ILogger<CourseService>>();
@@ -39,12 +47,13 @@ public sealed class CourseServiceTests : IDisposable
         _auditServiceMock
             .AddCourseChangeAudit(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<object?>());
 
-        _courseService = new CourseService(_context, _auditServiceMock, _classificationService, _loggerMock);
+        _courseService = new CourseService(_context, _coursesContext, _auditServiceMock, _classificationService, _loggerMock);
     }
 
     public void Dispose()
     {
         _context.Dispose();
+        _coursesContext.Dispose();
     }
 
     #region GetCoursesAsync Tests

--- a/test/Effort/CustodialDepartmentResolverTests.cs
+++ b/test/Effort/CustodialDepartmentResolverTests.cs
@@ -106,4 +106,56 @@ public sealed class CustodialDepartmentResolverTests
     }
 
     #endregion
+
+    #region Custodial (IOR-resolved) dept code resolution
+
+    [Fact]
+    public void ResolveWithCustodialCode_MapsIorCustodialCode_WhenSubjectAndBaseinfoDeptUnknown()
+    {
+        // IMM 294 shape: subject "IMM" is not an SVM dept and the baseinfo dept is not one of the
+        // six academic depts, but vw_xtnd_baseinfo resolved custodial_dept_code 072067 (PHR) via the IOR.
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode("IMM", "ANS", "072067");
+        Assert.Equal("PHR", result);
+    }
+
+    [Fact]
+    public void ResolveWithCustodialCode_PadsShortCustodialCode_WithLeadingZeros()
+    {
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode("IMM", "ANS", "72067");
+        Assert.Equal("PHR", result);
+    }
+
+    [Fact]
+    public void ResolveWithCustodialCode_PrefersBaseinfoDept_WhenAlreadyValidSvmDept()
+    {
+        // Legacy tier 1: a baseinfo dept that is already an SVM dept wins over the custodial code.
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode("IMM", "APC", "072067");
+        Assert.Equal("APC", result);
+    }
+
+    [Fact]
+    public void ResolveWithCustodialCode_PrefersSubjectCode_WhenValidSvmDept()
+    {
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode("VME", "ANS", "072067");
+        Assert.Equal("VME", result);
+    }
+
+    [Fact]
+    public void ResolveWithCustodialCode_FallsBackToBaseinfoNumeric_WhenNoCustodialCode()
+    {
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode("IMM", "072030", null);
+        Assert.Equal("VME", result);
+    }
+
+    [Theory]
+    [InlineData("IMM", "ANS", null)]
+    [InlineData("IMM", "ANS", "999999")]
+    [InlineData(null, null, null)]
+    public void ResolveWithCustodialCode_ReturnsUNK_WhenNoMatch(string? subj, string? dept, string? custodial)
+    {
+        var result = CustodialDepartmentResolver.ResolveWithCustodialCode(subj, dept, custodial);
+        Assert.Equal("UNK", result);
+    }
+
+    #endregion
 }

--- a/test/Effort/EffortRecordServiceTests.cs
+++ b/test/Effort/EffortRecordServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Viper.Areas.Effort;
@@ -71,6 +72,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             courseClassificationService,
             _rCourseServiceMock,
             _userHelperMock,
+            Options.Create(new EffortSettings { AutoCreateGenericRCourse = true }),
             _loggerMock);
 
         SeedTestData();
@@ -1487,6 +1489,55 @@ public sealed class EffortRecordServiceTests : IDisposable
             TestTermCode,
             TestUserId,
             RCourseCreationContext.OnDemand,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateEffortRecordAsync_DoesNotCallRCourseService_WhenAutoCreateDisabled()
+    {
+        // Arrange - first non-R-course record, but generic R-course auto-create disabled
+        var serviceWithRCourseDisabled = new EffortRecordService(
+            _context,
+            _rapsContext,
+            _auditServiceMock,
+            _instructorServiceMock,
+            new CourseClassificationService(),
+            _rCourseServiceMock,
+            _userHelperMock,
+            Options.Create(new EffortSettings { AutoCreateGenericRCourse = false }),
+            _loggerMock);
+
+        var newPersonId = 202;
+        _context.Persons.Add(new EffortPerson
+        {
+            PersonId = newPersonId,
+            TermCode = TestTermCode,
+            FirstName = "Disabled",
+            LastName = "Instructor",
+            EffortDept = "VME"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var request = new CreateEffortRecordRequest
+        {
+            PersonId = newPersonId,
+            TermCode = TestTermCode,
+            CourseId = TestCourseId, // VET 410 - not an R-course
+            EffortTypeId = "LEC",
+            RoleId = 1,
+            EffortValue = 40
+        };
+
+        // Act
+        var (result, _) = await serviceWithRCourseDisabled.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert - record created, but no generic R-course auto-created
+        Assert.NotNull(result);
+        await _rCourseServiceMock.DidNotReceive().CreateRCourseEffortRecordAsync(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<RCourseCreationContext>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/test/Effort/HarvestServiceTests.cs
+++ b/test/Effort/HarvestServiceTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Viper.Areas.Effort;
+using Viper.Areas.Effort.Constants;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Models.Entities;
 using Viper.Areas.Effort.Services;
@@ -33,6 +35,11 @@ public sealed class HarvestServiceTests : IDisposable
     private readonly IClinicalImportService _clinicalImportServiceMock;
     private readonly ILogger<HarvestService> _loggerMock;
     private readonly HarvestService _harvestService;
+
+    // R-course auto-creation enabled for the shared service so existing R-course tests
+    // exercise the generation path. Toggle-off behavior is covered by its own test.
+    private static readonly IOptions<EffortSettings> RCourseEnabledSettings =
+        Options.Create(new EffortSettings { AutoCreateGenericRCourse = true });
 
     private const int TestTermCode = 202410;
 
@@ -93,6 +100,8 @@ public sealed class HarvestServiceTests : IDisposable
             .GetTitleCodesAsync(Arg.Any<CancellationToken>()).Returns(new List<TitleCodeDto>());
         _instructorServiceMock
             .GetDepartmentSimpleNameLookupAsync(Arg.Any<CancellationToken>()).Returns(new Dictionary<string, string>());
+        _instructorServiceMock
+            .GetExcludedTitleCodesAsync(Arg.Any<CancellationToken>()).Returns(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         // Setup audit service mock for harvest operations
         _auditServiceMock
             .ClearAuditForTermAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
@@ -123,6 +132,7 @@ public sealed class HarvestServiceTests : IDisposable
             _instructorServiceMock,
             _rCourseServiceMock,
             _clinicalImportServiceMock,
+            RCourseEnabledSettings,
             _loggerMock);
     }
 
@@ -745,6 +755,7 @@ public sealed class HarvestServiceTests : IDisposable
             _instructorServiceMock,
             _rCourseServiceMock,
             _clinicalImportServiceMock,
+            RCourseEnabledSettings,
             _loggerMock);
 
         // Act - Run harvest (R-course detection uses inline EndsWith("R") logic)
@@ -760,6 +771,83 @@ public sealed class HarvestServiceTests : IDisposable
             123,
             RCourseCreationContext.Harvest,
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteHarvestAsync_DoesNotCallRCourseService_WhenAutoCreateDisabled()
+    {
+        // Arrange - same eligible-instructor setup as the enabled case
+        _context.Terms.Add(new EffortTerm { TermCode = TestTermCode });
+        _context.EffortTypes.Add(new EffortType
+        {
+            Id = "LEC",
+            Description = "Lecture",
+            AllowedOnRCourses = true,
+            IsActive = true
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var testPhase = new TestDataHarvestPhase(_context, TestTermCode);
+        var disabledSettings = Options.Create(new EffortSettings { AutoCreateGenericRCourse = false });
+
+        var harvestService = new HarvestService(
+            new List<IHarvestPhase> { testPhase },
+            _context,
+            _viperContext,
+            _coursesContext,
+            _crestContext,
+            _aaudContext,
+            _dictionaryContext,
+            _auditServiceMock,
+            _termServiceMock,
+            _instructorServiceMock,
+            _rCourseServiceMock,
+            _clinicalImportServiceMock,
+            disabledSettings,
+            _loggerMock);
+
+        // Act
+        var result = await harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, ct: TestContext.Current.CancellationToken);
+
+        // Assert - harvest succeeds but the generic R-course is not created
+        Assert.True(result.Success);
+        await _rCourseServiceMock.DidNotReceive().CreateRCourseEffortRecordAsync(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<RCourseCreationContext>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ApplyDirectorCustodialDeptFallback_InheritsDirectorDept_OnlyForNonAcademicCourses()
+    {
+        // Arrange — three non-CREST courses: UNK with academic director, already-academic,
+        // and UNK with a non-academic director.
+        var courses = new List<HarvestCoursePreview>
+        {
+            new() { Crn = "10001", CustDept = "UNK", Source = EffortConstants.SourceNonCrest },
+            new() { Crn = "10002", CustDept = "PMI", Source = EffortConstants.SourceNonCrest },
+            new() { Crn = "10003", CustDept = "UNK", Source = EffortConstants.SourceNonCrest },
+        };
+        var effort = new List<HarvestRecordPreview>
+        {
+            new() { Crn = "10001", MothraId = "AAA", RoleId = EffortConstants.DirectorRoleId },
+            new() { Crn = "10003", MothraId = "CCC", RoleId = EffortConstants.DirectorRoleId },
+        };
+        var batchDepts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["AAA"] = "VME",
+            ["CCC"] = "UNK",
+        };
+
+        // Act
+        NonCrestHarvestPhase.ApplyDirectorCustodialDeptFallback(courses, effort, batchDepts);
+
+        // Assert
+        Assert.Equal("VME", courses[0].CustDept); // inherited from academic IOR
+        Assert.Equal("PMI", courses[1].CustDept); // already academic — unchanged
+        Assert.Equal("UNK", courses[2].CustDept); // IOR dept not academic — unchanged
     }
 
     /// <summary>
@@ -780,6 +868,7 @@ public sealed class HarvestServiceTests : IDisposable
             _instructorServiceMock,
             _rCourseServiceMock,
             _clinicalImportServiceMock,
+            RCourseEnabledSettings,
             _loggerMock);
     }
 

--- a/test/Effort/InstructorServiceTests.cs
+++ b/test/Effort/InstructorServiceTests.cs
@@ -1114,6 +1114,75 @@ public sealed class InstructorServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task BatchResolveDepartmentsAsync_ReturnsVme_ForChristineJohnson_WithNoAcademicJob()
+    {
+        // Christine Johnson (00129082) has no academic-department job in AAUD and a
+        // non-academic home/effort dept (072016), so the dept cannot be auto-derived.
+        // The override pins her to VME.
+        const string mothraId = "00129082";
+        _aaudContext.Ids.Add(new Id
+        {
+            IdsPKey = "CJOHNSON01",
+            IdsTermCode = "202410",
+            IdsMothraid = mothraId,
+            IdsClientid = mothraId
+        });
+        _aaudContext.Employees.Add(new Employee
+        {
+            EmpPKey = "CJOHNSON01",
+            EmpTermCode = "202410",
+            EmpClientid = mothraId,
+            EmpHomeDept = "072016",
+            EmpAltDeptCode = "",
+            EmpEffortHomeDept = "072016",
+            EmpSchoolDivision = "VM",
+            EmpCbuc = "99",
+            EmpStatus = "A"
+        });
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _instructorService.BatchResolveDepartmentsAsync([mothraId], 202410, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("VME", result[mothraId]);
+    }
+
+    [Fact]
+    public async Task BatchResolveDepartmentsAsync_ReturnsVsr_ForMichaelMison_WithNonAcademicJob()
+    {
+        // Michael Mison (02493928) only has a VMTH job (non-academic); the override
+        // records his effort to VSR regardless of his AAUD job/employee depts.
+        const string mothraId = "02493928";
+        _aaudContext.Ids.Add(new Id
+        {
+            IdsPKey = "MISON00001",
+            IdsTermCode = "202410",
+            IdsMothraid = mothraId,
+            IdsClientid = mothraId
+        });
+        _aaudContext.Employees.Add(new Employee
+        {
+            EmpPKey = "MISON00001",
+            EmpTermCode = "202410",
+            EmpClientid = mothraId,
+            EmpHomeDept = "072000",
+            EmpAltDeptCode = "",
+            EmpEffortHomeDept = "072000",
+            EmpSchoolDivision = "VM",
+            EmpCbuc = "99",
+            EmpStatus = "A"
+        });
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _instructorService.BatchResolveDepartmentsAsync([mothraId], 202410, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("VSR", result[mothraId]);
+    }
+
+    [Fact]
     public async Task BatchResolveDepartmentsAsync_ReturnsAcademicDeptFromJobs_WhenAvailable()
     {
         // Arrange

--- a/web/Areas/Effort/Constants/EffortConstants.cs
+++ b/web/Areas/Effort/Constants/EffortConstants.cs
@@ -19,7 +19,11 @@ public static class EffortConstants
     /// </summary>
     public static readonly FrozenDictionary<string, string> DepartmentOverrides = new Dictionary<string, string>
     {
-        ["02493928"] = "VSR"
+        // Michael Mison — only has a VMTH job, but effort is recorded to VSR.
+        ["02493928"] = "VSR",
+        // Christine Johnson — no academic-department job in AAUD (home/effort dept 072016),
+        // so the dept cannot be auto-derived; effort is recorded to VME.
+        ["00129082"] = "VME"
     }.ToFrozenDictionary();
 
     /// <summary>

--- a/web/Areas/Effort/EffortSettings.cs
+++ b/web/Areas/Effort/EffortSettings.cs
@@ -14,4 +14,11 @@ public class EffortSettings
     /// Number of days instructors have to respond to verification emails.
     /// </summary>
     public int VerificationReplyDays { get; set; } = 7;
+
+    /// <summary>
+    /// When true, the harvest and on-demand effort entry auto-create the generic
+    /// "RES 000R-001" resident-teaching course (CRN "RESID") and its effort records.
+    /// Defaults to false — the placeholder course is not currently in use.
+    /// </summary>
+    public bool AutoCreateGenericRCourse { get; set; }
 }

--- a/web/Areas/Effort/Services/ClinicalImportService.cs
+++ b/web/Areas/Effort/Services/ClinicalImportService.cs
@@ -69,6 +69,11 @@ public class ClinicalImportService : IClinicalImportService
     /// </summary>
     private Dictionary<string, string?>? _jobGroupLookup;
 
+    /// <summary>
+    /// Lazily loaded set of emeritus/recall title codes to exclude from import.
+    /// </summary>
+    private HashSet<string>? _excludedTitleCodes;
+
     public ClinicalImportService(
         EffortDbContext context,
         VIPERContext viperContext,
@@ -117,10 +122,14 @@ public class ClinicalImportService : IClinicalImportService
             _jobGroupLookup ??= titleCodes.ToDictionary(t => t.Code, t => t.JobGroupId, StringComparer.OrdinalIgnoreCase);
         }
 
-        // Build lookup of MothraId → titleCode for those with valid title codes
+        HashSet<string> excludedTitleCodes = _excludedTitleCodes ??= await _instructorService.GetExcludedTitleCodesAsync(ct);
+
+        // Build lookup of MothraId → titleCode for those with valid, non-excluded title codes
+        // (emeritus/recall appointments are excluded from harvest).
         var titleCodeByMothraId = aaudImportInfo
             .Where(a => !string.IsNullOrEmpty(a.TitleCode?.Trim())
-                && _titleLookup.ContainsKey(a.TitleCode!.Trim()))
+                && _titleLookup.ContainsKey(a.TitleCode!.Trim())
+                && !excludedTitleCodes.Contains(a.TitleCode!.Trim()))
             .GroupBy(a => a.MothraId, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First().TitleCode!.Trim(), StringComparer.OrdinalIgnoreCase);
 
@@ -250,7 +259,7 @@ public class ClinicalImportService : IClinicalImportService
         var auditDetails = $"Clinical import ({mode}): {result.RecordsAdded} added, {result.RecordsUpdated} updated, {result.RecordsDeleted} deleted, {result.RecordsSkipped} skipped";
         if (result.SkippedInstructors.Count > 0)
         {
-            auditDetails += $". Skipped instructors (no AAUD record or invalid title): {string.Join(", ", result.SkippedInstructors)}";
+            auditDetails += $". Skipped instructors (no AAUD record, invalid title, or excluded appointment): {string.Join(", ", result.SkippedInstructors)}";
         }
         _auditService.AddImportAudit(termCode, EffortAuditActions.ImportClinical, auditDetails);
 
@@ -326,7 +335,7 @@ public class ClinicalImportService : IClinicalImportService
             var auditDetails = $"Clinical import ({mode}): {result.RecordsAdded} added, {result.RecordsUpdated} updated, {result.RecordsDeleted} deleted, {result.RecordsSkipped} skipped";
             if (result.SkippedInstructors.Count > 0)
             {
-                auditDetails += $". Skipped instructors (no AAUD record or invalid title): {string.Join(", ", result.SkippedInstructors)}";
+                auditDetails += $". Skipped instructors (no AAUD record, invalid title, or excluded appointment): {string.Join(", ", result.SkippedInstructors)}";
             }
             _auditService.AddImportAudit(termCode, EffortAuditActions.ImportClinical, auditDetails);
 
@@ -1092,10 +1101,12 @@ public class ClinicalImportService : IClinicalImportService
             _jobGroupLookup ??= titleCodes.ToDictionary(t => t.Code, t => t.JobGroupId, StringComparer.OrdinalIgnoreCase);
         }
 
-        if (string.IsNullOrEmpty(titleCode) || !_titleLookup.ContainsKey(titleCode))
+        var excludedTitleCodes = _excludedTitleCodes ??= await _instructorService.GetExcludedTitleCodesAsync(ct);
+
+        if (string.IsNullOrEmpty(titleCode) || !_titleLookup.ContainsKey(titleCode) || excludedTitleCodes.Contains(titleCode))
         {
             _logger.LogWarning(
-                "Skipping clinical instructor {MothraId}: no AAUD record or invalid title code '{TitleCode}'",
+                "Skipping clinical instructor {MothraId}: no AAUD record, invalid title, or excluded (emeritus/recall) title code '{TitleCode}'",
                 mothraId, titleCode);
             _processedMothraIds[mothraId] = false;
             return false;

--- a/web/Areas/Effort/Services/CourseService.cs
+++ b/web/Areas/Effort/Services/CourseService.cs
@@ -6,6 +6,7 @@ using Viper.Areas.Effort.Models.DTOs;
 using Viper.Areas.Effort.Models.DTOs.Requests;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Models.Entities;
+using Viper.Classes.SQLContext;
 using Viper.Classes.Utilities;
 
 namespace Viper.Areas.Effort.Services;
@@ -16,6 +17,7 @@ namespace Viper.Areas.Effort.Services;
 public class CourseService : ICourseService
 {
     private readonly EffortDbContext _context;
+    private readonly CoursesContext _coursesContext;
     private readonly IEffortAuditService _auditService;
     private readonly ICourseClassificationService _classificationService;
     private readonly ILogger<CourseService> _logger;
@@ -24,11 +26,13 @@ public class CourseService : ICourseService
 
     public CourseService(
         EffortDbContext context,
+        CoursesContext coursesContext,
         IEffortAuditService auditService,
         ICourseClassificationService classificationService,
         ILogger<CourseService> logger)
     {
         _context = context;
+        _coursesContext = coursesContext;
         _auditService = auditService;
         _classificationService = classificationService;
         _logger = logger;
@@ -205,9 +209,25 @@ public class CourseService : ICourseService
             ? request.Units.Value
             : bannerCourse.UnitLow;
 
-        // Determine custodial department - check subject code first, then fall back to dept code mapping
-        // For SVM courses, the subject code (e.g., "DVM", "VME", "PHR") often matches the custodial department
-        var custDept = CustodialDepartmentResolver.Resolve(bannerCourse.SubjCode, bannerCourse.DeptCode);
+        // Determine custodial department. Mirror the harvest / legacy getCustDept: use the
+        // IOR-resolved custodial_dept_code from vw_xtnd_baseinfo so non-SVM-subject courses
+        // (e.g. IMM 294, whose baseinfo dept is not an SVM department) get the instructor-of-record's
+        // department instead of "UNK".
+        var termCodeStr = request.TermCode.ToString();
+        var crn = bannerCourse.Crn;
+        // Compare BaseinfoCrn (a CHAR(5) fixed-length column) without wrapping it in Trim() so the
+        // query can seek the underlying baseinfo index; SQL Server ignores trailing spaces in string
+        // comparisons, so the padded column still matches the trimmed CRN. OrderBy makes the pick
+        // deterministic: a CRN with multiple instructors (POAs) yields multiple rows whose
+        // custodial_dept_code can differ, and an unordered FirstOrDefault would return an arbitrary one.
+        var custodialDeptCode = await _coursesContext.VwXtndBaseinfos
+            .AsNoTracking()
+            .Where(v => v.BaseinfoTermCode == termCodeStr && v.BaseinfoCrn == crn.Trim() && v.CustodialDeptCode != null)
+            .OrderBy(v => v.CustodialDeptCode)
+            .Select(v => v.CustodialDeptCode)
+            .FirstOrDefaultAsync(ct);
+
+        var custDept = CustodialDepartmentResolver.ResolveWithCustodialCode(bannerCourse.SubjCode, bannerCourse.DeptCode, custodialDeptCode);
 
         // Create the course
         var course = new EffortCourse
@@ -222,25 +242,7 @@ public class CourseService : ICourseService
             CustDept = custDept
         };
 
-        await using var transaction = await _context.Database.BeginTransactionAsync(ct);
-
-        _context.Courses.Add(course);
-        await _context.SaveChangesAsync(ct);
-
-        _auditService.AddCourseChangeAudit(course.Id, course.TermCode, EffortAuditActions.CreateCourse,
-            null,
-            new
-            {
-                course.Crn,
-                course.SubjCode,
-                course.CrseNumb,
-                course.SeqNumb,
-                course.Enrollment,
-                course.Units,
-                course.CustDept
-            });
-        await _context.SaveChangesAsync(ct);
-        await transaction.CommitAsync(ct);
+        await PersistNewCourseAsync(course, ct);
 
         _logger.LogInformation("Imported course {SubjCode} {CrseNumb}-{SeqNumb} (CRN: {Crn}) for term {TermCode}",
             LogSanitizer.SanitizeId(course.SubjCode), LogSanitizer.SanitizeId(course.CrseNumb), LogSanitizer.SanitizeId(course.SeqNumb), LogSanitizer.SanitizeId(course.Crn), course.TermCode);
@@ -262,6 +264,20 @@ public class CourseService : ICourseService
             CustDept = request.CustDept.Trim().ToUpperInvariant()
         };
 
+        await PersistNewCourseAsync(course, ct);
+
+        _logger.LogInformation("Created manual course {SubjCode} {CrseNumb}-{SeqNumb} (CRN: {Crn}) for term {TermCode}",
+            LogSanitizer.SanitizeId(course.SubjCode), LogSanitizer.SanitizeId(course.CrseNumb), LogSanitizer.SanitizeId(course.SeqNumb), LogSanitizer.SanitizeId(course.Crn), course.TermCode);
+
+        return ToDto(course);
+    }
+
+    /// <summary>
+    /// Persist a new course inside a transaction and write its create-course audit entry.
+    /// Shared by Banner import and manual creation.
+    /// </summary>
+    private async Task PersistNewCourseAsync(EffortCourse course, CancellationToken ct)
+    {
         await using var transaction = await _context.Database.BeginTransactionAsync(ct);
 
         _context.Courses.Add(course);
@@ -281,11 +297,6 @@ public class CourseService : ICourseService
             });
         await _context.SaveChangesAsync(ct);
         await transaction.CommitAsync(ct);
-
-        _logger.LogInformation("Created manual course {SubjCode} {CrseNumb}-{SeqNumb} (CRN: {Crn}) for term {TermCode}",
-            LogSanitizer.SanitizeId(course.SubjCode), LogSanitizer.SanitizeId(course.CrseNumb), LogSanitizer.SanitizeId(course.SeqNumb), LogSanitizer.SanitizeId(course.Crn), course.TermCode);
-
-        return ToDto(course);
     }
 
     public async Task<CourseDto?> UpdateCourseAsync(int courseId, UpdateCourseRequest request, CancellationToken ct = default)

--- a/web/Areas/Effort/Services/CustodialDepartmentResolver.cs
+++ b/web/Areas/Effort/Services/CustodialDepartmentResolver.cs
@@ -41,38 +41,74 @@ public static class CustodialDepartmentResolver
     /// Resolve a custodial department from subject code and/or Banner department code.
     /// For SVM courses, the subject code (e.g., "VME", "PMI") often IS the custodial department.
     /// Falls back to department code mapping for non-SVM subject codes.
+    /// Equivalent to <see cref="ResolveWithCustodialCode"/> with no IOR-resolved custodial code.
     /// </summary>
     public static string Resolve(string? subjCode, string? bannerDeptCode)
+        => ResolveWithCustodialCode(subjCode, bannerDeptCode, null);
+
+    /// <summary>
+    /// Resolve a custodial department using the IOR-resolved <c>custodial_dept_code</c> from
+    /// <c>vw_xtnd_baseinfo</c>. This mirrors the legacy Course.cfc <c>getCustDept</c> chain used by
+    /// the harvest, which maps the IOR-resolved custodial code (not the raw baseinfo dept) when the
+    /// course's baseinfo dept is not one of the SVM academic departments:
+    /// <list type="number">
+    /// <item>Subject code, if it is a valid SVM department (SVM courses).</item>
+    /// <item>Banner (baseinfo) dept code, if it is already a valid SVM department.</item>
+    /// <item>The IOR-resolved <paramref name="custodialDeptCode"/>, mapped from its numeric Banner code.</item>
+    /// <item>The baseinfo dept code, mapped from its numeric Banner code (defensive fallback).</item>
+    /// <item>"UNK".</item>
+    /// </list>
+    /// The legacy importer-department fallback (getCustDept tier 3) is intentionally omitted:
+    /// the automated harvest has no single importing user.
+    /// </summary>
+    public static string ResolveWithCustodialCode(string? subjCode, string? bannerDeptCode, string? custodialDeptCode)
     {
-        // First check if subject code is a valid SVM department (most common case for SVM courses)
-        if (!string.IsNullOrWhiteSpace(subjCode))
+        var trimmedSubj = subjCode?.Trim();
+        if (!string.IsNullOrEmpty(trimmedSubj) && ValidCustDepts.Contains(trimmedSubj))
         {
-            var trimmedSubj = subjCode.Trim().ToUpperInvariant();
-            if (ValidCustDepts.Contains(trimmedSubj))
-            {
-                return trimmedSubj;
-            }
+            return trimmedSubj.ToUpperInvariant();
         }
 
-        if (string.IsNullOrWhiteSpace(bannerDeptCode))
+        var trimmedDept = bannerDeptCode?.Trim();
+        if (!string.IsNullOrEmpty(trimmedDept) && ValidCustDepts.Contains(trimmedDept))
         {
-            return "UNK";
+            return trimmedDept.ToUpperInvariant();
         }
 
-        // Then check if dept code is already a valid SVM department code
-        var trimmed = bannerDeptCode.Trim();
-        if (ValidCustDepts.Contains(trimmed))
+        // Legacy getCustDept maps the IOR-resolved custodial_dept_code (not the raw baseinfo dept)
+        // when the baseinfo dept is not an SVM academic department.
+        if (TryMapBannerNumeric(custodialDeptCode, out var iorDept))
         {
-            return trimmed.ToUpperInvariant();
+            return iorDept;
         }
 
-        // Try to look up by numeric Banner code — normalize to 6 digits with leading zero
-        var normalizedCode = trimmed.PadLeft(6, '0');
-        if (BannerDeptMapping.TryGetValue(normalizedCode, out var custDept))
+        if (TryMapBannerNumeric(bannerDeptCode, out var bannerDept))
         {
-            return custDept;
+            return bannerDept;
         }
 
         return "UNK";
+    }
+
+    /// <summary>
+    /// Map a numeric Banner department code (e.g., "072067" or "72067") to an SVM custodial
+    /// department, normalizing to 6 digits with leading zeros first.
+    /// </summary>
+    private static bool TryMapBannerNumeric(string? code, out string custDept)
+    {
+        custDept = "";
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return false;
+        }
+
+        var normalizedCode = code.Trim().PadLeft(6, '0');
+        if (BannerDeptMapping.TryGetValue(normalizedCode, out var mapped))
+        {
+            custDept = mapped;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/web/Areas/Effort/Services/EffortRecordService.cs
+++ b/web/Areas/Effort/Services/EffortRecordService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Viper.Areas.Effort.Constants;
 using Viper.Areas.Effort.Exceptions;
 using Viper.Areas.Effort.Models.DTOs;
@@ -22,6 +23,7 @@ public class EffortRecordService : IEffortRecordService
     private readonly ICourseClassificationService _courseClassificationService;
     private readonly IRCourseService _rCourseService;
     private readonly IUserHelper _userHelper;
+    private readonly EffortSettings _settings;
     private readonly ILogger<EffortRecordService> _logger;
 
     public EffortRecordService(
@@ -32,6 +34,7 @@ public class EffortRecordService : IEffortRecordService
         ICourseClassificationService courseClassificationService,
         IRCourseService rCourseService,
         IUserHelper userHelper,
+        IOptions<EffortSettings> settings,
         ILogger<EffortRecordService> logger)
     {
         _context = context;
@@ -41,6 +44,7 @@ public class EffortRecordService : IEffortRecordService
         _courseClassificationService = courseClassificationService;
         _rCourseService = rCourseService;
         _userHelper = userHelper;
+        _settings = settings.Value;
         _logger = logger;
     }
 
@@ -687,6 +691,11 @@ public class EffortRecordService : IEffortRecordService
     /// </summary>
     private async Task TryCreateRCourseForInstructorAsync(int personId, int termCode, int modifiedBy, CancellationToken ct)
     {
+        if (!_settings.AutoCreateGenericRCourse)
+        {
+            return;
+        }
+
         // Count how many non-R-course effort records this instructor has in this term
         var nonRCourseCount = await _context.Records
             .AsNoTracking()

--- a/web/Areas/Effort/Services/Harvest/CrestHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/CrestHarvestPhase.cs
@@ -117,6 +117,7 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
             .ToDictionary(g => g.Key, g => g.First().JobGroupId, StringComparer.OrdinalIgnoreCase);
 
         context.DeptSimpleNameLookup ??= await context.InstructorService.GetDepartmentSimpleNameLookupAsync(ct);
+        var excludedTitleCodes = context.ExcludedTitleCodes ??= await context.InstructorService.GetExcludedTitleCodesAsync(ct);
 
         // Get VIPER person IDs for the instructors
         var mothraIds = crestInstructors.Select(i => i.MothraId).Distinct().ToList();
@@ -125,6 +126,8 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
             .Where(p => mothraIds.Contains(p.MothraId))
             .Select(p => new { p.PersonId, p.MothraId })
             .ToDictionaryAsync(p => p.MothraId ?? "", p => p.PersonId, ct);
+
+        var excludedInstructors = new List<string>();
 
         foreach (var instructor in crestInstructors)
         {
@@ -137,6 +140,16 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
             }
 
             var titleDesc = context.TitleLookup.TryGetValue(instructor.TitleCode, out var desc) ? desc : instructor.TitleCode;
+
+            // Exclude emeritus/recall appointments from harvest. Their effort records are
+            // skipped automatically because BuildCrestEffortRecordsAsync only emits records
+            // for instructors present in CrestInstructors.
+            if (excludedTitleCodes.Contains(instructor.TitleCode))
+            {
+                excludedInstructors.Add($"{instructor.LastName}, {instructor.FirstName} ({titleDesc})");
+                continue;
+            }
+
             // HomeDept is already fully resolved by BatchResolveDepartmentsAsync
             var dept = instructor.HomeDept;
 
@@ -153,6 +166,8 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
                 Source = EffortConstants.SourceCrest
             });
         }
+
+        AddEmeritusExclusionWarning(context, PhaseName, excludedInstructors);
 
         // Step 5: Build effort records
         await BuildCrestEffortRecordsAsync(context, courseOfferings, blockCourseIds, ct);
@@ -405,6 +420,12 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
         // Build effort records
         var effortByPersonCourse = new Dictionary<string, (HarvestRecordPreview Record, int TotalMinutes)>();
 
+        // Index instructors by MothraId once; effort records are only created for persons
+        // present in CrestInstructors (valid AAUD data, title code, and VIPER person record).
+        var instructorByMothraId = context.Preview.CrestInstructors
+            .GroupBy(i => i.MothraId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
         var offeringAssignments = courseOfferings
             .Join(
                 offerPersons,
@@ -422,10 +443,7 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
                 continue;
             }
 
-            // Only create effort records for persons who are in CrestInstructors
-            // (those with valid AAUD data, title code, and VIPER person record)
-            var instructor = context.Preview.CrestInstructors.FirstOrDefault(i => i.MothraId == mothraId);
-            if (instructor == null) continue;
+            if (!instructorByMothraId.TryGetValue(mothraId, out var instructor)) continue;
 
             var personName = instructor.FullName;
 

--- a/web/Areas/Effort/Services/Harvest/HarvestContext.cs
+++ b/web/Areas/Effort/Services/Harvest/HarvestContext.cs
@@ -55,6 +55,11 @@ public sealed class HarvestContext
     public Dictionary<string, string>? DeptSimpleNameLookup { get; set; }
 
     /// <summary>
+    /// Effort title codes to exclude from harvest (emeritus/recall appointments).
+    /// </summary>
+    public HashSet<string>? ExcludedTitleCodes { get; set; }
+
+    /// <summary>
     /// Warnings accumulated during harvest.
     /// </summary>
     public List<HarvestWarning> Warnings { get; } = [];

--- a/web/Areas/Effort/Services/Harvest/HarvestPhaseBase.cs
+++ b/web/Areas/Effort/Services/Harvest/HarvestPhaseBase.cs
@@ -285,6 +285,36 @@ public abstract class HarvestPhaseBase : IHarvestPhase
 
     #endregion
 
+    #region Exclusion Helpers
+
+    /// <summary>
+    /// Record a single warning listing instructors excluded from harvest because their
+    /// effort title is an emeritus/recall appointment. Added to both the preview warnings
+    /// (shown before commit) and the execution warnings (shown in the result).
+    /// </summary>
+    protected static void AddEmeritusExclusionWarning(
+        HarvestContext ctx,
+        string phaseName,
+        IReadOnlyCollection<string> excludedNames)
+    {
+        if (excludedNames.Count == 0)
+        {
+            return;
+        }
+
+        var warning = new HarvestWarning
+        {
+            Phase = phaseName,
+            Message = $"{excludedNames.Count} emeritus/recall instructor(s) excluded from harvest",
+            Details = string.Join("; ", excludedNames)
+        };
+
+        ctx.Warnings.Add(warning);
+        ctx.Preview.Warnings.Add(warning);
+    }
+
+    #endregion
+
     #region Department Resolution
 
     /// <summary>

--- a/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
@@ -89,6 +89,33 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
             .Where(c => !existingCrnUnits.Contains((c.Crn, (decimal)c.Units)))
             .ToList();
 
+        // Map each CRN to its IOR-resolved custodial department code from the vw_xtnd_baseinfo view.
+        // The view derives that code from the course POA (instructor of record) when the baseinfo
+        // dept is not an SVM academic department. The legacy harvest relied on it; without it,
+        // non-SVM-subject courses such as IMM 294 resolve to "UNK".
+        // Only the scheduled CRNs are ever looked up, so filter the registrar-wide view to them
+        // instead of loading every row for the term. BaseinfoCrn is CHAR(5): compare the column bare
+        // (keeping the predicate SARGable) and pass trimmed CRNs, relying on SQL Server's
+        // trailing-space-insensitive IN to match the padded column.
+        var scheduleCrns = allScheduleCourses.Select(c => c.Crn.Trim()).Distinct().ToList();
+        var custodialByCrn = (await context.CoursesContext.VwXtndBaseinfos
+                .AsNoTracking()
+                .Where(v => v.BaseinfoTermCode == termCodeStr
+                            && v.CustodialDeptCode != null
+                            && EF.Parameter(scheduleCrns).Contains(v.BaseinfoCrn))
+                .Select(v => new { v.BaseinfoCrn, v.CustodialDeptCode })
+                .ToListAsync(ct))
+            .GroupBy(v => v.BaseinfoCrn.Trim())
+            // OrderBy makes the pick deterministic when a CRN has multiple instructors (POAs)
+            // whose resolved custodial_dept_code differs; an unordered First() would be arbitrary.
+            .ToDictionary(g => g.Key, g => g.OrderBy(x => x.CustodialDeptCode).First().CustodialDeptCode, StringComparer.OrdinalIgnoreCase);
+
+        // Layer the IOR-resolved custodial code from the view on top of subject/dept resolution.
+        // Shared by the not-in-CREST and in-CREST preview loops below.
+        string ResolveCustDept(string subjCode, string deptCode, string crn) =>
+            CustodialDepartmentResolver.ResolveWithCustodialCode(
+                subjCode, deptCode, custodialByCrn.GetValueOrDefault(crn.Trim()));
+
         foreach (var course in allNonCrestCourses)
         {
             context.Preview.NonCrestCourses.Add(new HarvestCoursePreview
@@ -99,7 +126,7 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
                 SeqNumb = course.SeqNumb,
                 Enrollment = course.Enrollment,
                 Units = (decimal)course.Units,
-                CustDept = CustodialDepartmentResolver.Resolve(course.SubjCode, course.DeptCode),
+                CustDept = ResolveCustDept(course.SubjCode, course.DeptCode, course.Crn),
                 Source = EffortConstants.SourceNonCrest
             });
         }
@@ -119,7 +146,7 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
                 SeqNumb = course.SeqNumb,
                 Enrollment = course.Enrollment,
                 Units = (decimal)course.Units,
-                CustDept = CustodialDepartmentResolver.Resolve(course.SubjCode, course.DeptCode),
+                CustDept = ResolveCustDept(course.SubjCode, course.DeptCode, course.Crn),
                 Source = EffortConstants.SourceInCrest
             });
         }

--- a/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
@@ -265,6 +265,7 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
 
         // Batch-resolve departments using full resolution chain (jobs → employee fields → fallback)
         var batchDepts = await context.InstructorService.BatchResolveDepartmentsAsync(nonCrestMothraIds, context.TermCode, ct);
+        var excludedTitleCodes = context.ExcludedTitleCodes ??= await context.InstructorService.GetExcludedTitleCodesAsync(ct);
 
         // CRN-keyed lookup for SubjCode/CrseNumb resolution from POA rows (POA has no unit info).
         // Variable-unit CRNs produce multiple allNonCrestCourses rows; take the first since
@@ -274,6 +275,10 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
             .ToDictionary(g => g.Key, g => g.First());
 
         // Create instructor previews and effort records
+        var excludedMothraIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var excludedInstructors = new List<string>();
+        var addedInstructorMothraIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var poa in poaEntries)
         {
             var pidmStr = poa.PoaPidm;
@@ -298,8 +303,19 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
 
             var titleDesc = context.TitleLookup.TryGetValue(titleCode, out var desc) ? desc : titleCode;
 
+            // Exclude emeritus/recall appointments from harvest (skips both the instructor
+            // and the effort record built below).
+            if (excludedTitleCodes.Contains(titleCode))
+            {
+                if (excludedMothraIds.Add(mothraId))
+                {
+                    excludedInstructors.Add($"{fullName} ({titleDesc})");
+                }
+                continue;
+            }
+
             // Add instructor if not already added - skip if no valid VIPER person record
-            if (!context.Preview.NonCrestInstructors.Any(i => i.MothraId == mothraId))
+            if (!addedInstructorMothraIds.Contains(mothraId))
             {
                 if (!viperPersonLookup.TryGetValue(mothraId, out var personId))
                 {
@@ -309,6 +325,7 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
                     continue;
                 }
 
+                addedInstructorMothraIds.Add(mothraId);
                 context.Preview.NonCrestInstructors.Add(new HarvestPersonPreview
                 {
                     MothraId = mothraId,
@@ -342,9 +359,56 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
             });
         }
 
+        AddEmeritusExclusionWarning(context, PhaseName, excludedInstructors);
+
+        // Restore legacy IOR custodial-dept fallback (legacy Import.cfm Phase 2): when a
+        // non-CREST course's own Banner dept doesn't resolve to an academic department,
+        // inherit the custodial dept from its Director/IOR when that instructor's resolved
+        // department is academic. Without this, such courses harvest as "UNK".
+        ApplyDirectorCustodialDeptFallback(
+            context.Preview.NonCrestCourses, context.Preview.NonCrestEffort, batchDepts);
+
         // Sort instructors
         var sortedInstructors = context.Preview.NonCrestInstructors.OrderBy(i => i.FullName).ToList();
         context.Preview.NonCrestInstructors.Clear();
         context.Preview.NonCrestInstructors.AddRange(sortedInstructors);
+    }
+
+    /// <summary>
+    /// For non-CREST courses whose custodial dept is not one of the academic departments,
+    /// overwrite it with the Director/IOR's resolved department when that is academic.
+    /// Mirrors legacy Import.cfm Phase 2 ("look to the dept of the IOR"). Applies to all
+    /// unit variants of a CRN.
+    /// </summary>
+    internal static void ApplyDirectorCustodialDeptFallback(
+        List<HarvestCoursePreview> courses,
+        List<HarvestRecordPreview> effort,
+        Dictionary<string, string> batchDepts)
+    {
+        var academicDepts = EffortConstants.AcademicDepartments.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Map each CRN to its Director's department, keeping only academic departments.
+        var directorDeptByCrn = effort
+            .Where(e => e.RoleId == EffortConstants.DirectorRoleId && !string.IsNullOrWhiteSpace(e.Crn))
+            .Select(e => new { e.Crn, Dept = batchDepts.GetValueOrDefault(e.MothraId, "UNK") })
+            .Where(x => academicDepts.Contains(x.Dept))
+            .GroupBy(x => x.Crn, StringComparer.OrdinalIgnoreCase)
+            // OrderBy makes the choice deterministic when a CRN has multiple academic IOR depts.
+            .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Dept).First().Dept, StringComparer.OrdinalIgnoreCase);
+
+        if (directorDeptByCrn.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var course in courses
+            .Where(c => c.Source == EffortConstants.SourceNonCrest && !academicDepts.Contains(c.CustDept)))
+        {
+            if (!string.IsNullOrWhiteSpace(course.Crn) &&
+                directorDeptByCrn.TryGetValue(course.Crn, out var iorDept))
+            {
+                course.CustDept = iorDept;
+            }
+        }
     }
 }

--- a/web/Areas/Effort/Services/HarvestService.cs
+++ b/web/Areas/Effort/Services/HarvestService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Viper.Areas.Effort.Constants;
 using Viper.Areas.Effort.Models.DTOs.Responses;
 using Viper.Areas.Effort.Services.Harvest;
@@ -25,6 +26,7 @@ public class HarvestService : IHarvestService
     private readonly IInstructorService _instructorService;
     private readonly IRCourseService _rCourseService;
     private readonly IClinicalImportService _clinicalImportService;
+    private readonly EffortSettings _settings;
     private readonly ILogger<HarvestService> _logger;
 
     public HarvestService(
@@ -40,6 +42,7 @@ public class HarvestService : IHarvestService
         IInstructorService instructorService,
         IRCourseService rCourseService,
         IClinicalImportService clinicalImportService,
+        IOptions<EffortSettings> settings,
         ILogger<HarvestService> logger)
     {
         _phases = phases;
@@ -54,6 +57,7 @@ public class HarvestService : IHarvestService
         _instructorService = instructorService;
         _rCourseService = rCourseService;
         _clinicalImportService = clinicalImportService;
+        _settings = settings.Value;
         _logger = logger;
     }
 
@@ -347,6 +351,14 @@ public class HarvestService : IHarvestService
     /// </summary>
     private async Task GenerateRCoursesForEligibleInstructorsAsync(int termCode, int modifiedBy, CancellationToken ct)
     {
+        if (!_settings.AutoCreateGenericRCourse)
+        {
+            _logger.LogInformation(
+                "Skipping generic R-course generation for term {TermCode} (AutoCreateGenericRCourse disabled)",
+                termCode);
+            return;
+        }
+
         // Find all instructors in the term who have at least one non-R-course effort record
         var eligibleInstructors = await _context.Records
             .AsNoTracking()

--- a/web/Areas/Effort/Services/IInstructorService.cs
+++ b/web/Areas/Effort/Services/IInstructorService.cs
@@ -168,6 +168,14 @@ public interface IInstructorService
     Task<Dictionary<string, string>?> GetDepartmentSimpleNameLookupAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Get a cached set of effort title codes (dvtTitle_Code values) whose title name denotes
+    /// an emeritus or recall appointment, to be excluded from harvest. Empty set if unavailable.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Set of title codes whose names match "EMERITUS" or "RECALL" (e.g. the codes for "PROF EMERITUS" or "RECALL FACULTY").</returns>
+    Task<HashSet<string>> GetExcludedTitleCodesAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Resolve departments for multiple instructors in a single batch.
     /// Uses the full resolution chain (override → jobs → employee fields → fallback).
     /// </summary>

--- a/web/Areas/Effort/Services/InstructorService.cs
+++ b/web/Areas/Effort/Services/InstructorService.cs
@@ -29,6 +29,7 @@ public class InstructorService : IInstructorService
 
     private const string TitleCacheKey = "effort_title_lookup";
     private const string DeptSimpleNameCacheKey = "effort_dept_simple_name_lookup";
+    private const string ExcludedTitleCodesCacheKey = "effort_excluded_title_codes";
 
     /// <summary>
     /// Valid academic department codes.
@@ -1237,6 +1238,56 @@ public class InstructorService : IInstructorService
             _logger.LogWarning(ex, "Failed to load department lookup from dictionary database");
             return null;
         }
+    }
+
+    public async Task<HashSet<string>> GetExcludedTitleCodesAsync(CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue<HashSet<string>>(ExcludedTitleCodesCacheKey, out var cached) && cached != null)
+        {
+            // Return a copy so callers cannot mutate the shared cached instance.
+            return new HashSet<string>(cached, StringComparer.OrdinalIgnoreCase);
+        }
+
+        var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            // Emeritus and recall appointments are excluded from harvest. Match by title name
+            // in dictionary.dbo.dvtTitle (e.g., "PROF EMERITUS(WOS)", "RECALL FACULTY").
+            // ToLower() makes the match case-insensitive: it translates to SQL LOWER(...) LIKE
+            // and also evaluates correctly under the in-memory provider used in tests.
+            var codes = await _dictionaryContext.Titles
+                .AsNoTracking()
+                .Where(t => t.Code != null && t.Name != null &&
+                            (t.Name.ToLower().Contains("emerit") || t.Name.ToLower().Contains("recall")))
+                .Select(t => t.Code!.Trim())
+                .ToListAsync(ct);
+
+            foreach (var code in codes.Where(c => !string.IsNullOrEmpty(c)))
+            {
+                excluded.Add(code);
+            }
+
+            var cacheOptions = new MemoryCacheEntryOptions()
+                .SetSlidingExpiration(TimeSpan.FromHours(24));
+
+            _cache.Set(ExcludedTitleCodesCacheKey, excluded, cacheOptions);
+
+            _logger.LogInformation("Loaded {Count} excluded (emeritus/recall) title codes from dictionary database", excluded.Count);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Fail open: if the lookup is unavailable, harvest proceeds without exclusions
+            // rather than failing outright.
+            _logger.LogWarning(ex, "Failed to load excluded title codes from dictionary database");
+        }
+        catch (DbException ex)
+        {
+            _logger.LogWarning(ex, "Failed to load excluded title codes from dictionary database");
+        }
+
+        // Return a copy so the cached instance is never exposed to callers.
+        return new HashSet<string>(excluded, StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task<List<InstructorEffortRecordDto>> GetInstructorEffortRecordsAsync(


### PR DESCRIPTION
## Summary

Fixes three issues reported after the Winter Quarter 2026, Spring Quarter 2026, and Spring Semester 2026 harvests, plus one configuration request. Root causes were confirmed against the legacy ColdFusion `Import.cfm`/`Course.cfc` and live AAUD data.

## Issues addressed

### 1. Course List custodial department showing UNK (regression)
- **Reported:** Course lists now show custodial dept `UNK` where they previously inherited the assigned faculty member's department (e.g. course `63892` on term `202601`, whose instructor is VME).
- **Root cause:** The legacy non-CREST import resolved custodial dept through *two* fallbacks that the rewritten `NonCrestHarvestPhase` dropped: the `Course.cfc getCustDept` chain (which reads the IOR-resolved `custodial_dept_code` from the `vw_xtnd_baseinfo` view) and the `Import.cfm` instructor-of-record inheritance. The rewrite resolved custodial dept only from the course's own Banner subject/dept code, so non-SVM-subject courses (e.g. `IMM 294`) fell through to `UNK`.
- **Fix:** Restored *both* legacy fallbacks, which are complementary:
  1. **`getCustDept` primary resolution** — `CustodialDepartmentResolver.ResolveWithCustodialCode` maps the IOR-resolved `custodial_dept_code` from `vw_xtnd_baseinfo` when a course's own subject/Banner dept is not one of the six SVM academic departments. Applied in the non-CREST/in-CREST harvest preview and in single-course Banner/manual import, so manual adds match the harvest. The view query is SARGable (`CHAR(5)` CRN match, no column-side `TRIM`, so it can seek the baseinfo index) and selection is deterministic (`OrderBy custodial_dept_code`) for CRNs with multiple instructors.
  2. **`ApplyDirectorCustodialDeptFallback` post-pass** — a course still left non-academic inherits its Director/IOR's resolved department when that department is academic.

  Layer (1) resolves courses that carry a `custodial_dept_code` in the view but have no Director-role effort entry to inherit from; layer (2) catches courses where the view code is null/non-academic but a Director resolves to an academic dept.

### 2. Instructor harvested under UNK instead of their department
- **Reported:** Dr. Christine Johnson (VME) harvested as `UNK`.
- **Root cause:** Data, not code. Her AAUD record for the term has no job and a non-academic home/effort dept (`072016`), so no academic department is derivable; the legacy harvest would also have produced a blank/UNK dept.
- **Fix:** Added a department override (`00129082` to `VME`) in `EffortConstants.DepartmentOverrides`, mirroring the existing Mison (`02493928` to `VSR`) override.

### 3. Recall/emeritus faculty appearing in the harvest
- **Reported:** Recall emeritus faculty had to be manually deleted from each harvest.
- **Root cause:** No exclusion existed; emeritus/recall status is identifiable via `dictionary.dbo.dvtTitle` names (e.g. `RECALL FACULTY`, `PROF EMERITUS`).
- **Fix:** Added `InstructorService.GetExcludedTitleCodesAsync` and excluded matching instructors from all harvest phases (CREST, Non-CREST, Clinical). Excluded instructors are surfaced as a harvest **warning** rather than silently dropped.

### 4. Make the "RES 000R-001" generic course optional (request)
- **Requested:** Don't auto-create the generic resident-teaching placeholder course for now.
- **Fix:** Gated generic R-course creation behind `EffortSettings.AutoCreateGenericRCourse` (default **off**), covering both the harvest post-step (`HarvestService`) and the on-demand path (`EffortRecordService`).

## Verification

- **Backend suite:** 2097 passed / 0 failed. Added override tests (Johnson and Mison), the IOR-fallback unit test, the R-course toggle on/off tests, and 8 `ResolveWithCustodialCode` resolver tests covering the `getCustDept` custodial-code mapping, leading-zero padding, subject/dept precedence, and the UNK fallbacks.
- **Live re-harvest of Winter Quarter 2026 (202601):** Johnson resolves to VME; the three emeritus/recall instructors (Poppenga, Roberts, Sparger) excluded with a warning; no `RES 000R-001` course created. Custodial-dept coverage: with the Director/IOR fallback alone, 64 of 314 non-CREST courses remained UNK; the added `getCustDept` view-column fallback resolves further non-academic-subject courses (e.g. `IMM 294` to PHR). The exact combined UNK count will be confirmed on the next live re-harvest.

## Notes

- Harvest fixes only take effect on **re-harvest** (clear + reimport) of a term.
- Custodial dept is now resolved in two layers: the `getCustDept` view-column code first, then the Director/IOR post-pass for anything still non-academic.
- Emeritus exclusion covers both emeritus and recall titles; it can be narrowed to recall-only by adjusting the dvtTitle name pattern.
- If a non-CREST course's only IOR is an excluded emeritus, that course has no academic IOR to inherit from and remains UNK (consistent with the legacy "inherit only when academic" rule).
