### PR TITLE
feat(clinsched): permission-gated scheduler views for own-schedule & rotation-specific users

### DIFF
--- a/VueApp/src/ClinicalScheduler/__tests__/clinical-scheduler-home-display.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/clinical-scheduler-home-display.test.ts
@@ -52,7 +52,22 @@ describe("ClinicalSchedulerHome - Display Content", () => {
             })
 
             expect(wrapper.text()).toContain("Schedule clinicians for a specific rotation")
-            expect(wrapper.text()).toContain("Schedule rotations for a specific clinician")
+            expect(wrapper.text()).toContain("Schedule rotations for a clinician")
+        })
+
+        it("shows own-schedule description for own-schedule users", () => {
+            mockPermissionsStore.hasAnyEditPermission = true
+            mockPermissionsStore.hasOnlyOwnSchedulePermission = true
+            mockPermissionsStore.canAccessClinicianView = true
+            mockPermissionsStore.canAccessRotationView = false
+            mockPermissionsStore.clinicianViewLabel = "Edit My Schedule"
+
+            const wrapper = createTestWrapper({
+                component: ClinicalSchedulerHome,
+                router,
+            })
+
+            expect(wrapper.text()).toContain("Schedule your own rotations")
         })
     })
 })

--- a/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-basic.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-basic.test.ts
@@ -4,17 +4,17 @@ import { setupTest, createWrapper, mockErrorResponse, mockSuccessResponse } from
 // Mock services
 vi.mock("../services/clinician-service", () => ({
     ClinicianService: {
-        getClinicians: vi.fn(),
+        getClinicians: vi.fn<(...args: unknown[]) => unknown>(),
     },
 }))
 
 vi.mock("../services/permission-service", () => ({
     PermissionService: {
-        getUserPermissions: vi.fn(),
-        getPermissionSummary: vi.fn(),
-        canEditService: vi.fn(),
-        canEditRotation: vi.fn(),
-        canEditOwnSchedule: vi.fn(),
+        getUserPermissions: vi.fn<(...args: unknown[]) => unknown>(),
+        getPermissionSummary: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditService: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditRotation: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditOwnSchedule: vi.fn<(...args: unknown[]) => unknown>(),
     },
     permissionService: {},
 }))
@@ -31,6 +31,42 @@ describe("ClinicianSelector - Basic Functionality", () => {
 
             expect(wrapper.find(".q-select").exists()).toBeTruthy()
             expect(wrapper.find(".own-schedule-display").exists()).toBeFalsy()
+        })
+
+        it("renders read-only display and auto-selects if there is only 1 clinician", async () => {
+            const singleClinician = {
+                mothraId: "12345",
+                fullName: "Smith, John",
+                firstName: "John",
+                lastName: "Smith",
+            }
+            mockSuccessResponse([singleClinician])
+
+            const wrapper = createWrapper({
+                isOwnScheduleOnly: false,
+                showAffiliatesToggle: true,
+                modelValue: null,
+            })
+
+            // Fetch to trigger the list loading
+            await (wrapper.vm as any).fetchClinicians()
+            await wrapper.vm.$nextTick()
+
+            // It should auto-select the clinician
+            const emittedUpdate = wrapper.emitted("update:modelValue")?.[0]?.[0] as any
+            expect(emittedUpdate).toStrictEqual(singleClinician)
+
+            const emittedChange = wrapper.emitted("change")?.[0]?.[0] as any
+            expect(emittedChange).toStrictEqual(singleClinician)
+
+            // It should render select without readonly class/attribute instead of own-schedule-display
+            expect(wrapper.find(".own-schedule-display").exists()).toBeFalsy()
+            const select = wrapper.find(".q-select")
+            expect(select.exists()).toBeTruthy()
+            expect(select.classes()).not.toContain("q-field--readonly")
+
+            // The affiliates toggle should remain visible for admins
+            expect(wrapper.find(".affiliates-toggle-under-field").exists()).toBeTruthy()
         })
     })
 
@@ -54,16 +90,14 @@ describe("ClinicianSelector - Basic Functionality", () => {
         ])("fetches clinicians $name", async ({ props, expected }) => {
             const wrapper = createWrapper(props)
 
-            // For tests with year, wait for auto-fetch
-            if (props.year) {
-                await vi.waitFor(() => {
-                    expect(ClinicianService.getClinicians).toHaveBeenCalledWith(expected)
-                })
-            } else {
-                // Manual trigger for tests without year
+            // Tests without a year do not auto-fetch, so trigger the load manually.
+            if (!props.year) {
                 await (wrapper.vm as any).fetchClinicians()
-                expect(ClinicianService.getClinicians).toHaveBeenCalledWith(expected)
             }
+
+            await vi.waitFor(() => {
+                expect(ClinicianService.getClinicians).toHaveBeenCalledWith(expected)
+            })
         })
 
         it("loads and displays clinicians", async () => {

--- a/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-basic.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-basic.test.ts
@@ -33,7 +33,7 @@ describe("ClinicianSelector - Basic Functionality", () => {
             expect(wrapper.find(".own-schedule-display").exists()).toBeFalsy()
         })
 
-        it("renders read-only display and auto-selects if there is only 1 clinician", async () => {
+        it("does not auto-select the sole clinician for non-own-schedule users", async () => {
             const singleClinician = {
                 mothraId: "12345",
                 fullName: "Smith, John",
@@ -52,14 +52,12 @@ describe("ClinicianSelector - Basic Functionality", () => {
             await (wrapper.vm as any).fetchClinicians()
             await wrapper.vm.$nextTick()
 
-            // It should auto-select the clinician
-            const emittedUpdate = wrapper.emitted("update:modelValue")?.[0]?.[0] as any
-            expect(emittedUpdate).toStrictEqual(singleClinician)
+            // A non-own-schedule user (e.g. the RotationScheduler add-clinician picker)
+            // must not have the clinician staged without an explicit action.
+            expect(wrapper.emitted("update:modelValue")).toBeUndefined()
+            expect(wrapper.emitted("change")).toBeUndefined()
 
-            const emittedChange = wrapper.emitted("change")?.[0]?.[0] as any
-            expect(emittedChange).toStrictEqual(singleClinician)
-
-            // It should render select without readonly class/attribute instead of own-schedule-display
+            // The select stays interactive (not locked to read-only)
             expect(wrapper.find(".own-schedule-display").exists()).toBeFalsy()
             const select = wrapper.find(".q-select")
             expect(select.exists()).toBeTruthy()

--- a/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-permissions.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-permissions.test.ts
@@ -1,19 +1,20 @@
-import { setupTest, createWrapper } from "./clinician-selector-helpers"
+import { setupTest, createWrapper, mockSuccessResponse } from "./clinician-selector-helpers"
+import { usePermissionsStore } from "../stores/permissions"
 
 // Mock services
 vi.mock("../services/clinician-service", () => ({
     ClinicianService: {
-        getClinicians: vi.fn(),
+        getClinicians: vi.fn<(...args: unknown[]) => unknown>(),
     },
 }))
 
 vi.mock("../services/permission-service", () => ({
     PermissionService: {
-        getUserPermissions: vi.fn(),
-        getPermissionSummary: vi.fn(),
-        canEditService: vi.fn(),
-        canEditRotation: vi.fn(),
-        canEditOwnSchedule: vi.fn(),
+        getUserPermissions: vi.fn<(...args: unknown[]) => unknown>(),
+        getPermissionSummary: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditService: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditRotation: vi.fn<(...args: unknown[]) => unknown>(),
+        canEditOwnSchedule: vi.fn<(...args: unknown[]) => unknown>(),
     },
     permissionService: {},
 }))
@@ -61,6 +62,36 @@ describe("ClinicianSelector - Permission Scenarios", () => {
             })
 
             await wrapper.vm.$nextTick()
+            expect(wrapper.find(".affiliates-toggle-under-field").exists()).toBeFalsy()
+        })
+
+        it("locks selector to read-only when user has only own schedule permission and 1 clinician is returned", async () => {
+            const singleClinician = {
+                mothraId: "12345",
+                fullName: "Smith, John",
+                firstName: "John",
+                lastName: "Smith",
+            }
+            mockSuccessResponse([singleClinician])
+
+            const store = usePermissionsStore()
+            vi.spyOn(store, "hasOnlyOwnSchedulePermission", "get").mockReturnValue(true)
+
+            const wrapper = createWrapper({
+                isOwnScheduleOnly: false,
+                showAffiliatesToggle: true,
+                modelValue: null,
+            })
+
+            await (wrapper.vm as any).fetchClinicians()
+            await wrapper.vm.$nextTick()
+
+            // The select should be read-only
+            const select = wrapper.find(".q-select")
+            expect(select.exists()).toBeTruthy()
+            expect(select.classes()).toContain("q-field--readonly")
+
+            // The affiliates toggle should be hidden
             expect(wrapper.find(".affiliates-toggle-under-field").exists()).toBeFalsy()
         })
     })

--- a/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-permissions.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/clinician-selector-permissions.test.ts
@@ -65,7 +65,7 @@ describe("ClinicianSelector - Permission Scenarios", () => {
             expect(wrapper.find(".affiliates-toggle-under-field").exists()).toBeFalsy()
         })
 
-        it("locks selector to read-only when user has only own schedule permission and 1 clinician is returned", async () => {
+        it("locks selector to read-only and auto-selects once when user has only own schedule permission and 1 clinician is returned", async () => {
             const singleClinician = {
                 mothraId: "12345",
                 fullName: "Smith, John",
@@ -93,6 +93,57 @@ describe("ClinicianSelector - Permission Scenarios", () => {
 
             // The affiliates toggle should be hidden
             expect(wrapper.find(".affiliates-toggle-under-field").exists()).toBeFalsy()
+
+            // The sole clinician is auto-selected exactly once (no duplicate emits)
+            expect(wrapper.emitted("update:modelValue")).toHaveLength(1)
+            expect(wrapper.emitted("update:modelValue")?.[0]?.[0]).toStrictEqual(singleClinician)
+            expect(wrapper.emitted("change")).toHaveLength(1)
+            expect(wrapper.emitted("change")?.[0]?.[0]).toStrictEqual(singleClinician)
+        })
+
+        it("auto-selects the current user exactly once when isOwnScheduleOnly and user is in the list", async () => {
+            const ownUser = {
+                mothraId: "12345",
+                fullName: "Smith, John",
+                firstName: "John",
+                lastName: "Smith",
+            }
+            const otherClinician = {
+                mothraId: "67890",
+                fullName: "Doe, Jane",
+                firstName: "Jane",
+                lastName: "Doe",
+            }
+            mockSuccessResponse([ownUser, otherClinician])
+
+            const store = usePermissionsStore()
+            vi.spyOn(store, "userPermissions", "get").mockReturnValue({
+                user: { mothraId: "12345", displayName: "John Smith" },
+                permissions: {
+                    hasAdminPermission: false,
+                    hasManagePermission: false,
+                    hasEditClnSchedulesPermission: false,
+                    hasEditOwnSchedulePermission: true,
+                    servicePermissions: {},
+                    editableServiceCount: 0,
+                },
+                editableServices: [],
+            } as any)
+
+            const wrapper = createWrapper({
+                isOwnScheduleOnly: true,
+                modelValue: null,
+            })
+
+            await (wrapper.vm as any).fetchClinicians()
+            await wrapper.vm.$nextTick()
+
+            // Own-schedule block narrows the list to the current user, then the
+            // single-clinician auto-select emits exactly once (no duplicate update:modelValue).
+            expect(wrapper.emitted("update:modelValue")).toHaveLength(1)
+            expect(wrapper.emitted("update:modelValue")?.[0]?.[0]).toStrictEqual(ownUser)
+            expect(wrapper.emitted("change")).toHaveLength(1)
+            expect(wrapper.emitted("change")?.[0]?.[0]).toStrictEqual(ownUser)
         })
     })
 

--- a/VueApp/src/ClinicalScheduler/__tests__/rotation-selector-clinician-reactivity.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/rotation-selector-clinician-reactivity.test.ts
@@ -1,0 +1,66 @@
+import { mount, flushPromises } from "@vue/test-utils"
+import { setActivePinia, createPinia } from "pinia"
+import { Quasar } from "quasar"
+
+import RotationSelector from "../components/RotationSelector.vue"
+import { RotationService } from "../services/rotation-service"
+import { usePermissionsStore } from "../stores/permissions"
+
+vi.mock("../services/rotation-service", () => ({
+    RotationService: {
+        getRotations: vi.fn<(...args: unknown[]) => unknown>(),
+        getRotationsWithScheduledWeeks: vi.fn<(...args: unknown[]) => unknown>(),
+    },
+}))
+
+const emptyOk = { success: true, result: [], errors: [] }
+
+function mountSelector(props: Record<string, unknown> = {}) {
+    return mount(RotationSelector, {
+        props,
+        global: { plugins: [[Quasar, {}]] },
+    })
+}
+
+describe("RotationSelector - clinician self-scheduling reactivity", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        vi.clearAllMocks()
+        // Skip the store's network init; the plain rotations path does not read permissions client-side.
+        const store = usePermissionsStore()
+        vi.spyOn(store, "initialize").mockResolvedValue()
+        vi.mocked(RotationService.getRotations).mockResolvedValue(emptyOk)
+        vi.mocked(RotationService.getRotationsWithScheduledWeeks).mockResolvedValue(emptyOk)
+    })
+
+    it("forwards clinicianMothraId to the all-rotations endpoint (legacy: every active rotation)", async () => {
+        mountSelector({ onlyWithScheduledWeeks: false, clinicianMothraId: "111" })
+        await flushPromises()
+
+        expect(RotationService.getRotations).toHaveBeenCalledWith(expect.objectContaining({ clinicianMothraId: "111" }))
+        expect(RotationService.getRotationsWithScheduledWeeks).not.toHaveBeenCalled()
+    })
+
+    it("forwards clinicianMothraId to the scheduled-weeks endpoint when that mode is on", async () => {
+        mountSelector({ onlyWithScheduledWeeks: true, clinicianMothraId: "111", year: 2026 })
+        await flushPromises()
+
+        expect(RotationService.getRotationsWithScheduledWeeks).toHaveBeenCalledWith(
+            expect.objectContaining({ clinicianMothraId: "111" }),
+        )
+    })
+
+    it("refetches when clinicianMothraId changes", async () => {
+        const wrapper = mountSelector({ onlyWithScheduledWeeks: false, clinicianMothraId: "111" })
+        await flushPromises()
+        expect(RotationService.getRotations).toHaveBeenCalledOnce()
+
+        await wrapper.setProps({ clinicianMothraId: "222" })
+        await flushPromises()
+
+        expect(RotationService.getRotations).toHaveBeenCalledTimes(2)
+        expect(RotationService.getRotations).toHaveBeenLastCalledWith(
+            expect.objectContaining({ clinicianMothraId: "222" }),
+        )
+    })
+})

--- a/VueApp/src/ClinicalScheduler/__tests__/rotation-selector-clinician-reactivity.test.ts
+++ b/VueApp/src/ClinicalScheduler/__tests__/rotation-selector-clinician-reactivity.test.ts
@@ -63,4 +63,53 @@ describe("RotationSelector - clinician self-scheduling reactivity", () => {
             expect.objectContaining({ clinicianMothraId: "222" }),
         )
     })
+
+    it("ignores a stale response that resolves after a newer request's response", async () => {
+        let resolveFirst!: (value: any) => void
+        let resolveSecond!: (value: any) => void
+
+        const firstCall = new Promise<typeof emptyOk>((resolve) => {
+            resolveFirst = resolve
+        })
+        const secondCall = new Promise<typeof emptyOk>((resolve) => {
+            resolveSecond = resolve
+        })
+
+        vi.mocked(RotationService.getRotations).mockReturnValueOnce(firstCall).mockReturnValueOnce(secondCall)
+
+        const wrapper = mountSelector({ onlyWithScheduledWeeks: false, clinicianMothraId: "111" })
+        await flushPromises()
+
+        // Trigger the second (newer) request before the first has resolved.
+        await wrapper.setProps({ clinicianMothraId: "222" })
+        await flushPromises()
+
+        expect(RotationService.getRotations).toHaveBeenCalledTimes(2)
+
+        const rotationA = {
+            rotId: 1,
+            name: "Rotation A (stale)",
+            abbreviation: "A",
+        }
+        const rotationB = {
+            rotId: 2,
+            name: "Rotation B (fresh)",
+            abbreviation: "B",
+        }
+
+        // Resolve the newer request first, then the stale one after.
+        resolveSecond({ success: true, result: [rotationB], errors: [] })
+        await flushPromises()
+
+        resolveFirst({ success: true, result: [rotationA], errors: [] })
+        await flushPromises()
+
+        const vm = wrapper.vm as unknown as {
+            filteredRotations: { rotId: number; name?: string }[]
+        }
+
+        expect(vm.filteredRotations).toHaveLength(1)
+        expect(vm.filteredRotations[0]?.rotId).toBe(rotationB.rotId)
+        expect(vm.filteredRotations.some((r) => r.rotId === rotationA.rotId)).toBeFalsy()
+    })
 })

--- a/VueApp/src/ClinicalScheduler/components/ClinicianSelector.vue
+++ b/VueApp/src/ClinicalScheduler/components/ClinicianSelector.vue
@@ -9,13 +9,9 @@
                 dense
                 filled
                 class="own-schedule-field"
-                for="clinician-selector-own-display"
             >
                 <template #control>
-                    <div
-                        id="clinician-selector-own-display"
-                        class="self-center full-width no-outline q-pa-xs"
-                    >
+                    <div class="self-center full-width no-outline q-pa-xs">
                         <div class="text-body1">
                             {{ props.modelValue?.fullName || "Loading..." }}
                         </div>
@@ -190,6 +186,13 @@ const isSingleClinicianReadOnly = computed(() => {
     )
 })
 
+// Auto-select is only appropriate for own-schedule contexts (a user scheduling
+// themselves). Admins/service schedulers must never have a clinician staged
+// without an explicit action (e.g. RotationScheduleView's add-clinician picker).
+const isOwnScheduleContext = computed(() => {
+    return props.isOwnScheduleOnly || permissionsStore.hasOnlyOwnSchedulePermission
+})
+
 // Methods
 const fetchClinicians = async () => {
     loading.value = true
@@ -226,11 +229,6 @@ const fetchClinicians = async () => {
                 if (userClinician) {
                     // User found in clinicians list
                     validClinicians = [userClinician]
-
-                    // Auto-select the current user immediately if not already selected
-                    if (!props.modelValue) {
-                        emit("update:modelValue", userClinician)
-                    }
                 } else {
                     // User not found - create a synthetic clinician entry
                     const syntheticClinician = {
@@ -240,19 +238,16 @@ const fetchClinicians = async () => {
                         lastName: currentUserDisplayName?.split(" ").slice(1).join(" ") || "",
                     }
                     validClinicians = [syntheticClinician]
-
-                    // Auto-select the synthetic user immediately
-                    if (!props.modelValue) {
-                        emit("update:modelValue", syntheticClinician)
-                    }
                 }
+                // Emitting is handled by the single-clinician auto-select block below,
+                // so a single fetch emits update:modelValue/change at most once.
             }
 
             clinicians.value = validClinicians
             filteredClinicians.value = validClinicians
 
-            // If there is only 1 clinician in the list, auto-select it and emit the change
-            if (validClinicians.length === 1) {
+            // Auto-select the sole clinician (own-schedule contexts only, see isOwnScheduleContext)
+            if (isOwnScheduleContext.value && validClinicians.length === 1) {
                 const singleClinician = validClinicians[0]
                 if (!props.modelValue || props.modelValue.mothraId !== singleClinician.mothraId) {
                     emit("update:modelValue", singleClinician)

--- a/VueApp/src/ClinicalScheduler/components/ClinicianSelector.vue
+++ b/VueApp/src/ClinicalScheduler/components/ClinicianSelector.vue
@@ -9,9 +9,13 @@
                 dense
                 filled
                 class="own-schedule-field"
+                for="clinician-selector-own-display"
             >
                 <template #control>
-                    <div class="self-center full-width no-outline q-pa-xs">
+                    <div
+                        id="clinician-selector-own-display"
+                        class="self-center full-width no-outline q-pa-xs"
+                    >
                         <div class="text-body1">
                             {{ props.modelValue?.fullName || "Loading..." }}
                         </div>
@@ -32,15 +36,15 @@
             :loading="loading"
             :error="!!error"
             :error-message="error || undefined"
-            placeholder="Search for a clinician..."
+            :placeholder="isSingleClinicianReadOnly ? '' : 'Search for a clinician...'"
             emit-value
             map-options
-            :use-input="!props.includeAllAffiliates"
-            :fill-input="!props.includeAllAffiliates"
-            :hide-selected="!props.includeAllAffiliates"
+            :use-input="!props.includeAllAffiliates && !isSingleClinicianReadOnly"
+            :fill-input="!props.includeAllAffiliates && !isSingleClinicianReadOnly"
+            :hide-selected="!props.includeAllAffiliates && !isSingleClinicianReadOnly"
             option-label="fullName"
             option-value="mothraId"
-            clearable
+            :clearable="!isSingleClinicianReadOnly"
             dense
             options-dense
             :input-debounce="100"
@@ -48,9 +52,11 @@
             @popup-show="onPopupShow"
             @update:model-value="onClinicianChange"
             :virtual-scroll-slice-size="50"
+            :readonly="isSingleClinicianReadOnly"
+            :hide-dropdown-icon="isSingleClinicianReadOnly"
         >
             <template #prepend>
-                <q-icon name="search" />
+                <q-icon :name="isSingleClinicianReadOnly ? 'person' : 'search'" />
             </template>
 
             <template #no-option>
@@ -96,7 +102,7 @@
 
         <!-- Include All Affiliates Toggle -->
         <div
-            v-if="showAffiliatesToggle && !props.isOwnScheduleOnly"
+            v-if="showAffiliatesToggle && !isSingleClinicianReadOnly"
             class="affiliates-toggle-under-field"
         >
             <q-checkbox
@@ -177,6 +183,13 @@ const selectedClinician = computed({
     },
 })
 
+const isSingleClinicianReadOnly = computed(() => {
+    return (
+        props.isOwnScheduleOnly ||
+        (permissionsStore.hasOnlyOwnSchedulePermission && (loading.value || clinicians.value.length === 1))
+    )
+})
+
 // Methods
 const fetchClinicians = async () => {
     loading.value = true
@@ -237,6 +250,15 @@ const fetchClinicians = async () => {
 
             clinicians.value = validClinicians
             filteredClinicians.value = validClinicians
+
+            // If there is only 1 clinician in the list, auto-select it and emit the change
+            if (validClinicians.length === 1) {
+                const singleClinician = validClinicians[0]
+                if (!props.modelValue || props.modelValue.mothraId !== singleClinician.mothraId) {
+                    emit("update:modelValue", singleClinician)
+                    emit("change", singleClinician)
+                }
+            }
 
             // Emit event to notify parent that clinicians are loaded
             emit("clinicians-loaded", result.result)

--- a/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
+++ b/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
@@ -81,6 +81,7 @@ interface Props {
     onlyWithScheduledWeeks?: boolean
     excludeRotationNames?: string[] // For filtering out already assigned rotations
     hideBottomSpace?: boolean
+    clinicianMothraId?: string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -90,6 +91,7 @@ const props = withDefaults(defineProps<Props>(), {
     onlyWithScheduledWeeks: false,
     excludeRotationNames: () => [],
     hideBottomSpace: false,
+    clinicianMothraId: null,
 })
 
 // Emits
@@ -133,11 +135,13 @@ async function loadRotations() {
             // Use the new API that only returns rotations with scheduled weeks
             result = await RotationService.getRotationsWithScheduledWeeks({
                 year: props.year || undefined,
+                clinicianMothraId: props.clinicianMothraId || undefined,
             })
         } else {
             // Use the original API that returns all rotations
             result = await RotationService.getRotations({
                 serviceId: props.serviceFilter || undefined,
+                clinicianMothraId: props.clinicianMothraId || undefined,
             })
         }
 

--- a/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
+++ b/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
@@ -112,6 +112,11 @@ const isLoading = ref(false)
 const error = ref<string | null>(null)
 const searchQuery = ref("")
 
+// Guards against out-of-order responses: onMounted plus four prop watches can all
+// trigger loadRotations concurrently, and a slower earlier request could otherwise
+// overwrite a faster later one.
+let latestRequestId = 0
+
 // Computed
 const selectedRotation = computed({
     get: () => {
@@ -125,6 +130,7 @@ const selectedRotation = computed({
 
 // Methods
 async function loadRotations() {
+    const requestId = ++latestRequestId
     isLoading.value = true
     error.value = null
 
@@ -144,6 +150,9 @@ async function loadRotations() {
                 clinicianMothraId: props.clinicianMothraId || undefined,
             })
         }
+
+        // A newer request has since started; this response is stale, so drop it.
+        if (requestId !== latestRequestId) return
 
         if (result.success) {
             // Filter out excluded rotation names and system-excluded rotations
@@ -169,9 +178,12 @@ async function loadRotations() {
             error.value = result.errors.join(", ") || "Failed to load rotations"
         }
     } catch {
+        if (requestId !== latestRequestId) return
         error.value = "An unexpected error occurred while loading rotations"
     } finally {
-        isLoading.value = false
+        if (requestId === latestRequestId) {
+            isLoading.value = false
+        }
     }
 }
 

--- a/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
+++ b/VueApp/src/ClinicalScheduler/components/RotationSelector.vue
@@ -230,6 +230,14 @@ watch(
     },
 )
 
+// Refetch when the target clinician changes so the self-scheduling rotation list stays in sync
+watch(
+    () => props.clinicianMothraId,
+    () => {
+        void loadRotations()
+    },
+)
+
 // Watch for model value changes to clear search
 watch(
     () => props.modelValue,

--- a/VueApp/src/ClinicalScheduler/pages/ClinicalSchedulerHome.vue
+++ b/VueApp/src/ClinicalScheduler/pages/ClinicalSchedulerHome.vue
@@ -105,9 +105,9 @@
                                         class="opacity-70"
                                     />
                                 </div>
-                                <p class="text-grey-8 q-mb-sm">Schedule rotations for a specific clinician</p>
+                                <p class="text-grey-8 q-mb-sm">{{ clinicianViewDescription }}</p>
                                 <q-banner
-                                    v-if="permissionsStore.hasOnlyOwnSchedulePermission"
+                                    v-if="isPersonalClinicianView"
                                     dense
                                     inline-actions
                                     class="text-primary bg-primary-1 rounded-borders"
@@ -158,6 +158,21 @@ const canAccessClinicianView = computed(() => {
     // Available to full access users and own schedule users, but NOT rotation-specific only users
     return permissionsStore.canAccessClinicianView
 })
+
+// True when the clinician view is the personal "Edit My Schedule" variant. This covers both
+// pure own-schedule users (hasOnlyOwnSchedulePermission) and hybrid users who also manage a
+// service but still only edit their own schedule here (hasClinicianViewReadOnly). Together these
+// equal "EditOwnSchedule without full access", the same condition behind clinicianViewLabel, so
+// the card's heading, description, and "your schedule only" banner stay consistent.
+const isPersonalClinicianView = computed(
+    () => permissionsStore.hasOnlyOwnSchedulePermission || permissionsStore.hasClinicianViewReadOnly,
+)
+
+// Card description for the clinician view. The personal edit-my-schedule variant gets clearer
+// copy than the generic "for a clinician" wording.
+const clinicianViewDescription = computed(() =>
+    isPersonalClinicianView.value ? "Schedule your own rotations" : "Schedule rotations for a clinician",
+)
 
 // Methods
 const navigateToRotationView = () => {

--- a/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
+++ b/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
@@ -122,7 +122,6 @@
                             v-model="selectedNewRotationId"
                             :exclude-rotation-names="assignedRotationNames"
                             :only-with-scheduled-weeks="false"
-                            :year="currentYear"
                             :clinician-mothra-id="selectedClinician?.mothraId"
                             hide-bottom-space
                             @rotation-selected="onAddRotationSelected"

--- a/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
+++ b/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
@@ -116,10 +116,12 @@
                     @schedule-selected="handleScheduleSelected"
                 >
                     <template #selector>
+                        <!-- Show all active rotations (mimics the legacy scheduler, which listed every
+                             active rotation) rather than only rotations already scheduled for the year. -->
                         <RotationSelector
                             v-model="selectedNewRotationId"
                             :exclude-rotation-names="assignedRotationNames"
-                            :only-with-scheduled-weeks="true"
+                            :only-with-scheduled-weeks="false"
                             :year="currentYear"
                             :clinician-mothra-id="selectedClinician?.mothraId"
                             hide-bottom-space

--- a/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
+++ b/VueApp/src/ClinicalScheduler/pages/ClinicianScheduleView.vue
@@ -121,6 +121,7 @@
                             :exclude-rotation-names="assignedRotationNames"
                             :only-with-scheduled-weeks="true"
                             :year="currentYear"
+                            :clinician-mothra-id="selectedClinician?.mothraId"
                             hide-bottom-space
                             @rotation-selected="onAddRotationSelected"
                             style="min-width: 280px"

--- a/VueApp/src/ClinicalScheduler/services/rotation-service.ts
+++ b/VueApp/src/ClinicalScheduler/services/rotation-service.ts
@@ -24,13 +24,19 @@ class RotationService {
     /**
      * Get all rotations with optional filtering
      */
-    static async getRotations(options?: { serviceId?: number }): Promise<ApiResult<RotationWithService[]>> {
+    static async getRotations(options?: {
+        serviceId?: number
+        clinicianMothraId?: string
+    }): Promise<ApiResult<RotationWithService[]>> {
         try {
-            const { serviceId } = options || {}
+            const { serviceId, clinicianMothraId } = options || {}
 
             const params: Record<string, string | number | boolean> = {}
             if (typeof serviceId === "number") {
                 params.serviceId = serviceId
+            }
+            if (clinicianMothraId) {
+                params.clinicianMothraId = clinicianMothraId
             }
 
             const url = this.buildUrl(this.BASE_URL, params)
@@ -50,13 +56,17 @@ class RotationService {
      */
     static async getRotationsWithScheduledWeeks(options?: {
         year?: number
+        clinicianMothraId?: string
     }): Promise<ApiResult<RotationWithService[]>> {
         try {
-            const { year } = options || {}
+            const { year, clinicianMothraId } = options || {}
 
             const params: Record<string, string | number | boolean> = {}
             if (typeof year === "number") {
                 params.year = year
+            }
+            if (clinicianMothraId) {
+                params.clinicianMothraId = clinicianMothraId
             }
 
             const url = this.buildUrl(`${this.BASE_URL}/with-scheduled-weeks`, params)

--- a/test/ClinicalScheduler/Integration/ControllerServiceIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/ControllerServiceIntegrationTest.cs
@@ -135,7 +135,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 _rotationService,
                 mockPermissionService,
                 _evaluationPolicyService,
-                mockLogger
+                mockLogger,
+                Substitute.For<IUserHelper>()
             );
 
             controller.ControllerContext = new ControllerContext
@@ -180,7 +181,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 _rotationService,
                 mockPermissionService,
                 _evaluationPolicyService,
-                mockLogger
+                mockLogger,
+                Substitute.For<IUserHelper>()
             );
 
             controller.ControllerContext = new ControllerContext
@@ -221,7 +223,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 mockRotationService,
                 mockPermissionService,
                 mockEvaluationPolicyService,
-                mockLogger
+                mockLogger,
+                Substitute.For<IUserHelper>()
             );
 
             SetupControllerContext(controller);

--- a/test/ClinicalScheduler/RotationsControllerTest.cs
+++ b/test/ClinicalScheduler/RotationsControllerTest.cs
@@ -41,7 +41,8 @@ namespace Viper.test.ClinicalScheduler
                 _mockRotationService,
                 _mockPermissionService,
                 _mockEvaluationPolicyService,
-                _mockLogger);
+                _mockLogger,
+                MockUserHelper);
             var serviceProvider = new ServiceCollection().BuildServiceProvider();
             TestDataBuilder.SetupControllerContext(_controller, serviceProvider);
         }
@@ -245,6 +246,38 @@ namespace Viper.test.ClinicalScheduler
 
             var rotations = ExtractRotationsFromResult(result);
             Assert.Empty(rotations); // Should return empty list when no permissions
+        }
+
+        [Fact]
+        public async Task GetRotations_ForClinician_ReturnsAllRotations()
+        {
+            // Setup: User has EditOwnSchedule permission
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotations(clinicianMothraId: TestUserMothraId);
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Equal(2, rotations.Count()); // Clinician should see all rotations when self-scheduling
+        }
+
+        [Fact]
+        public async Task GetRotations_ForClinicianWithoutMothraId_ReturnsFilteredRotations()
+        {
+            // Setup: User has EditOwnSchedule permission, but calling without specifying clinicianMothraId
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotations();
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations); // Should filter and return empty (since clinician has no service permissions)
         }
 
         #region GetRotationSchedule Security Tests
@@ -479,6 +512,43 @@ namespace Viper.test.ClinicalScheduler
 
             // Assert: Should return all rotations with scheduled weeks
             Assert.IsType<OkObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task GetRotationsWithScheduledWeeks_ForClinician_ReturnsAllRotations()
+        {
+            // Setup: own-schedule user self-scheduling (passes their own mothra ID). They have no
+            // service edit permissions, so without the self-scheduling bypass this list would be empty
+            // (the empty-rotation-dropdown regression). This is the endpoint the "Add New Rotation"
+            // selector actually calls (only-with-scheduled-weeks), so it must be covered directly.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotationsWithScheduledWeeks(TestYear, clinicianMothraId: TestUserMothraId);
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Equal(2, rotations.Count()); // Self-scheduling clinician sees all rotations with scheduled weeks
+        }
+
+        [Fact]
+        public async Task GetRotationsWithScheduledWeeks_ForClinicianWithoutMothraId_ReturnsFilteredRotations()
+        {
+            // Setup: own-schedule user but no clinicianMothraId supplied, so normal service-permission
+            // filtering applies. With no editable services the result is empty - EditOwnSchedule alone
+            // does not bypass filtering unless the caller is self-scheduling.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotationsWithScheduledWeeks(TestYear);
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations);
         }
 
         #endregion

--- a/test/ClinicalScheduler/RotationsControllerTest.cs
+++ b/test/ClinicalScheduler/RotationsControllerTest.cs
@@ -280,6 +280,41 @@ namespace Viper.test.ClinicalScheduler
             Assert.Empty(rotations); // Should filter and return empty (since clinician has no service permissions)
         }
 
+        [Fact]
+        public async Task GetRotations_ForOtherClinician_ReturnsFilteredRotations()
+        {
+            // Security: the self-scheduling bypass must only apply when the caller is looking at their
+            // OWN schedule. A user with EditOwnSchedule must not be able to see all rotations by passing
+            // someone else's clinicianMothraId.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotations(clinicianMothraId: "someoneElse");
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations); // Should filter (bypass must not apply for another clinician's ID)
+        }
+
+        [Fact]
+        public async Task GetRotations_WithoutEditOwnSchedulePermission_ReturnsFilteredRotations()
+        {
+            // Security: passing your own mothraId must not bypass filtering unless the caller actually
+            // holds EditOwnSchedule. Without that permission, the request must still be filtered normally.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(false);
+            SetupUserWithPermissions(TestUserMothraId, Array.Empty<string>());
+            RecreateController();
+
+            var result = await _controller.GetRotations(clinicianMothraId: TestUserMothraId);
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations); // Should filter (no EditOwnSchedule means no bypass, even for own ID)
+        }
+
         #region GetRotationSchedule Security Tests
 
         [Fact]
@@ -549,6 +584,41 @@ namespace Viper.test.ClinicalScheduler
 
             var rotations = ExtractRotationsFromResult(result);
             Assert.Empty(rotations);
+        }
+
+        [Fact]
+        public async Task GetRotationsWithScheduledWeeks_ForOtherClinician_ReturnsFilteredRotations()
+        {
+            // Security: same bypass-scoping check as GetRotations, but for the endpoint the "Add New
+            // Rotation" selector actually calls. A clinicianMothraId that isn't the caller's own must not
+            // grant the unfiltered self-scheduling view.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(true);
+            SetupUserWithPermissions(TestUserMothraId, new[] { ClinicalSchedulePermissions.EditOwnSchedule });
+            RecreateController();
+
+            var result = await _controller.GetRotationsWithScheduledWeeks(TestYear, clinicianMothraId: "someoneElse");
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations); // Should filter (bypass must not apply for another clinician's ID)
+        }
+
+        [Fact]
+        public async Task GetRotationsWithScheduledWeeks_WithoutEditOwnSchedulePermission_ReturnsFilteredRotations()
+        {
+            // Security: without EditOwnSchedule, passing your own mothraId must not unlock the
+            // self-scheduling bypass; normal service-permission filtering must still apply.
+            SetupMockPermissions();
+            _mockPermissionService.HasEditOwnSchedulePermissionAsync(Arg.Any<CancellationToken>())
+                .Returns(false);
+            SetupUserWithPermissions(TestUserMothraId, Array.Empty<string>());
+            RecreateController();
+
+            var result = await _controller.GetRotationsWithScheduledWeeks(TestYear, clinicianMothraId: TestUserMothraId);
+
+            var rotations = ExtractRotationsFromResult(result);
+            Assert.Empty(rotations); // Should filter (no EditOwnSchedule means no bypass, even for own ID)
         }
 
         #endregion

--- a/test/ClinicalScheduler/SchedulePermissionServiceTest.cs
+++ b/test/ClinicalScheduler/SchedulePermissionServiceTest.cs
@@ -408,6 +408,176 @@ namespace Viper.test.ClinicalScheduler
             Assert.False(result);
         }
 
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithManagePermission_ReturnsTrue()
+        {
+            // Arrange
+            SetupUserWithManagePermission();
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithAdminPermission_ReturnsTrue()
+        {
+            // Arrange
+            SetupUserWithAdminPermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithEditClnSchedulesPermission_ReturnsTrue()
+        {
+            // Arrange
+            SetupUserWithEditClnSchedulesPermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithServiceSpecificPermission_ReturnsTrue()
+        {
+            // Arrange - user can edit at least one service (Cardiology)
+            SetupUserWithServiceSpecificPermission(TestUserMothraId, CardiologyEditPermission);
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithOnlyEditOwnSchedulePermission_ReturnsFalse()
+        {
+            // Arrange - own-schedule user with no full access and no editable services
+            // (mirrors a user who has EditOwnSchedule + view permissions but cannot schedule rotations)
+            SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task CanAccessRotationViewAsync_WithNullUser_ReturnsFalse()
+        {
+            // Arrange
+            SetupNullUser();
+
+            // Act
+            var result = await _permissionService.CanAccessRotationViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task CanAccessClinicianViewAsync_WithManagePermission_ReturnsTrue()
+        {
+            // Arrange
+            SetupUserWithManagePermission();
+
+            // Act
+            var result = await _permissionService.CanAccessClinicianViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessClinicianViewAsync_WithEditOwnSchedulePermission_ReturnsTrue()
+        {
+            // Arrange
+            SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.CanAccessClinicianViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanAccessClinicianViewAsync_WithOnlyServiceSpecificPermission_ReturnsFalse()
+        {
+            // Arrange - rotation-specific user (no full access, no EditOwnSchedule) cannot access clinician view
+            SetupUserWithServiceSpecificPermission(TestUserMothraId, CardiologyEditPermission);
+
+            // Act
+            var result = await _permissionService.CanAccessClinicianViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task CanAccessClinicianViewAsync_WithNullUser_ReturnsFalse()
+        {
+            // Arrange
+            SetupNullUser();
+
+            // Act
+            var result = await _permissionService.CanAccessClinicianViewAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetClinicianViewLabelAsync_WithEditOwnScheduleOnly_ReturnsEditMySchedule()
+        {
+            // Arrange - own-schedule user with no full access (the Guzman case)
+            SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.GetClinicianViewLabelAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal("Edit My Schedule", result);
+        }
+
+        [Fact]
+        public async Task GetClinicianViewLabelAsync_WithManagePermission_ReturnsScheduleByClinician()
+        {
+            // Arrange - full access user
+            SetupUserWithManagePermission();
+
+            // Act
+            var result = await _permissionService.GetClinicianViewLabelAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal("Schedule by Clinician", result);
+        }
+
+        [Fact]
+        public async Task GetClinicianViewLabelAsync_WithEditClnSchedulesPermission_ReturnsScheduleByClinician()
+        {
+            // Arrange - full access via EditClnSchedules
+            SetupUserWithEditClnSchedulesPermission(TestUserMothraId);
+
+            // Act
+            var result = await _permissionService.GetClinicianViewLabelAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal("Schedule by Clinician", result);
+        }
+
         // Helper methods for permission setups
 
         private void SetupUserWithAdminPermission(string mothraId)

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -28,7 +28,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             IGradYearService gradYearService, IWeekService weekService, IRotationService rotationService,
             ISchedulePermissionService permissionService, IEvaluationPolicyService evaluationPolicyService,
             ILogger<RotationsController> logger,
-            IUserHelper? userHelper = null)
+            IUserHelper userHelper)
             : base(gradYearService, logger)
         {
             _context = context;
@@ -36,7 +36,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             _rotationService = rotationService;
             _permissionService = permissionService;
             _evaluationPolicyService = evaluationPolicyService;
-            _userHelper = userHelper ?? new UserHelper();
+            _userHelper = userHelper;
         }
 
 

--- a/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/RotationsController.cs
@@ -22,11 +22,13 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
         private readonly IRotationService _rotationService;
         private readonly ISchedulePermissionService _permissionService;
         private readonly IEvaluationPolicyService _evaluationPolicyService;
+        private readonly IUserHelper _userHelper;
 
         public RotationsController(ClinicalSchedulerContext context,
             IGradYearService gradYearService, IWeekService weekService, IRotationService rotationService,
             ISchedulePermissionService permissionService, IEvaluationPolicyService evaluationPolicyService,
-            ILogger<RotationsController> logger)
+            ILogger<RotationsController> logger,
+            IUserHelper? userHelper = null)
             : base(gradYearService, logger)
         {
             _context = context;
@@ -34,6 +36,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             _rotationService = rotationService;
             _permissionService = permissionService;
             _evaluationPolicyService = evaluationPolicyService;
+            _userHelper = userHelper ?? new UserHelper();
         }
 
 
@@ -43,11 +46,12 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
         /// Get all rotations with optional filtering
         /// </summary>
         /// <param name="serviceId">Optional service ID to filter by</param>
+        /// <param name="clinicianMothraId">When it matches the current user's mothra ID, own-schedule users see all rotations (self-scheduling)</param>
         /// <returns>List of rotations</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<RotationDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<IEnumerable<RotationDto>>> GetRotations(int? serviceId = null)
+        public async Task<ActionResult<IEnumerable<RotationDto>>> GetRotations(int? serviceId = null, [FromQuery] string? clinicianMothraId = null)
         {
             if (!ModelState.IsValid)
             {
@@ -63,9 +67,8 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     ? await _rotationService.GetRotationsByServiceAsync(serviceId.Value, HttpContext.RequestAborted)
                     : await _rotationService.GetRotationsAsync(HttpContext.RequestAborted);
 
-                // Filter rotations based on user permissions
-                var allowedServiceIds = await GetAllowedServiceIdsAsync(HttpContext.RequestAborted);
-                var filteredRotations = rotations.Where(r => allowedServiceIds.Contains(r.ServiceId)).ToList();
+                // Filter rotations based on user permissions (self-scheduling own-schedule users see all)
+                var filteredRotations = await FilterRotationsByPermissionAsync(rotations, clinicianMothraId, HttpContext.RequestAborted);
 
                 _logger.LogDebug("Retrieved {Count} rotations, filtered to {FilteredCount} based on permissions",
                     rotations.Count, filteredRotations.Count);
@@ -246,11 +249,12 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
         /// Get rotations that have scheduled weeks for a specific year
         /// </summary>
         /// <param name="year">Year to filter by (optional, defaults to current year)</param>
+        /// <param name="clinicianMothraId">When it matches the current user's mothra ID, own-schedule users see all rotations (self-scheduling)</param>
         /// <returns>List of rotations with scheduled weeks</returns>
         [HttpGet("with-scheduled-weeks")]
         [ProducesResponseType(typeof(IEnumerable<RotationDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<IEnumerable<RotationDto>>> GetRotationsWithScheduledWeeks([FromQuery] int? year = null)
+        public async Task<ActionResult<IEnumerable<RotationDto>>> GetRotationsWithScheduledWeeks([FromQuery] int? year = null, [FromQuery] string? clinicianMothraId = null)
         {
             if (!ModelState.IsValid)
             {
@@ -292,9 +296,8 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                     })
                     .ToListAsync();
 
-                // Filter results based on user permissions
-                var allowedServiceIds = await GetAllowedServiceIdsAsync(HttpContext.RequestAborted);
-                var filteredRotations = rotationsWithSchedules.Where(r => allowedServiceIds.Contains(r.ServiceId)).ToList();
+                // Filter results based on user permissions (self-scheduling own-schedule users see all)
+                var filteredRotations = await FilterRotationsByPermissionAsync(rotationsWithSchedules, clinicianMothraId, HttpContext.RequestAborted);
 
                 _logger.LogInformation("Retrieved {Count} rotations with scheduled weeks for year {Year} (filtered to {FilteredCount})", rotationsWithSchedules.Count, LogSanitizer.SanitizeYear(targetYear), filteredRotations.Count);
                 return Ok(filteredRotations);
@@ -354,6 +357,31 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                 ServiceCount = summary.Count,
                 Services = summary
             });
+        }
+
+        /// <summary>
+        /// Filter a rotation list by the current user's permissions. A self-scheduling own-schedule
+        /// user (identified by passing their own mothra ID) sees the full list so they can add any
+        /// rotation to their own schedule; everyone else is filtered to the services they can edit.
+        /// Shared by GetRotations and GetRotationsWithScheduledWeeks so both paths stay consistent and
+        /// the own-schedule rotation dropdown never silently empties on one endpoint but not the other.
+        /// </summary>
+        private async Task<List<RotationDto>> FilterRotationsByPermissionAsync(
+            List<RotationDto> rotations, string? clinicianMothraId, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(clinicianMothraId))
+            {
+                var currentUser = _userHelper.GetCurrentUser();
+                if (currentUser != null &&
+                    currentUser.MothraId.Equals(clinicianMothraId, StringComparison.OrdinalIgnoreCase) &&
+                    await _permissionService.HasEditOwnSchedulePermissionAsync(cancellationToken))
+                {
+                    return rotations;
+                }
+            }
+
+            var allowedServiceIds = await GetAllowedServiceIdsAsync(cancellationToken);
+            return rotations.Where(r => allowedServiceIds.Contains(r.ServiceId)).ToList();
         }
 
         /// <summary>

--- a/web/Areas/ClinicalScheduler/Services/ClinicalSchedulerNavMenu.cs
+++ b/web/Areas/ClinicalScheduler/Services/ClinicalSchedulerNavMenu.cs
@@ -6,18 +6,20 @@ namespace Viper.Areas.ClinicalScheduler.Services
     public class ClinicalSchedulerNavMenu
     {
         private readonly RAPSContext _rapsContext;
+        private readonly ISchedulePermissionService _permissionService;
 
-        public ClinicalSchedulerNavMenu(RAPSContext context)
+        public ClinicalSchedulerNavMenu(RAPSContext context, ISchedulePermissionService permissionService)
         {
             _rapsContext = context;
+            _permissionService = permissionService;
         }
 
-        public NavMenu Nav()
+        public async Task<NavMenu> Nav(CancellationToken cancellationToken = default)
         {
             var oldViperUrl = HttpHelper.GetOldViperRootURL();
             var userHelper = new UserHelper();
             var user = userHelper.GetCurrentUser();
-            var hasAccess = userHelper.HasPermission(_rapsContext, user, "SVMSecure.ClnSched");
+            var hasAccess = userHelper.HasPermission(_rapsContext, user, ClinicalSchedulePermissions.Base);
 
             var nav = new List<NavMenuItem>
             {
@@ -27,8 +29,21 @@ namespace Viper.Areas.ClinicalScheduler.Services
             if (hasAccess)
             {
                 nav.Add(new NavMenuItem { MenuItemText = "Clinical Scheduler 2.0", MenuItemURL = "~/ClinicalScheduler/" });
-                nav.Add(new NavMenuItem { MenuItemText = "Schedule by Rotation", MenuItemURL = "~/ClinicalScheduler/rotation", IndentLevel = 1 });
-                nav.Add(new NavMenuItem { MenuItemText = "Schedule by Clinician", MenuItemURL = "~/ClinicalScheduler/clinician", IndentLevel = 1 });
+
+                // Only show the sub-views the user can actually open. These checks mirror the
+                // client-side canAccessRotationView / canAccessClinicianView getters so the nav
+                // does not advertise a view that the Vue app will reject with "Access Denied".
+                if (await _permissionService.CanAccessRotationViewAsync(cancellationToken))
+                {
+                    nav.Add(new NavMenuItem { MenuItemText = "Schedule by Rotation", MenuItemURL = "~/ClinicalScheduler/rotation", IndentLevel = 1 });
+                }
+
+                if (await _permissionService.CanAccessClinicianViewAsync(cancellationToken))
+                {
+                    var clinicianLabel = await _permissionService.GetClinicianViewLabelAsync(cancellationToken);
+                    nav.Add(new NavMenuItem { MenuItemText = clinicianLabel, MenuItemURL = "~/ClinicalScheduler/clinician", IndentLevel = 1 });
+                }
+
                 nav.Add(new NavMenuItem { MenuItemText = "Clinical Scheduler 1.0", MenuItemURL = $"{oldViperUrl}/clinicalScheduler/" });
             }
 

--- a/web/Areas/ClinicalScheduler/Services/ISchedulePermissionService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ISchedulePermissionService.cs
@@ -31,6 +31,33 @@ namespace Viper.Areas.ClinicalScheduler.Services
         Task<List<Service>> GetUserEditableServicesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Determine if the current user can access the Schedule by Rotation view.
+        /// Mirrors the client-side canAccessRotationView getter: full access (Admin/Manage/EditClnSchedules),
+        /// or edit permission for at least one service.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>True if the current user can access the rotation scheduling view</returns>
+        Task<bool> CanAccessRotationViewAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Determine if the current user can access the Schedule by Clinician view.
+        /// Mirrors the client-side canAccessClinicianView getter: full access (Admin/Manage/EditClnSchedules),
+        /// or permission to edit their own schedule.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>True if the current user can access the clinician scheduling view</returns>
+        Task<bool> CanAccessClinicianViewAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get the label for the clinician scheduling view link. Mirrors the client-side
+        /// clinicianViewLabel getter: "Edit My Schedule" for users who can only edit their own
+        /// schedule (EditOwnSchedule without full access), otherwise "Schedule by Clinician".
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The display label for the clinician scheduling view</returns>
+        Task<string> GetClinicianViewLabelAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Get current user's effective permissions for all services
         /// </summary>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -52,6 +79,13 @@ namespace Viper.Areas.ClinicalScheduler.Services
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>True if current user can edit their own schedule for this entry</returns>
         Task<bool> CanEditOwnScheduleAsync(int instructorScheduleId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Check if the current user has the EditOwnSchedule permission in general
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>True if current user has EditOwnSchedule permission</returns>
+        Task<bool> HasEditOwnSchedulePermissionAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Check access to student schedules with the given parameters

--- a/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
+++ b/web/Areas/ClinicalScheduler/Services/SchedulePermissionService.cs
@@ -63,6 +63,14 @@ namespace Viper.Areas.ClinicalScheduler.Services
         }
 
         /// <summary>
+        /// Check if the user has permission to edit their own schedule
+        /// </summary>
+        private bool HasEditOwnSchedulePermission(AaudUser user)
+        {
+            return _userHelper.HasPermission(_rapsContext, user, ClinicalSchedulePermissions.EditOwnSchedule);
+        }
+
+        /// <summary>
         /// Check if the current user has edit permissions for a specific service
         /// Enhanced with permission hierarchy (Admin > Manage > EditClnSchedules > Service-specific)
         /// </summary>
@@ -157,6 +165,61 @@ namespace Viper.Areas.ClinicalScheduler.Services
                 _logger.LogError(ex, "Error getting editable services for user {MothraId}", LogSanitizer.SanitizeId(user?.MothraId));
                 return new List<Service>();
             }
+        }
+
+        /// <summary>
+        /// Determine if the current user can access the Schedule by Rotation view.
+        /// Mirrors the client-side canAccessRotationView getter: full access, or edit
+        /// permission for at least one service.
+        /// </summary>
+        public async Task<bool> CanAccessRotationViewAsync(CancellationToken cancellationToken = default)
+        {
+            var user = GetValidatedCurrentUser("checking rotation view access");
+            if (user == null) return false;
+
+            // Full access users can always access the rotation view
+            if (HasFullAccessPermission(user)) return true;
+
+            // Otherwise the user needs edit permission for at least one service
+            var editableServices = await GetUserEditableServicesAsync(cancellationToken);
+            return editableServices.Count > 0;
+        }
+
+        /// <summary>
+        /// Determine if the current user can access the Schedule by Clinician view.
+        /// Mirrors the client-side canAccessClinicianView getter: full access, or
+        /// permission to edit their own schedule.
+        /// </summary>
+        /// <remarks>
+        /// Returns via Task.FromResult since this only performs in-memory permission checks.
+        /// </remarks>
+        public Task<bool> CanAccessClinicianViewAsync(CancellationToken cancellationToken = default)
+        {
+            var user = GetValidatedCurrentUser("checking clinician view access");
+            if (user == null) return Task.FromResult(false);
+
+            var canAccess = HasFullAccessPermission(user) || HasEditOwnSchedulePermission(user);
+            return Task.FromResult(canAccess);
+        }
+
+        /// <summary>
+        /// Get the label for the clinician scheduling view link.
+        /// Mirrors the client-side clinicianViewLabel getter: "Edit My Schedule" for users who can
+        /// only edit their own schedule (EditOwnSchedule without full access), otherwise
+        /// "Schedule by Clinician".
+        /// </summary>
+        /// <remarks>
+        /// Returns via Task.FromResult since this only performs in-memory permission checks.
+        /// </remarks>
+        public Task<string> GetClinicianViewLabelAsync(CancellationToken cancellationToken = default)
+        {
+            var user = GetValidatedCurrentUser("getting clinician view label");
+            var label = user != null
+                        && !HasFullAccessPermission(user)
+                        && HasEditOwnSchedulePermission(user)
+                ? "Edit My Schedule"
+                : "Schedule by Clinician";
+            return Task.FromResult(label);
         }
 
         /// <summary>
@@ -266,6 +329,16 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     LogSanitizer.SanitizeId(user?.MothraId), instructorScheduleId);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Check if the current user has the EditOwnSchedule permission in general
+        /// </summary>
+        public Task<bool> HasEditOwnSchedulePermissionAsync(CancellationToken cancellationToken = default)
+        {
+            var user = GetValidatedCurrentUser("checking EditOwnSchedule permission");
+            if (user == null) return Task.FromResult(false);
+            return Task.FromResult(HasEditOwnSchedulePermission(user));
         }
 
         /// <summary>

--- a/web/Controllers/LayoutController.cs
+++ b/web/Controllers/LayoutController.cs
@@ -13,6 +13,7 @@ namespace Viper.Controllers
     {
         private readonly RAPSContext _context;
         private readonly VIPERContext _viperContext;
+        private readonly ISchedulePermissionService _schedulePermissionService;
 
         private readonly List<string[]> links = new()
         {
@@ -38,10 +39,11 @@ namespace Viper.Controllers
             new[] { "https://ucdsvm.knowledgeowl.com/help", "", "", "Help" }
         };
 
-        public LayoutController(RAPSContext context, VIPERContext viperContext)
+        public LayoutController(RAPSContext context, VIPERContext viperContext, ISchedulePermissionService schedulePermissionService)
         {
             _context = context;
             _viperContext = viperContext;
+            _schedulePermissionService = schedulePermissionService;
         }
 
         [HttpGet("topnav")]
@@ -77,7 +79,7 @@ namespace Viper.Controllers
         }
 
         [HttpGet("leftnav")]
-        public ActionResult<NavMenu> GetLeftNav(bool area = true, string nav = "viper-home")
+        public async Task<ActionResult<NavMenu>> GetLeftNav(bool area = true, string nav = "viper-home")
         {
             NavMenu? menu = null;
             if (area)
@@ -92,7 +94,7 @@ namespace Viper.Controllers
                         break;
                     case "viper-clinical-scheduler":
                     case "clinicalscheduler":
-                        menu = new ClinicalSchedulerNavMenu(_context).Nav();
+                        menu = await new ClinicalSchedulerNavMenu(_context, _schedulePermissionService).Nav(HttpContext.RequestAborted);
                         break;
                 }
                 if (menu != null)


### PR DESCRIPTION
## Summary
Permission-gates the Clinical Scheduler so the UI only surfaces the views a user can actually use, and lets `EditOwnSchedule` users manage their own rotations.

- **Own-schedule users** see a single "Edit My Schedule" card; the clinician selector is read-only, pre-populated with themselves; the clinicians API returns only them.
- **Rotation-specific users** see only "Schedule by Rotation" limited to their permitted rotations; the clinician view is hard-denied.
- Nav and home cards only advertise views the user can open (server-side checks mirror the client getters), with a dynamic "Edit My Schedule" label.

## Commits
1. `add view-access and own-schedule permission checks` - new permission-service methods + unit tests.
2. `gate nav and home cards by scheduler permissions` - nav menu + home cards + async left-nav.
3. `let own-schedule users self-schedule all rotations` - rotations API bypass for self-scheduling (fixes the empty "Add Rotation" dropdown). The bypass is DRY'd into one shared helper covering both the plain and `with-scheduled-weeks` endpoints, each with a regression test so the empty-dropdown cannot return on either path.
4. `make clinician selector read-only in own-schedule mode` - read-only single-clinician display + auto-select.

## Testing
- Backend + frontend unit tests pass (pre-commit gate green on every commit).
- Manually smoke-tested via user emulation: own-schedule and rotation-specific flows.