### PR TITLE
VPR-59 [1/6] CMS migration: file management (API + UI)

### DIFF
--- a/VueApp/src/CMS/components/FileFormDialog.vue
+++ b/VueApp/src/CMS/components/FileFormDialog.vue
@@ -1,0 +1,292 @@
+<template>
+    <q-dialog
+        :model-value="modelValue"
+        aria-labelledby="file-dialog-title"
+        @update:model-value="emit('update:modelValue', $event)"
+        @hide="resetForm"
+    >
+        <q-card style="width: 600px; max-width: 95vw">
+            <q-card-section class="row items-center q-pb-none">
+                <div
+                    id="file-dialog-title"
+                    class="text-h6"
+                >
+                    {{ isEdit ? "Edit File" : "Upload File" }}
+                </div>
+                <q-space />
+                <q-btn
+                    icon="close"
+                    flat
+                    round
+                    dense
+                    aria-label="Close dialog"
+                    v-close-popup
+                />
+            </q-card-section>
+
+            <q-form
+                ref="formRef"
+                greedy
+                @submit.prevent="save"
+            >
+                <q-card-section class="q-gutter-y-sm">
+                    <div
+                        v-if="isEdit"
+                        class="text-body2 q-mb-sm"
+                    >
+                        <strong>{{ file?.friendlyName }}</strong>
+                        <div class="text-caption text-grey-8">
+                            Link:
+                            <a
+                                :href="file?.friendlyUrl"
+                                target="_blank"
+                                rel="noopener"
+                            >
+                                {{ file?.friendlyUrl }}
+                            </a>
+                            <q-btn
+                                flat
+                                dense
+                                size="sm"
+                                icon="content_copy"
+                                aria-label="Copy link"
+                                @click="copyUrl"
+                            >
+                                <q-tooltip>Copy link</q-tooltip>
+                            </q-btn>
+                        </div>
+                    </div>
+
+                    <q-file
+                        v-model="form.upload"
+                        dense
+                        outlined
+                        :label="isEdit ? 'Replace file (optional)' : 'File'"
+                        :accept="acceptedExtensions"
+                        :rules="isEdit ? [] : [(v: File | null) => !!v || 'Please choose a file']"
+                        :hint="
+                            isEdit
+                                ? 'Uploading a new file replaces the current content, keeping the same name'
+                                : undefined
+                        "
+                    >
+                        <template #prepend>
+                            <q-icon name="attach_file" />
+                        </template>
+                    </q-file>
+
+                    <q-select
+                        v-if="!isEdit"
+                        v-model="form.folder"
+                        dense
+                        options-dense
+                        outlined
+                        label="VIPER app (folder)"
+                        :options="folders"
+                        :rules="[(v: string | null) => !!v || 'Please select a folder']"
+                    />
+
+                    <q-input
+                        v-model="form.description"
+                        dense
+                        outlined
+                        type="textarea"
+                        rows="2"
+                        label="Description"
+                        maxlength="1000"
+                    />
+
+                    <q-input
+                        v-model="form.oldUrl"
+                        dense
+                        outlined
+                        label="Old URL"
+                        maxlength="256"
+                        hint="Legacy VIPER 1 path this file replaces (optional)"
+                    />
+
+                    <PermissionSelector v-model="form.permissions" />
+
+                    <PersonSelector
+                        v-model="form.people"
+                        label="People with access"
+                    />
+
+                    <div class="row q-gutter-x-lg">
+                        <q-toggle
+                            v-model="form.allowPublicAccess"
+                            label="Public access"
+                        />
+                        <q-toggle
+                            v-model="form.encrypt"
+                            label="Encrypt file"
+                        />
+                        <q-checkbox
+                            v-if="!isEdit"
+                            v-model="form.makeUnique"
+                            label="Rename automatically if name exists"
+                        />
+                    </div>
+                </q-card-section>
+
+                <q-card-actions align="right">
+                    <q-btn
+                        flat
+                        label="Cancel"
+                        dense
+                        no-caps
+                        v-close-popup
+                    />
+                    <q-btn
+                        type="submit"
+                        :label="isEdit ? 'Save Changes' : 'Upload'"
+                        color="primary"
+                        dense
+                        no-caps
+                        class="q-pr-md"
+                        :loading="saving"
+                    />
+                </q-card-actions>
+            </q-form>
+        </q-card>
+    </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, watch } from "vue"
+import { useQuasar } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
+import PersonSelector from "@/CMS/components/PersonSelector.vue"
+import type { CmsFile, CmsFilePerson } from "@/CMS/types/"
+
+const props = defineProps<{
+    modelValue: boolean
+    folders: string[]
+    file: CmsFile | null
+}>()
+
+const emit = defineEmits<{
+    "update:modelValue": [value: boolean]
+    saved: [file: CmsFile]
+}>()
+
+const apiURL = inject("apiURL") + "cms/files/"
+const $q = useQuasar()
+
+const acceptedExtensions =
+    ".pdf,.docx,.doc,.xls,.xlsx,.csv,.ppt,.pptx,.pptm,.txt,.html,.gif,.png,.jpg,.jpeg,.tiff,.mp3,.wav,.mp4,.webm,.oft,.eps,.zip,.7z,.dmg,.exe"
+
+const isEdit = computed(() => props.file !== null)
+const formRef = ref()
+const saving = ref(false)
+
+type FileForm = {
+    upload: File | null
+    folder: string | null
+    description: string
+    oldUrl: string
+    allowPublicAccess: boolean
+    encrypt: boolean
+    makeUnique: boolean
+    permissions: string[]
+    people: CmsFilePerson[]
+}
+
+const emptyForm = (): FileForm => ({
+    upload: null,
+    folder: null,
+    description: "",
+    oldUrl: "",
+    allowPublicAccess: false,
+    encrypt: false,
+    makeUnique: false,
+    permissions: [],
+    people: [],
+})
+
+const form = ref<FileForm>(emptyForm())
+
+watch(
+    () => [props.modelValue, props.file] as const,
+    ([open]) => {
+        if (!open) return
+        if (props.file) {
+            form.value = {
+                upload: null,
+                folder: props.file.folder,
+                description: props.file.description ?? "",
+                oldUrl: props.file.oldUrl ?? "",
+                allowPublicAccess: props.file.allowPublicAccess,
+                encrypt: props.file.encrypted,
+                makeUnique: false,
+                permissions: [...props.file.permissions],
+                people: props.file.people.map((p) => ({ ...p })),
+            }
+        } else {
+            form.value = emptyForm()
+        }
+    },
+)
+
+function resetForm() {
+    form.value = emptyForm()
+    formRef.value?.resetValidation()
+}
+
+async function copyUrl() {
+    if (!props.file) return
+    try {
+        await navigator.clipboard.writeText(props.file.friendlyUrl)
+        $q.notify({ type: "positive", message: "Link copied" })
+    } catch {
+        $q.notify({ type: "negative", message: "Failed to copy link" })
+    }
+}
+
+function buildFormData(): FormData {
+    const data = new FormData()
+    if (form.value.upload) {
+        data.append("file", form.value.upload)
+    }
+    if (!isEdit.value) {
+        data.append("folder", form.value.folder ?? "")
+        data.append("makeUnique", form.value.makeUnique.toString())
+    }
+    data.append("description", form.value.description)
+    data.append("oldUrl", form.value.oldUrl)
+    data.append("allowPublicAccess", form.value.allowPublicAccess.toString())
+    data.append("encrypt", form.value.encrypt.toString())
+    for (const p of form.value.permissions) {
+        data.append("permissions", p)
+    }
+    for (const person of form.value.people) {
+        data.append("iamIds", person.iamId)
+    }
+    return data
+}
+
+async function save() {
+    const valid = await formRef.value?.validate()
+    if (!valid) return
+
+    saving.value = true
+    const { postForm, putForm } = useFetch()
+    const res = isEdit.value
+        ? await putForm(apiURL + props.file!.fileGuid, buildFormData())
+        : await postForm(apiURL, buildFormData())
+    saving.value = false
+
+    if (!res.success) {
+        $q.notify({
+            type: "negative",
+            message: res.errors?.[0] ?? `Failed to ${isEdit.value ? "save" : "upload"} file`,
+        })
+        return
+    }
+
+    $q.notify({ type: "positive", message: isEdit.value ? "File updated" : "File uploaded" })
+    emit("saved", res.result)
+    emit("update:modelValue", false)
+}
+</script>

--- a/VueApp/src/CMS/components/PermissionSelector.vue
+++ b/VueApp/src/CMS/components/PermissionSelector.vue
@@ -1,0 +1,61 @@
+<template>
+    <q-select
+        :model-value="modelValue"
+        multiple
+        use-chips
+        use-input
+        input-debounce="100"
+        dense
+        options-dense
+        clearable
+        :label="label"
+        :options="filteredOptions"
+        :loading="loading"
+        hint="Users need any one of the selected permissions"
+        @update:model-value="emit('update:modelValue', $event ?? [])"
+        @filter="filterOptions"
+    />
+</template>
+
+<script setup lang="ts">
+import { inject, ref } from "vue"
+import { useFetch } from "@/composables/ViperFetch"
+
+withDefaults(
+    defineProps<{
+        modelValue: string[]
+        label?: string
+    }>(),
+    { label: "Permissions" },
+)
+
+const emit = defineEmits<{ "update:modelValue": [value: string[]] }>()
+
+const apiURL = inject("apiURL") + "cms/options/"
+const allPermissions = ref<string[]>([])
+const filteredOptions = ref<string[]>([])
+const loading = ref(false)
+let loaded = false
+
+async function loadPermissions() {
+    loading.value = true
+    const { get } = useFetch()
+    const res = await get(apiURL + "permissions")
+    if (res.success) {
+        allPermissions.value = res.result
+        loaded = true
+    }
+    loading.value = false
+}
+
+async function filterOptions(val: string, update: (fn: () => void) => void) {
+    if (!loaded) {
+        await loadPermissions()
+    }
+    update(() => {
+        const needle = val.toLowerCase()
+        filteredOptions.value =
+            needle === "" ? allPermissions.value : allPermissions.value.filter((p) => p.toLowerCase().includes(needle))
+    })
+}
+</script>

--- a/VueApp/src/CMS/components/PersonSelector.vue
+++ b/VueApp/src/CMS/components/PersonSelector.vue
@@ -1,0 +1,81 @@
+<template>
+    <q-select
+        :model-value="modelValue"
+        multiple
+        use-chips
+        use-input
+        input-debounce="300"
+        dense
+        options-dense
+        :label="label"
+        :options="options"
+        :loading="loading"
+        option-value="iamId"
+        hint="Type at least 2 characters to search people"
+        @update:model-value="emit('update:modelValue', $event ?? [])"
+        @filter="searchPeople"
+    >
+        <template #option="{ itemProps, opt }">
+            <q-item v-bind="itemProps">
+                <q-item-section>
+                    <q-item-label>{{ opt.name }}</q-item-label>
+                    <q-item-label caption>{{ opt.loginId ?? opt.iamId }}</q-item-label>
+                </q-item-section>
+            </q-item>
+        </template>
+        <template #selected-item="scope">
+            <q-chip
+                removable
+                dense
+                :tabindex="scope.tabindex"
+                @remove="scope.removeAtIndex(scope.index)"
+            >
+                {{ scope.opt.name ?? scope.opt.iamId }}
+            </q-chip>
+        </template>
+        <template #no-option>
+            <q-item>
+                <q-item-section class="text-grey">No matching people</q-item-section>
+            </q-item>
+        </template>
+    </q-select>
+</template>
+
+<script setup lang="ts">
+import { inject, ref } from "vue"
+import { useFetch } from "@/composables/ViperFetch"
+import type { CmsPersonOption } from "@/CMS/types/"
+
+// Selected people keep { iamId, name } so chips can show names for people
+// loaded from an existing file (where only iamId + name are known).
+defineProps<{
+    modelValue: { iamId: string; name: string | null }[]
+    label?: string
+}>()
+
+const emit = defineEmits<{ "update:modelValue": [value: { iamId: string; name: string | null }[]] }>()
+
+const apiURL = inject("apiURL") + "cms/options/"
+const options = ref<CmsPersonOption[]>([])
+const loading = ref(false)
+// Guards against out-of-order responses: only the latest search may update options
+let searchSeq = 0
+
+async function searchPeople(val: string, update: (fn: () => void) => void) {
+    if (val.trim().length < 2) {
+        update(() => {
+            options.value = []
+        })
+        return
+    }
+    const seq = ++searchSeq
+    loading.value = true
+    const { get, createUrlSearchParams } = useFetch()
+    const res = await get(apiURL + "people?" + createUrlSearchParams({ search: val.trim() }))
+    if (seq !== searchSeq) return
+    loading.value = false
+    update(() => {
+        options.value = res.success ? res.result : []
+    })
+}
+</script>

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -1,5 +1,78 @@
 <template>
     <div class="q-pa-md">
-        <h1 class="text-h4 text-primary q-my-none">CMS Home</h1>
+        <h1 class="text-h4 text-primary q-my-none q-mb-md">CMS Home</h1>
+
+        <div class="row q-col-gutter-md">
+            <div
+                v-for="section in visibleSections"
+                :key="section.title"
+                class="col-12 col-sm-6 col-md-4"
+            >
+                <q-card
+                    flat
+                    bordered
+                >
+                    <q-card-section>
+                        <div class="text-h6 text-primary">
+                            <q-icon
+                                :name="section.icon"
+                                class="q-mr-sm"
+                            />
+                            {{ section.title }}
+                        </div>
+                        <div class="text-body2 text-grey-8 q-mt-xs">{{ section.description }}</div>
+                    </q-card-section>
+                    <q-card-actions>
+                        <q-btn
+                            v-for="action in section.actions"
+                            :key="action.label"
+                            flat
+                            dense
+                            no-caps
+                            color="primary"
+                            :label="action.label"
+                            :to="action.to"
+                        />
+                    </q-card-actions>
+                </q-card>
+            </div>
+        </div>
     </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useUserStore } from "@/store/UserStore"
+
+const userStore = useUserStore()
+
+type Section = {
+    title: string
+    icon: string
+    description: string
+    permission: string
+    actions: { label: string; to: { name: string; query?: Record<string, string> } }[]
+}
+
+const sections: Section[] = [
+    {
+        title: "Files",
+        icon: "folder",
+        description: "Upload and manage files with permission-based access and audit logging.",
+        permission: "SVMSecure.CMS.AllFiles",
+        actions: [
+            { label: "Manage Files", to: { name: "CmsFiles" } },
+            { label: "Audit Log", to: { name: "CmsFileAudit" } },
+        ],
+    },
+    {
+        title: "Link Collections",
+        icon: "link",
+        description: "Curate collections of links with tags and ordering.",
+        permission: "SVMSecure.CMS.ManageContentBlocks",
+        actions: [{ label: "Manage Link Collections", to: { name: "ManageLinkCollections" } }],
+    },
+]
+
+const visibleSections = computed(() => sections.filter((s) => userStore.userInfo.permissions.includes(s.permission)))
+</script>

--- a/VueApp/src/CMS/pages/FileAuditLog.vue
+++ b/VueApp/src/CMS/pages/FileAuditLog.vue
@@ -1,0 +1,233 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">File Audit Log</h1>
+            <q-space />
+            <q-btn
+                flat
+                dense
+                no-caps
+                color="primary"
+                icon="arrow_back"
+                label="Back to Files"
+                :to="{ name: 'CmsFiles' }"
+            />
+        </div>
+
+        <div class="row q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.action"
+                    dense
+                    options-dense
+                    clearable
+                    label="Action"
+                    :options="actionOptions"
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-input
+                    v-model="filters.loginId"
+                    dense
+                    clearable
+                    debounce="400"
+                    label="Login ID"
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-input
+                    v-model="filters.from"
+                    dense
+                    clearable
+                    label="From"
+                    type="date"
+                    stack-label
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-input
+                    v-model="filters.to"
+                    dense
+                    clearable
+                    label="To"
+                    type="date"
+                    stack-label
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-4 col-lg-3">
+                <q-input
+                    v-model="filters.search"
+                    dense
+                    clearable
+                    debounce="400"
+                    label="Search path or detail"
+                    @update:model-value="reload"
+                >
+                    <template #prepend>
+                        <q-icon name="search" />
+                    </template>
+                </q-input>
+            </div>
+        </div>
+
+        <div
+            v-if="fileGuid"
+            class="q-mb-sm"
+        >
+            <q-chip
+                removable
+                dense
+                color="primary"
+                text-color="white"
+                @remove="clearFileFilter"
+            >
+                Filtered to one file: {{ fileGuid }}
+            </q-chip>
+        </div>
+
+        <q-table
+            :rows="entries"
+            :columns="columns"
+            row-key="auditId"
+            :loading="loading"
+            v-model:pagination="pagination"
+            :rows-per-page-options="[25, 50, 100, 250]"
+            dense
+            flat
+            bordered
+            @request="onRequest"
+        >
+            <template #body-cell-timestamp="cellProps">
+                <q-td :props="cellProps">
+                    {{ formatDateTime(cellProps.row.timestamp) }}
+                </q-td>
+            </template>
+            <template #body-cell-filePath="cellProps">
+                <q-td :props="cellProps">
+                    <span class="ellipsis file-path">
+                        {{ cellProps.row.filePath }}
+                        <q-tooltip v-if="cellProps.row.filePath">{{ cellProps.row.filePath }}</q-tooltip>
+                    </span>
+                </q-td>
+            </template>
+        </q-table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, ref } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { type QTableProps } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import type { CmsFileAudit } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "cms/files/audit"
+const route = useRoute()
+const router = useRouter()
+const { get, createUrlSearchParams } = useFetch()
+
+const entries = ref<CmsFileAudit[]>([])
+const loading = ref(false)
+const fileGuid = ref<string | null>((route.query.fileGuid as string) || null)
+
+const filters = ref({
+    action: null as string | null,
+    loginId: "",
+    from: "",
+    to: "",
+    search: "",
+})
+
+const actionOptions = [
+    "AccessFile",
+    "AccessFileDenied",
+    "AddFile",
+    "UploadFile",
+    "EditFile",
+    "DeleteFile",
+    "CancelDelete",
+    "ImportFile",
+]
+
+const pagination = ref({
+    sortBy: "timestamp",
+    descending: true,
+    page: 1,
+    rowsPerPage: 50,
+    rowsNumber: 0,
+})
+
+const columns: QTableProps["columns"] = [
+    { name: "timestamp", label: "When", field: "timestamp", align: "left" },
+    { name: "loginid", label: "User", field: "loginid", align: "left" },
+    { name: "action", label: "Action", field: "action", align: "left" },
+    { name: "detail", label: "Detail", field: "detail", align: "left" },
+    { name: "filePath", label: "File", field: "filePath", align: "left" },
+]
+
+type TableRequestPagination = {
+    sortBy: string
+    descending: boolean
+    page: number
+    rowsPerPage: number
+    rowsNumber?: number
+}
+
+async function onRequest(requestProps: { pagination: TableRequestPagination }) {
+    const { page, rowsPerPage } = requestProps.pagination
+    loading.value = true
+    const params = createUrlSearchParams({
+        fileGuid: fileGuid.value,
+        action: filters.value.action,
+        loginId: filters.value.loginId || null,
+        from: filters.value.from || null,
+        to: filters.value.to || null,
+        search: filters.value.search || null,
+        page,
+        perPage: rowsPerPage,
+    })
+    const res = await get(apiURL + "?" + params)
+    if (res.success) {
+        entries.value = res.result
+        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
+        pagination.value.page = page
+        pagination.value.rowsPerPage = rowsPerPage
+    }
+    loading.value = false
+}
+
+function reload() {
+    void onRequest({ pagination: { ...pagination.value, page: 1 } })
+}
+
+function clearFileFilter() {
+    fileGuid.value = null
+    void router.replace({ query: {} })
+    reload()
+}
+
+function formatDateTime(value: string | null): string {
+    if (!value) return ""
+    return new Date(value).toLocaleString("en-US", {
+        year: "2-digit",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "numeric",
+        minute: "2-digit",
+    })
+}
+
+onMounted(reload)
+</script>
+
+<style scoped>
+.file-path {
+    max-width: 320px;
+    display: inline-block;
+    vertical-align: middle;
+}
+</style>

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -1,0 +1,415 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">File Management</h1>
+            <q-space />
+            <q-btn
+                color="positive"
+                icon="add"
+                label="Upload File"
+                no-caps
+                dense
+                class="q-pr-md"
+                @click="openUploadDialog"
+            />
+        </div>
+
+        <div class="row q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.folder"
+                    dense
+                    options-dense
+                    clearable
+                    label="VIPER app"
+                    :options="folders"
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.status"
+                    dense
+                    options-dense
+                    emit-value
+                    map-options
+                    label="Status"
+                    :options="statusOptions"
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-12 col-sm-4 col-lg-3">
+                <q-input
+                    v-model="filters.search"
+                    dense
+                    clearable
+                    debounce="400"
+                    label="Search name, description, or URL"
+                    @update:model-value="reload"
+                >
+                    <template #prepend>
+                        <q-icon name="search" />
+                    </template>
+                </q-input>
+            </div>
+            <div class="col-auto flex items-center">
+                <q-toggle
+                    v-model="filters.encryptedOnly"
+                    dense
+                    label="Encrypted only"
+                    @update:model-value="reload"
+                />
+            </div>
+            <div class="col-auto flex items-center">
+                <q-btn
+                    flat
+                    dense
+                    no-caps
+                    color="primary"
+                    icon="history"
+                    label="Audit Log"
+                    :to="{ name: 'CmsFileAudit' }"
+                />
+            </div>
+        </div>
+
+        <q-table
+            :rows="files"
+            :columns="columns"
+            row-key="fileGuid"
+            :loading="loading"
+            v-model:pagination="pagination"
+            :rows-per-page-options="[25, 50, 100, 250]"
+            dense
+            flat
+            bordered
+            @request="onRequest"
+        >
+            <template #body-cell-friendlyName="cellProps">
+                <q-td :props="cellProps">
+                    <div class="row items-center no-wrap q-gutter-x-xs">
+                        <a
+                            :href="cellProps.row.friendlyUrl"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            {{ cellProps.row.friendlyName }}
+                        </a>
+                        <q-icon
+                            v-if="cellProps.row.encrypted"
+                            name="lock"
+                            color="warning"
+                        >
+                            <q-tooltip>Encrypted</q-tooltip>
+                        </q-icon>
+                        <q-icon
+                            v-if="cellProps.row.allowPublicAccess"
+                            name="public"
+                            color="positive"
+                        >
+                            <q-tooltip>Public access</q-tooltip>
+                        </q-icon>
+                        <q-icon
+                            v-if="cellProps.row.deletedOn"
+                            name="delete_outline"
+                            color="negative"
+                        >
+                            <q-tooltip>Deleted {{ formatDate(cellProps.row.deletedOn) }}</q-tooltip>
+                        </q-icon>
+                    </div>
+                </q-td>
+            </template>
+
+            <template #body-cell-permissions="cellProps">
+                <q-td :props="cellProps">
+                    <template v-if="cellProps.row.permissions.length || cellProps.row.people.length">
+                        <q-chip
+                            v-for="p in cellProps.row.permissions.slice(0, 2)"
+                            :key="p"
+                            dense
+                            square
+                            size="sm"
+                        >
+                            {{ p }}
+                        </q-chip>
+                        <q-chip
+                            v-if="cellProps.row.permissions.length > 2"
+                            dense
+                            square
+                            size="sm"
+                            color="grey-4"
+                        >
+                            +{{ cellProps.row.permissions.length - 2 }} more
+                        </q-chip>
+                        <q-chip
+                            v-if="cellProps.row.people.length"
+                            dense
+                            square
+                            size="sm"
+                            icon="person"
+                            color="grey-4"
+                        >
+                            {{ cellProps.row.people.length }}
+                        </q-chip>
+                    </template>
+                    <span
+                        v-else
+                        class="text-grey-7"
+                    >
+                        All VIPER users
+                    </span>
+                </q-td>
+            </template>
+
+            <template #body-cell-oldUrl="cellProps">
+                <q-td :props="cellProps">
+                    <span
+                        v-if="cellProps.row.oldUrl"
+                        class="ellipsis old-url"
+                    >
+                        {{ cellProps.row.oldUrl }}
+                        <q-tooltip>{{ cellProps.row.oldUrl }}</q-tooltip>
+                    </span>
+                </q-td>
+            </template>
+
+            <template #body-cell-modifiedOn="cellProps">
+                <q-td :props="cellProps">
+                    {{ formatDate(cellProps.row.modifiedOn) }}
+                    <span class="text-grey-7">{{ cellProps.row.modifiedBy }}</span>
+                </q-td>
+            </template>
+
+            <template #body-cell-actions="cellProps">
+                <q-td :props="cellProps">
+                    <q-btn
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="secondary"
+                        icon="edit"
+                        aria-label="Edit file"
+                        @click="openEditDialog(cellProps.row)"
+                    >
+                        <q-tooltip>Edit</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="secondary"
+                        icon="content_copy"
+                        aria-label="Copy link"
+                        @click="copyUrl(cellProps.row)"
+                    >
+                        <q-tooltip>Copy link</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                        v-if="!cellProps.row.deletedOn"
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="negative"
+                        icon="delete"
+                        aria-label="Delete file"
+                        @click="deleteFile(cellProps.row)"
+                    >
+                        <q-tooltip>Delete</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                        v-else
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="positive"
+                        icon="restore_from_trash"
+                        aria-label="Restore file"
+                        @click="restoreFile(cellProps.row)"
+                    >
+                        <q-tooltip>Restore</q-tooltip>
+                    </q-btn>
+                </q-td>
+            </template>
+        </q-table>
+
+        <FileFormDialog
+            v-model="showDialog"
+            :folders="folders"
+            :file="editingFile"
+            @saved="reload"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, ref } from "vue"
+import { useQuasar, type QTableProps } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
+import type { CmsFile } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "cms/files/"
+const $q = useQuasar()
+const { get, del, post, createUrlSearchParams } = useFetch()
+
+const files = ref<CmsFile[]>([])
+const folders = ref<string[]>([])
+const loading = ref(false)
+const showDialog = ref(false)
+const editingFile = ref<CmsFile | null>(null)
+
+const filters = ref({
+    folder: null as string | null,
+    status: "active",
+    search: "",
+    encryptedOnly: false,
+})
+
+const statusOptions = [
+    { label: "Active", value: "active" },
+    { label: "Deleted", value: "deleted" },
+    { label: "All", value: "all" },
+]
+
+const pagination = ref({
+    sortBy: "friendlyName",
+    descending: false,
+    page: 1,
+    rowsPerPage: 50,
+    rowsNumber: 0,
+})
+
+const columns: QTableProps["columns"] = [
+    { name: "friendlyName", label: "File", field: "friendlyName", align: "left", sortable: true },
+    { name: "folder", label: "VIPER app", field: "folder", align: "left", sortable: true },
+    { name: "permissions", label: "Access", field: "permissions", align: "left" },
+    { name: "oldUrl", label: "Old URL", field: "oldUrl", align: "left", sortable: true },
+    { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
+    { name: "actions", label: "Actions", field: "fileGuid", align: "center" },
+]
+
+async function loadFolders() {
+    const res = await get(apiURL + "folders")
+    folders.value = res.success ? res.result : []
+}
+
+type TableRequestPagination = {
+    sortBy: string
+    descending: boolean
+    page: number
+    rowsPerPage: number
+    rowsNumber?: number
+}
+
+async function onRequest(requestProps: { pagination: TableRequestPagination }) {
+    const { page, rowsPerPage, sortBy, descending } = requestProps.pagination
+    loading.value = true
+    const params = createUrlSearchParams({
+        folder: filters.value.folder,
+        status: filters.value.status,
+        search: filters.value.search || null,
+        encrypted: filters.value.encryptedOnly ? "true" : null,
+        page,
+        perPage: rowsPerPage,
+        sortBy: sortBy ?? "friendlyName",
+        descending: descending ? "true" : "false",
+    })
+    const res = await get(apiURL + "?" + params)
+    if (res.success) {
+        files.value = res.result
+        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
+        pagination.value.page = page
+        pagination.value.rowsPerPage = rowsPerPage
+        pagination.value.sortBy = sortBy
+        pagination.value.descending = descending
+    }
+    loading.value = false
+}
+
+function reload() {
+    void onRequest({ pagination: { ...pagination.value, page: 1 } })
+}
+
+function openUploadDialog() {
+    editingFile.value = null
+    showDialog.value = true
+}
+
+function openEditDialog(file: CmsFile) {
+    editingFile.value = file
+    showDialog.value = true
+}
+
+async function copyUrl(file: CmsFile) {
+    try {
+        await navigator.clipboard.writeText(file.friendlyUrl)
+        $q.notify({ type: "positive", message: "Link copied" })
+    } catch {
+        $q.notify({ type: "negative", message: "Failed to copy link" })
+    }
+}
+
+async function deleteFile(file: CmsFile) {
+    const confirmed = await confirmAction(
+        "Delete File",
+        `Mark "${file.friendlyName}" as deleted? It can be restored later.`,
+        "Delete",
+        "negative",
+    )
+    if (!confirmed) return
+    const res = await del(apiURL + file.fileGuid)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to delete file" })
+        return
+    }
+    $q.notify({ type: "positive", message: "File marked as deleted" })
+    reload()
+}
+
+async function restoreFile(file: CmsFile) {
+    const res = await post(apiURL + file.fileGuid + "/restore")
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to restore file" })
+        return
+    }
+    $q.notify({ type: "positive", message: "File restored" })
+    reload()
+}
+
+async function confirmAction(title: string, message: string, okLabel: string, okColor = "primary") {
+    return await new Promise<boolean>((resolve) => {
+        $q.dialog({
+            title,
+            message,
+            cancel: { label: "Cancel", flat: true },
+            persistent: true,
+            ok: { label: okLabel, color: okColor, unelevated: true },
+        })
+            .onOk(() => resolve(true))
+            .onCancel(() => resolve(false))
+            .onDismiss(() => resolve(false))
+    })
+}
+
+function formatDate(value: string | null): string {
+    if (!value) return ""
+    return new Date(value).toLocaleDateString("en-US", { year: "2-digit", month: "2-digit", day: "2-digit" })
+}
+
+onMounted(() => {
+    loadFolders()
+    reload()
+})
+</script>
+
+<style scoped>
+.old-url {
+    max-width: 200px;
+    display: inline-block;
+    vertical-align: middle;
+}
+</style>

--- a/VueApp/src/CMS/router/routes.ts
+++ b/VueApp/src/CMS/router/routes.ts
@@ -20,6 +20,20 @@ const routes = [
         component: () => import("@/CMS/pages/ManageLinkCollections.vue"),
     },
     {
+        // Not /CMS/Files: that path is the MVC download handler (CMSController.Files),
+        // which takes precedence over the SPA shell.
+        path: "/CMS/ManageFiles",
+        name: "CmsFiles",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.AllFiles"] },
+        component: () => import("@/CMS/pages/Files.vue"),
+    },
+    {
+        path: "/CMS/ManageFiles/Audit",
+        name: "CmsFileAudit",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.AllFiles"] },
+        component: () => import("@/CMS/pages/FileAuditLog.vue"),
+    },
+    {
         path: "/:catchAll(.*)*",
         meta: { layout: ViperLayout },
         component: () => import("@/pages/Error404.vue"),

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -4,6 +4,49 @@ type ContentBlock = {
     title: string | null
 }
 
+type CmsFile = {
+    fileGuid: string
+    fileName: string
+    folder: string | null
+    friendlyName: string
+    encrypted: boolean
+    description: string
+    allowPublicAccess: boolean
+    oldUrl: string | null
+    modifiedOn: string
+    modifiedBy: string
+    deletedOn: string | null
+    permissions: string[]
+    people: CmsFilePerson[]
+    url: string
+    friendlyUrl: string
+}
+
+type CmsFilePerson = {
+    iamId: string
+    name: string | null
+}
+
+type CmsPersonOption = {
+    iamId: string
+    name: string
+    loginId: string | null
+    mailId: string | null
+}
+
+type CmsFileAudit = {
+    auditId: number
+    timestamp: string
+    loginid: string | null
+    action: string
+    detail: string | null
+    fileGuid: string | null
+    filePath: string | null
+    iamId: string | null
+    fileMetaData: string | null
+    clientData: string | null
+}
+
 type LinkCollection = {
     linkCollectionId: number
     linkCollection: string
@@ -49,4 +92,16 @@ type LinkWithTags = {
     sortOrder: number
 }
 
-export type { ContentBlock, LinkCollection, LinkCollectionTagCategory, Link, LinkTag, LinkTagFilter, LinkWithTags }
+export type {
+    ContentBlock,
+    CmsFile,
+    CmsFilePerson,
+    CmsPersonOption,
+    CmsFileAudit,
+    LinkCollection,
+    LinkCollectionTagCategory,
+    Link,
+    LinkTag,
+    LinkTagFilter,
+    LinkWithTags,
+}

--- a/VueApp/src/composables/ViperFetch.ts
+++ b/VueApp/src/composables/ViperFetch.ts
@@ -163,8 +163,8 @@ async function fetchWrapper(url: string, options: any = {}) {
             }
         })
     const resultObj: Result = {
-        result: result,
-        errors: errors,
+        result,
+        errors,
         success: errors.length === 0,
         pagination: null,
         status: httpStatus,
@@ -271,7 +271,21 @@ function useFetch() {
         return await fetchWrapper(url, options)
     }
 
-    return { get, post, put, del, patch, createUrlSearchParams }
+    // Multipart variants for file uploads: the browser sets the Content-Type
+    // (with boundary) itself, so no header is added here.
+    async function postForm(url: string = "", body: FormData, options: any = {}): Promise<Result> {
+        options.method = "POST"
+        options.body = body
+        return await fetchWrapper(url, options)
+    }
+
+    async function putForm(url: string = "", body: FormData, options: any = {}): Promise<Result> {
+        options.method = "PUT"
+        options.body = body
+        return await fetchWrapper(url, options)
+    }
+
+    return { get, post, put, del, patch, postForm, putForm, createUrlSearchParams }
 }
 
 function downloadBlob(blob: Blob, filename: string): void {

--- a/test/CMS/CmsFileCryptoTests.cs
+++ b/test/CMS/CmsFileCryptoTests.cs
@@ -1,0 +1,110 @@
+using System.Security.Cryptography;
+using System.Text;
+using Viper.Areas.CMS.Services;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for the CF-compatible CMS file crypto primitives. The DB key format
+/// (UUEncode over AES-ECB) and content encryption must round-trip so files written
+/// by the new system stay readable by the legacy ColdFusion CMS and vice versa.
+/// </summary>
+public sealed class CmsFileCryptoTests
+{
+    private static string NewMasterKey() => Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+
+    [Fact]
+    public void GenerateFileKey_IsBase64Of128BitKey()
+    {
+        var key = CmsFileCrypto.GenerateFileKey();
+
+        var bytes = Convert.FromBase64String(key);
+        Assert.Equal(16, bytes.Length);
+    }
+
+    [Fact]
+    public void DbKey_RoundTrips_ThroughEncryptAndDecrypt()
+    {
+        var masterKey = NewMasterKey();
+        var fileKey = CmsFileCrypto.GenerateFileKey();
+
+        var dbKey = CmsFileCrypto.EncryptDbKey(fileKey, masterKey);
+        var decrypted = CmsFileCrypto.DecryptDbKey(dbKey, masterKey);
+
+        Assert.Equal(fileKey, decrypted);
+        // Stored keys must be printable (UU-encoded) for the varchar column.
+        Assert.All(dbKey, c => Assert.True(c < 127));
+    }
+
+    [Fact]
+    public void DbKey_DiffersPerCall_EvenForSameFileKey()
+    {
+        // Same plaintext under different master keys must never produce the same stored key.
+        var fileKey = CmsFileCrypto.GenerateFileKey();
+
+        var dbKey1 = CmsFileCrypto.EncryptDbKey(fileKey, NewMasterKey());
+        var dbKey2 = CmsFileCrypto.EncryptDbKey(fileKey, NewMasterKey());
+
+        Assert.NotEqual(dbKey1, dbKey2);
+    }
+
+    [Fact]
+    public void FileContents_RoundTrip_ThroughEncryptAndDecrypt()
+    {
+        var fileKey = CmsFileCrypto.GenerateFileKey();
+        var contents = Encoding.UTF8.GetBytes("PDF-1.7 pretend file contents éü with some length to cross a block boundary.");
+
+        var encrypted = CmsFileCrypto.EncryptBytes(contents, fileKey);
+        var decrypted = CmsFileCrypto.DecryptBytes(encrypted, fileKey);
+
+        Assert.NotEqual(contents, encrypted);
+        Assert.Equal(contents, decrypted);
+    }
+
+    [Fact]
+    public void FullFlow_DbKeyPlusContents_MatchesLegacyDecryptPath()
+    {
+        // Mirrors CMS.DecryptFile: db key -> per-file key -> ECB decrypt of contents.
+        var masterKey = NewMasterKey();
+        var fileKey = CmsFileCrypto.GenerateFileKey();
+        var dbKey = CmsFileCrypto.EncryptDbKey(fileKey, masterKey);
+        var contents = RandomNumberGenerator.GetBytes(1024);
+
+        var encrypted = CmsFileCrypto.EncryptBytes(contents, fileKey);
+        var decrypted = CmsFileCrypto.DecryptBytes(encrypted, CmsFileCrypto.DecryptDbKey(dbKey, masterKey));
+
+        Assert.Equal(contents, decrypted);
+    }
+
+    [Fact]
+    public void ReadMasterKey_ReadsSecondLine()
+    {
+        var path = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        try
+        {
+            File.WriteAllLines(path, new[] { "first line is ignored", "  the-master-key  ", "third" });
+
+            Assert.Equal("the-master-key", CmsFileCrypto.ReadMasterKey(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReadMasterKey_MissingKeyLine_Throws()
+    {
+        var path = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        try
+        {
+            File.WriteAllLines(path, new[] { "only one line" });
+
+            Assert.Throws<InvalidOperationException>(() => CmsFileCrypto.ReadMasterKey(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -1,0 +1,399 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Areas.CMS.Services;
+using Viper.Classes.SQLContext;
+using File = Viper.Models.VIPER.File;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for CmsFileService CRUD orchestration: friendly-name generation, permission and
+/// person deltas, soft delete/restore, and audit calls. Storage and encryption are mocked;
+/// the database is EF in-memory.
+/// </summary>
+public sealed class CmsFileServiceTests : IDisposable
+{
+    private readonly VIPERContext _context;
+    private readonly AAUDContext _aaudContext;
+    private readonly ICmsFileStorageService _storage;
+    private readonly ICmsFileEncryptionService _encryption;
+    private readonly ICmsFileAuditService _audit;
+    private readonly IUserHelper _userHelper;
+    private readonly CmsFileService _service;
+
+    public CmsFileServiceTests()
+    {
+        _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
+        _aaudContext = new AAUDContext(new DbContextOptionsBuilder<AAUDContext>()
+            .UseInMemoryDatabase("AAUD_" + Guid.NewGuid()).Options);
+
+        _storage = Substitute.For<ICmsFileStorageService>();
+        _storage.RootFolder.Returns(@"C:\FakeRoot");
+        _storage.IsValidFolder(Arg.Any<string>()).Returns(true);
+        _storage.SaveToTempAsync(Arg.Any<IFormFile>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(@"C:\FakeTemp\" + Guid.NewGuid().ToString("N")));
+        _storage.MoveIntoPlace(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
+            .Returns(callInfo => Path.Join(@"C:\FakeRoot", callInfo.ArgAt<string>(1), Path.GetFileName(callInfo.ArgAt<string>(2))));
+
+        _encryption = Substitute.For<ICmsFileEncryptionService>();
+        _encryption.GenerateKeyForDb().Returns("encrypted-db-key");
+
+        _audit = Substitute.For<ICmsFileAuditService>();
+        _userHelper = Substitute.For<IUserHelper>();
+
+        _service = new CmsFileService(_context, _aaudContext, _storage, _encryption, _audit, _userHelper);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _aaudContext.Dispose();
+    }
+
+    private static IFormFile MakeFormFile(string fileName = "report.pdf")
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        return new FormFile(stream, 0, stream.Length, "file", fileName);
+    }
+
+    private async Task<File> SeedFileAsync(Action<File>? customize = null)
+    {
+        var file = new File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = @"C:\FakeRoot\cats\seeded.pdf",
+            Folder = "cats",
+            FriendlyName = "cats-seeded.pdf",
+            Description = "seeded",
+            ModifiedBy = "test",
+            ModifiedOn = DateTime.Now.AddDays(-1)
+        };
+        customize?.Invoke(file);
+        _context.Files.Add(file);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return file;
+    }
+
+    #region Create
+
+    [Fact]
+    public async Task CreateFile_BuildsFriendlyNameFromFolderAndFileName()
+    {
+        var request = new CmsFileCreateRequest { Folder = @"cats\photos" };
+
+        var dto = await _service.CreateFileAsync(request, MakeFormFile("pic.jpg"), TestContext.Current.CancellationToken);
+
+        Assert.Equal("cats-photos-pic.jpg", dto.FriendlyName);
+        Assert.Equal("pic.jpg", dto.FileName);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(@"cats\photos", saved.Folder);
+        Assert.False(saved.Encrypted);
+        Assert.Null(saved.Key);
+    }
+
+    [Fact]
+    public async Task CreateFile_SavesPermissionsAndPeople_Deduplicated()
+    {
+        var request = new CmsFileCreateRequest
+        {
+            Folder = "cats",
+            Permissions = new List<string> { "SVMSecure.CATS", "svmsecure.cats", " SVMSecure.Admin " },
+            IamIds = new List<string> { "1000123", "1000123", "1000456" }
+        };
+
+        var dto = await _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, dto.Permissions.Count);
+        Assert.Contains("SVMSecure.Admin", dto.Permissions);
+        Assert.Equal(2, dto.People.Count);
+    }
+
+    [Fact]
+    public async Task CreateFile_WithEncrypt_GeneratesKeyAndEncryptsTemp()
+    {
+        var request = new CmsFileCreateRequest { Folder = "cats", Encrypt = true };
+
+        var dto = await _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken);
+
+        Assert.True(dto.Encrypted);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("encrypted-db-key", saved.Key);
+        _encryption.Received(1).EncryptFileInPlace(Arg.Any<string>(), "encrypted-db-key");
+    }
+
+    [Fact]
+    public async Task CreateFile_AuditsAddAndUpload()
+    {
+        var request = new CmsFileCreateRequest { Folder = "cats" };
+
+        await _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken);
+
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.AddFile, Arg.Any<string>());
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.UploadFile, "NewFile");
+    }
+
+    [Fact]
+    public async Task CreateFile_DuplicateFriendlyName_DeletesMovedFileAndThrows()
+    {
+        await SeedFileAsync(f => f.FriendlyName = "cats-report.pdf");
+        var request = new CmsFileCreateRequest { Folder = "cats" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.CreateFileAsync(request, MakeFormFile("report.pdf"), TestContext.Current.CancellationToken));
+
+        _storage.Received(1).DeleteManagedFile(@"C:\FakeRoot\cats\report.pdf");
+    }
+
+    [Fact]
+    public async Task CreateFile_InvalidFolder_Throws()
+    {
+        _storage.IsValidFolder("badfolder").Returns(false);
+        var request = new CmsFileCreateRequest { Folder = "badfolder" };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CreateFile_DisallowedExtension_Throws()
+    {
+        var request = new CmsFileCreateRequest { Folder = "cats" };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.CreateFileAsync(request, MakeFormFile("evil.bat"), TestContext.Current.CancellationToken));
+    }
+
+    #endregion
+
+    #region Update
+
+    [Fact]
+    public async Task UpdateFile_AppliesPermissionDeltas()
+    {
+        var file = await SeedFileAsync(f =>
+        {
+            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Old" });
+            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Keep" });
+        });
+        var request = new CmsFileUpdateRequest
+        {
+            Description = "seeded",
+            Permissions = new List<string> { "SVMSecure.Keep", "SVMSecure.New" }
+        };
+
+        var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        Assert.Equal(new List<string> { "SVMSecure.Keep", "SVMSecure.New" }, dto!.Permissions);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.EditFile,
+            Arg.Is<string>(d => d.Contains("Permission removed: SVMSecure.Old") && d.Contains("Permission added: SVMSecure.New")));
+    }
+
+    [Fact]
+    public async Task UpdateFile_AppliesPersonDeltas()
+    {
+        var file = await SeedFileAsync(f =>
+            f.FileToPeople.Add(new Viper.Models.VIPER.FileToPerson { FileGuid = f.FileGuid, IamId = "100OLD" }));
+        var request = new CmsFileUpdateRequest
+        {
+            Description = "seeded",
+            IamIds = new List<string> { "100NEW" }
+        };
+
+        var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        Assert.Single(dto!.People);
+        Assert.Equal("100NEW", dto.People[0].IamId);
+    }
+
+    [Fact]
+    public async Task UpdateFile_EncryptToggleOn_EncryptsExistingFile()
+    {
+        var file = await SeedFileAsync();
+        _storage.ManagedFileExists(file.FilePath).Returns(true);
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = true };
+
+        var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
+
+        Assert.True(dto!.Encrypted);
+        _encryption.Received(1).EncryptFileInPlace(file.FilePath, "encrypted-db-key");
+    }
+
+    [Fact]
+    public async Task UpdateFile_EncryptToggleOff_DecryptsExistingFile()
+    {
+        var file = await SeedFileAsync(f =>
+        {
+            f.Encrypted = true;
+            f.Key = "old-key";
+        });
+        _storage.ManagedFileExists(file.FilePath).Returns(true);
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = false };
+
+        var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
+
+        Assert.False(dto!.Encrypted);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Null(saved.Key);
+        _encryption.Received(1).DecryptFileInPlace(file.FilePath, "old-key");
+    }
+
+    [Fact]
+    public async Task UpdateFile_WithReplacementUpload_ReplacesInPlaceAndAudits()
+    {
+        var file = await SeedFileAsync();
+        var request = new CmsFileUpdateRequest { Description = "seeded" };
+
+        await _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken);
+
+        _storage.Received(1).ReplaceInPlace(Arg.Any<string>(), file.FilePath);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.UploadFile, "ReplacingFile");
+    }
+
+    [Fact]
+    public async Task UpdateFile_UnknownGuid_ReturnsNull()
+    {
+        var dto = await _service.UpdateFileAsync(Guid.NewGuid(), new CmsFileUpdateRequest(), null, TestContext.Current.CancellationToken);
+
+        Assert.Null(dto);
+    }
+
+    #endregion
+
+    #region Delete / Restore
+
+    [Fact]
+    public async Task SoftDelete_SetsDeletedOn_AndAudits()
+    {
+        var file = await SeedFileAsync();
+
+        var result = await _service.SoftDeleteFileAsync(file.FileGuid, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(saved.DeletedOn);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+    }
+
+    [Fact]
+    public async Task Restore_ClearsDeletedOn_AndAudits()
+    {
+        var file = await SeedFileAsync(f => f.DeletedOn = DateTime.Now);
+
+        var result = await _service.RestoreFileAsync(file.FileGuid, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Null(saved.DeletedOn);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.CancelDelete, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task PermanentDelete_RemovesRowAndDiskFile()
+    {
+        var file = await SeedFileAsync(f =>
+            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure" }));
+        _storage.ManagedFileExists(file.FilePath).Returns(true);
+
+        var result = await _service.PermanentlyDeleteFileAsync(file.FileGuid, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        Assert.Empty(await _context.Files.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.FileToPermissions.ToListAsync(TestContext.Current.CancellationToken));
+        _storage.Received(1).DeleteManagedFile(file.FilePath);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.DeleteFile, "File Deleted");
+    }
+
+    #endregion
+
+    #region List
+
+    [Fact]
+    public async Task GetFiles_FiltersByStatus()
+    {
+        await SeedFileAsync();
+        await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-deleted.pdf";
+            f.FilePath = @"C:\FakeRoot\cats\deleted.pdf";
+            f.DeletedOn = DateTime.Now;
+        });
+
+        var (active, activeTotal) = await _service.GetFilesAsync(null, "active", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+        var (deleted, deletedTotal) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+        var (all, allTotal) = await _service.GetFilesAsync(null, "all", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, activeTotal);
+        Assert.Single(active);
+        Assert.Equal(1, deletedTotal);
+        Assert.Single(deleted);
+        Assert.Equal(2, allTotal);
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task GetFiles_FiltersByFolderIncludingSubfolders()
+    {
+        await SeedFileAsync();
+        await SeedFileAsync(f =>
+        {
+            f.Folder = @"cats\photos";
+            f.FriendlyName = "cats-photos-pic.jpg";
+            f.FilePath = @"C:\FakeRoot\cats\photos\pic.jpg";
+        });
+        await SeedFileAsync(f =>
+        {
+            f.Folder = "students";
+            f.FriendlyName = "students-doc.pdf";
+            f.FilePath = @"C:\FakeRoot\students\doc.pdf";
+        });
+
+        var (files, total) = await _service.GetFilesAsync("cats", "active", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, total);
+        Assert.All(files, f => Assert.StartsWith("cats", f.Folder));
+    }
+
+    [Fact]
+    public async Task GetFiles_SearchMatchesFriendlyNameAndDescription()
+    {
+        await SeedFileAsync(f => f.Description = "the yearly budget");
+        await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-other.pdf";
+            f.FilePath = @"C:\FakeRoot\cats\other.pdf";
+            f.Description = "unrelated";
+        });
+
+        var (files, total) = await _service.GetFilesAsync(null, "active", "budget", null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, total);
+        Assert.Equal("cats-seeded.pdf", files[0].FriendlyName);
+    }
+
+    [Fact]
+    public async Task GetFiles_PaginationAppliesSkipTake()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var index = i;
+            await SeedFileAsync(f =>
+            {
+                f.FriendlyName = $"cats-file{index}.pdf";
+                f.FilePath = $@"C:\FakeRoot\cats\file{index}.pdf";
+            });
+        }
+
+        var (page2, total) = await _service.GetFilesAsync(null, "active", null, null, null, 2, 2, "friendlyName", false, TestContext.Current.CancellationToken);
+
+        Assert.Equal(5, total);
+        Assert.Equal(2, page2.Count);
+        Assert.Equal("cats-file2.pdf", page2[0].FriendlyName);
+    }
+
+    #endregion
+}

--- a/test/CMS/CmsFileStorageServiceTests.cs
+++ b/test/CMS/CmsFileStorageServiceTests.cs
@@ -1,0 +1,290 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Viper.Areas.CMS.Services;
+using Viper.Classes.SQLContext;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for CmsFileStorageService: folder validation (user input must never escape the
+/// storage root), name-collision handling, and managed-file containment checks.
+/// </summary>
+public sealed class CmsFileStorageServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly VIPERContext _context;
+    private readonly CmsFileStorageService _service;
+
+    public CmsFileStorageServiceTests()
+    {
+        _root = Path.Join(Path.GetTempPath(), "ViperCmsStorageTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Join(_root, "cats"));
+        Directory.CreateDirectory(Path.Join(_root, "students"));
+
+        var options = new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new VIPERContext(options);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["CMS:FileStorageRoot"] = _root })
+            .Build();
+        _service = new CmsFileStorageService(_context, configuration);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private static string CreateTempFile(string contents = "test contents")
+    {
+        var path = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    #region GetTopLevelFolders / IsValidFolder
+
+    [Fact]
+    public void GetTopLevelFolders_ReturnsDirectoriesUnderRoot()
+    {
+        var folders = _service.GetTopLevelFolders();
+
+        Assert.Equal(new[] { "cats", "students" }, folders);
+    }
+
+    [Theory]
+    [InlineData("cats")]
+    [InlineData("students")]
+    [InlineData(@"cats\photos")]
+    [InlineData("cats/photos/2026")]
+    public void IsValidFolder_AcceptsExistingTopLevelAndSubfolders(string folder)
+    {
+        Assert.True(_service.IsValidFolder(folder));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("doesnotexist")]
+    [InlineData(@"..\cats")]
+    [InlineData(@"cats\..\..\evil")]
+    [InlineData(@"cats\.")]
+    [InlineData(@"C:\Windows")]
+    [InlineData(@"\\server\share")]
+    [InlineData("cats\\sub<dir>")]
+    public void IsValidFolder_RejectsUnknownTraversalAndInvalid(string folder)
+    {
+        Assert.False(_service.IsValidFolder(folder));
+    }
+
+    #endregion
+
+    #region MoveIntoPlace
+
+    [Fact]
+    public void MoveIntoPlace_MovesTempFileIntoFolder()
+    {
+        var temp = CreateTempFile();
+
+        var finalPath = _service.MoveIntoPlace(temp, "cats", "report.pdf", makeUnique: false);
+
+        Assert.Equal(Path.Join(_root, "cats", "report.pdf"), finalPath);
+        Assert.True(File.Exists(finalPath));
+        Assert.False(File.Exists(temp));
+    }
+
+    [Fact]
+    public void MoveIntoPlace_CreatesSubfolders()
+    {
+        var temp = CreateTempFile();
+
+        var finalPath = _service.MoveIntoPlace(temp, @"cats\photos", "pic.jpg", makeUnique: false);
+
+        Assert.Equal(Path.Join(_root, "cats", "photos", "pic.jpg"), finalPath);
+        Assert.True(File.Exists(finalPath));
+    }
+
+    [Fact]
+    public void MoveIntoPlace_Conflict_WithoutMakeUnique_Throws()
+    {
+        File.WriteAllText(Path.Join(_root, "cats", "report.pdf"), "existing");
+        var temp = CreateTempFile();
+
+        Assert.Throws<InvalidOperationException>(() => _service.MoveIntoPlace(temp, "cats", "report.pdf", makeUnique: false));
+    }
+
+    [Fact]
+    public void MoveIntoPlace_Conflict_WithMakeUnique_AppendsCounter()
+    {
+        File.WriteAllText(Path.Join(_root, "cats", "report.pdf"), "existing");
+        File.WriteAllText(Path.Join(_root, "cats", "report_0.pdf"), "existing");
+        var temp = CreateTempFile();
+
+        var finalPath = _service.MoveIntoPlace(temp, "cats", "report.pdf", makeUnique: true);
+
+        Assert.Equal(Path.Join(_root, "cats", "report_1.pdf"), finalPath);
+    }
+
+    [Fact]
+    public void MoveIntoPlace_StripsPathComponentsFromFileName()
+    {
+        var temp = CreateTempFile();
+
+        var finalPath = _service.MoveIntoPlace(temp, "cats", @"..\..\evil.pdf", makeUnique: false);
+
+        Assert.Equal(Path.Join(_root, "cats", "evil.pdf"), finalPath);
+    }
+
+    [Theory]
+    [InlineData("malware.bat")]
+    [InlineData("script.ps1")]
+    [InlineData("noextension")]
+    public void MoveIntoPlace_DisallowedExtension_Throws(string fileName)
+    {
+        var temp = CreateTempFile();
+
+        try
+        {
+            Assert.Throws<ArgumentException>(() => _service.MoveIntoPlace(temp, "cats", fileName, makeUnique: false));
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void MoveIntoPlace_InvalidFolder_Throws()
+    {
+        var temp = CreateTempFile();
+
+        try
+        {
+            Assert.Throws<ArgumentException>(() => _service.MoveIntoPlace(temp, @"..\evil", "report.pdf", makeUnique: false));
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    #endregion
+
+    #region FileNameInUse
+
+    [Fact]
+    public void FileNameInUse_DetectsFileOnDisk()
+    {
+        File.WriteAllText(Path.Join(_root, "cats", "ondisk.pdf"), "x");
+
+        Assert.True(_service.FileNameInUse("cats", "ondisk.pdf"));
+        Assert.False(_service.FileNameInUse("cats", "notthere.pdf"));
+    }
+
+    [Fact]
+    public void FileNameInUse_DetectsDatabaseRecordWithoutDiskFile()
+    {
+        _context.Files.Add(new Viper.Models.VIPER.File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = Path.Join(_root, "cats", "dbonly.pdf"),
+            Folder = "cats",
+            FriendlyName = "cats-dbonly.pdf",
+            Description = "",
+            ModifiedBy = "test",
+            ModifiedOn = DateTime.Now
+        });
+        _context.SaveChanges();
+
+        Assert.True(_service.FileNameInUse("cats", "dbonly.pdf"));
+    }
+
+    #endregion
+
+    #region SaveToTempAsync / ReplaceInPlace / DeleteManagedFile
+
+    [Fact]
+    public async Task SaveToTempAsync_WritesUploadOutsideStorageRoot()
+    {
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var formFile = new FormFile(stream, 0, stream.Length, "file", "upload.pdf");
+
+        var tempPath = await _service.SaveToTempAsync(formFile, TestContext.Current.CancellationToken);
+
+        try
+        {
+            Assert.True(File.Exists(tempPath));
+            Assert.False(tempPath.StartsWith(_root, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void ReplaceInPlace_OverwritesManagedFile()
+    {
+        var managed = Path.Join(_root, "cats", "replace.pdf");
+        File.WriteAllText(managed, "old");
+        var temp = CreateTempFile("new");
+
+        _service.ReplaceInPlace(temp, managed);
+
+        Assert.Equal("new", File.ReadAllText(managed));
+        Assert.False(File.Exists(temp));
+    }
+
+    [Fact]
+    public void ReplaceInPlace_TargetOutsideRoot_Throws()
+    {
+        var outside = CreateTempFile("victim");
+        var temp = CreateTempFile("new");
+
+        try
+        {
+            Assert.Throws<ArgumentException>(() => _service.ReplaceInPlace(temp, outside));
+        }
+        finally
+        {
+            File.Delete(outside);
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void DeleteManagedFile_DeletesUnderRoot()
+    {
+        var managed = Path.Join(_root, "cats", "todelete.pdf");
+        File.WriteAllText(managed, "x");
+
+        _service.DeleteManagedFile(managed);
+
+        Assert.False(File.Exists(managed));
+    }
+
+    [Fact]
+    public void DeleteManagedFile_OutsideRoot_Throws()
+    {
+        var outside = CreateTempFile();
+
+        try
+        {
+            Assert.Throws<ArgumentException>(() => _service.DeleteManagedFile(outside));
+            Assert.True(File.Exists(outside));
+        }
+        finally
+        {
+            File.Delete(outside);
+        }
+    }
+
+    #endregion
+}

--- a/web/Areas/CMS/Constants/CmsFileTypes.cs
+++ b/web/Areas/CMS/Constants/CmsFileTypes.cs
@@ -1,0 +1,56 @@
+namespace Viper.Areas.CMS.Constants
+{
+    /// <summary>
+    /// Allowed CMS file extensions and their MIME types. Mirrors the legacy
+    /// ColdFusion Lookups.cfc allow-list; extensions not in this map are rejected on upload.
+    /// </summary>
+    public static class CmsFileTypes
+    {
+        public static readonly IReadOnlyDictionary<string, string> MimeTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["pdf"] = "application/pdf",
+            ["docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ["doc"] = "application/msword",
+            ["xls"] = "application/vnd.ms-excel",
+            ["xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ["csv"] = "text/csv",
+            ["ppt"] = "application/vnd.ms-powerpoint",
+            ["pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ["pptm"] = "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+            ["txt"] = "text/plain",
+            ["html"] = "application/xhtml+xml",
+            ["gif"] = "image/gif",
+            ["png"] = "image/png",
+            ["jpg"] = "image/jpeg",
+            ["jpeg"] = "image/jpeg",
+            ["tiff"] = "image/tiff",
+            ["mp3"] = "audio/mpeg",
+            ["wav"] = "audio/wav",
+            ["mp4"] = "video/mp4",
+            ["webm"] = "video/webm",
+            ["oft"] = "application/vnd.ms-outlook",
+            ["eps"] = "application/postscript",
+            ["zip"] = "application/zip",
+            ["7z"] = "application/x-7z-compressed",
+            ["dmg"] = "application/x-apple-diskimage",
+            ["exe"] = "application/vnd.microsoft.portable-executable"
+        };
+
+        public static bool IsAllowedFileName(string fileName)
+        {
+            return MimeTypes.ContainsKey(GetExtension(fileName));
+        }
+
+        public static string GetMimeType(string fileName)
+        {
+            return MimeTypes.TryGetValue(GetExtension(fileName), out var mimeType)
+                ? mimeType
+                : "application/octet-stream";
+        }
+
+        private static string GetExtension(string fileName)
+        {
+            return Path.GetExtension(fileName).TrimStart('.');
+        }
+    }
+}

--- a/web/Areas/CMS/Constants/CmsPermissions.cs
+++ b/web/Areas/CMS/Constants/CmsPermissions.cs
@@ -1,0 +1,15 @@
+namespace Viper.Areas.CMS.Constants
+{
+    /// <summary>
+    /// RAPS permission strings used by the CMS area.
+    /// </summary>
+    public static class CmsPermissions
+    {
+        public const string Base = "SVMSecure.CMS";
+        public const string AllFiles = "SVMSecure.CMS.AllFiles";
+        public const string ManageContentBlocks = "SVMSecure.CMS.ManageContentBlocks";
+        public const string CreateContentBlock = "SVMSecure.CMS.CreateContentBlock";
+        public const string ManageNavigation = "SVMSecure.CMS.ManageNavigation";
+        public const string Admin = "SVMSecure.CATS.Admin";
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSFilesController.cs
+++ b/web/Areas/CMS/Controllers/CMSFilesController.cs
@@ -1,0 +1,204 @@
+using Microsoft.AspNetCore.Mvc;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Areas.CMS.Services;
+using Viper.Classes;
+using Viper.Classes.SQLContext;
+using Viper.Classes.Utilities;
+using Viper.Models;
+using Viper.Models.VIPER;
+using Web.Authorization;
+
+namespace Viper.Areas.CMS.Controllers
+{
+    /// <summary>
+    /// File management API (list/upload/edit/delete/restore/audit). Downloads are served by
+    /// the existing permission-checked CMSController (/CMS/Files), which legacy URLs point at.
+    /// </summary>
+    [Route("/api/cms/files")]
+    [Permission(Allow = CmsPermissions.AllFiles)]
+    public class CMSFilesController : ApiController
+    {
+        private const long MaxUploadBytes = 100_000_000;
+
+        private readonly ICmsFileService _fileService;
+        private readonly ICmsFileStorageService _storage;
+        private readonly ICmsFileAuditService _auditService;
+        private readonly RAPSContext _rapsContext;
+        private readonly ILogger<CMSFilesController> _logger;
+        private readonly IUserHelper _userHelper;
+
+        public CMSFilesController(ICmsFileService fileService, ICmsFileStorageService storage,
+            ICmsFileAuditService auditService, RAPSContext rapsContext, ILogger<CMSFilesController> logger,
+            IUserHelper userHelper)
+        {
+            _fileService = fileService;
+            _storage = storage;
+            _auditService = auditService;
+            _rapsContext = rapsContext;
+            _logger = logger;
+            _userHelper = userHelper;
+        }
+
+        // GET /api/cms/files
+        [HttpGet]
+        [ApiPagination(DefaultPerPage = 50, MaxPerPage = 500)]
+        public async Task<ActionResult<List<CmsFileDto>>> GetFiles(
+            string? folder,
+            string? search,
+            bool? encrypted,
+            bool? isPublic,
+            ApiPagination? pagination,
+            string status = "active",
+            string? sortBy = "friendlyName",
+            bool descending = false,
+            CancellationToken ct = default)
+        {
+            var page = pagination?.Page ?? 1;
+            var perPage = pagination?.PerPage ?? 50;
+            var (files, total) = await _fileService.GetFilesAsync(folder, status, search, encrypted, isPublic,
+                page, perPage, sortBy, descending, ct);
+            if (pagination != null)
+            {
+                pagination.TotalRecords = total;
+            }
+            return files;
+        }
+
+        // GET /api/cms/files/folders
+        [HttpGet("folders")]
+        public ActionResult<List<string>> GetFolders()
+        {
+            return _storage.GetTopLevelFolders();
+        }
+
+        // GET /api/cms/files/audit
+        [HttpGet("audit")]
+        [ApiPagination(DefaultPerPage = 50, MaxPerPage = 500)]
+        public async Task<ActionResult<List<FileAudit>>> GetAudit(
+            Guid? fileGuid,
+            string? action,
+            string? loginId,
+            DateTime? from,
+            DateTime? to,
+            string? search,
+            ApiPagination? pagination,
+            CancellationToken ct = default)
+        {
+            var filter = new CmsFileAuditFilter
+            {
+                FileGuid = fileGuid,
+                Action = action,
+                LoginId = loginId,
+                From = from,
+                To = to,
+                Search = search
+            };
+            var page = pagination?.Page ?? 1;
+            var perPage = pagination?.PerPage ?? 50;
+            var entries = await _auditService.GetAuditEntriesAsync(filter, page, perPage, ct);
+            if (pagination != null)
+            {
+                pagination.TotalRecords = await _auditService.GetAuditEntryCountAsync(filter, ct);
+            }
+            return entries;
+        }
+
+        // GET /api/cms/files/{fileGuid}
+        [HttpGet("{fileGuid:guid}")]
+        public async Task<ActionResult<CmsFileDto>> GetFile(Guid fileGuid, CancellationToken ct = default)
+        {
+            var file = await _fileService.GetFileAsync(fileGuid, ct);
+            if (file == null)
+            {
+                return NotFound();
+            }
+            return file;
+        }
+
+        // POST /api/cms/files
+        [HttpPost]
+        [RequestSizeLimit(MaxUploadBytes)]
+        [RequestFormLimits(MultipartBodyLengthLimit = MaxUploadBytes)]
+        public async Task<ActionResult<CmsFileDto>> UploadFile([FromForm] CmsFileCreateRequest request, IFormFile? file,
+            CancellationToken ct = default)
+        {
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest("A file is required.");
+            }
+
+            try
+            {
+                return await _fileService.CreateFileAsync(request, file, ct);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogFileConflict(nameof(UploadFile), request.Folder, file.FileName, ex);
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // PUT /api/cms/files/{fileGuid}
+        [HttpPut("{fileGuid:guid}")]
+        [RequestSizeLimit(MaxUploadBytes)]
+        [RequestFormLimits(MultipartBodyLengthLimit = MaxUploadBytes)]
+        public async Task<ActionResult<CmsFileDto>> UpdateFile(Guid fileGuid, [FromForm] CmsFileUpdateRequest request,
+            IFormFile? file, CancellationToken ct = default)
+        {
+            try
+            {
+                var updated = await _fileService.UpdateFileAsync(fileGuid, request, file, ct);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+                return updated;
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogFileConflict(nameof(UpdateFile), null, file?.FileName, ex);
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // DELETE /api/cms/files/{fileGuid}?permanent=true|false
+        [HttpDelete("{fileGuid:guid}")]
+        public async Task<IActionResult> DeleteFile(Guid fileGuid, bool permanent = false, CancellationToken ct = default)
+        {
+            if (permanent)
+            {
+                // Hard delete is restricted to admins; soft delete is available to all file managers.
+                if (!_userHelper.HasPermission(_rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin))
+                {
+                    return ForbidApi();
+                }
+                return await _fileService.PermanentlyDeleteFileAsync(fileGuid, ct) ? NoContent() : NotFound();
+            }
+            return await _fileService.SoftDeleteFileAsync(fileGuid, ct) ? NoContent() : NotFound();
+        }
+
+        // POST /api/cms/files/{fileGuid}/restore
+        [HttpPost("{fileGuid:guid}/restore")]
+        public async Task<IActionResult> RestoreFile(Guid fileGuid, CancellationToken ct = default)
+        {
+            return await _fileService.RestoreFileAsync(fileGuid, ct) ? Ok() : NotFound();
+        }
+
+        private void LogFileConflict(string operation, string? folder, string? fileName, Exception ex)
+        {
+            _logger.LogWarning(ex, "CMS file {Operation} conflict folder={Folder} fileName={FileName}",
+                LogSanitizer.SanitizeString(operation),
+                LogSanitizer.SanitizeString(folder),
+                LogSanitizer.SanitizeString(fileName));
+        }
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSOptionsController.cs
+++ b/web/Areas/CMS/Controllers/CMSOptionsController.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.RAPS.Services;
+using Viper.Classes;
+using Viper.Classes.SQLContext;
+using Web.Authorization;
+
+namespace Viper.Areas.CMS.Controllers
+{
+    /// <summary>
+    /// Option lists for CMS management forms (permission and person selectors). The RAPS
+    /// permissions API requires RAPS roles + 2FA, which CMS content managers don't have,
+    /// so the CMS exposes its own read-only lists gated by the CMS manage permissions.
+    /// </summary>
+    [Route("/api/cms/options")]
+    [Permission(Allow = CmsPermissions.AllFiles + "," + CmsPermissions.ManageContentBlocks + "," + CmsPermissions.ManageNavigation)]
+    public class CMSOptionsController : ApiController
+    {
+        private readonly RAPSContext _rapsContext;
+        private readonly AAUDContext _aaudContext;
+
+        public CMSOptionsController(RAPSContext rapsContext, AAUDContext aaudContext)
+        {
+            _rapsContext = rapsContext;
+            _aaudContext = aaudContext;
+        }
+
+        /// <summary>
+        /// All VIPER-instance permission names, for tagging files/blocks/nav items with
+        /// required permissions (matches the legacy CMS permission multi-select).
+        /// </summary>
+        [HttpGet("permissions")]
+        public async Task<ActionResult<List<string>>> GetPermissions(CancellationToken ct = default)
+        {
+            return await _rapsContext.TblPermissions
+                .AsNoTracking()
+                .Where(RAPSSecurityService.FilterPermissionsToInstance("VIPER"))
+                .OrderBy(p => p.Permission)
+                .Select(p => p.Permission)
+                .ToListAsync(ct);
+        }
+
+        /// <summary>
+        /// Search current people by name, login id, or mail id for person-level file access.
+        /// </summary>
+        [HttpGet("people")]
+        public async Task<ActionResult<List<CmsPersonOption>>> SearchPeople(string search, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(search) || search.Trim().Length < 2)
+            {
+                return new List<CmsPersonOption>();
+            }
+            search = search.Trim();
+
+            return await _aaudContext.AaudUsers
+                .AsNoTracking()
+                .Where(u => u.Current != 0 && u.IamId != null)
+                .Where(u => (u.DisplayLastName + ", " + u.DisplayFirstName).Contains(search)
+                    || (u.DisplayFirstName + " " + u.DisplayLastName).Contains(search)
+                    || (u.LoginId != null && u.LoginId.Contains(search))
+                    || (u.MailId != null && u.MailId.Contains(search)))
+                .OrderBy(u => u.DisplayLastName)
+                .ThenBy(u => u.DisplayFirstName)
+                .Take(25)
+                .Select(u => new CmsPersonOption
+                {
+                    IamId = u.IamId!,
+                    Name = u.DisplayLastName + ", " + u.DisplayFirstName,
+                    LoginId = u.LoginId,
+                    MailId = u.MailId
+                })
+                .ToListAsync(ct);
+        }
+    }
+
+    public class CmsPersonOption
+    {
+        public string IamId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? LoginId { get; set; }
+        public string? MailId { get; set; }
+    }
+}

--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -1,6 +1,5 @@
 using System.IO.Compression;
 using System.Net;
-using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
@@ -27,35 +26,8 @@ namespace Viper.Areas.CMS.Data
 
         public IUserHelper UserHelper { get; set; }
 
-        public Dictionary<string, string> MimeTypes { get; set; } = new()
-        {
-            ["pdf"] = "application/pdf",
-            ["docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            ["doc"] = "application/msword",
-            ["xls"] = "application/vnd.ms-excel",
-            ["xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            ["csv"] = "text/csv",
-            ["ppt"] = "application/vnd.ms-powerpoint",
-            ["pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            ["pptm"] = "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
-            ["txt"] = "text/plain",
-            ["html"] = "application/xhtml+xml",
-            ["gif"] = "image/gif",
-            ["png"] = "image/png",
-            ["jpg"] = "image/jpeg",
-            ["jpeg"] = "image/jpeg",
-            ["tiff"] = "image/tiff",
-            ["mp3"] = "audio/mpeg",
-            ["wav"] = "audio/wav",
-            ["mp4"] = "video/mp4",
-            ["webm"] = "video/webm",
-            ["oft"] = "application/vnd.ms-outlook",
-            ["eps"] = "application/postscript",
-            ["zip"] = "application/zip",
-            ["7z"] = "application/x-7z-compressed",
-            ["dmg"] = "application/x-apple-diskimage",
-            ["exe"] = "application/vnd.microsoft.portable-executable"
-        };
+        public Dictionary<string, string> MimeTypes { get; set; } =
+            new(Constants.CmsFileTypes.MimeTypes, StringComparer.OrdinalIgnoreCase);
 
         #endregion
 
@@ -664,81 +636,19 @@ namespace Viper.Areas.CMS.Data
         #region public byte[] DecryptFile(byte[] encryptedData, string keystring)
         public byte[] DecryptFile(byte[] encryptedData, string keystring)
         {
-            byte[] secretkey = GetSecretKey(keystring);
-
-            using Aes aes = Aes.Create();
-            aes.Mode = CipherMode.ECB;
-
-            using var ms = new MemoryStream();
-            using (var cs = new CryptoStream(ms, aes.CreateDecryptor(secretkey, null), CryptoStreamMode.Write))
-            {
-                cs.Write(encryptedData, 0, encryptedData.Length);
-            }
-            byte[] decryptedData = ms.ToArray();
-
-            return decryptedData;
-
+            string masterKey = CmsFileCrypto.ReadMasterKey(CmsFileCrypto.GetDefaultKeyFilePath());
+            return CmsFileCrypto.DecryptBytes(encryptedData, CmsFileCrypto.DecryptDbKey(keystring, masterKey));
         }
         #endregion
 
         #region public string DecryptAES(string encryptedString, string Key)
         /// <summary>
-        /// Required for Unix decoding FROM https://rextester.com/TGN19503
+        /// Decrypt a CF-format (UU-encoded AES-ECB) string with the given base64 key.
         /// </summary>
         /// <returns>decoded string</returns>
         public string DecryptAES(string encryptedString, string Key)
         {
-            //First write to memory
-            using MemoryStream mmsStream = new();
-            using StreamWriter srwTemp = new(mmsStream);
-            srwTemp.Write(encryptedString);
-            srwTemp.Flush();
-            mmsStream.Position = 0;
-
-            using MemoryStream outstream = new();
-
-            //CallingUUDecode
-            Codecs.UUDecode(mmsStream, outstream);
-
-            //Extract the bytes of each of the values
-            byte[] input = outstream.ToArray();
-            byte[] key = Convert.FromBase64String(Key);
-
-            string? decryptedText = null;
-
-            using (Aes aes = Aes.Create())
-            {
-                // initialize settings to match those used by CF
-                aes.Mode = CipherMode.ECB;
-                aes.Padding = PaddingMode.PKCS7;
-                aes.BlockSize = 128;
-                aes.KeySize = 128;
-                aes.Key = key;
-
-                ICryptoTransform decryptor = aes.CreateDecryptor();
-
-                using MemoryStream msDecrypt = new(input);
-                using CryptoStream csDecrypt = new(msDecrypt, decryptor, CryptoStreamMode.Read);
-                using StreamReader srDecrypt = new(csDecrypt);
-                decryptedText = srDecrypt.ReadToEnd();
-            }
-            return decryptedText;
-        }
-        #endregion
-
-        #region private byte[] getSecretKey(string key)
-        private byte[] GetSecretKey(string key)
-        {
-            string keyFileFolder = @"S:\Settings\";
-
-            if (HttpHelper.Environment?.EnvironmentName == "Development")
-            {
-                keyFileFolder = @"C:\Sites\Settings\";
-            }
-            string keyString = System.IO.File.ReadLines(keyFileFolder + "viperfiles.txt").Skip(1).Take(1).First();
-
-            byte[] hiddenKey = Convert.FromBase64String(DecryptAES(key, keyString));
-            return hiddenKey;
+            return CmsFileCrypto.DecryptDbKey(encryptedString, Key);
         }
         #endregion
 

--- a/web/Areas/CMS/Models/CmsFileMapper.cs
+++ b/web/Areas/CMS/Models/CmsFileMapper.cs
@@ -1,0 +1,39 @@
+using Riok.Mapperly.Abstractions;
+using Viper.Areas.CMS.Models.DTOs;
+using File = Viper.Models.VIPER.File;
+
+namespace Viper.Areas.CMS.Models
+{
+    [Mapper(RequiredMappingStrategy = RequiredMappingStrategy.None)]
+    public static partial class CmsFileMapper
+    {
+        /// <summary>
+        /// Map a file entity to its DTO; permission/person collections and computed URLs are
+        /// filled in here rather than by the generated mapping.
+        /// </summary>
+        public static CmsFileDto ToCmsFileDto(File file, IReadOnlyDictionary<string, string>? namesByIamId = null)
+        {
+            var dto = ToCmsFileDtoBase(file);
+            dto.FileName = Path.GetFileName(file.FilePath);
+            dto.Permissions = file.FileToPermissions.Select(p => p.Permission).OrderBy(p => p).ToList();
+            dto.People = file.FileToPeople
+                .Select(p => new CmsFilePersonDto
+                {
+                    IamId = p.IamId,
+                    Name = namesByIamId != null && namesByIamId.TryGetValue(p.IamId, out var name) ? name : null
+                })
+                .OrderBy(p => p.Name ?? p.IamId)
+                .ToList();
+            dto.Url = Data.CMS.GetURL(file.FileGuid.ToString(), file.AllowPublicAccess);
+            dto.FriendlyUrl = Data.CMS.GetFriendlyURL(file.FriendlyName, file.AllowPublicAccess);
+            return dto;
+        }
+
+        [MapperIgnoreTarget(nameof(CmsFileDto.FileName))]
+        [MapperIgnoreTarget(nameof(CmsFileDto.Permissions))]
+        [MapperIgnoreTarget(nameof(CmsFileDto.People))]
+        [MapperIgnoreTarget(nameof(CmsFileDto.Url))]
+        [MapperIgnoreTarget(nameof(CmsFileDto.FriendlyUrl))]
+        private static partial CmsFileDto ToCmsFileDtoBase(File file);
+    }
+}

--- a/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
+++ b/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
@@ -1,0 +1,27 @@
+namespace Viper.Areas.CMS.Models.DTOs
+{
+    public class CmsFileDto
+    {
+        public Guid FileGuid { get; set; }
+        public string FileName { get; set; } = string.Empty;
+        public string? Folder { get; set; }
+        public string FriendlyName { get; set; } = string.Empty;
+        public bool Encrypted { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public bool AllowPublicAccess { get; set; }
+        public string? OldUrl { get; set; }
+        public DateTime ModifiedOn { get; set; }
+        public string ModifiedBy { get; set; } = string.Empty;
+        public DateTime? DeletedOn { get; set; }
+        public List<string> Permissions { get; set; } = new();
+        public List<CmsFilePersonDto> People { get; set; } = new();
+        public string Url { get; set; } = string.Empty;
+        public string FriendlyUrl { get; set; } = string.Empty;
+    }
+
+    public class CmsFilePersonDto
+    {
+        public string IamId { get; set; } = string.Empty;
+        public string? Name { get; set; }
+    }
+}

--- a/web/Areas/CMS/Models/DTOs/CmsFileRequests.cs
+++ b/web/Areas/CMS/Models/DTOs/CmsFileRequests.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Viper.Areas.CMS.Models.DTOs
+{
+    /// <summary>
+    /// Form fields accompanying a new file upload (multipart/form-data).
+    /// </summary>
+    public class CmsFileCreateRequest
+    {
+        [Required]
+        public string Folder { get; set; } = string.Empty;
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        public bool? AllowPublicAccess { get; set; }
+
+        [MaxLength(256)]
+        public string? OldUrl { get; set; }
+
+        public List<string> Permissions { get; set; } = new();
+
+        public List<string> IamIds { get; set; } = new();
+
+        public bool? Encrypt { get; set; }
+
+        /// <summary>When true, auto-rename on name conflict (name_0..name_999) instead of failing.</summary>
+        public bool? MakeUnique { get; set; }
+    }
+
+    /// <summary>
+    /// Form fields for editing file metadata; the file itself is an optional replacement upload.
+    /// </summary>
+    public class CmsFileUpdateRequest
+    {
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        public bool? AllowPublicAccess { get; set; }
+
+        [MaxLength(256)]
+        public string? OldUrl { get; set; }
+
+        public List<string> Permissions { get; set; } = new();
+
+        public List<string> IamIds { get; set; } = new();
+
+        public bool? Encrypt { get; set; }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileAuditService.cs
+++ b/web/Areas/CMS/Services/CmsFileAuditService.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Models;
+using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
+using File = Viper.Models.VIPER.File;
+
+namespace Viper.Areas.CMS.Services
+{
+    /// <summary>
+    /// File audit actions, matching the legacy ColdFusion FileAudit.cfc action names so the
+    /// shared fileAudit table stays consistent across both systems.
+    /// </summary>
+    public static class CmsFileAuditActions
+    {
+        public const string UploadFile = "UploadFile";
+        public const string AddFile = "AddFile";
+        public const string EditFile = "EditFile";
+        public const string DeleteFile = "DeleteFile";
+        public const string CancelDelete = "CancelDelete";
+        public const string ImportFile = "ImportFile";
+        public const string AccessFile = "AccessFile";
+        public const string AccessFileDenied = "AccessFileDenied";
+    }
+
+    public class CmsFileAuditFilter
+    {
+        public Guid? FileGuid { get; set; }
+        public string? Action { get; set; }
+        public string? LoginId { get; set; }
+        public DateTime? From { get; set; }
+        public DateTime? To { get; set; }
+        public string? Search { get; set; }
+    }
+
+    public interface ICmsFileAuditService
+    {
+        /// <summary>Add an audit row for a file operation. Does not call SaveChanges.</summary>
+        void Audit(File file, string action, string detail = "");
+
+        Task<List<FileAudit>> GetAuditEntriesAsync(CmsFileAuditFilter filter, int page, int perPage, CancellationToken ct = default);
+
+        Task<int> GetAuditEntryCountAsync(CmsFileAuditFilter filter, CancellationToken ct = default);
+    }
+
+    public class CmsFileAuditService : ICmsFileAuditService
+    {
+        private readonly VIPERContext _context;
+        private readonly IUserHelper _userHelper;
+
+        public CmsFileAuditService(VIPERContext context, IUserHelper userHelper)
+        {
+            _context = context;
+            _userHelper = userHelper;
+        }
+
+        public void Audit(File file, string action, string detail = "")
+        {
+            var user = _userHelper.GetCurrentUser();
+            var metaData = new CMSFileMetaData
+            {
+                Folder = file.Folder,
+                Encrypted = file.Encrypted,
+                Public = file.AllowPublicAccess,
+                Modified = file.ModifiedOn.ToString("yyyy-MM-dd HH:mm:ss"),
+                ModifiedBy = file.ModifiedBy
+            };
+
+            _context.FileAudits.Add(new FileAudit
+            {
+                Timestamp = DateTime.Now,
+                Loginid = user?.LoginId,
+                Action = action,
+                Detail = detail,
+                FileGuid = file.FileGuid,
+                FilePath = file.FilePath,
+                IamId = user?.IamId,
+                FileMetaData = JsonSerializer.Serialize(metaData),
+                ClientData = JsonSerializer.Serialize(_userHelper.GetClientData())
+            });
+        }
+
+        public async Task<List<FileAudit>> GetAuditEntriesAsync(CmsFileAuditFilter filter, int page, int perPage, CancellationToken ct = default)
+        {
+            return await BuildQuery(filter)
+                .OrderByDescending(a => a.Timestamp)
+                .ThenByDescending(a => a.AuditId)
+                .Skip((page - 1) * perPage)
+                .Take(perPage)
+                .ToListAsync(ct);
+        }
+
+        public async Task<int> GetAuditEntryCountAsync(CmsFileAuditFilter filter, CancellationToken ct = default)
+        {
+            return await BuildQuery(filter).CountAsync(ct);
+        }
+
+        private IQueryable<FileAudit> BuildQuery(CmsFileAuditFilter filter)
+        {
+            var query = _context.FileAudits.AsNoTracking();
+            if (filter.FileGuid != null)
+            {
+                query = query.Where(a => a.FileGuid == filter.FileGuid);
+            }
+            if (!string.IsNullOrEmpty(filter.Action))
+            {
+                query = query.Where(a => a.Action == filter.Action);
+            }
+            if (!string.IsNullOrEmpty(filter.LoginId))
+            {
+                query = query.Where(a => a.Loginid == filter.LoginId);
+            }
+            if (filter.From != null)
+            {
+                query = query.Where(a => a.Timestamp >= filter.From);
+            }
+            if (filter.To != null)
+            {
+                // Treat the To date as inclusive through end of day.
+                var to = filter.To.Value.Date == filter.To.Value ? filter.To.Value.AddDays(1) : filter.To.Value;
+                query = query.Where(a => a.Timestamp < to);
+            }
+            if (!string.IsNullOrEmpty(filter.Search))
+            {
+                query = query.Where(a => (a.FilePath != null && a.FilePath.Contains(filter.Search))
+                    || (a.Detail != null && a.Detail.Contains(filter.Search)));
+            }
+            return query;
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileCrypto.cs
+++ b/web/Areas/CMS/Services/CmsFileCrypto.cs
@@ -1,0 +1,121 @@
+using System.Security.Cryptography;
+using System.Text;
+using Viper.Areas.CMS.Data;
+
+namespace Viper.Areas.CMS.Services
+{
+    /// <summary>
+    /// CMS file encryption primitives, byte-for-byte compatible with the legacy ColdFusion CMS
+    /// (CF encrypt()/encryptBinary() with algorithm "AES" = AES-128-ECB-PKCS7, key strings UU-encoded).
+    /// Both systems share the same files and database during the migration, so the format cannot
+    /// change until ColdFusion is decommissioned (see PLAN-CMS.md §12.6 for the GCM migration plan).
+    ///
+    /// Key model:
+    ///  - The master key is a base64 string on line 2 of viperfiles.txt.
+    ///  - Each file has its own random AES-128 key. The DB "key" column stores
+    ///    UUEncode(AES-ECB(masterKey, base64(fileKey))).
+    ///  - File contents are AES-ECB encrypted with the per-file key.
+    /// </summary>
+    public static class CmsFileCrypto
+    {
+        /// <summary>
+        /// Default location of the master key file for the current environment.
+        /// </summary>
+        public static string GetDefaultKeyFilePath()
+        {
+            string settingsFolder = HttpHelper.Environment?.EnvironmentName == "Development"
+                ? @"C:\Sites\Settings"
+                : @"S:\Settings";
+            return Path.Join(settingsFolder, "viperfiles.txt");
+        }
+
+        /// <summary>
+        /// Read the master key (base64 string) from line 2 of the key file.
+        /// </summary>
+        public static string ReadMasterKey(string keyFilePath)
+        {
+            string? masterKey = System.IO.File.ReadLines(keyFilePath).Skip(1).FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(masterKey))
+            {
+                throw new InvalidOperationException("CMS master key file is missing the key line.");
+            }
+            return masterKey.Trim();
+        }
+
+        /// <summary>
+        /// Generate a new random per-file AES-128 key, returned as base64 (the format CF
+        /// generateSecretKey("AES") produced).
+        /// </summary>
+        public static string GenerateFileKey()
+        {
+            return Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+        }
+
+        /// <summary>
+        /// Encrypt a per-file key for storage in the files.key column:
+        /// UUEncode(AES-ECB(masterKey, UTF8(fileKeyBase64))).
+        /// </summary>
+        public static string EncryptDbKey(string fileKeyBase64, string masterKeyBase64)
+        {
+            byte[] cipher = EncryptEcb(Encoding.UTF8.GetBytes(fileKeyBase64), Convert.FromBase64String(masterKeyBase64));
+            using MemoryStream input = new(cipher);
+            using MemoryStream output = new();
+            Codecs.UUEncode(input, output);
+            return Encoding.ASCII.GetString(output.ToArray());
+        }
+
+        /// <summary>
+        /// Decrypt a files.key column value back to the per-file key (base64 string).
+        /// Mirrors legacy CF decrypt(key, masterKey, "AES") with default UU encoding.
+        /// </summary>
+        public static string DecryptDbKey(string dbKey, string masterKeyBase64)
+        {
+            using MemoryStream input = new(Encoding.ASCII.GetBytes(dbKey));
+            using MemoryStream decoded = new();
+            Codecs.UUDecode(input, decoded);
+            byte[] plain = DecryptEcb(decoded.ToArray(), Convert.FromBase64String(masterKeyBase64));
+            return Encoding.UTF8.GetString(plain);
+        }
+
+        /// <summary>
+        /// Encrypt file contents with a per-file key (base64), matching CF encryptBinary(data, key, "AES").
+        /// </summary>
+        public static byte[] EncryptBytes(byte[] data, string fileKeyBase64)
+        {
+            return EncryptEcb(data, Convert.FromBase64String(fileKeyBase64));
+        }
+
+        /// <summary>
+        /// Decrypt file contents with a per-file key (base64), matching CF decryptBinary(data, key, "AES").
+        /// </summary>
+        public static byte[] DecryptBytes(byte[] data, string fileKeyBase64)
+        {
+            return DecryptEcb(data, Convert.FromBase64String(fileKeyBase64));
+        }
+
+        private static byte[] EncryptEcb(byte[] data, byte[] key)
+        {
+            using Aes aes = CreateCfCompatibleAes(key);
+            using ICryptoTransform encryptor = aes.CreateEncryptor();
+            return encryptor.TransformFinalBlock(data, 0, data.Length);
+        }
+
+        private static byte[] DecryptEcb(byte[] data, byte[] key)
+        {
+            using Aes aes = CreateCfCompatibleAes(key);
+            using ICryptoTransform decryptor = aes.CreateDecryptor();
+            return decryptor.TransformFinalBlock(data, 0, data.Length);
+        }
+
+        private static Aes CreateCfCompatibleAes(byte[] key)
+        {
+            Aes aes = Aes.Create();
+            // Settings match ColdFusion's "AES" algorithm defaults; ECB is required for
+            // compatibility with existing encrypted files (GCM migration is planned post-CF).
+            aes.Mode = CipherMode.ECB;
+            aes.Padding = PaddingMode.PKCS7;
+            aes.Key = key;
+            return aes;
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileEncryptionService.cs
+++ b/web/Areas/CMS/Services/CmsFileEncryptionService.cs
@@ -1,0 +1,99 @@
+namespace Viper.Areas.CMS.Services
+{
+    public interface ICmsFileEncryptionService
+    {
+        /// <summary>
+        /// Generate a new per-file key, returned in the encrypted form stored in files.key.
+        /// </summary>
+        string GenerateKeyForDb();
+
+        byte[] Encrypt(byte[] data, string dbKey);
+
+        byte[] Decrypt(byte[] data, string dbKey);
+
+        void EncryptFileInPlace(string filePath, string dbKey);
+
+        void DecryptFileInPlace(string filePath, string dbKey);
+    }
+
+    /// <summary>
+    /// DI wrapper around <see cref="CmsFileCrypto"/> that resolves and caches the master key.
+    /// Registered by the Scrutor convention scan of Viper.Areas.CMS.Services.
+    /// </summary>
+    public class CmsFileEncryptionService : ICmsFileEncryptionService
+    {
+        private readonly Lazy<string> _masterKey;
+
+        public CmsFileEncryptionService(IConfiguration configuration)
+        {
+            string keyFilePath = configuration["CMS:EncryptionKeyFile"] ?? CmsFileCrypto.GetDefaultKeyFilePath();
+            _masterKey = new Lazy<string>(() => CmsFileCrypto.ReadMasterKey(keyFilePath));
+        }
+
+        public string GenerateKeyForDb()
+        {
+            return CmsFileCrypto.EncryptDbKey(CmsFileCrypto.GenerateFileKey(), _masterKey.Value);
+        }
+
+        public byte[] Encrypt(byte[] data, string dbKey)
+        {
+            return CmsFileCrypto.EncryptBytes(data, CmsFileCrypto.DecryptDbKey(dbKey, _masterKey.Value));
+        }
+
+        public byte[] Decrypt(byte[] data, string dbKey)
+        {
+            return CmsFileCrypto.DecryptBytes(data, CmsFileCrypto.DecryptDbKey(dbKey, _masterKey.Value));
+        }
+
+        public void EncryptFileInPlace(string filePath, string dbKey)
+        {
+            ReplaceFileContents(filePath, contents => Encrypt(contents, dbKey));
+        }
+
+        public void DecryptFileInPlace(string filePath, string dbKey)
+        {
+            ReplaceFileContents(filePath, contents => Decrypt(contents, dbKey));
+        }
+
+        /// <summary>
+        /// Rewrite a file via a temp file in the same directory so an interrupted write
+        /// can't leave the target truncated or half-transformed.
+        /// </summary>
+        private static void ReplaceFileContents(string filePath, Func<byte[], byte[]> transform)
+        {
+            byte[] contents = System.IO.File.ReadAllBytes(filePath);
+            string tempPath = filePath + ".tmp";
+            try
+            {
+                System.IO.File.WriteAllBytes(tempPath, transform(contents));
+                System.IO.File.Move(tempPath, filePath, overwrite: true);
+            }
+            catch (IOException)
+            {
+                CleanUpTempFile(tempPath);
+                throw;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                CleanUpTempFile(tempPath);
+                throw;
+            }
+        }
+
+        private static void CleanUpTempFile(string tempPath)
+        {
+            try
+            {
+                System.IO.File.Delete(tempPath);
+            }
+            catch (IOException)
+            {
+                // Best effort; the orphaned .tmp file is harmless and the original error matters more.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best effort; see above.
+            }
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -1,0 +1,478 @@
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Models;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Classes.SQLContext;
+using File = Viper.Models.VIPER.File;
+
+namespace Viper.Areas.CMS.Services
+{
+    public interface ICmsFileService
+    {
+        Task<(List<CmsFileDto> Files, int Total)> GetFilesAsync(string? folder, string status, string? search,
+            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending, CancellationToken ct = default);
+
+        Task<CmsFileDto?> GetFileAsync(Guid fileGuid, CancellationToken ct = default);
+
+        Task<CmsFileDto> CreateFileAsync(CmsFileCreateRequest request, IFormFile file, CancellationToken ct = default);
+
+        Task<CmsFileDto?> UpdateFileAsync(Guid fileGuid, CmsFileUpdateRequest request, IFormFile? file, CancellationToken ct = default);
+
+        Task<bool> SoftDeleteFileAsync(Guid fileGuid, CancellationToken ct = default);
+
+        Task<bool> RestoreFileAsync(Guid fileGuid, CancellationToken ct = default);
+
+        Task<bool> PermanentlyDeleteFileAsync(Guid fileGuid, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Management operations for CMS files (the admin side; downloads are served by
+    /// CMSController/Data.CMS). Behavior mirrors the legacy ColdFusion Files.cfc:
+    /// friendly names are folder-filename with backslashes dashed, permission and person
+    /// lists are replaced as deltas, and every operation writes a fileAudit row.
+    /// </summary>
+    public class CmsFileService : ICmsFileService
+    {
+        private readonly VIPERContext _context;
+        private readonly AAUDContext _aaudContext;
+        private readonly ICmsFileStorageService _storage;
+        private readonly ICmsFileEncryptionService _encryption;
+        private readonly ICmsFileAuditService _audit;
+        private readonly IUserHelper _userHelper;
+
+        public CmsFileService(VIPERContext context, AAUDContext aaudContext, ICmsFileStorageService storage,
+            ICmsFileEncryptionService encryption, ICmsFileAuditService audit, IUserHelper userHelper)
+        {
+            _context = context;
+            _aaudContext = aaudContext;
+            _storage = storage;
+            _encryption = encryption;
+            _audit = audit;
+            _userHelper = userHelper;
+        }
+
+        public async Task<(List<CmsFileDto> Files, int Total)> GetFilesAsync(string? folder, string status, string? search,
+            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending, CancellationToken ct = default)
+        {
+            var query = _context.Files
+                .AsNoTracking()
+                .Include(f => f.FileToPermissions)
+                .Include(f => f.FileToPeople)
+                .AsSplitQuery()
+                .TagWith("CmsFileService.GetFiles")
+                .AsQueryable();
+
+            if (!string.IsNullOrEmpty(folder))
+            {
+                // Folder may have subfolders stored as "folder\sub"; match the top-level folder.
+                var folderPrefix = folder + @"\";
+                query = query.Where(f => f.Folder == folder || (f.Folder != null && f.Folder.StartsWith(folderPrefix)));
+            }
+
+            query = status.ToLowerInvariant() switch
+            {
+                "active" => query.Where(f => f.DeletedOn == null),
+                "deleted" => query.Where(f => f.DeletedOn != null),
+                _ => query
+            };
+
+            if (encrypted != null)
+            {
+                query = query.Where(f => f.Encrypted == encrypted);
+            }
+
+            if (isPublic != null)
+            {
+                query = query.Where(f => f.AllowPublicAccess == isPublic);
+            }
+
+            if (!string.IsNullOrEmpty(search))
+            {
+                query = query.Where(f => f.FriendlyName.Contains(search)
+                    || f.Description.Contains(search)
+                    || (f.OldUrl != null && f.OldUrl.Contains(search))
+                    || f.FilePath.Contains(search));
+            }
+
+            int total = await query.CountAsync(ct);
+
+            query = (sortBy?.ToLowerInvariant(), descending) switch
+            {
+                ("folder", false) => query.OrderBy(f => f.Folder).ThenBy(f => f.FriendlyName),
+                ("folder", true) => query.OrderByDescending(f => f.Folder).ThenBy(f => f.FriendlyName),
+                ("modifiedon", false) => query.OrderBy(f => f.ModifiedOn),
+                ("modifiedon", true) => query.OrderByDescending(f => f.ModifiedOn),
+                ("oldurl", false) => query.OrderBy(f => f.OldUrl),
+                ("oldurl", true) => query.OrderByDescending(f => f.OldUrl),
+                (_, true) => query.OrderByDescending(f => f.FriendlyName),
+                _ => query.OrderBy(f => f.FriendlyName)
+            };
+
+            var files = await query
+                .Skip((page - 1) * perPage)
+                .Take(perPage)
+                .ToListAsync(ct);
+
+            var names = await GetNamesByIamIdAsync(files.SelectMany(f => f.FileToPeople.Select(p => p.IamId)), ct);
+            return (files.Select(f => CmsFileMapper.ToCmsFileDto(f, names)).ToList(), total);
+        }
+
+        public async Task<CmsFileDto?> GetFileAsync(Guid fileGuid, CancellationToken ct = default)
+        {
+            var file = await LoadFileAsync(fileGuid, tracking: false, ct);
+            if (file == null)
+            {
+                return null;
+            }
+            var names = await GetNamesByIamIdAsync(file.FileToPeople.Select(p => p.IamId), ct);
+            return CmsFileMapper.ToCmsFileDto(file, names);
+        }
+
+        public async Task<CmsFileDto> CreateFileAsync(CmsFileCreateRequest request, IFormFile file, CancellationToken ct = default)
+        {
+            if (!_storage.IsValidFolder(request.Folder))
+            {
+                throw new ArgumentException("Invalid folder.");
+            }
+            if (!CmsFileTypes.IsAllowedFileName(file.FileName))
+            {
+                throw new ArgumentException("File type is not allowed.");
+            }
+
+            bool encrypt = request.Encrypt ?? false;
+            string? dbKey = encrypt ? _encryption.GenerateKeyForDb() : null;
+
+            string tempPath = await _storage.SaveToTempAsync(file, ct);
+            string finalPath;
+            try
+            {
+                if (dbKey != null)
+                {
+                    _encryption.EncryptFileInPlace(tempPath, dbKey);
+                }
+                finalPath = _storage.MoveIntoPlace(tempPath, request.Folder, file.FileName, request.MakeUnique ?? false);
+            }
+            finally
+            {
+                if (System.IO.File.Exists(tempPath))
+                {
+                    System.IO.File.Delete(tempPath);
+                }
+            }
+
+            string friendlyName = BuildFriendlyName(request.Folder, Path.GetFileName(finalPath));
+            if (await _context.Files.AnyAsync(f => f.FriendlyName == friendlyName, ct))
+            {
+                _storage.DeleteManagedFile(finalPath);
+                throw new InvalidOperationException($"A file with the name {friendlyName} already exists.");
+            }
+
+            var entity = new File
+            {
+                FileGuid = Guid.NewGuid(),
+                FilePath = finalPath,
+                Folder = request.Folder,
+                FriendlyName = friendlyName,
+                Encrypted = encrypt,
+                Key = dbKey,
+                Description = request.Description ?? string.Empty,
+                AllowPublicAccess = request.AllowPublicAccess ?? false,
+                OldUrl = NullIfEmpty(request.OldUrl),
+                ModifiedOn = DateTime.Now,
+                ModifiedBy = CurrentLoginId()
+            };
+
+            foreach (var permission in CleanList(request.Permissions))
+            {
+                entity.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = entity.FileGuid, Permission = permission });
+            }
+            foreach (var iamId in CleanList(request.IamIds))
+            {
+                entity.FileToPeople.Add(new Viper.Models.VIPER.FileToPerson { FileGuid = entity.FileGuid, IamId = iamId });
+            }
+
+            _context.Files.Add(entity);
+            _audit.Audit(entity, CmsFileAuditActions.AddFile, BuildCreateDetail(entity));
+            _audit.Audit(entity, CmsFileAuditActions.UploadFile, "NewFile");
+            await _context.SaveChangesAsync(ct);
+
+            var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
+            return CmsFileMapper.ToCmsFileDto(entity, names);
+        }
+
+        public async Task<CmsFileDto?> UpdateFileAsync(Guid fileGuid, CmsFileUpdateRequest request, IFormFile? file, CancellationToken ct = default)
+        {
+            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
+            if (entity == null)
+            {
+                return null;
+            }
+
+            var changes = new List<string>();
+            bool encrypt = request.Encrypt ?? false;
+            bool allowPublicAccess = request.AllowPublicAccess ?? false;
+
+            // Encryption toggle happens before any file replacement so the replacement upload
+            // is written with the file's final encryption state.
+            if (encrypt && !entity.Encrypted)
+            {
+                string dbKey = _encryption.GenerateKeyForDb();
+                if (_storage.ManagedFileExists(entity.FilePath))
+                {
+                    _encryption.EncryptFileInPlace(entity.FilePath, dbKey);
+                }
+                entity.Key = dbKey;
+                entity.Encrypted = true;
+                changes.Add("Encrypted file");
+            }
+            else if (!encrypt && entity.Encrypted)
+            {
+                if (!string.IsNullOrEmpty(entity.Key) && _storage.ManagedFileExists(entity.FilePath))
+                {
+                    _encryption.DecryptFileInPlace(entity.FilePath, entity.Key);
+                }
+                entity.Key = null;
+                entity.Encrypted = false;
+                changes.Add("Decrypted file");
+            }
+
+            string newDescription = request.Description ?? string.Empty;
+            if (entity.Description != newDescription)
+            {
+                entity.Description = newDescription;
+                changes.Add("Description updated");
+            }
+            if (entity.AllowPublicAccess != allowPublicAccess)
+            {
+                entity.AllowPublicAccess = allowPublicAccess;
+                changes.Add($"Public access changed to {allowPublicAccess}");
+            }
+            string? newOldUrl = NullIfEmpty(request.OldUrl);
+            if (entity.OldUrl != newOldUrl)
+            {
+                entity.OldUrl = newOldUrl;
+                changes.Add("Old URL updated");
+            }
+
+            ApplyPermissionDeltas(entity, CleanList(request.Permissions), changes);
+            ApplyPersonDeltas(entity, CleanList(request.IamIds), changes);
+
+            if (file != null)
+            {
+                if (!CmsFileTypes.IsAllowedFileName(file.FileName))
+                {
+                    throw new ArgumentException("File type is not allowed.");
+                }
+                string tempPath = await _storage.SaveToTempAsync(file, ct);
+                try
+                {
+                    if (entity.Encrypted && !string.IsNullOrEmpty(entity.Key))
+                    {
+                        _encryption.EncryptFileInPlace(tempPath, entity.Key);
+                    }
+                    _storage.ReplaceInPlace(tempPath, entity.FilePath);
+                }
+                finally
+                {
+                    if (System.IO.File.Exists(tempPath))
+                    {
+                        System.IO.File.Delete(tempPath);
+                    }
+                }
+                _audit.Audit(entity, CmsFileAuditActions.UploadFile, "ReplacingFile");
+            }
+
+            entity.ModifiedOn = DateTime.Now;
+            entity.ModifiedBy = CurrentLoginId();
+
+            _audit.Audit(entity, CmsFileAuditActions.EditFile, string.Join("; ", changes));
+            await _context.SaveChangesAsync(ct);
+
+            var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
+            return CmsFileMapper.ToCmsFileDto(entity, names);
+        }
+
+        public async Task<bool> SoftDeleteFileAsync(Guid fileGuid, CancellationToken ct = default)
+        {
+            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
+            if (entity == null)
+            {
+                return false;
+            }
+            entity.DeletedOn = DateTime.Now;
+            entity.ModifiedOn = DateTime.Now;
+            entity.ModifiedBy = CurrentLoginId();
+            _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<bool> RestoreFileAsync(Guid fileGuid, CancellationToken ct = default)
+        {
+            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
+            if (entity == null)
+            {
+                return false;
+            }
+            entity.DeletedOn = null;
+            entity.ModifiedOn = DateTime.Now;
+            entity.ModifiedBy = CurrentLoginId();
+            _audit.Audit(entity, CmsFileAuditActions.CancelDelete, "Delete cancelled");
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<bool> PermanentlyDeleteFileAsync(Guid fileGuid, CancellationToken ct = default)
+        {
+            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
+            if (entity == null)
+            {
+                return false;
+            }
+
+            _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Deleted");
+            _context.RemoveRange(entity.FileToPermissions);
+            _context.RemoveRange(entity.FileToPeople);
+            _context.Remove(entity);
+            await _context.SaveChangesAsync(ct);
+
+            if (_storage.ManagedFileExists(entity.FilePath))
+            {
+                _storage.DeleteManagedFile(entity.FilePath);
+            }
+            return true;
+        }
+
+        private async Task<File?> LoadFileAsync(Guid fileGuid, bool tracking, CancellationToken ct)
+        {
+            var query = _context.Files
+                .Include(f => f.FileToPermissions)
+                .Include(f => f.FileToPeople)
+                .AsSplitQuery();
+            if (!tracking)
+            {
+                query = query.AsNoTracking();
+            }
+            var file = await query.FirstOrDefaultAsync(f => f.FileGuid == fileGuid, ct);
+            if (file != null)
+            {
+                file.FilePath = NormalizeRootFolder(file.FilePath);
+            }
+            return file;
+        }
+
+        /// <summary>
+        /// Fix up the storage root if the record was created on another environment
+        /// (e.g. a dev path on prod), mirroring Data.CMS.ReplaceRootFolder but guarded
+        /// against paths that don't contain a \Files segment.
+        /// </summary>
+        private string NormalizeRootFolder(string filePath)
+        {
+            string root = _storage.RootFolder;
+            if (!filePath.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            {
+                int filesIndex = filePath.IndexOf(@"\Files\", StringComparison.OrdinalIgnoreCase);
+                if (filesIndex >= 0)
+                {
+                    return root + filePath[(filesIndex + @"\Files".Length)..];
+                }
+            }
+            return filePath;
+        }
+
+        private void ApplyPermissionDeltas(File entity, List<string> requested, List<string> changes)
+        {
+            var existing = entity.FileToPermissions.ToList();
+            foreach (var fp in existing.Where(fp => !requested.Contains(fp.Permission, StringComparer.OrdinalIgnoreCase)))
+            {
+                entity.FileToPermissions.Remove(fp);
+                _context.Remove(fp);
+                changes.Add($"Permission removed: {fp.Permission}");
+            }
+            var existingNames = existing.Select(p => p.Permission).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var permission in requested.Where(p => !existingNames.Contains(p)))
+            {
+                entity.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = entity.FileGuid, Permission = permission });
+                changes.Add($"Permission added: {permission}");
+            }
+        }
+
+        private void ApplyPersonDeltas(File entity, List<string> requested, List<string> changes)
+        {
+            var existing = entity.FileToPeople.ToList();
+            foreach (var fp in existing.Where(fp => !requested.Contains(fp.IamId, StringComparer.OrdinalIgnoreCase)))
+            {
+                entity.FileToPeople.Remove(fp);
+                _context.Remove(fp);
+                changes.Add($"Person removed: {fp.IamId}");
+            }
+            var existingIds = existing.Select(p => p.IamId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var iamId in requested.Where(p => !existingIds.Contains(p)))
+            {
+                entity.FileToPeople.Add(new Viper.Models.VIPER.FileToPerson { FileGuid = entity.FileGuid, IamId = iamId });
+                changes.Add($"Person added: {iamId}");
+            }
+        }
+
+        private async Task<Dictionary<string, string>> GetNamesByIamIdAsync(IEnumerable<string> iamIds, CancellationToken ct)
+        {
+            var ids = iamIds.Distinct().ToList();
+            if (ids.Count == 0)
+            {
+                return new Dictionary<string, string>();
+            }
+            return await _aaudContext.AaudUsers
+                .AsNoTracking()
+                .Where(u => u.IamId != null && EF.Parameter(ids).Contains(u.IamId))
+                .GroupBy(u => u.IamId!)
+                .Select(g => new { IamId = g.Key, Name = g.Select(u => u.DisplayFullName).First() })
+                .ToDictionaryAsync(x => x.IamId, x => x.Name, ct);
+        }
+
+        private string CurrentLoginId()
+        {
+            return _userHelper.GetCurrentUser()?.LoginId ?? "unknown";
+        }
+
+        private static string BuildFriendlyName(string folder, string fileName)
+        {
+            return folder.Replace('\\', '-').Replace('/', '-') + "-" + fileName;
+        }
+
+        private static string BuildCreateDetail(File entity)
+        {
+            var parts = new List<string> { $"Folder: {entity.Folder}" };
+            if (entity.AllowPublicAccess)
+            {
+                parts.Add("Public access: true");
+            }
+            if (entity.Encrypted)
+            {
+                parts.Add("Encrypted: true");
+            }
+            if (entity.FileToPermissions.Count > 0)
+            {
+                parts.Add("Permissions: " + string.Join(", ", entity.FileToPermissions.Select(p => p.Permission)));
+            }
+            if (entity.FileToPeople.Count > 0)
+            {
+                parts.Add("People: " + string.Join(", ", entity.FileToPeople.Select(p => p.IamId)));
+            }
+            return string.Join("; ", parts);
+        }
+
+        private static List<string> CleanList(List<string> values)
+        {
+            return values
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static string? NullIfEmpty(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileStorageService.cs
+++ b/web/Areas/CMS/Services/CmsFileStorageService.cs
@@ -1,0 +1,204 @@
+using Viper.Areas.CMS.Constants;
+using Viper.Classes.SQLContext;
+
+namespace Viper.Areas.CMS.Services
+{
+    public interface ICmsFileStorageService
+    {
+        string RootFolder { get; }
+
+        /// <summary>Top-level folders ("VIPER apps") that files can be stored under.</summary>
+        List<string> GetTopLevelFolders();
+
+        /// <summary>
+        /// Validate a user-supplied folder (may contain subfolders, e.g. "cats\photos").
+        /// The first segment must be an existing top-level folder and the resolved path
+        /// must stay inside the root.
+        /// </summary>
+        bool IsValidFolder(string folder);
+
+        /// <summary>True if the name exists on disk or in the files table for this folder.</summary>
+        bool FileNameInUse(string folder, string fileName);
+
+        /// <summary>Save an upload to a temp file (outside the storage root); returns the temp path.</summary>
+        Task<string> SaveToTempAsync(IFormFile file, CancellationToken ct = default);
+
+        /// <summary>
+        /// Move a temp file into the storage root at folder\fileName. On name conflict, either
+        /// auto-rename (name_0..name_999) or throw, per <paramref name="makeUnique"/>.
+        /// Returns the final absolute path.
+        /// </summary>
+        string MoveIntoPlace(string tempPath, string folder, string fileName, bool makeUnique);
+
+        /// <summary>Overwrite the managed file at <paramref name="existingFilePath"/> with a temp file.</summary>
+        void ReplaceInPlace(string tempPath, string existingFilePath);
+
+        /// <summary>Delete a file, verifying it lives under the storage root first.</summary>
+        void DeleteManagedFile(string filePath);
+
+        bool ManagedFileExists(string filePath);
+    }
+
+    /// <summary>
+    /// On-disk storage for CMS-managed files. User input never becomes a path without
+    /// validation: folders are checked against the top-level folder list and resolved-path
+    /// containment, and file names are stripped to their final segment (see PLAN-CMS.md §11.7).
+    /// </summary>
+    public class CmsFileStorageService : ICmsFileStorageService
+    {
+        private readonly VIPERContext _context;
+
+        public string RootFolder { get; }
+
+        public CmsFileStorageService(VIPERContext context, IConfiguration configuration)
+        {
+            _context = context;
+            RootFolder = configuration["CMS:FileStorageRoot"] ?? Data.CMS.GetRootFileFolder();
+        }
+
+        public List<string> GetTopLevelFolders()
+        {
+            if (!System.IO.Directory.Exists(RootFolder))
+            {
+                return new List<string>();
+            }
+            return System.IO.Directory.GetDirectories(RootFolder)
+                .Select(d => Path.GetFileName(d) ?? string.Empty)
+                .Where(d => !string.IsNullOrEmpty(d))
+                .OrderBy(d => d)
+                .ToList();
+        }
+
+        public bool IsValidFolder(string folder)
+        {
+            if (string.IsNullOrWhiteSpace(folder))
+            {
+                return false;
+            }
+
+            var segments = folder.Split(['\\', '/'], StringSplitOptions.None);
+            if (segments.Any(s => string.IsNullOrWhiteSpace(s) || s == "." || s == ".."
+                    || s.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0))
+            {
+                return false;
+            }
+
+            // First segment must be an existing top-level folder (legacy rule); subfolders
+            // may be created on demand by MoveIntoPlace.
+            if (!GetTopLevelFolders().Any(f => string.Equals(f, segments[0], StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            return IsUnderRoot(Path.Join(RootFolder, Path.Join(segments)));
+        }
+
+        public bool FileNameInUse(string folder, string fileName)
+        {
+            string targetPath = BuildTargetPath(folder, fileName);
+            if (System.IO.File.Exists(targetPath))
+            {
+                return true;
+            }
+            // Also check the DB in case a record exists whose disk file is missing; a new file
+            // at that path would be served under the orphaned record's permissions.
+            return _context.Files.Any(f => f.FilePath == targetPath);
+        }
+
+        public async Task<string> SaveToTempAsync(IFormFile file, CancellationToken ct = default)
+        {
+            string tempFolder = Path.Join(Path.GetTempPath(), "Viper-CMS-Uploads");
+            System.IO.Directory.CreateDirectory(tempFolder);
+            string tempPath = Path.Join(tempFolder, Guid.NewGuid().ToString("N"));
+            await using FileStream stream = new(tempPath, FileMode.CreateNew);
+            await file.CopyToAsync(stream, ct);
+            return tempPath;
+        }
+
+        public string MoveIntoPlace(string tempPath, string folder, string fileName, bool makeUnique)
+        {
+            if (!IsValidFolder(folder))
+            {
+                throw new ArgumentException($"Invalid folder", nameof(folder));
+            }
+
+            string finalName = Path.GetFileName(fileName);
+            if (string.IsNullOrWhiteSpace(finalName) || !CmsFileTypes.IsAllowedFileName(finalName))
+            {
+                throw new ArgumentException("Invalid file name", nameof(fileName));
+            }
+
+            if (FileNameInUse(folder, finalName))
+            {
+                if (!makeUnique)
+                {
+                    throw new InvalidOperationException($"File {finalName} already exists in folder {folder}.");
+                }
+                finalName = GetUniqueFileName(folder, finalName);
+            }
+
+            string targetPath = BuildTargetPath(folder, finalName);
+            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            System.IO.File.Move(tempPath, targetPath);
+            return targetPath;
+        }
+
+        public void ReplaceInPlace(string tempPath, string existingFilePath)
+        {
+            AssertUnderRoot(existingFilePath);
+            System.IO.File.Move(tempPath, existingFilePath, overwrite: true);
+        }
+
+        public void DeleteManagedFile(string filePath)
+        {
+            AssertUnderRoot(filePath);
+            if (System.IO.File.Exists(filePath))
+            {
+                System.IO.File.Delete(filePath);
+            }
+        }
+
+        public bool ManagedFileExists(string filePath)
+        {
+            return IsUnderRoot(filePath) && System.IO.File.Exists(filePath);
+        }
+
+        private string GetUniqueFileName(string folder, string fileName)
+        {
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            string extension = Path.GetExtension(fileName);
+            // Match legacy behavior: append _0, _1, ... _999 until unique.
+            for (int i = 0; i < 1000; i++)
+            {
+                string candidate = $"{baseName}_{i}{extension}";
+                if (!FileNameInUse(folder, candidate))
+                {
+                    return candidate;
+                }
+            }
+            throw new InvalidOperationException($"Unable to generate a unique name for {fileName} in {folder}.");
+        }
+
+        private string BuildTargetPath(string folder, string fileName)
+        {
+            string path = Path.GetFullPath(Path.Join(RootFolder, folder, Path.GetFileName(fileName)));
+            AssertUnderRoot(path);
+            return path;
+        }
+
+        private void AssertUnderRoot(string filePath)
+        {
+            if (!IsUnderRoot(filePath))
+            {
+                throw new ArgumentException("Path is outside the CMS file storage root.", nameof(filePath));
+            }
+        }
+
+        private bool IsUnderRoot(string filePath)
+        {
+            string fullPath = Path.GetFullPath(filePath);
+            string root = Path.GetFullPath(RootFolder + Path.DirectorySeparatorChar);
+            return fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of 6 stacked PRs splitting #242 (the full CMS migration, ~24k changed lines) into reviewable, feature-grouped slices that each fit under GitHub Copilot's 20k-line review limit. Merging this PR alone ships the file-management feature; each later PR stacks on the previous one.

**Scope**
- `/api/cms/files` backend: `CmsFileService`, `CmsFileStorageService` (folders, save/replace, collision handling, MIME/extension allow-list), `CmsFileEncryptionService` + `CmsFileCrypto` (CF-compatible AES so legacy ColdFusion can still read encrypted files), `CmsFileAuditService`, paged list with filters, upload, edit with permission/person deltas, soft delete/restore.
- Files UI at `/CMS/ManageFiles`: server-paged QTable, filters, upload/edit dialog with `PermissionSelector`/`PersonSelector`, audit log page, CMS home cards.
- `CMSOptionsController` for permission/person typeahead options.
- Unit tests for crypto, storage, service, and controller.

The pre-existing `/CMS/Files` download handler (`Data/CMS.cs`) is intentionally kept: it serves all legacy URL shapes (`?fn=`, `?id=`, `?oldURL=`) and was hardened separately under VPR-138/143.

**Stack**: this PR → content blocks/left nav → import/photos/rate limiting → hub/UX → responsive/tests → hardening/final. Each cut point passes the full backend + frontend suites.
