### PR TITLE
feat(tooling): add Jenkins build status checker

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -36,7 +36,8 @@ while read local_ref local_sha remote_ref remote_sha; do
         # Credentials passed via stdin to avoid exposure in process listings
         (
             sleep 10
-            curl -s -X POST --ssl-revoke-best-effort --config - <<EOF
+            # -k: skip TLS verification for the internal Jenkins self-signed cert (interim until the CA is trusted)
+            curl -s -k -X POST --ssl-revoke-best-effort --config - <<EOF
 user = "${JENKINS_USER}:${JENKINS_API_TOKEN}"
 url = "${JENKINS_URL}?token=${JENKINS_JOB_TOKEN}&Branch=Development&cause=Git+push+to+Development"
 EOF

--- a/README.md
+++ b/README.md
@@ -314,6 +314,17 @@ When you next push to `Development`, the hook waits about 10 seconds so the push
 lands first, then triggers the parameterized Jenkins job in the background.
 Credentials stay in `.env.local`, which is not tracked by git.
 
+**Checking build status:**
+
+The same Jenkins credentials power a build status checker:
+
+- `npm run jenkins:status` - one-shot status of the deploy job's latest build
+- `npm run jenkins:watch` - poll an in-progress build until it finishes
+
+Both report the build number, result, and live progress. The internal Jenkins
+uses a self-signed cert, which these tools (and the pre-push trigger) currently
+skip verifying, pending a trusted certificate.
+
 ## Email Testing with Mailpit
 
 Mailpit captures emails sent by the application during development without sending real emails.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "mailpit:start": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js start",
         "mailpit:status": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js status",
         "mailpit:stop": "node --env-file-if-exists=.env.local scripts/manage-mailpit.js stop",
+        "jenkins:status": "node --env-file-if-exists=.env.local scripts/jenkins-status.js",
+        "jenkins:watch": "node --env-file-if-exists=.env.local scripts/jenkins-status.js --watch",
         "merge": "node scripts/merge-to-dev.js",
         "precommit": "node scripts/precommit.js",
         "prepare": "husky",

--- a/scripts/jenkins-status.js
+++ b/scripts/jenkins-status.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/* oxlint-disable no-await-in-loop -- Polling intentionally awaits each cycle sequentially */
+
+// Jenkins deploy build status checker. Reports the current/last build for the
+// deploy job and, with --watch, polls an in-progress build until it finishes.
+// Ignores the internal Jenkins self-signed cert (rejectUnauthorized: false) —
+// interim until the CA is trusted. Reads JENKINS_URL/USER/API_TOKEN from the
+// environment (loaded via --env-file-if-exists=.env.local) or from .env.local.
+//
+// Usage:
+//   node scripts/jenkins-status.js           # one-shot status
+//   node scripts/jenkins-status.js --watch    # poll until the active build ends
+
+const fs = require("node:fs")
+const path = require("node:path")
+const https = require("node:https")
+
+const POLL_INTERVAL_MS = 10_000
+const MS_PER_SEC = 1000
+const PERCENT_SCALE = 100
+const PROGRESS_CAP = 99
+const HTTP_OK = 200
+const HTTP_REDIRECT_MIN = 300
+const HTTP_REDIRECT_MAX = 400
+const MAX_REDIRECTS = 5
+const REQUEST_TIMEOUT_MS = 15_000
+
+const ENV_FILE = path.join(__dirname, "..", ".env.local")
+const BUILD_FIELDS = "number,building,result,timestamp,estimatedDuration,duration"
+const TREE = `inQueue,queueItem[why],lastBuild[${BUILD_FIELDS}]`
+
+const sleep = (ms) =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms)
+    })
+
+// Prefer process.env (npm --env-file), fall back to parsing .env.local directly
+// so the script also works when invoked as `node scripts/jenkins-status.js`.
+function loadJenkinsEnv() {
+    const { env: baseEnv } = process
+    const env = { ...baseEnv }
+    if (fs.existsSync(ENV_FILE)) {
+        for (const line of fs.readFileSync(ENV_FILE, "utf8").split(/\r?\n/u)) {
+            const match = line.match(/^\s*(?<key>JENKINS_[A-Z_]+)\s*=\s*(?<value>.*?)\s*$/u)
+            if (match && !env[match.groups.key]) {
+                env[match.groups.key] = match.groups.value.replaceAll(/^["']|["']$/gu, "")
+            }
+        }
+    }
+    const url = env.JENKINS_URL
+    const user = env.JENKINS_USER
+    const token = env.JENKINS_API_TOKEN
+    if (!url || !user || !token) {
+        console.error("❌ Missing JENKINS_URL / JENKINS_USER / JENKINS_API_TOKEN (set them in .env.local).")
+        process.exit(1)
+    }
+    return { url, user, token }
+}
+
+// Job root is the trigger URL minus its trailing /build or /buildWithParameters action.
+function jobUrlFromTrigger(triggerUrl) {
+    return triggerUrl.replace(/\/(?:buildWithParameters|build)\/?$/u, "")
+}
+
+function getJson(url, auth, redirects = 0) {
+    return new Promise((resolve, reject) => {
+        const request = https.request(
+            new URL(url),
+            {
+                method: "GET",
+                timeout: REQUEST_TIMEOUT_MS,
+                rejectUnauthorized: false, // Internal Jenkins uses a self-signed cert
+                headers: { Authorization: `Basic ${Buffer.from(auth).toString("base64")}` },
+            },
+            (res) => {
+                if (res.statusCode >= HTTP_REDIRECT_MIN && res.statusCode < HTTP_REDIRECT_MAX && res.headers.location) {
+                    res.resume()
+                    if (redirects >= MAX_REDIRECTS) {
+                        reject(new Error(`Too many redirects (> ${MAX_REDIRECTS}) from Jenkins`))
+                        return
+                    }
+                    resolve(getJson(new URL(res.headers.location, url).toString(), auth, redirects + 1))
+                    return
+                }
+                let body = ""
+                res.on("data", (chunk) => {
+                    body += chunk
+                })
+                res.on("end", () => {
+                    if (res.statusCode !== HTTP_OK) {
+                        reject(new Error(`HTTP ${res.statusCode} from Jenkins`))
+                        return
+                    }
+                    try {
+                        resolve(JSON.parse(body))
+                    } catch {
+                        reject(new Error("Non-JSON response from Jenkins"))
+                    }
+                })
+            },
+        )
+        request.on("timeout", () => {
+            request.destroy(new Error(`Jenkins request timed out after ${REQUEST_TIMEOUT_MS / MS_PER_SEC}s`))
+        })
+        request.on("error", reject)
+        request.end()
+    })
+}
+
+// Turn the job JSON into a one-line status plus a done flag for the watch loop.
+function describe(job) {
+    const build = job.lastBuild || {}
+    if (job.inQueue) {
+        const why = job.queueItem && job.queueItem.why ? ` (${job.queueItem.why})` : ""
+        return { done: false, text: `⏳ Queued${why}` }
+    }
+    if (build.building) {
+        const elapsed = Date.now() - build.timestamp
+        const estimated = build.estimatedDuration > 0 ? build.estimatedDuration : 0
+        const pct = estimated ? Math.min(PROGRESS_CAP, Math.round((elapsed / estimated) * PERCENT_SCALE)) : "?"
+        const estText = estimated ? `${Math.round(estimated / MS_PER_SEC)}s` : "unknown"
+        const elapsedText = `${Math.round(elapsed / MS_PER_SEC)}s`
+        return { done: false, text: `🔨 Building #${build.number} — ~${pct}% (${elapsedText} / est ${estText})` }
+    }
+    if (build.number) {
+        const icon = build.result === "SUCCESS" ? "✅" : "❌"
+        return {
+            done: true,
+            text: `${icon} Last build #${build.number}: ${build.result} (${Math.round((build.duration || 0) / MS_PER_SEC)}s)`,
+        }
+    }
+    return { done: true, text: "No builds found for this job." }
+}
+
+async function checkOnce(jobApi, auth) {
+    const job = await getJson(jobApi, auth)
+    const status = describe(job)
+    console.log(`${new Date().toLocaleTimeString()}  ${status.text}`)
+    return status.done
+}
+
+async function main() {
+    const watch = process.argv.includes("--watch")
+    const { url, user, token } = loadJenkinsEnv()
+    const jobApi = `${jobUrlFromTrigger(url)}/api/json?tree=${TREE}`
+    const auth = `${user}:${token}`
+
+    let done = await checkOnce(jobApi, auth)
+    if (watch) {
+        while (!done) {
+            await sleep(POLL_INTERVAL_MS)
+            done = await checkOnce(jobApi, auth)
+        }
+    }
+}
+
+// oxlint-disable-next-line promise/prefer-await-to-then -- Top-level entry point
+main().catch((error) => {
+    console.error(`❌ ${error.message}`)
+    process.exit(1)
+})


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #237** (`dependabot/npm_and_yarn/npm-root-dd79dbcc37`). Base is that branch, so this diff shows only the 3-file change below. GitHub will auto-retarget this PR to `main` once #237 merges. Review/merge #237 first.

## What

- **`scripts/jenkins-status.js`** (new) — checks the deploy job's build status. One-shot (`npm run jenkins:status`) or `--watch` (`npm run jenkins:watch`) to poll an in-progress build until it finishes (`🔨 Building #N — ~X% (elapsed / est)`). Uses Node `https` with `rejectUnauthorized: false` (no curl), follows redirects, and reads `JENKINS_*` from the env (`--env-file-if-exists=.env.local`) or by parsing `.env.local`.
- **`.husky/pre-push`** — adds `curl -k` to the Jenkins trigger so the push-to-`Development` auto-deploy succeeds against the internal **self-signed cert** (interim, until the CA is trusted).
- **`package.json`** — `jenkins:status` / `jenkins:watch` scripts.

## Why stacked

The checker is a `scripts/**` CommonJS build script, so it depends on the `no-implicit-globals` / `node/no-sync` oxlint override that #237 adds to `.oxlintrc.json`. Stacking on #237 lets it inherit that override instead of duplicating the config change (which would add/add-conflict).

## Testing

- `node scripts/jenkins-status.js` → `✅ Last build #2183: SUCCESS (348s)` (verified against the live deploy job)
- `oxlint` 0 issues, `oxfmt` clean, CRLF preserved (hook stays CRLF)
- Full pre-commit gate passed (build + lint + tests + verify:build)

## Note

The `-k` is a deliberate interim measure while the Jenkins certificate is being replaced; it should be removed once the CA is trusted. Pushing this branch does not trigger a deploy (the pre-push hook only fires Jenkins for pushes to `Development`).
