### PR TITLE
fix(computing): release Biorender semaphore permit on invalid email

### DIFF
--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -23,29 +23,30 @@ namespace Viper.Areas.Computing.Services
             var throttler = new SemaphoreSlim(initialCount: 20);
             foreach (var email in emails)
             {
-                await throttler.WaitAsync();
-
                 var emailTrimmed = email.Trim();
                 if (!emailTrimmed.Contains('@'))
                 {
                     emailTrimmed += "@ucdavis.edu";
                 }
-                if (IsValidEmail(emailTrimmed))
+                if (!IsValidEmail(emailTrimmed))
                 {
-                    resultList.Add(
-                        Task.Run(async () =>
-                        {
-                            try
-                            {
-                                return await GetSingleStudent(emailTrimmed);
-                            }
-                            finally
-                            {
-                                throttler.Release();
-                            }
-                        })
-                    );
+                    continue;
                 }
+
+                await throttler.WaitAsync();
+                resultList.Add(
+                    Task.Run(async () =>
+                    {
+                        try
+                        {
+                            return await GetSingleStudent(emailTrimmed);
+                        }
+                        finally
+                        {
+                            throttler.Release();
+                        }
+                    })
+                );
             }
 
             var taskResults = await Task.WhenAll(resultList);


### PR DESCRIPTION
## Summary

Fixes a `SemaphoreSlim` permit leak in the Biorender student lookup that can permanently exhaust the throttler and deadlock the lookup loop.

## The bug

`GetBiorenderStudentInfo` throttles concurrent lookups with a `SemaphoreSlim(20)`. The original control flow acquired a permit before validating the email:

1. `await throttler.WaitAsync()` (acquire a permit)
2. trim and validate the email
3. only **valid** emails get a `Task.Run` whose `finally` calls `throttler.Release()`

An invalid email therefore acquires a permit that is never released, because the only `Release()` lives inside the task that runs solely for valid emails. Permits leak permanently. 20 invalid emails in a row exhaust the semaphore, and the loop then blocks forever on `WaitAsync()`.

## The fix

Move trim and validation ahead of `WaitAsync()` and `continue` on invalid emails, so a permit is only acquired when work is actually scheduled. Every acquired permit is now matched by a `Release()`.

## Notes

Caught in CodeRabbit review of #192 and split out from it, because this is a control-flow correctness fix rather than the dispose-hygiene change #192 covered. Single-file change in `web/Areas/Computing/Services/BiorenderStudentLookup.cs`.
