### PR TITLE
VPR-92 fix(raps): clone user fails on role removals and date updates

### DIFF
--- a/test/RAPS/CloneServiceTests.cs
+++ b/test/RAPS/CloneServiceTests.cs
@@ -1,0 +1,217 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Viper.Areas.RAPS.Models;
+using Viper.Areas.RAPS.Services;
+using Viper.Classes.SQLContext;
+using Viper.Models.AAUD;
+using Viper.Models.RAPS;
+
+namespace Viper.test.RAPS
+{
+    public class CloneServiceTests
+    {
+        private const string SourceMemberId = "SRC00001";
+        private const string TargetMemberId = "TGT00001";
+        private static readonly DateTime OriginalAddDate = new(2020, 1, 15, 0, 0, 0, DateTimeKind.Local);
+
+        /// <summary>
+        /// The audit log's ModBy is non-nullable, so the service needs a current user.
+        /// Granting all permissions makes IsAllowedTo("ClonePermissions") pass via its RAPS.Admin check.
+        /// </summary>
+        private static IUserHelper MockUserHelper(bool canClonePermissions = false)
+        {
+            var mockUser = Substitute.For<IUserHelper>();
+            mockUser.GetCurrentUser().Returns(new AaudUser { LoginId = "testuser" });
+            if (canClonePermissions)
+            {
+                mockUser.HasPermission(Arg.Any<RAPSContext?>(), Arg.Any<AaudUser?>(), Arg.Any<string>()).Returns(true);
+            }
+            return mockUser;
+        }
+
+        /// <summary>
+        /// Clone uses real EF change tracking (GetUserComparison tracks the target's rows, then Clone acts on them),
+        /// so these tests need SQLite rather than NSubstitute mocks
+        /// </summary>
+        private static async Task<RAPSContext> CreateContextAsync(SqliteConnection connection)
+        {
+            await connection.OpenAsync(TestContext.Current.CancellationToken);
+            var options = new DbContextOptionsBuilder<RAPSContext>()
+                .UseSqlite(connection)
+                .Options;
+            var context = new RAPSContext(options);
+            await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+            context.VwAaudUser.AddRange(
+                new VwAaudUser { MothraId = SourceMemberId, DisplayFirstName = "Source", DisplayLastName = "User", DisplayFullName = "User, Source" },
+                new VwAaudUser { MothraId = TargetMemberId, DisplayFirstName = "Target", DisplayLastName = "User", DisplayFullName = "User, Target" });
+            context.TblRoles.AddRange(
+                new TblRole { RoleId = 1, Role = "VIPER.CloneRoleOne", Application = 0, UpdateFreq = 0, AllowAllUsers = false },
+                new TblRole { RoleId = 2, Role = "VIPER.CloneRoleTwo", Application = 0, UpdateFreq = 0, AllowAllUsers = false });
+            context.TblPermissions.AddRange(
+                new TblPermission { PermissionId = 1, Permission = "VIPER.ClonePermissionOne" },
+                new TblPermission { PermissionId = 2, Permission = "VIPER.ClonePermissionTwo" });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            return context;
+        }
+
+        [Fact]
+        public async Task Clone_AddsRole_WhenTargetLacksIt()
+        {
+            // arrange
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            context.TblRoleMembers.Add(new TblRoleMember { RoleId = 1, MemberId = SourceMemberId, StartDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Local) });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            // act
+            await new CloneService(context, MockUserHelper()).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { RoleIds = new List<int> { 1 } });
+
+            // assert
+            var targetRole = await context.TblRoleMembers.FindAsync(new object?[] { 1, TargetMemberId }, TestContext.Current.CancellationToken);
+            Assert.NotNull(targetRole);
+            Assert.Equal(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Local), targetRole.StartDate);
+            Assert.NotNull(targetRole.AddDate);
+        }
+
+        [Fact]
+        public async Task Clone_RemovesRole_WhenSourceLacksIt()
+        {
+            // arrange: both users have role 1; only the target has role 2, so cloning role 2 is a Delete
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            context.TblRoleMembers.AddRange(
+                new TblRoleMember { RoleId = 1, MemberId = SourceMemberId },
+                new TblRoleMember { RoleId = 1, MemberId = TargetMemberId },
+                new TblRoleMember { RoleId = 2, MemberId = TargetMemberId, AddDate = OriginalAddDate });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            context.ChangeTracker.Clear();
+
+            // act: threw InvalidOperationException (identity conflict with the rows tracked by GetUserComparison)
+            // before Clone was changed to act on tracked entities
+            await new CloneService(context, MockUserHelper()).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { RoleIds = new List<int> { 2 } });
+
+            // assert
+            var removedRole = await context.TblRoleMembers.FindAsync(new object?[] { 2, TargetMemberId }, TestContext.Current.CancellationToken);
+            Assert.Null(removedRole);
+            var keptRole = await context.TblRoleMembers.FindAsync(new object?[] { 1, TargetMemberId }, TestContext.Current.CancellationToken);
+            Assert.NotNull(keptRole);
+        }
+
+        [Fact]
+        public async Task Clone_UpdatesDatesAndKeepsAddDate_WhenDatesDiffer()
+        {
+            // arrange: both users have role 1 but with different dates, so cloning role 1 is an Update
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            context.TblRoleMembers.AddRange(
+                new TblRoleMember { RoleId = 1, MemberId = SourceMemberId, StartDate = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Local), EndDate = new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Local) },
+                new TblRoleMember { RoleId = 1, MemberId = TargetMemberId, AddDate = OriginalAddDate });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            context.ChangeTracker.Clear();
+
+            // act
+            await new CloneService(context, MockUserHelper()).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { RoleIds = new List<int> { 1 } });
+
+            // assert: dates copied from the source, AddDate not overwritten
+            context.ChangeTracker.Clear();
+            var targetRole = await context.TblRoleMembers.FindAsync(new object?[] { 1, TargetMemberId }, TestContext.Current.CancellationToken);
+            Assert.NotNull(targetRole);
+            Assert.Equal(new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Local), targetRole.StartDate);
+            Assert.Equal(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Local), targetRole.EndDate);
+            Assert.Equal(OriginalAddDate, targetRole.AddDate);
+        }
+
+        [Fact]
+        public async Task Clone_AddsPermission_WhenTargetLacksIt()
+        {
+            // arrange
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            context.TblMemberPermissions.Add(new TblMemberPermission
+            {
+                PermissionId = 1,
+                MemberId = SourceMemberId,
+                Access = 1,
+                StartDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Local)
+            });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            context.ChangeTracker.Clear();
+
+            // act
+            await new CloneService(context, MockUserHelper(canClonePermissions: true)).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { PermissionIds = new List<int> { 1 } });
+
+            // assert
+            var targetPermission = await context.TblMemberPermissions.FindAsync(new object?[] { TargetMemberId, 1 }, TestContext.Current.CancellationToken);
+            Assert.NotNull(targetPermission);
+            Assert.Equal(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Local), targetPermission.StartDate);
+            Assert.Equal((byte)1, targetPermission.Access);
+            Assert.NotNull(targetPermission.AddDate);
+        }
+
+        [Fact]
+        public async Task Clone_RemovesPermission_WhenSourceLacksIt()
+        {
+            // arrange: both users have permission 1; only the target has permission 2, so cloning permission 2 is a Delete
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            context.TblMemberPermissions.AddRange(
+                new TblMemberPermission { PermissionId = 1, MemberId = SourceMemberId, Access = 1 },
+                new TblMemberPermission { PermissionId = 1, MemberId = TargetMemberId, Access = 1 },
+                new TblMemberPermission { PermissionId = 2, MemberId = TargetMemberId, Access = 1, AddDate = OriginalAddDate });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            context.ChangeTracker.Clear();
+
+            // act
+            await new CloneService(context, MockUserHelper(canClonePermissions: true)).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { PermissionIds = new List<int> { 2 } });
+
+            // assert
+            var removedPermission = await context.TblMemberPermissions.FindAsync(new object?[] { TargetMemberId, 2 }, TestContext.Current.CancellationToken);
+            Assert.Null(removedPermission);
+            var keptPermission = await context.TblMemberPermissions.FindAsync(new object?[] { TargetMemberId, 1 }, TestContext.Current.CancellationToken);
+            Assert.NotNull(keptPermission);
+        }
+
+        [Fact]
+        public async Task Clone_UpdatesPermissionDatesAndAccess_WhenTheyDiffer()
+        {
+            // arrange: both users have permission 1 but with different dates and access flags (UpdateAndAccessFlag)
+            await using var connection = new SqliteConnection("Filename=:memory:");
+            using var context = await CreateContextAsync(connection);
+            var sourcePermission = new TblMemberPermission
+            {
+                PermissionId = 1,
+                MemberId = SourceMemberId,
+                StartDate = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Local),
+                EndDate = new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Local)
+            };
+            context.TblMemberPermissions.AddRange(
+                sourcePermission,
+                new TblMemberPermission { PermissionId = 1, MemberId = TargetMemberId, Access = 1, AddDate = OriginalAddDate });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            // Access has a DB default of 1, so EF replaces a seeded 0 on insert; a deny flag must be set via update
+            sourcePermission.Access = 0;
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            context.ChangeTracker.Clear();
+
+            // act
+            await new CloneService(context, MockUserHelper(canClonePermissions: true)).Clone("VIPER", SourceMemberId, TargetMemberId,
+                new CloneConfirm { PermissionIds = new List<int> { 1 } });
+
+            // assert: dates and access copied from the source, AddDate not overwritten
+            context.ChangeTracker.Clear();
+            var targetPermission = await context.TblMemberPermissions.FindAsync(new object?[] { TargetMemberId, 1 }, TestContext.Current.CancellationToken);
+            Assert.NotNull(targetPermission);
+            Assert.Equal(new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Local), targetPermission.StartDate);
+            Assert.Equal(new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Local), targetPermission.EndDate);
+            Assert.Equal((byte)0, targetPermission.Access);
+            Assert.Equal(OriginalAddDate, targetPermission.AddDate);
+        }
+    }
+}

--- a/web/Areas/RAPS/Services/CloneService.cs
+++ b/web/Areas/RAPS/Services/CloneService.cs
@@ -21,12 +21,12 @@ namespace Viper.Areas.RAPS.Services
             "VMDO SVM-IT"
         };
 
-        public CloneService(RAPSContext context)
+        public CloneService(RAPSContext context, IUserHelper? userHelper = null)
         {
             _context = context;
-            _auditService = new RAPSAuditService(context);
-            _securityService = new RAPSSecurityService(context);
-            UserHelper = new UserHelper();
+            UserHelper = userHelper ?? new UserHelper();
+            _auditService = new RAPSAuditService(context, UserHelper);
+            _securityService = new RAPSSecurityService(context, UserHelper);
         }
 
         private async Task<List<TblRoleMember>> GetRoleMembers(string instance, string memberId)
@@ -185,71 +185,119 @@ namespace Viper.Areas.RAPS.Services
 
         public async Task Clone(string instance, string sourceMemberId, string targetMemberId, CloneConfirm objectsToClone)
         {
+            //GetUserComparison loads the target's existing rows into the change tracker, so Update/Delete
+            //must act on those tracked instances (via FindAsync) instead of attaching new ones with the same keys
             MemberCloneObjects memberCloneObjects = await GetUserComparison(instance, sourceMemberId, targetMemberId);
-            foreach (RoleClone role in memberCloneObjects.Roles
-                .Where(role => objectsToClone.RoleIds.Contains(role.RoleId)))
+            string? modBy = UserHelper.GetCurrentUser()?.LoginId;
+            await CloneRoles(memberCloneObjects.Roles, new HashSet<int>(objectsToClone.RoleIds), targetMemberId, modBy);
+            await ClonePermissions(memberCloneObjects.Permissions, new HashSet<int>(objectsToClone.PermissionIds), targetMemberId, modBy);
+
+            //single save so role changes, permission changes, and audit logs commit or fail together
+            await _context.SaveChangesAsync();
+        }
+
+        private async Task CloneRoles(List<RoleClone> roles, HashSet<int> roleIds, string targetMemberId, string? modBy)
+        {
+            foreach (RoleClone role in roles
+                .Where(role => roleIds.Contains(role.RoleId)))
             {
-                RAPSAuditService.AuditActionType action = RAPSAuditService.AuditActionType.Create;
-                TblRoleMember rm = new()
-                {
-                    RoleId = role.RoleId,
-                    MemberId = targetMemberId,
-                    ModBy = UserHelper.GetCurrentUser()?.LoginId,
-                    ModTime = DateTime.Now,
-                    StartDate = role.Source?.StartDate?.ToDateTime(new TimeOnly(0, 0, 0)),
-                    EndDate = role.Source?.EndDate?.ToDateTime(new TimeOnly(0, 0, 0))
-                };
+                DateTime? startDate = role.Source?.StartDate?.ToDateTime(new TimeOnly(0, 0, 0));
+                DateTime? endDate = role.Source?.EndDate?.ToDateTime(new TimeOnly(0, 0, 0));
                 switch (role.Action)
                 {
                     case RoleClone.CloneAction.Create:
-                        rm.AddDate = DateTime.Now;
-                        _context.TblRoleMembers.Add(rm);
-                        break;
+                        {
+                            TblRoleMember rm = new()
+                            {
+                                RoleId = role.RoleId,
+                                MemberId = targetMemberId,
+                                ModBy = modBy,
+                                ModTime = DateTime.Now,
+                                StartDate = startDate,
+                                EndDate = endDate,
+                                AddDate = DateTime.Now
+                            };
+                            _context.TblRoleMembers.Add(rm);
+                            _auditService.AuditRoleMemberChange(rm, RAPSAuditService.AuditActionType.Create, null, modBy);
+                            break;
+                        }
                     case RoleClone.CloneAction.Update:
-                        action = RAPSAuditService.AuditActionType.Update;
-                        _context.TblRoleMembers.Update(rm);
-                        break;
+                        {
+                            TblRoleMember? existing = await _context.TblRoleMembers.FindAsync(role.RoleId, targetMemberId);
+                            if (existing != null)
+                            {
+                                existing.StartDate = startDate;
+                                existing.EndDate = endDate;
+                                existing.ModBy = modBy;
+                                existing.ModTime = DateTime.Now;
+                                _auditService.AuditRoleMemberChange(existing, RAPSAuditService.AuditActionType.Update, null, modBy);
+                            }
+                            break;
+                        }
                     case RoleClone.CloneAction.Delete:
-                        action = RAPSAuditService.AuditActionType.Delete;
-                        _context.TblRoleMembers.Remove(rm);
-                        break;
+                        {
+                            TblRoleMember? existing = await _context.TblRoleMembers.FindAsync(role.RoleId, targetMemberId);
+                            if (existing != null)
+                            {
+                                _context.TblRoleMembers.Remove(existing);
+                                _auditService.AuditRoleMemberChange(existing, RAPSAuditService.AuditActionType.Delete, null, modBy);
+                            }
+                            break;
+                        }
                 }
-                _auditService.AuditRoleMemberChange(rm, action, null);
             }
-            await _context.SaveChangesAsync();
+        }
 
-            foreach (PermissionClone permission in memberCloneObjects.Permissions
-                .Where(p => objectsToClone.PermissionIds.Contains(p.PermissionId)))
+        private async Task ClonePermissions(List<PermissionClone> permissions, HashSet<int> permissionIds, string targetMemberId, string? modBy)
+        {
+            foreach (PermissionClone permission in permissions
+                .Where(p => permissionIds.Contains(p.PermissionId)))
             {
-                RAPSAuditService.AuditActionType action = RAPSAuditService.AuditActionType.Create;
-                TblMemberPermission mp = new()
-                {
-                    PermissionId = permission.PermissionId,
-                    MemberId = targetMemberId,
-                    ModBy = UserHelper.GetCurrentUser()?.LoginId,
-                    ModTime = DateTime.Now,
-                    StartDate = permission.Source?.StartDate,
-                    EndDate = permission.Source?.EndDate,
-                    Access = permission.Source?.Access ?? 1
-                };
                 switch (permission.Action)
                 {
                     case PermissionClone.CloneAction.Create:
-                        mp.AddDate = DateTime.Now;
-                        _context.TblMemberPermissions.Add(mp);
-                        break;
+                        {
+                            TblMemberPermission mp = new()
+                            {
+                                PermissionId = permission.PermissionId,
+                                MemberId = targetMemberId,
+                                ModBy = modBy,
+                                ModTime = DateTime.Now,
+                                StartDate = permission.Source?.StartDate,
+                                EndDate = permission.Source?.EndDate,
+                                Access = permission.Source?.Access ?? 1,
+                                AddDate = DateTime.Now
+                            };
+                            _context.TblMemberPermissions.Add(mp);
+                            _auditService.AuditPermissionMemberChange(mp, RAPSAuditService.AuditActionType.Create);
+                            break;
+                        }
                     case PermissionClone.CloneAction.Delete:
-                        action = RAPSAuditService.AuditActionType.Delete;
-                        _context.TblMemberPermissions.Remove(mp);
-                        break;
+                        {
+                            TblMemberPermission? existing = await _context.TblMemberPermissions.FindAsync(targetMemberId, permission.PermissionId);
+                            if (existing != null)
+                            {
+                                _context.TblMemberPermissions.Remove(existing);
+                                _auditService.AuditPermissionMemberChange(existing, RAPSAuditService.AuditActionType.Delete);
+                            }
+                            break;
+                        }
                     default: //Update, AccessFlag, UpdateAndAccessFlag
-                        action = RAPSAuditService.AuditActionType.Update;
-                        _context.TblMemberPermissions.Update(mp);
-                        break;
+                        {
+                            TblMemberPermission? existing = await _context.TblMemberPermissions.FindAsync(targetMemberId, permission.PermissionId);
+                            if (existing != null)
+                            {
+                                existing.StartDate = permission.Source?.StartDate;
+                                existing.EndDate = permission.Source?.EndDate;
+                                existing.Access = permission.Source?.Access ?? 1;
+                                existing.ModBy = modBy;
+                                existing.ModTime = DateTime.Now;
+                                _auditService.AuditPermissionMemberChange(existing, RAPSAuditService.AuditActionType.Update);
+                            }
+                            break;
+                        }
                 }
-                _auditService.AuditPermissionMemberChange(mp, action);
             }
-            await _context.SaveChangesAsync();
         }
     }
 }

--- a/web/Areas/RAPS/Views/Members/Clone.cshtml
+++ b/web/Areas/RAPS/Views/Members/Clone.cshtml
@@ -152,12 +152,18 @@
             methods: {
                 //if both source and target user are selected, load the roles/permissions to clone
                 checkUsersSelected: function () {
-                    if (this?.sourceUser?.value.length && this?.targetUser?.value.length) {
+                    //any reload invalidates row selections from the previous comparison
+                    this.selectedRoles = []
+                    this.selectedPermissions = []
+                    if (this.sourceUser?.value?.length && this.targetUser?.value?.length) {
                         viperFetch(this, `Members/${this.sourceUser.value}/cloneTo/${this.targetUser.value}`)
                             .then(data => {
                                 this.cloneObject = data
                                 this.dataLoaded = true
                             })
+                    }
+                    else {
+                        this.dataLoaded = false
                     }
                 },
                 submitClone: async function () {
@@ -179,7 +185,7 @@
 
                     if(this.VMACSPush) {
                         Quasar.Loading.show({ message: "Updating VMACS" })
-                        await viperFetch(this, "Members/" + this.sourceUser.value + "/Roles/VMACSExport", { method: "POST" })
+                        await viperFetch(this, "Members/" + this.targetUser.value + "/Roles/VMACSExport", { method: "POST" })
                         Quasar.Loading.hide()
                     }
                 }


### PR DESCRIPTION
## Summary

RAPS 2.0 Clone User Permissions returned HTTP 500 whenever the selection included a "will be removed" or "dates will be updated" row; only pure adds worked. Jira: VPR-92 - RAPS 2.0 - Clone user not working.

**Root cause:** `CloneService.GetUserComparison()` loads the target user's role/permission rows as tracked EF entities. `Clone()` then constructed new stub entities with the same composite keys and called `Update()`/`Remove()` on them, hitting an EF identity-map conflict (`InvalidOperationException: The instance of entity type 'TblRoleMember' cannot be tracked because another instance with the same key value ... is already being tracked`).

## Changes

- **CloneService**: Update/Delete now fetch the tracked row via `FindAsync` (already in the change tracker, no extra query) and mutate/remove that instance. Also stops the Update path from overwriting the membership `AddDate` with null. Loops extracted to `CloneRoles`/`ClonePermissions` helpers (CA1502), selected-ID lists hoisted to `HashSet`s, and the injected `IUserHelper` is now passed through to `RAPSAuditService`/`RAPSSecurityService`.
- **Clone.cshtml**: after a clone in a VMACS instance, the VMACS export now pushes the **target** user (previously exported the unchanged source, so target changes never reached VMACS). Clearing a user select no longer throws and hides the stale diff table.
- **Tests**: new `CloneServiceTests` (in-memory SQLite with real change tracking) covering Create/Update/Delete for both roles and permissions, including `AddDate` preservation. The Delete/Update tests fail with the identity-conflict exception before this fix.

## Testing

- Full backend suite: 2136/2136 pass; lint clean on changed files
- Verified live on dev: add-only clone 204 (regression check), removal clone 204 (was 500 with the stack trace above), clearing a selection produces no console error and hides the diff
- Automated review loop (refinement + reviewer): clean, "good to go", 0 issues
