### PR TITLE
VPR-59 [2/6] CMS migration: content blocks + left navigation

### DIFF
--- a/VueApp/src/CMS/components/DeleteRestoreButtons.vue
+++ b/VueApp/src/CMS/components/DeleteRestoreButtons.vue
@@ -1,0 +1,37 @@
+<template>
+    <q-btn
+        v-if="!deleted"
+        dense
+        flat
+        no-caps
+        size="sm"
+        color="negative"
+        icon="delete"
+        :aria-label="`Delete ${entityName}`"
+        @click="emit('delete')"
+    >
+        <q-tooltip>Delete</q-tooltip>
+    </q-btn>
+    <q-btn
+        v-else
+        dense
+        flat
+        no-caps
+        size="sm"
+        color="positive"
+        icon="restore_from_trash"
+        :aria-label="`Restore ${entityName}`"
+        @click="emit('restore')"
+    >
+        <q-tooltip>Restore</q-tooltip>
+    </q-btn>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+    deleted: boolean
+    entityName: string
+}>()
+
+const emit = defineEmits<{ delete: []; restore: [] }>()
+</script>

--- a/VueApp/src/CMS/components/EditButton.vue
+++ b/VueApp/src/CMS/components/EditButton.vue
@@ -1,0 +1,26 @@
+<template>
+    <q-btn
+        dense
+        flat
+        no-caps
+        size="sm"
+        color="secondary"
+        icon="edit"
+        :aria-label="`Edit ${entityName}`"
+        :to="to"
+        @click="emit('click')"
+    >
+        <q-tooltip>Edit</q-tooltip>
+    </q-btn>
+</template>
+
+<script setup lang="ts">
+import type { RouteLocationRaw } from "vue-router"
+
+defineProps<{
+    entityName: string
+    to?: RouteLocationRaw
+}>()
+
+const emit = defineEmits<{ click: [] }>()
+</script>

--- a/VueApp/src/CMS/components/ModifiedStamp.vue
+++ b/VueApp/src/CMS/components/ModifiedStamp.vue
@@ -1,0 +1,22 @@
+<template>
+    <q-td :props="cellProps">
+        {{ formatted }}
+        <span class="text-grey-7">{{ cellProps.row.modifiedBy }}</span>
+    </q-td>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+
+const props = defineProps<{
+    cellProps: { row: { modifiedOn: string; modifiedBy: string } }
+}>()
+
+const formatted = computed(() =>
+    new Date(props.cellProps.row.modifiedOn).toLocaleDateString("en-US", {
+        year: "2-digit",
+        month: "2-digit",
+        day: "2-digit",
+    }),
+)
+</script>

--- a/VueApp/src/CMS/components/PermissionChips.vue
+++ b/VueApp/src/CMS/components/PermissionChips.vue
@@ -1,0 +1,49 @@
+<template>
+    <template v-if="permissions.length || peopleCount > 0">
+        <q-chip
+            v-for="p in permissions.slice(0, maxShown)"
+            :key="p"
+            dense
+            square
+            size="sm"
+        >
+            {{ p }}
+        </q-chip>
+        <q-chip
+            v-if="permissions.length > maxShown"
+            dense
+            square
+            size="sm"
+            color="grey-4"
+        >
+            +{{ permissions.length - maxShown }} more
+        </q-chip>
+        <q-chip
+            v-if="peopleCount > 0"
+            dense
+            square
+            size="sm"
+            icon="person"
+            color="grey-4"
+        >
+            {{ peopleCount }}
+        </q-chip>
+    </template>
+    <span
+        v-else
+        class="text-grey-7"
+    >
+        All VIPER users
+    </span>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+    defineProps<{
+        permissions: string[]
+        peopleCount?: number
+        maxShown?: number
+    }>(),
+    { peopleCount: 0, maxShown: 2 },
+)
+</script>

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -66,6 +66,16 @@ const sections: Section[] = [
         ],
     },
     {
+        title: "Content Blocks",
+        icon: "article",
+        description: "Edit page content with version history, permissions, and attached files.",
+        permission: "SVMSecure.CMS.ManageContentBlocks",
+        actions: [
+            { label: "Manage Content Blocks", to: { name: "CmsContentBlocks" } },
+            { label: "New Content Block", to: { name: "CmsContentBlockEdit" } },
+        ],
+    },
+    {
         title: "Link Collections",
         icon: "link",
         description: "Curate collections of links with tags and ordering.",

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -82,6 +82,13 @@ const sections: Section[] = [
         permission: "SVMSecure.CMS.ManageContentBlocks",
         actions: [{ label: "Manage Link Collections", to: { name: "ManageLinkCollections" } }],
     },
+    {
+        title: "Left Navigation",
+        icon: "menu",
+        description: "Build left-nav menus with headers, links, ordering, and per-item visibility.",
+        permission: "SVMSecure.CMS.ManageNavigation",
+        actions: [{ label: "Manage Left Nav Menus", to: { name: "CmsLeftNavMenus" } }],
+    },
 ]
 
 const visibleSections = computed(() => sections.filter((s) => userStore.userInfo.permissions.includes(s.permission)))

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -1,0 +1,460 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">
+                {{ isNew ? "Create Content Block" : "Edit Content Block" }}
+            </h1>
+            <q-space />
+            <q-btn
+                flat
+                dense
+                no-caps
+                color="primary"
+                icon="arrow_back"
+                label="Back to Content Blocks"
+                :to="{ name: 'CmsContentBlocks' }"
+            />
+        </div>
+
+        <q-banner
+            v-if="block.deletedOn"
+            class="bg-orange-2 q-mb-md"
+            dense
+            rounded
+        >
+            This content block is marked as deleted. Restore it to make it available again.
+            <template #action>
+                <q-btn
+                    flat
+                    dense
+                    no-caps
+                    color="primary"
+                    label="Restore"
+                    @click="restoreBlock"
+                />
+            </template>
+        </q-banner>
+
+        <q-form
+            ref="formRef"
+            greedy
+            @submit.prevent="saveBlock"
+        >
+            <div class="row q-col-gutter-lg">
+                <div class="col-12 col-lg-8">
+                    <q-input
+                        v-model="block.title"
+                        dense
+                        outlined
+                        label="Title"
+                        class="q-mb-sm required-field"
+                        :rules="[(v: string | null) => (v && v.trim().length > 0) || 'Title is required']"
+                        aria-required="true"
+                        hide-bottom-space
+                    />
+
+                    <div class="text-subtitle2 q-mb-xs">Content</div>
+                    <q-editor
+                        v-model="block.content"
+                        min-height="20rem"
+                        :toolbar="editorToolbar"
+                        :definitions="{}"
+                    />
+
+                    <div
+                        v-if="!isNew && history.length"
+                        class="q-mt-md row items-center q-col-gutter-sm"
+                    >
+                        <div class="col-auto text-subtitle2">Version history:</div>
+                        <div class="col-12 col-sm-5 col-md-4">
+                            <q-select
+                                v-model="selectedHistory"
+                                dense
+                                options-dense
+                                outlined
+                                clearable
+                                label="Load a previous version"
+                                :options="history"
+                                :option-label="historyLabel"
+                                @update:model-value="loadHistoryVersion"
+                            />
+                        </div>
+                        <div
+                            v-if="viewingVersion"
+                            class="col-auto"
+                        >
+                            <q-chip
+                                color="orange-2"
+                                dense
+                                square
+                            >
+                                Viewing an old version — Save to restore it
+                            </q-chip>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12 col-lg-4">
+                    <q-card
+                        flat
+                        bordered
+                        class="q-mb-md"
+                    >
+                        <q-card-section class="q-gutter-y-sm">
+                            <div class="text-h6">Settings</div>
+
+                            <q-select
+                                v-model="block.system"
+                                dense
+                                options-dense
+                                outlined
+                                label="System"
+                                :options="['Viper', 'Public']"
+                                :rules="[(v: string | null) => !!v || 'System is required']"
+                                hide-bottom-space
+                            />
+
+                            <q-select
+                                v-model="block.viperSectionPath"
+                                dense
+                                options-dense
+                                outlined
+                                clearable
+                                use-input
+                                new-value-mode="add-unique"
+                                input-debounce="0"
+                                label="VIPER section path"
+                                hint="Pick an existing section or type a new one"
+                                :options="sectionPaths"
+                            />
+
+                            <q-input
+                                v-model="block.page"
+                                dense
+                                outlined
+                                label="Page"
+                            />
+
+                            <q-input
+                                v-model.number="block.blockOrder"
+                                dense
+                                outlined
+                                type="number"
+                                label="Block order"
+                            />
+
+                            <q-input
+                                v-model="block.friendlyName"
+                                dense
+                                outlined
+                                label="Friendly name"
+                                hint="Used for URL-friendly access; must be unique"
+                            />
+
+                            <q-toggle
+                                v-model="block.allowPublicAccess"
+                                label="Public access"
+                            />
+                        </q-card-section>
+                    </q-card>
+
+                    <q-card
+                        flat
+                        bordered
+                        class="q-mb-md"
+                    >
+                        <q-card-section>
+                            <div class="text-h6 q-mb-sm">Permissions</div>
+                            <PermissionSelector v-model="block.permissions" />
+                        </q-card-section>
+                    </q-card>
+
+                    <q-card
+                        flat
+                        bordered
+                    >
+                        <q-card-section>
+                            <div class="text-h6 q-mb-sm">Attached Files</div>
+                            <div
+                                v-for="file in block.files"
+                                :key="file.fileGuid"
+                                class="row items-center q-mb-xs"
+                            >
+                                <a
+                                    :href="file.url"
+                                    target="_blank"
+                                    rel="noopener"
+                                    class="col ellipsis"
+                                >
+                                    {{ file.friendlyName }}
+                                </a>
+                                <q-btn
+                                    dense
+                                    flat
+                                    size="sm"
+                                    icon="close"
+                                    color="negative"
+                                    aria-label="Detach file"
+                                    @click="detachFile(file)"
+                                >
+                                    <q-tooltip>Detach</q-tooltip>
+                                </q-btn>
+                            </div>
+                            <q-select
+                                v-model="fileToAttach"
+                                dense
+                                options-dense
+                                outlined
+                                use-input
+                                input-debounce="300"
+                                label="Attach a file"
+                                hint="Search managed files by name"
+                                :options="fileOptions"
+                                option-label="friendlyName"
+                                :loading="searchingFiles"
+                                @filter="searchFiles"
+                                @update:model-value="attachFile"
+                            />
+                        </q-card-section>
+                    </q-card>
+                </div>
+            </div>
+
+            <div class="q-mt-md">
+                <q-btn
+                    type="submit"
+                    color="primary"
+                    :label="isNew ? 'Create' : 'Save'"
+                    dense
+                    no-caps
+                    class="q-pr-md"
+                    :loading="saving"
+                />
+                <q-btn
+                    flat
+                    label="Cancel"
+                    dense
+                    no-caps
+                    class="q-ml-sm"
+                    :to="{ name: 'CmsContentBlocks' }"
+                />
+            </div>
+        </q-form>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onMounted, ref } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useQuasar } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
+import type { CmsContentBlock, CmsContentBlockFile, CmsContentHistoryItem, CmsFile } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "CMS/content"
+const filesApiURL = inject("apiURL") + "cms/files/"
+const route = useRoute()
+const router = useRouter()
+const $q = useQuasar()
+const { get, post, put, createUrlSearchParams } = useFetch()
+
+const blockId = computed(() => (route.params.id ? Number(route.params.id) : null))
+const isNew = computed(() => blockId.value === null)
+
+const formRef = ref()
+const saving = ref(false)
+
+const emptyBlock = (): CmsContentBlock => ({
+    contentBlockId: 0,
+    content: "",
+    title: null,
+    system: "Viper",
+    application: null,
+    page: null,
+    viperSectionPath: null,
+    blockOrder: 1,
+    friendlyName: null,
+    allowPublicAccess: false,
+    modifiedOn: "",
+    modifiedBy: "",
+    deletedOn: null,
+    permissions: [],
+    files: [],
+})
+
+const block = ref<CmsContentBlock>(emptyBlock())
+const sectionPaths = ref<string[]>([])
+const history = ref<CmsContentHistoryItem[]>([])
+const selectedHistory = ref<CmsContentHistoryItem | null>(null)
+const viewingVersion = ref(false)
+
+const fileToAttach = ref<CmsFile | null>(null)
+const fileOptions = ref<CmsFile[]>([])
+const searchingFiles = ref(false)
+
+const editorToolbar = [
+    ["bold", "italic", "underline", "strike"],
+    [{ icon: "format_size", options: ["p", "h2", "h3", "h4", "h5"] }],
+    ["unordered", "ordered", "outdent", "indent"],
+    ["link", "hr", "quote"],
+    ["removeFormat"],
+    ["undo", "redo"],
+]
+
+async function loadBlock() {
+    if (blockId.value === null) return
+    const res = await get(apiURL + "/" + blockId.value)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Content block not found" })
+        void router.push({ name: "CmsContentBlocks" })
+        return
+    }
+    block.value = res.result
+    await loadHistory()
+}
+
+async function loadHistory() {
+    if (blockId.value === null) return
+    const res = await get(apiURL + "/" + blockId.value + "/history")
+    history.value = res.success ? res.result : []
+}
+
+async function loadSectionPaths() {
+    const res = await get(apiURL + "/section-paths")
+    sectionPaths.value = res.success ? res.result : []
+}
+
+function historyLabel(h: CmsContentHistoryItem): string {
+    const when = h.modifiedOn ? new Date(h.modifiedOn).toLocaleString() : "unknown date"
+    return `${when} (${h.modifiedBy ?? "unknown"})`
+}
+
+async function loadHistoryVersion() {
+    if (!selectedHistory.value) {
+        viewingVersion.value = false
+        return
+    }
+    const res = await get(apiURL + "/" + blockId.value + "/history/" + selectedHistory.value.contentHistoryId)
+    if (res.success) {
+        block.value.content = res.result.content
+        viewingVersion.value = true
+        $q.notify({
+            type: "info",
+            message: "Loaded an older version into the editor. Save to make it the current version.",
+        })
+    }
+}
+
+async function searchFiles(val: string, update: (fn: () => void) => void) {
+    if (val.trim().length < 2) {
+        update(() => {
+            fileOptions.value = []
+        })
+        return
+    }
+    searchingFiles.value = true
+    const params = createUrlSearchParams({ search: val.trim(), status: "active", perPage: 15 })
+    const res = await get(filesApiURL + "?" + params)
+    searchingFiles.value = false
+    update(() => {
+        const attachedGuids = new Set(block.value.files.map((f) => f.fileGuid))
+        fileOptions.value = res.success ? res.result.filter((f: CmsFile) => !attachedGuids.has(f.fileGuid)) : []
+    })
+}
+
+function attachFile() {
+    if (!fileToAttach.value) return
+    block.value.files.push({
+        fileGuid: fileToAttach.value.fileGuid,
+        friendlyName: fileToAttach.value.friendlyName,
+        url: fileToAttach.value.friendlyUrl,
+    })
+    fileToAttach.value = null
+}
+
+function detachFile(file: CmsContentBlockFile) {
+    block.value.files = block.value.files.filter((f) => f.fileGuid !== file.fileGuid)
+}
+
+async function saveBlock() {
+    const valid = await formRef.value?.validate()
+    if (!valid) return
+
+    saving.value = true
+    const payload = {
+        contentBlockId: block.value.contentBlockId,
+        content: block.value.content,
+        title: block.value.title,
+        system: block.value.system,
+        application: block.value.application,
+        page: block.value.page,
+        viperSectionPath: block.value.viperSectionPath,
+        blockOrder: block.value.blockOrder,
+        friendlyName: block.value.friendlyName || null,
+        allowPublicAccess: block.value.allowPublicAccess,
+        permissions: block.value.permissions,
+        fileGuids: block.value.files.map((f) => f.fileGuid),
+        lastModifiedOn: isNew.value ? null : block.value.modifiedOn,
+    }
+
+    const res = isNew.value
+        ? await post(apiURL, payload)
+        : await put(apiURL + "/" + block.value.contentBlockId, payload)
+    saving.value = false
+
+    if (res.status === 409) {
+        $q.dialog({
+            title: "Edit Conflict",
+            message:
+                (res.errors?.[0] ?? "This content block was changed by someone else.") +
+                " Reload the latest version? Your unsaved changes will be lost.",
+            cancel: { label: "Keep editing", flat: true },
+            persistent: true,
+            ok: { label: "Reload", color: "primary", unelevated: true },
+        }).onOk(() => {
+            void loadBlock()
+            viewingVersion.value = false
+            selectedHistory.value = null
+        })
+        return
+    }
+
+    if (!res.success) {
+        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to save content block" })
+        return
+    }
+
+    $q.notify({ type: "positive", message: isNew.value ? "Content block created" : "Content block saved" })
+    viewingVersion.value = false
+    selectedHistory.value = null
+
+    if (isNew.value) {
+        void router.push({ name: "CmsContentBlockEdit", params: { id: res.result.contentBlockId } })
+        block.value = res.result
+        await loadHistory()
+    } else {
+        block.value = res.result
+        await loadHistory()
+    }
+}
+
+async function restoreBlock() {
+    const res = await post(apiURL + "/" + block.value.contentBlockId + "/restore")
+    if (res.success) {
+        $q.notify({ type: "positive", message: "Content block restored" })
+        await loadBlock()
+    }
+}
+
+onMounted(() => {
+    loadSectionPaths()
+    loadBlock()
+})
+</script>
+
+<style scoped>
+.required-field :deep(.q-field__label)::after {
+    content: " *";
+    color: var(--q-negative);
+}
+</style>

--- a/VueApp/src/CMS/pages/ContentBlocks.vue
+++ b/VueApp/src/CMS/pages/ContentBlocks.vue
@@ -110,26 +110,15 @@
             </template>
 
             <template #body-cell-modifiedOn="cellProps">
-                <q-td :props="cellProps">
-                    {{ formatDate(cellProps.row.modifiedOn) }}
-                    <span class="text-grey-7">{{ cellProps.row.modifiedBy }}</span>
-                </q-td>
+                <ModifiedStamp :cell-props="cellProps" />
             </template>
 
             <template #body-cell-actions="cellProps">
                 <q-td :props="cellProps">
-                    <q-btn
-                        dense
-                        flat
-                        no-caps
-                        size="sm"
-                        color="secondary"
-                        icon="edit"
-                        aria-label="Edit content block"
+                    <EditButton
+                        entity-name="content block"
                         :to="{ name: 'CmsContentBlockEdit', params: { id: cellProps.row.contentBlockId } }"
-                    >
-                        <q-tooltip>Edit</q-tooltip>
-                    </q-btn>
+                    />
                     <DeleteRestoreButtons
                         :deleted="!!cellProps.row.deletedOn"
                         entity-name="content block"
@@ -147,6 +136,8 @@ import { inject, onMounted, ref } from "vue"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
+import EditButton from "@/CMS/components/EditButton.vue"
+import ModifiedStamp from "@/CMS/components/ModifiedStamp.vue"
 import PermissionChips from "@/CMS/components/PermissionChips.vue"
 import type { CmsContentBlock } from "@/CMS/types/"
 
@@ -231,10 +222,6 @@ async function restoreBlock(block: CmsContentBlock) {
     }
     $q.notify({ type: "positive", message: "Content block restored" })
     loadBlocks()
-}
-
-function formatDate(value: string): string {
-    return new Date(value).toLocaleDateString("en-US", { year: "2-digit", month: "2-digit", day: "2-digit" })
 }
 
 onMounted(() => {

--- a/VueApp/src/CMS/pages/ContentBlocks.vue
+++ b/VueApp/src/CMS/pages/ContentBlocks.vue
@@ -1,0 +1,244 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">Content Blocks</h1>
+            <q-space />
+            <q-btn
+                color="positive"
+                icon="add"
+                label="New Content Block"
+                no-caps
+                dense
+                class="q-pr-md"
+                :to="{ name: 'CmsContentBlockEdit' }"
+            />
+        </div>
+
+        <div class="row q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.status"
+                    dense
+                    options-dense
+                    emit-value
+                    map-options
+                    label="Status"
+                    :options="statusOptions"
+                    @update:model-value="loadBlocks"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.system"
+                    dense
+                    options-dense
+                    clearable
+                    label="System"
+                    :options="['Viper', 'Public']"
+                    @update:model-value="loadBlocks"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.viperSectionPath"
+                    dense
+                    options-dense
+                    clearable
+                    label="VIPER section"
+                    :options="sectionPaths"
+                    @update:model-value="loadBlocks"
+                />
+            </div>
+            <div class="col-12 col-sm-3 col-lg-3">
+                <q-input
+                    v-model="filters.search"
+                    dense
+                    clearable
+                    debounce="400"
+                    label="Search title, name, page, or content"
+                    @update:model-value="loadBlocks"
+                >
+                    <template #prepend>
+                        <q-icon name="search" />
+                    </template>
+                </q-input>
+            </div>
+        </div>
+
+        <q-table
+            :rows="blocks"
+            :columns="columns"
+            row-key="contentBlockId"
+            :loading="loading"
+            :pagination="{ rowsPerPage: 50, sortBy: 'title' }"
+            :rows-per-page-options="[25, 50, 100, 0]"
+            dense
+            flat
+            bordered
+        >
+            <template #body-cell-title="cellProps">
+                <q-td :props="cellProps">
+                    <div class="row items-center no-wrap q-gutter-x-xs">
+                        <router-link
+                            :to="{ name: 'CmsContentBlockEdit', params: { id: cellProps.row.contentBlockId } }"
+                        >
+                            {{ cellProps.row.title || "(untitled)" }}
+                        </router-link>
+                        <q-icon
+                            v-if="cellProps.row.allowPublicAccess"
+                            name="public"
+                            color="positive"
+                        >
+                            <q-tooltip>Public access</q-tooltip>
+                        </q-icon>
+                        <q-icon
+                            v-if="cellProps.row.deletedOn"
+                            name="delete_outline"
+                            color="negative"
+                        >
+                            <q-tooltip>Deleted</q-tooltip>
+                        </q-icon>
+                    </div>
+                    <div class="text-caption text-grey-7">{{ cellProps.row.friendlyName }}</div>
+                </q-td>
+            </template>
+
+            <template #body-cell-permissions="cellProps">
+                <q-td :props="cellProps">
+                    <PermissionChips :permissions="cellProps.row.permissions" />
+                </q-td>
+            </template>
+
+            <template #body-cell-modifiedOn="cellProps">
+                <q-td :props="cellProps">
+                    {{ formatDate(cellProps.row.modifiedOn) }}
+                    <span class="text-grey-7">{{ cellProps.row.modifiedBy }}</span>
+                </q-td>
+            </template>
+
+            <template #body-cell-actions="cellProps">
+                <q-td :props="cellProps">
+                    <q-btn
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="secondary"
+                        icon="edit"
+                        aria-label="Edit content block"
+                        :to="{ name: 'CmsContentBlockEdit', params: { id: cellProps.row.contentBlockId } }"
+                    >
+                        <q-tooltip>Edit</q-tooltip>
+                    </q-btn>
+                    <DeleteRestoreButtons
+                        :deleted="!!cellProps.row.deletedOn"
+                        entity-name="content block"
+                        @delete="deleteBlock(cellProps.row)"
+                        @restore="restoreBlock(cellProps.row)"
+                    />
+                </q-td>
+            </template>
+        </q-table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, ref } from "vue"
+import { useQuasar, type QTableProps } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
+import PermissionChips from "@/CMS/components/PermissionChips.vue"
+import type { CmsContentBlock } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "CMS/content"
+const $q = useQuasar()
+const { get, del, post, createUrlSearchParams } = useFetch()
+
+const blocks = ref<CmsContentBlock[]>([])
+const sectionPaths = ref<string[]>([])
+const loading = ref(false)
+
+const filters = ref({
+    status: "active",
+    system: null as string | null,
+    viperSectionPath: null as string | null,
+    search: "",
+})
+
+const statusOptions = [
+    { label: "Active", value: "active" },
+    { label: "Deleted", value: "deleted" },
+    { label: "All", value: "all" },
+]
+
+const columns: QTableProps["columns"] = [
+    { name: "title", label: "Title", field: "title", align: "left", sortable: true },
+    { name: "system", label: "System", field: "system", align: "left", sortable: true },
+    { name: "viperSectionPath", label: "VIPER section", field: "viperSectionPath", align: "left", sortable: true },
+    { name: "page", label: "Page", field: "page", align: "left", sortable: true },
+    { name: "blockOrder", label: "Order", field: "blockOrder", align: "center", sortable: true },
+    { name: "permissions", label: "Access", field: "permissions", align: "left" },
+    { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
+    { name: "actions", label: "Actions", field: "contentBlockId", align: "center" },
+]
+
+async function loadBlocks() {
+    loading.value = true
+    const params = createUrlSearchParams({
+        status: filters.value.status,
+        system: filters.value.system,
+        viperSectionPath: filters.value.viperSectionPath,
+        search: filters.value.search || null,
+    })
+    const res = await get(apiURL + "?" + params)
+    blocks.value = res.success ? res.result : []
+    loading.value = false
+}
+
+async function loadSectionPaths() {
+    const res = await get(apiURL + "/section-paths")
+    sectionPaths.value = res.success ? res.result : []
+}
+
+async function deleteBlock(block: CmsContentBlock) {
+    const confirmed = await new Promise<boolean>((resolve) => {
+        $q.dialog({
+            title: "Delete Content Block",
+            message: `Mark "${block.title}" as deleted? It can be restored later.`,
+            cancel: { label: "Cancel", flat: true },
+            persistent: true,
+            ok: { label: "Delete", color: "negative", unelevated: true },
+        })
+            .onOk(() => resolve(true))
+            .onCancel(() => resolve(false))
+            .onDismiss(() => resolve(false))
+    })
+    if (!confirmed) return
+    const res = await del(apiURL + "/" + block.contentBlockId)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to delete content block" })
+        return
+    }
+    $q.notify({ type: "positive", message: "Content block marked as deleted" })
+    loadBlocks()
+}
+
+async function restoreBlock(block: CmsContentBlock) {
+    const res = await post(apiURL + "/" + block.contentBlockId + "/restore")
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to restore content block" })
+        return
+    }
+    $q.notify({ type: "positive", message: "Content block restored" })
+    loadBlocks()
+}
+
+function formatDate(value: string): string {
+    return new Date(value).toLocaleDateString("en-US", { year: "2-digit", month: "2-digit", day: "2-digit" })
+}
+
+onMounted(() => {
+    loadSectionPaths()
+    loadBlocks()
+})
+</script>

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -142,26 +142,15 @@
             </template>
 
             <template #body-cell-modifiedOn="cellProps">
-                <q-td :props="cellProps">
-                    {{ formatDate(cellProps.row.modifiedOn) }}
-                    <span class="text-grey-7">{{ cellProps.row.modifiedBy }}</span>
-                </q-td>
+                <ModifiedStamp :cell-props="cellProps" />
             </template>
 
             <template #body-cell-actions="cellProps">
                 <q-td :props="cellProps">
-                    <q-btn
-                        dense
-                        flat
-                        no-caps
-                        size="sm"
-                        color="secondary"
-                        icon="edit"
-                        aria-label="Edit file"
+                    <EditButton
+                        entity-name="file"
                         @click="openEditDialog(cellProps.row)"
-                    >
-                        <q-tooltip>Edit</q-tooltip>
-                    </q-btn>
+                    />
                     <q-btn
                         dense
                         flat
@@ -199,6 +188,8 @@ import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
 import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
+import EditButton from "@/CMS/components/EditButton.vue"
+import ModifiedStamp from "@/CMS/components/ModifiedStamp.vue"
 import PermissionChips from "@/CMS/components/PermissionChips.vue"
 import type { CmsFile } from "@/CMS/types/"
 

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -122,42 +122,10 @@
 
             <template #body-cell-permissions="cellProps">
                 <q-td :props="cellProps">
-                    <template v-if="cellProps.row.permissions.length || cellProps.row.people.length">
-                        <q-chip
-                            v-for="p in cellProps.row.permissions.slice(0, 2)"
-                            :key="p"
-                            dense
-                            square
-                            size="sm"
-                        >
-                            {{ p }}
-                        </q-chip>
-                        <q-chip
-                            v-if="cellProps.row.permissions.length > 2"
-                            dense
-                            square
-                            size="sm"
-                            color="grey-4"
-                        >
-                            +{{ cellProps.row.permissions.length - 2 }} more
-                        </q-chip>
-                        <q-chip
-                            v-if="cellProps.row.people.length"
-                            dense
-                            square
-                            size="sm"
-                            icon="person"
-                            color="grey-4"
-                        >
-                            {{ cellProps.row.people.length }}
-                        </q-chip>
-                    </template>
-                    <span
-                        v-else
-                        class="text-grey-7"
-                    >
-                        All VIPER users
-                    </span>
+                    <PermissionChips
+                        :permissions="cellProps.row.permissions"
+                        :people-count="cellProps.row.people.length"
+                    />
                 </q-td>
             </template>
 
@@ -206,32 +174,12 @@
                     >
                         <q-tooltip>Copy link</q-tooltip>
                     </q-btn>
-                    <q-btn
-                        v-if="!cellProps.row.deletedOn"
-                        dense
-                        flat
-                        no-caps
-                        size="sm"
-                        color="negative"
-                        icon="delete"
-                        aria-label="Delete file"
-                        @click="deleteFile(cellProps.row)"
-                    >
-                        <q-tooltip>Delete</q-tooltip>
-                    </q-btn>
-                    <q-btn
-                        v-else
-                        dense
-                        flat
-                        no-caps
-                        size="sm"
-                        color="positive"
-                        icon="restore_from_trash"
-                        aria-label="Restore file"
-                        @click="restoreFile(cellProps.row)"
-                    >
-                        <q-tooltip>Restore</q-tooltip>
-                    </q-btn>
+                    <DeleteRestoreButtons
+                        :deleted="!!cellProps.row.deletedOn"
+                        entity-name="file"
+                        @delete="deleteFile(cellProps.row)"
+                        @restore="restoreFile(cellProps.row)"
+                    />
                 </q-td>
             </template>
         </q-table>
@@ -250,6 +198,8 @@ import { inject, onMounted, ref } from "vue"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
+import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
+import PermissionChips from "@/CMS/components/PermissionChips.vue"
 import type { CmsFile } from "@/CMS/types/"
 
 const apiURL = inject("apiURL") + "cms/files/"

--- a/VueApp/src/CMS/pages/LeftNavEdit.vue
+++ b/VueApp/src/CMS/pages/LeftNavEdit.vue
@@ -1,0 +1,444 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">
+                {{ isNew ? "Create Navigation Menu" : "Edit Navigation Menu" }}
+            </h1>
+            <q-space />
+            <q-btn
+                flat
+                dense
+                no-caps
+                color="primary"
+                icon="arrow_back"
+                label="Back to Menus"
+                :to="{ name: 'CmsLeftNavMenus' }"
+            />
+        </div>
+
+        <div class="row q-col-gutter-lg">
+            <div class="col-12 col-md-4">
+                <q-card
+                    flat
+                    bordered
+                >
+                    <q-card-section class="q-gutter-y-sm">
+                        <div class="text-h6">Menu Settings</div>
+
+                        <q-form
+                            ref="menuFormRef"
+                            greedy
+                            @submit.prevent="saveMenu"
+                        >
+                            <q-input
+                                v-model="menu.menuHeaderText"
+                                dense
+                                outlined
+                                label="Menu header"
+                                class="required-field q-mb-sm"
+                                :rules="[(v: string | null) => (v && v.trim().length > 0) || 'Menu header is required']"
+                                aria-required="true"
+                                hide-bottom-space
+                            />
+
+                            <q-select
+                                v-model="menu.system"
+                                dense
+                                options-dense
+                                outlined
+                                label="System"
+                                class="q-mb-sm"
+                                :options="['Viper', 'Public']"
+                            />
+
+                            <q-input
+                                v-model="menu.viperSectionPath"
+                                dense
+                                outlined
+                                label="VIPER section path"
+                                class="q-mb-sm"
+                            />
+
+                            <q-input
+                                v-model="menu.page"
+                                dense
+                                outlined
+                                label="Page"
+                                class="q-mb-sm"
+                            />
+
+                            <q-input
+                                v-model="menu.friendlyName"
+                                dense
+                                outlined
+                                label="Friendly name"
+                                hint="Used by pages to look up this menu"
+                                class="q-mb-sm"
+                            />
+
+                            <q-btn
+                                type="submit"
+                                color="primary"
+                                :label="isNew ? 'Create Menu' : 'Save Menu Settings'"
+                                dense
+                                no-caps
+                                class="q-pr-md"
+                                :loading="savingMenu"
+                            />
+                        </q-form>
+                    </q-card-section>
+                </q-card>
+            </div>
+
+            <div
+                v-if="!isNew"
+                class="col-12 col-md-8"
+            >
+                <q-card
+                    flat
+                    bordered
+                >
+                    <q-card-section>
+                        <div class="row items-center q-mb-sm">
+                            <div class="text-h6">Menu Items</div>
+                            <q-space />
+                            <q-btn
+                                flat
+                                dense
+                                no-caps
+                                color="positive"
+                                icon="add"
+                                label="Add Header"
+                                @click="addItem(true)"
+                            />
+                            <q-btn
+                                flat
+                                dense
+                                no-caps
+                                color="positive"
+                                icon="add"
+                                label="Add Link"
+                                class="q-ml-sm"
+                                @click="addItem(false)"
+                            />
+                        </div>
+
+                        <VueDraggable
+                            v-model="items"
+                            :animation="200"
+                            handle=".handle"
+                        >
+                            <div
+                                v-for="(item, index) in items"
+                                :key="item.key"
+                                :class="['nav-item row items-start q-col-gutter-sm', { 'is-header': item.isHeader }]"
+                            >
+                                <div class="col-auto flex items-center">
+                                    <q-icon
+                                        class="handle q-mt-sm"
+                                        name="drag_handle"
+                                    >
+                                        <q-tooltip>Drag to reorder</q-tooltip>
+                                    </q-icon>
+                                </div>
+                                <div class="col-3">
+                                    <q-input
+                                        v-model="item.menuItemText"
+                                        dense
+                                        outlined
+                                        :label="item.isHeader ? 'Header text' : 'Link text'"
+                                    />
+                                </div>
+                                <div class="col">
+                                    <q-input
+                                        v-if="!item.isHeader"
+                                        v-model="item.url"
+                                        dense
+                                        outlined
+                                        label="URL"
+                                    />
+                                    <div
+                                        v-else
+                                        class="text-grey-7 q-mt-sm text-caption"
+                                    >
+                                        Section header
+                                    </div>
+                                </div>
+                                <div class="col-3">
+                                    <PermissionSelector
+                                        v-model="item.permissions"
+                                        label="Visible to"
+                                    />
+                                </div>
+                                <div class="col-auto">
+                                    <q-btn
+                                        dense
+                                        flat
+                                        no-caps
+                                        size="sm"
+                                        color="secondary"
+                                        icon="arrow_upward"
+                                        aria-label="Move item up"
+                                        :disable="index === 0"
+                                        @click="moveItem(index, -1)"
+                                    />
+                                    <q-btn
+                                        dense
+                                        flat
+                                        no-caps
+                                        size="sm"
+                                        color="secondary"
+                                        icon="arrow_downward"
+                                        aria-label="Move item down"
+                                        :disable="index === items.length - 1"
+                                        @click="moveItem(index, 1)"
+                                    />
+                                    <q-btn
+                                        dense
+                                        flat
+                                        no-caps
+                                        size="sm"
+                                        color="negative"
+                                        icon="delete"
+                                        aria-label="Remove item"
+                                        @click="removeItem(index)"
+                                    />
+                                </div>
+                            </div>
+                        </VueDraggable>
+
+                        <div
+                            v-if="!items.length"
+                            class="text-grey-7 q-my-md"
+                        >
+                            No items yet — add a header or link above.
+                        </div>
+
+                        <div class="q-mt-md">
+                            <q-btn
+                                color="primary"
+                                label="Save Items"
+                                dense
+                                no-caps
+                                class="q-pr-md"
+                                :loading="savingItems"
+                                @click="saveItems"
+                            />
+                            <q-btn
+                                flat
+                                label="Revert"
+                                dense
+                                no-caps
+                                class="q-ml-sm"
+                                @click="revertItems"
+                            />
+                        </div>
+                    </q-card-section>
+                </q-card>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onMounted, ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useQuasar } from "quasar"
+import { VueDraggable } from "vue-draggable-plus"
+import { useFetch } from "@/composables/ViperFetch"
+import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
+import type { CmsLeftNavMenu } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "cms/left-navs"
+const route = useRoute()
+const router = useRouter()
+const $q = useQuasar()
+const { get, post, put } = useFetch()
+
+const menuId = computed(() => (route.params.id ? Number(route.params.id) : null))
+const isNew = computed(() => menuId.value === null)
+
+const menuFormRef = ref()
+const savingMenu = ref(false)
+const savingItems = ref(false)
+
+const menu = ref({
+    menuHeaderText: "" as string | null,
+    system: "Viper",
+    viperSectionPath: null as string | null,
+    page: null as string | null,
+    friendlyName: null as string | null,
+})
+
+type EditableItem = {
+    key: number
+    leftNavItemId: number
+    menuItemText: string | null
+    isHeader: boolean
+    url: string | null
+    permissions: string[]
+}
+
+const items = ref<EditableItem[]>([])
+let savedMenu: CmsLeftNavMenu | null = null
+let nextKey = -1
+
+function toEditableItems(source: CmsLeftNavMenu): EditableItem[] {
+    return source.items.map((i) => ({
+        key: i.leftNavItemId,
+        leftNavItemId: i.leftNavItemId,
+        menuItemText: i.menuItemText,
+        isHeader: i.isHeader,
+        url: i.url,
+        permissions: [...i.permissions],
+    }))
+}
+
+async function loadMenu() {
+    if (menuId.value === null) return
+    const res = await get(apiURL + "/" + menuId.value)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Menu not found" })
+        void router.push({ name: "CmsLeftNavMenus" })
+        return
+    }
+    savedMenu = res.result
+    menu.value = {
+        menuHeaderText: res.result.menuHeaderText,
+        system: res.result.system,
+        viperSectionPath: res.result.viperSectionPath,
+        page: res.result.page,
+        friendlyName: res.result.friendlyName,
+    }
+    items.value = toEditableItems(res.result)
+}
+
+async function saveMenu() {
+    const valid = await menuFormRef.value?.validate()
+    if (!valid) return
+
+    savingMenu.value = true
+    const payload = {
+        menuHeaderText: menu.value.menuHeaderText,
+        system: menu.value.system,
+        viperSectionPath: menu.value.viperSectionPath || null,
+        page: menu.value.page || null,
+        friendlyName: menu.value.friendlyName || null,
+    }
+    const res = isNew.value ? await post(apiURL, payload) : await put(apiURL + "/" + menuId.value, payload)
+    savingMenu.value = false
+
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to save menu" })
+        return
+    }
+    $q.notify({ type: "positive", message: isNew.value ? "Menu created — now add items" : "Menu settings saved" })
+    if (isNew.value) {
+        // the menuId watch loads the created menu once the route changes
+        void router.push({ name: "CmsLeftNavEdit", params: { id: res.result.leftNavMenuId } })
+    }
+}
+
+function addItem(isHeader: boolean) {
+    items.value.push({
+        key: nextKey--,
+        leftNavItemId: 0,
+        menuItemText: "",
+        isHeader,
+        url: isHeader ? null : "",
+        permissions: [],
+    })
+}
+
+function removeItem(index: number) {
+    items.value.splice(index, 1)
+}
+
+function moveItem(index: number, direction: -1 | 1) {
+    const newIndex = index + direction
+    if (newIndex < 0 || newIndex >= items.value.length) return
+    const [item] = items.value.splice(index, 1)
+    items.value.splice(newIndex, 0, item!)
+}
+
+async function saveItems() {
+    const emptyItem = items.value.find((i) => !i.menuItemText || i.menuItemText.trim() === "")
+    if (emptyItem) {
+        $q.notify({ type: "negative", message: "Every item needs text" })
+        return
+    }
+
+    savingItems.value = true
+    const payload = items.value.map((i) => ({
+        leftNavItemId: i.leftNavItemId,
+        menuItemText: i.menuItemText,
+        isHeader: i.isHeader,
+        url: i.isHeader ? null : i.url,
+        permissions: i.permissions,
+    }))
+    const res = await put(apiURL + "/" + menuId.value + "/items", payload)
+    savingItems.value = false
+
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to save items" })
+        return
+    }
+    $q.notify({ type: "positive", message: "Items saved" })
+    savedMenu = res.result
+    items.value = toEditableItems(res.result)
+}
+
+function revertItems() {
+    if (savedMenu) {
+        items.value = toEditableItems(savedMenu)
+        $q.notify({ type: "info", message: "Items reverted to last saved state" })
+    }
+}
+
+// The create and edit routes share this component, so vue-router reuses the
+// instance and onMounted does not re-fire when navigating between them
+// (create -> redirect after save, or browser back to the create route).
+watch(menuId, (id) => {
+    if (id === null) {
+        menu.value = {
+            menuHeaderText: "",
+            system: "Viper",
+            viperSectionPath: null,
+            page: null,
+            friendlyName: null,
+        }
+        items.value = []
+        savedMenu = null
+    } else {
+        void loadMenu()
+    }
+})
+
+onMounted(loadMenu)
+</script>
+
+<style scoped>
+.nav-item {
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    margin-bottom: 8px;
+    padding: 8px;
+}
+
+.nav-item.is-header {
+    background: #f5f7fb;
+}
+
+.handle {
+    cursor: grab;
+}
+
+.handle:active {
+    cursor: grabbing;
+}
+
+.required-field :deep(.q-field__label)::after {
+    content: " *";
+    color: var(--q-negative);
+}
+</style>

--- a/VueApp/src/CMS/pages/LeftNavMenus.vue
+++ b/VueApp/src/CMS/pages/LeftNavMenus.vue
@@ -1,0 +1,162 @@
+<template>
+    <div class="q-pa-md">
+        <div class="row items-center q-mb-md">
+            <h1 class="text-h4 text-primary q-my-none">Left Navigation Menus</h1>
+            <q-space />
+            <q-btn
+                color="positive"
+                icon="add"
+                label="New Menu"
+                no-caps
+                dense
+                class="q-pr-md"
+                :to="{ name: 'CmsLeftNavEdit' }"
+            />
+        </div>
+
+        <div class="row q-col-gutter-md q-mb-sm">
+            <div class="col-12 col-sm-3 col-lg-2">
+                <q-select
+                    v-model="filters.system"
+                    dense
+                    options-dense
+                    clearable
+                    label="System"
+                    :options="['Viper', 'Public']"
+                    @update:model-value="loadMenus"
+                />
+            </div>
+            <div class="col-12 col-sm-4 col-lg-3">
+                <q-input
+                    v-model="filters.search"
+                    dense
+                    clearable
+                    debounce="400"
+                    label="Search header, name, or page"
+                    @update:model-value="loadMenus"
+                >
+                    <template #prepend>
+                        <q-icon name="search" />
+                    </template>
+                </q-input>
+            </div>
+        </div>
+
+        <q-table
+            :rows="menus"
+            :columns="columns"
+            row-key="leftNavMenuId"
+            :loading="loading"
+            :pagination="{ rowsPerPage: 50, sortBy: 'menuHeaderText' }"
+            :rows-per-page-options="[25, 50, 100, 0]"
+            dense
+            flat
+            bordered
+        >
+            <template #body-cell-menuHeaderText="cellProps">
+                <q-td :props="cellProps">
+                    <router-link :to="{ name: 'CmsLeftNavEdit', params: { id: cellProps.row.leftNavMenuId } }">
+                        {{ cellProps.row.menuHeaderText || "(untitled)" }}
+                    </router-link>
+                </q-td>
+            </template>
+
+            <template #body-cell-items="cellProps">
+                <q-td :props="cellProps">{{ cellProps.row.items.length }}</q-td>
+            </template>
+
+            <template #body-cell-modifiedOn="cellProps">
+                <ModifiedStamp :cell-props="cellProps" />
+            </template>
+
+            <template #body-cell-actions="cellProps">
+                <q-td :props="cellProps">
+                    <EditButton
+                        entity-name="menu"
+                        :to="{ name: 'CmsLeftNavEdit', params: { id: cellProps.row.leftNavMenuId } }"
+                    />
+                    <q-btn
+                        dense
+                        flat
+                        no-caps
+                        size="sm"
+                        color="negative"
+                        icon="delete"
+                        aria-label="Delete menu"
+                        @click="deleteMenu(cellProps.row)"
+                    >
+                        <q-tooltip>Delete</q-tooltip>
+                    </q-btn>
+                </q-td>
+            </template>
+        </q-table>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, ref } from "vue"
+import { useQuasar, type QTableProps } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+import EditButton from "@/CMS/components/EditButton.vue"
+import ModifiedStamp from "@/CMS/components/ModifiedStamp.vue"
+import type { CmsLeftNavMenu } from "@/CMS/types/"
+
+const apiURL = inject("apiURL") + "cms/left-navs"
+const $q = useQuasar()
+const { get, del, createUrlSearchParams } = useFetch()
+
+const menus = ref<CmsLeftNavMenu[]>([])
+const loading = ref(false)
+
+const filters = ref({
+    system: null as string | null,
+    search: "",
+})
+
+const columns: QTableProps["columns"] = [
+    { name: "menuHeaderText", label: "Menu Header", field: "menuHeaderText", align: "left", sortable: true },
+    { name: "system", label: "System", field: "system", align: "left", sortable: true },
+    { name: "viperSectionPath", label: "VIPER section", field: "viperSectionPath", align: "left", sortable: true },
+    { name: "page", label: "Page", field: "page", align: "left", sortable: true },
+    { name: "friendlyName", label: "Friendly name", field: "friendlyName", align: "left", sortable: true },
+    { name: "items", label: "Items", field: (row: CmsLeftNavMenu) => row.items.length, align: "center" },
+    { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
+    { name: "actions", label: "Actions", field: "leftNavMenuId", align: "center" },
+]
+
+async function loadMenus() {
+    loading.value = true
+    const params = createUrlSearchParams({
+        system: filters.value.system,
+        search: filters.value.search || null,
+    })
+    const res = await get(apiURL + "?" + params)
+    menus.value = res.success ? res.result : []
+    loading.value = false
+}
+
+async function deleteMenu(menu: CmsLeftNavMenu) {
+    const confirmed = await new Promise<boolean>((resolve) => {
+        $q.dialog({
+            title: "Delete Menu",
+            message: `Permanently delete "${menu.menuHeaderText}" and its ${menu.items.length} items? This cannot be undone.`,
+            cancel: { label: "Cancel", flat: true },
+            persistent: true,
+            ok: { label: "Delete Menu", color: "negative", unelevated: true },
+        })
+            .onOk(() => resolve(true))
+            .onCancel(() => resolve(false))
+            .onDismiss(() => resolve(false))
+    })
+    if (!confirmed) return
+    const res = await del(apiURL + "/" + menu.leftNavMenuId)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to delete menu" })
+        return
+    }
+    $q.notify({ type: "positive", message: "Menu deleted" })
+    loadMenus()
+}
+
+onMounted(loadMenus)
+</script>

--- a/VueApp/src/CMS/router/routes.ts
+++ b/VueApp/src/CMS/router/routes.ts
@@ -46,6 +46,18 @@ const routes = [
         component: () => import("@/CMS/pages/ContentBlockEdit.vue"),
     },
     {
+        path: "/CMS/ManageLeftNav",
+        name: "CmsLeftNavMenus",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.ManageNavigation"] },
+        component: () => import("@/CMS/pages/LeftNavMenus.vue"),
+    },
+    {
+        path: "/CMS/ManageLeftNav/Edit/:id?",
+        name: "CmsLeftNavEdit",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.ManageNavigation"] },
+        component: () => import("@/CMS/pages/LeftNavEdit.vue"),
+    },
+    {
         path: "/:catchAll(.*)*",
         meta: { layout: ViperLayout },
         component: () => import("@/pages/Error404.vue"),

--- a/VueApp/src/CMS/router/routes.ts
+++ b/VueApp/src/CMS/router/routes.ts
@@ -34,6 +34,18 @@ const routes = [
         component: () => import("@/CMS/pages/FileAuditLog.vue"),
     },
     {
+        path: "/CMS/ManageContentBlocks",
+        name: "CmsContentBlocks",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.ManageContentBlocks"] },
+        component: () => import("@/CMS/pages/ContentBlocks.vue"),
+    },
+    {
+        path: "/CMS/ManageContentBlocks/Edit/:id?",
+        name: "CmsContentBlockEdit",
+        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS.ManageContentBlocks"] },
+        component: () => import("@/CMS/pages/ContentBlockEdit.vue"),
+    },
+    {
         path: "/:catchAll(.*)*",
         meta: { layout: ViperLayout },
         component: () => import("@/pages/Error404.vue"),

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -64,6 +64,27 @@ type CmsContentHistoryItem = {
     modifiedBy: string | null
 }
 
+type CmsLeftNavMenu = {
+    leftNavMenuId: number
+    menuHeaderText: string | null
+    system: string
+    viperSectionPath: string | null
+    page: string | null
+    friendlyName: string | null
+    modifiedOn: string
+    modifiedBy: string
+    items: CmsLeftNavItem[]
+}
+
+type CmsLeftNavItem = {
+    leftNavItemId: number
+    menuItemText: string | null
+    isHeader: boolean
+    url: string | null
+    displayOrder: number | null
+    permissions: string[]
+}
+
 type CmsFileAudit = {
     auditId: number
     timestamp: string
@@ -127,6 +148,7 @@ export type {
     CmsContentBlock,
     CmsContentBlockFile,
     CmsContentHistoryItem,
+    CmsLeftNavMenu,
     CmsFile,
     CmsFilePerson,
     CmsPersonOption,

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -34,6 +34,36 @@ type CmsPersonOption = {
     mailId: string | null
 }
 
+type CmsContentBlock = {
+    contentBlockId: number
+    content: string
+    title: string | null
+    system: string
+    application: string | null
+    page: string | null
+    viperSectionPath: string | null
+    blockOrder: number | null
+    friendlyName: string | null
+    allowPublicAccess: boolean
+    modifiedOn: string
+    modifiedBy: string
+    deletedOn: string | null
+    permissions: string[]
+    files: CmsContentBlockFile[]
+}
+
+type CmsContentBlockFile = {
+    fileGuid: string
+    friendlyName: string
+    url: string
+}
+
+type CmsContentHistoryItem = {
+    contentHistoryId: number
+    modifiedOn: string | null
+    modifiedBy: string | null
+}
+
 type CmsFileAudit = {
     auditId: number
     timestamp: string
@@ -94,6 +124,9 @@ type LinkWithTags = {
 
 export type {
     ContentBlock,
+    CmsContentBlock,
+    CmsContentBlockFile,
+    CmsContentHistoryItem,
     CmsFile,
     CmsFilePerson,
     CmsPersonOption,

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -1,0 +1,326 @@
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Viper.Areas.CMS.Models;
+using Viper.Areas.CMS.Services;
+using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
+using Viper.Services;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for CmsContentBlockService: filtering, create/update with permission and file deltas,
+/// history semantics (previous version is stored, stamped with its original author/time),
+/// concurrency conflicts, soft delete/restore, and permanent delete cascade.
+/// </summary>
+public sealed class CmsContentBlockServiceTests : IDisposable
+{
+    private readonly VIPERContext _context;
+    private readonly IHtmlSanitizerService _sanitizer;
+    private readonly IUserHelper _userHelper;
+    private readonly CmsContentBlockService _service;
+
+    public CmsContentBlockServiceTests()
+    {
+        _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
+        _sanitizer = Substitute.For<IHtmlSanitizerService>();
+        _sanitizer.Sanitize(Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+        _userHelper = Substitute.For<IUserHelper>();
+
+        _service = new CmsContentBlockService(_context, _sanitizer, _userHelper);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private async Task<ContentBlock> SeedBlockAsync(Action<ContentBlock>? customize = null)
+    {
+        var block = new ContentBlock
+        {
+            Content = "<p>original</p>",
+            Title = "Seeded Block",
+            System = "Viper",
+            ViperSectionPath = "cats",
+            Page = "home",
+            BlockOrder = 1,
+            FriendlyName = "seeded-block-" + Guid.NewGuid().ToString("N")[..8],
+            ModifiedOn = DateTime.Now.AddDays(-2),
+            ModifiedBy = "originalAuthor"
+        };
+        customize?.Invoke(block);
+        _context.ContentBlocks.Add(block);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return block;
+    }
+
+    private static CMSBlockAddEdit MakeRequest(ContentBlock block, Action<CMSBlockAddEdit>? customize = null)
+    {
+        var request = new CMSBlockAddEdit
+        {
+            ContentBlockId = block.ContentBlockId,
+            Content = block.Content,
+            Title = block.Title,
+            System = block.System,
+            Page = block.Page,
+            ViperSectionPath = block.ViperSectionPath,
+            BlockOrder = block.BlockOrder,
+            FriendlyName = block.FriendlyName,
+            AllowPublicAccess = block.AllowPublicAccess,
+            LastModifiedOn = block.ModifiedOn
+        };
+        customize?.Invoke(request);
+        return request;
+    }
+
+    #region List / Get
+
+    [Fact]
+    public async Task GetContentBlocks_FiltersByStatus()
+    {
+        await SeedBlockAsync();
+        await SeedBlockAsync(b => b.DeletedOn = DateTime.Now);
+
+        var active = await _service.GetContentBlocksAsync("active", null, null, null, TestContext.Current.CancellationToken);
+        var deleted = await _service.GetContentBlocksAsync("deleted", null, null, null, TestContext.Current.CancellationToken);
+        var all = await _service.GetContentBlocksAsync("all", null, null, null, TestContext.Current.CancellationToken);
+
+        Assert.Single(active);
+        Assert.Single(deleted);
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task GetContentBlocks_ListOmitsContent()
+    {
+        await SeedBlockAsync();
+
+        var list = await _service.GetContentBlocksAsync("active", null, null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(string.Empty, list[0].Content);
+    }
+
+    [Fact]
+    public async Task GetContentBlock_ReturnsContentAndRelations()
+    {
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = "SVMSecure.CATS" }));
+
+        var dto = await _service.GetContentBlockAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        Assert.Equal("<p>original</p>", dto!.Content);
+        Assert.Equal(new List<string> { "SVMSecure.CATS" }, dto.Permissions);
+    }
+
+    #endregion
+
+    #region Create
+
+    [Fact]
+    public async Task Create_SavesBlockWithPermissionsAndNoHistory()
+    {
+        var request = new CMSBlockAddEdit
+        {
+            ContentBlockId = 0,
+            Content = "<p>new</p>",
+            Title = "New Block",
+            System = "Viper",
+            AllowPublicAccess = false,
+            Permissions = new List<string> { "SVMSecure.CATS" }
+        };
+
+        var dto = await _service.CreateContentBlockAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.True(dto.ContentBlockId > 0);
+        Assert.Equal(new List<string> { "SVMSecure.CATS" }, dto.Permissions);
+        // Legacy semantics: history holds previous versions only, so a new block has none.
+        Assert.Empty(_context.ContentHistories.Where(h => h.ContentBlockId == dto.ContentBlockId));
+    }
+
+    [Fact]
+    public async Task Create_DuplicateFriendlyName_Throws()
+    {
+        var existing = await SeedBlockAsync();
+        var request = new CMSBlockAddEdit
+        {
+            ContentBlockId = 0,
+            Content = "x",
+            Title = "Dup",
+            System = "Viper",
+            AllowPublicAccess = false,
+            FriendlyName = existing.FriendlyName
+        };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.CreateContentBlockAsync(request, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Create_UnknownFileGuid_Throws()
+    {
+        var request = new CMSBlockAddEdit
+        {
+            ContentBlockId = 0,
+            Content = "x",
+            Title = "Has Bad File",
+            System = "Viper",
+            AllowPublicAccess = false,
+            FileGuids = new List<Guid> { Guid.NewGuid() }
+        };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.CreateContentBlockAsync(request, TestContext.Current.CancellationToken));
+    }
+
+    #endregion
+
+    #region Update
+
+    [Fact]
+    public async Task Update_WritesPreviousVersionToHistory()
+    {
+        var block = await SeedBlockAsync();
+        var originalModifiedOn = block.ModifiedOn;
+        var request = MakeRequest(block, r => r.Content = "<p>updated</p>");
+
+        var dto = await _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken);
+
+        Assert.Equal("<p>updated</p>", dto!.Content);
+        var history = Assert.Single(_context.ContentHistories.Where(h => h.ContentBlockId == block.ContentBlockId));
+        Assert.Equal("<p>original</p>", history.ContentBlockContent);
+        Assert.Equal("originalAuthor", history.ModifiedBy);
+        Assert.Equal(originalModifiedOn, history.ModifiedOn);
+    }
+
+    [Fact]
+    public async Task Update_StaleLastModifiedOn_ThrowsConcurrency()
+    {
+        var block = await SeedBlockAsync();
+        var request = MakeRequest(block, r => r.LastModifiedOn = block.ModifiedOn.AddMinutes(-5));
+
+        await Assert.ThrowsAsync<CmsConcurrencyException>(
+            () => _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Update_NullLastModifiedOn_Throws()
+    {
+        var block = await SeedBlockAsync();
+        var request = MakeRequest(block, r => r.LastModifiedOn = null);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Update_UnknownFileGuid_Throws()
+    {
+        var block = await SeedBlockAsync();
+        var request = MakeRequest(block, r => r.FileGuids = new List<Guid> { Guid.NewGuid() });
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Update_AppliesPermissionAndFileDeltas()
+    {
+        var file = new Viper.Models.VIPER.File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = @"C:\FakeRoot\cats\attach.pdf",
+            Folder = "cats",
+            FriendlyName = "cats-attach.pdf",
+            Description = "",
+            ModifiedBy = "test",
+            ModifiedOn = DateTime.Now
+        };
+        _context.Files.Add(file);
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = "SVMSecure.Old" }));
+
+        var request = MakeRequest(block, r =>
+        {
+            r.Permissions = new List<string> { "SVMSecure.New" };
+            r.FileGuids = new List<Guid> { file.FileGuid };
+        });
+
+        var dto = await _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new List<string> { "SVMSecure.New" }, dto!.Permissions);
+        Assert.Single(dto.Files);
+        Assert.Equal("cats-attach.pdf", dto.Files[0].FriendlyName);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_PreservesOtherFieldsAndWritesHistory()
+    {
+        var block = await SeedBlockAsync();
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>quick edit</p>", block.ModifiedOn,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("<p>quick edit</p>", dto!.Content);
+        Assert.Equal("Seeded Block", dto.Title);
+        var history = Assert.Single(_context.ContentHistories.Where(h => h.ContentBlockId == block.ContentBlockId));
+        Assert.Equal("<p>original</p>", history.ContentBlockContent);
+    }
+
+    #endregion
+
+    #region Delete / Restore / History
+
+    [Fact]
+    public async Task SoftDeleteAndRestore_ToggleDeletedOn()
+    {
+        var block = await SeedBlockAsync();
+
+        Assert.True(await _service.SoftDeleteAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+        Assert.NotNull((await _context.ContentBlocks.SingleAsync(TestContext.Current.CancellationToken)).DeletedOn);
+
+        Assert.True(await _service.RestoreAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+        Assert.Null((await _context.ContentBlocks.SingleAsync(TestContext.Current.CancellationToken)).DeletedOn);
+    }
+
+    [Fact]
+    public async Task PermanentDelete_RemovesBlockAndChildren()
+    {
+        var block = await SeedBlockAsync(b =>
+        {
+            b.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = "SVMSecure" });
+            b.ContentHistories.Add(new ContentHistory
+            {
+                ContentBlockContent = "old",
+                ModifiedOn = DateTime.Now.AddDays(-3),
+                ModifiedBy = "x"
+            });
+        });
+
+        var result = await _service.PermanentlyDeleteAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        Assert.Empty(await _context.ContentBlocks.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.ContentHistories.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.ContentBlockToPermissions.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task History_ListAndVersionRetrieval()
+    {
+        var block = await SeedBlockAsync();
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v3</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+
+        var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
+        Assert.Equal(2, history.Count);
+
+        var oldest = await _service.GetHistoryVersionAsync(block.ContentBlockId, history[^1].ContentHistoryId,
+            TestContext.Current.CancellationToken);
+        Assert.Equal("<p>original</p>", oldest!.Content);
+    }
+
+    #endregion
+}

--- a/test/CMS/CmsLeftNavServiceTests.cs
+++ b/test/CMS/CmsLeftNavServiceTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Areas.CMS.Services;
+using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for CmsLeftNavService: menu CRUD with cascade delete and the batch item save
+/// (add/update/delete/reorder in one call, replacing the legacy DataTables editor).
+/// </summary>
+public sealed class CmsLeftNavServiceTests : IDisposable
+{
+    private readonly VIPERContext _context;
+    private readonly CmsLeftNavService _service;
+
+    public CmsLeftNavServiceTests()
+    {
+        _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
+        _service = new CmsLeftNavService(_context, Substitute.For<IUserHelper>());
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private async Task<LeftNavMenu> SeedMenuAsync(Action<LeftNavMenu>? customize = null)
+    {
+        var menu = new LeftNavMenu
+        {
+            MenuHeaderText = "Seeded Menu",
+            System = "Viper",
+            ViperSectionPath = "cats",
+            FriendlyName = "seeded-menu-" + Guid.NewGuid().ToString("N")[..8],
+            ModifiedOn = DateTime.Now.AddDays(-1),
+            ModifiedBy = "test"
+        };
+        customize?.Invoke(menu);
+        _context.LeftNavMenus.Add(menu);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return menu;
+    }
+
+    private static LeftNavItem MakeItem(string text, int order, bool isHeader = false, string? url = null, params string[] permissions)
+    {
+        var item = new LeftNavItem
+        {
+            MenuItemText = text,
+            IsHeader = isHeader,
+            Url = url,
+            DisplayOrder = order
+        };
+        foreach (var p in permissions)
+        {
+            item.LeftNavItemToPermissions.Add(new LeftNavItemToPermission { Permission = p });
+        }
+        return item;
+    }
+
+    [Fact]
+    public async Task GetMenus_FiltersBySystemAndSearch()
+    {
+        await SeedMenuAsync();
+        await SeedMenuAsync(m =>
+        {
+            m.MenuHeaderText = "Public Menu";
+            m.System = "Public";
+        });
+
+        var viperMenus = await _service.GetMenusAsync("Viper", null, null, TestContext.Current.CancellationToken);
+        var searched = await _service.GetMenusAsync(null, null, "Public", TestContext.Current.CancellationToken);
+
+        Assert.Single(viperMenus);
+        Assert.Single(searched);
+        Assert.Equal("Public Menu", searched[0].MenuHeaderText);
+    }
+
+    [Fact]
+    public async Task GetMenu_ReturnsItemsInDisplayOrder()
+    {
+        var menu = await SeedMenuAsync(m =>
+        {
+            m.LeftNavItems.Add(MakeItem("Second", 2, url: "/two"));
+            m.LeftNavItems.Add(MakeItem("First", 1, isHeader: true));
+        });
+
+        var dto = await _service.GetMenuAsync(menu.LeftNavMenuId, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new[] { "First", "Second" }, dto!.Items.Select(i => i.MenuItemText).ToArray());
+        Assert.True(dto.Items[0].IsHeader);
+    }
+
+    [Fact]
+    public async Task CreateAndUpdateMenu_PersistFields()
+    {
+        var created = await _service.CreateMenuAsync(new LeftNavMenuAddEdit
+        {
+            MenuHeaderText = "New Menu",
+            System = "Viper",
+            ViperSectionPath = "students",
+            Page = "home",
+            FriendlyName = "new-menu"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.True(created.LeftNavMenuId > 0);
+
+        var updated = await _service.UpdateMenuAsync(created.LeftNavMenuId, new LeftNavMenuAddEdit
+        {
+            MenuHeaderText = "Renamed Menu",
+            System = "Viper"
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal("Renamed Menu", updated!.MenuHeaderText);
+        Assert.Null(updated.ViperSectionPath);
+    }
+
+    [Fact]
+    public async Task DeleteMenu_CascadesToItemsAndPermissions()
+    {
+        var menu = await SeedMenuAsync(m => m.LeftNavItems.Add(MakeItem("Link", 1, url: "/x", permissions: "SVMSecure.CATS")));
+
+        var result = await _service.DeleteMenuAsync(menu.LeftNavMenuId, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        Assert.Empty(await _context.LeftNavMenus.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.LeftNavItems.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.LeftNavItemToPermissions.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SaveItems_AddsUpdatesDeletesAndReorders()
+    {
+        var menu = await SeedMenuAsync(m =>
+        {
+            m.LeftNavItems.Add(MakeItem("Keep Me", 1, url: "/keep", permissions: "SVMSecure.Old"));
+            m.LeftNavItems.Add(MakeItem("Delete Me", 2, url: "/delete"));
+        });
+        var keepId = menu.LeftNavItems.First(i => i.MenuItemText == "Keep Me").LeftNavItemId;
+
+        var dto = await _service.SaveItemsAsync(menu.LeftNavMenuId, new List<LeftNavItemEdit>
+        {
+            new() { LeftNavItemId = 0, MenuItemText = "New Header", IsHeader = true },
+            new() { LeftNavItemId = keepId, MenuItemText = "Keep Me Renamed", Url = "/kept", Permissions = new List<string> { "SVMSecure.New" } },
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, dto!.Items.Count);
+        Assert.Equal("New Header", dto.Items[0].MenuItemText);
+        Assert.Equal(1, dto.Items[0].DisplayOrder);
+        Assert.True(dto.Items[0].IsHeader);
+        Assert.Equal("Keep Me Renamed", dto.Items[1].MenuItemText);
+        Assert.Equal(2, dto.Items[1].DisplayOrder);
+        Assert.Equal(new List<string> { "SVMSecure.New" }, dto.Items[1].Permissions);
+        // Deleted item's permissions are gone too
+        Assert.Equal(1, await _context.LeftNavItemToPermissions.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SaveItems_HeaderItems_DropUrl()
+    {
+        var menu = await SeedMenuAsync();
+
+        var dto = await _service.SaveItemsAsync(menu.LeftNavMenuId, new List<LeftNavItemEdit>
+        {
+            new() { LeftNavItemId = 0, MenuItemText = "Header", IsHeader = true, Url = "/should-be-dropped" },
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Null(dto!.Items[0].Url);
+    }
+
+    [Fact]
+    public async Task SaveItems_UnknownMenu_ReturnsNull()
+    {
+        var dto = await _service.SaveItemsAsync(9999, new List<LeftNavItemEdit>(), TestContext.Current.CancellationToken);
+
+        Assert.Null(dto);
+    }
+}

--- a/test/CMS/SafeUrlAttributeTests.cs
+++ b/test/CMS/SafeUrlAttributeTests.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel.DataAnnotations;
+using Areas.CMS.Validation;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for SafeUrlAttribute, in both absolute-only mode (link collections) and
+/// AllowRelative mode (left nav item URLs).
+/// </summary>
+public sealed class SafeUrlAttributeTests
+{
+    private static ValidationResult? Validate(string? url, bool allowRelative)
+    {
+        var attribute = new SafeUrlAttribute { AllowRelative = allowRelative };
+        return attribute.GetValidationResult(url, new ValidationContext(new object()));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://example.com/page")]
+    [InlineData("http://example.com")]
+    [InlineData("mailto:someone@example.com")]
+    [InlineData("tel:+15305551234")]
+    public void AbsoluteMode_AllowsSafeSchemesAndEmpty(string? url)
+    {
+        Assert.Equal(ValidationResult.Success, Validate(url, allowRelative: false));
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(document.cookie)")]
+    [InlineData("JAVASCRIPT:alert(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("java\tscript:alert(1)")]
+    [InlineData("java\nscript:alert(1)")]
+    public void BothModes_RejectDangerousUrls(string url)
+    {
+        Assert.NotEqual(ValidationResult.Success, Validate(url, allowRelative: false));
+        Assert.NotEqual(ValidationResult.Success, Validate(url, allowRelative: true));
+    }
+
+    [Theory]
+    [InlineData("/CMS/files")]
+    [InlineData("~/ManageLeftNav")]
+    [InlineData("page.cfm?x=1")]
+    [InlineData("path/to/page#section")]
+    public void RelativeMode_AllowsRelativeUrls(string url)
+    {
+        Assert.Equal(ValidationResult.Success, Validate(url, allowRelative: true));
+    }
+
+    [Fact]
+    public void AbsoluteMode_RejectsRelativeUrls()
+    {
+        Assert.NotEqual(ValidationResult.Success, Validate("/CMS/files", allowRelative: false));
+    }
+
+    [Fact]
+    public void RelativeMode_RejectsColonInFirstSegment()
+    {
+        Assert.NotEqual(ValidationResult.Success, Validate("foo:bar/baz", allowRelative: true));
+    }
+
+    [Fact]
+    public void RelativeMode_AllowsColonAfterFirstSegment()
+    {
+        Assert.Equal(ValidationResult.Success, Validate("path/page:1", allowRelative: true));
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Areas.CMS.Services;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models.VIPER;
@@ -16,33 +18,60 @@ namespace Viper.Areas.CMS.Controllers
         private readonly VIPERContext _context;
         private readonly RAPSContext _rapsContext;
         private readonly IHtmlSanitizerService _sanitizerService;
-        public IUserHelper UserHelper { get; private set; }
+        private readonly ICmsContentBlockService _blockService;
+        private readonly IUserHelper _userHelper;
 
-        public CMSContentController(VIPERContext context, RAPSContext rapsContext, IHtmlSanitizerService sanitizerService)
+        public CMSContentController(VIPERContext context, RAPSContext rapsContext,
+            IHtmlSanitizerService sanitizerService, ICmsContentBlockService blockService, IUserHelper userHelper)
         {
             _context = context;
             _rapsContext = rapsContext;
             _sanitizerService = sanitizerService;
-            UserHelper = new UserHelper();
+            _blockService = blockService;
+            _userHelper = userHelper;
         }
 
         //GET: content
         [HttpGet]
-        [Permission(Allow = "SVMSecure.CMS.ManageContentBlocks")]
-        public ActionResult<List<ContentBlock>> GetContentBlocks()
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<List<ContentBlockDto>>> GetContentBlocks(
+            string status = "active",
+            string? system = null,
+            string? viperSectionPath = null,
+            string? search = null,
+            CancellationToken ct = default)
         {
-            if (_context.ContentBlocks == null)
+            return await _blockService.GetContentBlocksAsync(status, system, viperSectionPath, search, ct);
+        }
+
+        //GET: content/section-paths
+        [HttpGet("section-paths")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<List<string>>> GetViperSectionPaths(CancellationToken ct = default)
+        {
+            return await _blockService.GetViperSectionPathsAsync(ct);
+        }
+
+        //GET: content/5
+        [HttpGet("{contentBlockId:int}")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<ContentBlockDto>> GetContentBlock(int contentBlockId, CancellationToken ct = default)
+        {
+            var block = await _blockService.GetContentBlockAsync(contentBlockId, ct);
+            if (block == null)
             {
                 return NotFound();
             }
-            return new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocks()?.ToList() ?? new List<ContentBlock>();
+            return block;
         }
 
-        //GET: content/fn/{friendlyName}
+        //GET: content/fn/{friendlyName} — public display endpoint; permission filtering happens
+        //inside GetContentBlocksAllowed (public flag, block permissions, or CMS admin).
         [HttpGet("fn/{friendlyName}")]
         public ActionResult<ContentBlock?> GetContentBlockByFn(string friendlyName)
         {
-            var blocks = new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocksAllowed(null, friendlyName, null, null, null, null, null, null)?.ToList();
+            var blocks = new Data.CMS(_context, _rapsContext, _sanitizerService)
+                .GetContentBlocksAllowed(null, friendlyName, null, null, null, null, null, null)?.ToList();
             if (blocks == null || blocks.Count == 0)
             {
                 return NotFound();
@@ -51,18 +80,55 @@ namespace Viper.Areas.CMS.Controllers
             return blocks[0];
         }
 
-        //PUT: content/5
-        [HttpPut("{contentBlockId}")]
-        [Permission(Allow = "SVMSecure.CMS.ManageContentBlocks")]
-        public async Task<ActionResult<ContentBlock>> UpdateContentBlock(int contentBlockId, CMSBlockAddEdit block)
+        //GET: content/5/history
+        [HttpGet("{contentBlockId:int}/history")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<List<ContentHistoryListItemDto>>> GetHistory(int contentBlockId, CancellationToken ct = default)
         {
-            //check data is valid and block is found
-            var existingBlock = await _context.ContentBlocks.FindAsync(contentBlockId);
-            if (existingBlock == null)
+            return await _blockService.GetHistoryAsync(contentBlockId, ct);
+        }
+
+        //GET: content/5/history/12
+        [HttpGet("{contentBlockId:int}/history/{contentHistoryId:int}")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<ContentHistoryDto>> GetHistoryVersion(int contentBlockId, int contentHistoryId,
+            CancellationToken ct = default)
+        {
+            var version = await _blockService.GetHistoryVersionAsync(contentBlockId, contentHistoryId, ct);
+            if (version == null)
             {
                 return NotFound();
             }
+            return version;
+        }
 
+        //POST: content
+        [HttpPost]
+        [Permission(Allow = CmsPermissions.CreateContentBlock + "," + CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<ContentBlockDto>> CreateContentBlock(CMSBlockAddEdit block, CancellationToken ct = default)
+        {
+            string inputCheck = CheckBlockForRequiredFields(block);
+            if (!string.IsNullOrEmpty(inputCheck))
+            {
+                return BadRequest(inputCheck);
+            }
+
+            try
+            {
+                return await _blockService.CreateContentBlockAsync(block, ct);
+            }
+            catch (ArgumentException ex)
+            {
+                return ValidationProblem(ex.Message);
+            }
+        }
+
+        //PUT: content/5
+        [HttpPut("{contentBlockId:int}")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<ContentBlockDto>> UpdateContentBlock(int contentBlockId, CMSBlockAddEdit block,
+            CancellationToken ct = default)
+        {
             if (contentBlockId != block.ContentBlockId)
             {
                 return BadRequest();
@@ -74,92 +140,74 @@ namespace Viper.Areas.CMS.Controllers
                 return BadRequest(inputCheck);
             }
 
-            var friendlyNameCheck = new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocks(friendlyName: block.FriendlyName)?.FirstOrDefault();
-            if (friendlyNameCheck != null && friendlyNameCheck.ContentBlockId != contentBlockId)
+            try
             {
-                return ValidationProblem("Friendly name must be unique");
+                var updated = await _blockService.UpdateContentBlockAsync(contentBlockId, block, ct);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+                return updated;
             }
-
-            if (friendlyNameCheck != null)
+            catch (CmsConcurrencyException ex)
             {
-                _context.Entry(friendlyNameCheck).State = EntityState.Detached;
+                return Conflict(ex.Message);
             }
-
-            //modify database object
-            ModifyBlockWithUserInput(existingBlock, block);
-            _context.Entry(existingBlock).State = EntityState.Modified;
-
-            //save history
-            var contentHistory = new ContentHistory
+            catch (ArgumentException ex)
             {
-                ContentBlockId = contentBlockId,
-                ContentBlockContent = block.Content,
-                ModifiedOn = DateTime.Now,
-                ModifiedBy = UserHelper.GetCurrentUser()?.LoginId
-            };
-            _context.ContentHistories.Add(contentHistory);
-
-            //save and return the saved block
-            await _context.SaveChangesAsync();
-            var returnBlock = new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocks(contentBlockID: contentBlockId)?.FirstOrDefault();
-            if (returnBlock == null)
-            {
-                return NotFound();
+                return ValidationProblem(ex.Message);
             }
-            return returnBlock;
         }
 
-        //POST: content
-        [HttpPost]
-        [Permission(Allow = "SVMSecure.CMS.ManageContentBlocks")]
-        public async Task<ActionResult<ContentBlock>> CreateContentBlock(CMSBlockAddEdit block)
+        //PATCH: content/5/content — quick save for content-only edits
+        [HttpPatch("{contentBlockId:int}/content")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<ActionResult<ContentBlockDto>> UpdateContentOnly(int contentBlockId,
+            ContentOnlyUpdate update, CancellationToken ct = default)
         {
-            string inputCheck = CheckBlockForRequiredFields(block);
-            if (!string.IsNullOrEmpty(inputCheck))
+            try
             {
-                return BadRequest(inputCheck);
+                var updated = await _blockService.UpdateContentOnlyAsync(contentBlockId, update.Content, update.LastModifiedOn, ct);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+                return updated;
             }
-            var friendlyNameCheck = new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocks(friendlyName: block.FriendlyName)?.FirstOrDefault();
-            if (friendlyNameCheck != null)
+            catch (CmsConcurrencyException ex)
             {
-                return ValidationProblem("Friendly name must be unique");
+                return Conflict(ex.Message);
             }
-
-            var newBlock = new ContentBlock();
-            ModifyBlockWithUserInput(newBlock, block);
-
-            _context.ContentBlocks.Add(newBlock);
-            await _context.SaveChangesAsync();
-
-            var contentHistory = new ContentHistory
+            catch (ArgumentException ex)
             {
-                ContentBlockId = block.ContentBlockId,
-                ContentBlockContent = block.Content,
-                ModifiedOn = DateTime.Now,
-                ModifiedBy = UserHelper.GetCurrentUser()?.LoginId
-            };
-            _context.ContentHistories.Add(contentHistory);
-            await _context.SaveChangesAsync();
-
-            return newBlock;
+                return ValidationProblem(ex.Message);
+            }
         }
 
-        //DELETE: content/5
-        [HttpDelete("{contentBlockId}")]
-        [Permission(Allow = "SVMSecure.CMS.ManageContentBlocks")]
-        public async Task<ActionResult<ContentBlock>> DeleteContentBlock(int contentBlockId)
+        //POST: content/5/restore
+        [HttpPost("{contentBlockId:int}/restore")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<IActionResult> RestoreContentBlock(int contentBlockId, CancellationToken ct = default)
         {
-            var block = new Data.CMS(_context, _rapsContext, _sanitizerService).GetContentBlocks(contentBlockID: contentBlockId)?.FirstOrDefault();
-            if (block == null)
-            {
-                return NotFound();
-            }
+            return await _blockService.RestoreAsync(contentBlockId, ct) ? Ok() : NotFound();
+        }
 
-            block.DeletedOn = DateTime.Now;
-            block.ModifiedBy = UserHelper.GetCurrentUser()?.LoginId;
-            _context.Entry(block).State = EntityState.Modified;
-            await _context.SaveChangesAsync();
-            return block;
+        //DELETE: content/5?permanent=true|false
+        [HttpDelete("{contentBlockId:int}")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        public async Task<IActionResult> DeleteContentBlock(int contentBlockId, bool permanent = false,
+            CancellationToken ct = default)
+        {
+            if (permanent)
+            {
+                // Permanent delete removes history and cannot be undone; admin only.
+                if (!_userHelper.HasPermission(_rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin))
+                {
+                    return ForbidApi();
+                }
+                return await _blockService.PermanentlyDeleteAsync(contentBlockId, ct) ? NoContent() : NotFound();
+            }
+            return await _blockService.SoftDeleteAsync(contentBlockId, ct) ? NoContent() : NotFound();
         }
 
         private static string CheckBlockForRequiredFields(CMSBlockAddEdit userInput)
@@ -175,39 +223,11 @@ namespace Viper.Areas.CMS.Controllers
             }
             return errors;
         }
+    }
 
-        private void ModifyBlockWithUserInput(ContentBlock contentBlock, CMSBlockAddEdit userInput)
-        {
-            //update info
-            contentBlock.Title = userInput.Title;
-            contentBlock.Content = userInput.Content;
-            contentBlock.FriendlyName = userInput.FriendlyName;
-            contentBlock.System = userInput.System;
-            contentBlock.Application = userInput.Application;
-            contentBlock.Page = userInput.Page;
-            contentBlock.ViperSectionPath = userInput.ViperSectionPath;
-            contentBlock.AllowPublicAccess = userInput.AllowPublicAccess;
-            contentBlock.BlockOrder = userInput.BlockOrder;
-            contentBlock.ModifiedOn = DateTime.Now;
-            contentBlock.ModifiedBy = UserHelper.GetCurrentUser()?.LoginId;
-
-            //adjust permissions
-            //remove content block permisisons that are not in the user input
-            foreach (var cbp in contentBlock.ContentBlockToPermissions.Where(cbp => !userInput.Permissions.Contains(cbp.Permission)))
-            {
-                contentBlock.ContentBlockToPermissions.Remove(cbp);
-            }
-
-            //add new content block permissions, if they are not in the existing list
-            var existingPermissions = contentBlock.ContentBlockToPermissions.Select(p => p.Permission).ToList();
-            foreach (var p in userInput.Permissions.Where(p => !existingPermissions.Contains(p)))
-            {
-                contentBlock.ContentBlockToPermissions.Add(new ContentBlockToPermission
-                {
-                    Permission = p,
-                    ContentBlockId = userInput.ContentBlockId
-                });
-            }
-        }
+    public class ContentOnlyUpdate
+    {
+        public string Content { get; set; } = string.Empty;
+        public DateTime? LastModifiedOn { get; set; }
     }
 }

--- a/web/Areas/CMS/Controllers/CMSLeftNavController.cs
+++ b/web/Areas/CMS/Controllers/CMSLeftNavController.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Mvc;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Areas.CMS.Services;
+using Viper.Classes;
+using Web.Authorization;
+
+namespace Viper.Areas.CMS.Controllers
+{
+    /// <summary>
+    /// Left navigation menu management. Display of menus to end users goes through
+    /// LayoutController / Data.LeftNavMenu, which filters items by user permission.
+    /// </summary>
+    [Route("/api/cms/left-navs")]
+    [Permission(Allow = CmsPermissions.ManageNavigation)]
+    public class CMSLeftNavController : ApiController
+    {
+        private readonly ICmsLeftNavService _leftNavService;
+
+        public CMSLeftNavController(ICmsLeftNavService leftNavService)
+        {
+            _leftNavService = leftNavService;
+        }
+
+        // GET /api/cms/left-navs
+        [HttpGet]
+        public async Task<ActionResult<List<LeftNavMenuDto>>> GetMenus(
+            string? system, string? viperSectionPath, string? search, CancellationToken ct = default)
+        {
+            return await _leftNavService.GetMenusAsync(system, viperSectionPath, search, ct);
+        }
+
+        // GET /api/cms/left-navs/5
+        [HttpGet("{leftNavMenuId:int}")]
+        public async Task<ActionResult<LeftNavMenuDto>> GetMenu(int leftNavMenuId, CancellationToken ct = default)
+        {
+            var menu = await _leftNavService.GetMenuAsync(leftNavMenuId, ct);
+            if (menu == null)
+            {
+                return NotFound();
+            }
+            return menu;
+        }
+
+        // POST /api/cms/left-navs
+        [HttpPost]
+        public async Task<ActionResult<LeftNavMenuDto>> CreateMenu(LeftNavMenuAddEdit menu, CancellationToken ct = default)
+        {
+            var created = await _leftNavService.CreateMenuAsync(menu, ct);
+            return CreatedAtAction(nameof(GetMenu), new { leftNavMenuId = created.LeftNavMenuId }, created);
+        }
+
+        // PUT /api/cms/left-navs/5
+        [HttpPut("{leftNavMenuId:int}")]
+        public async Task<ActionResult<LeftNavMenuDto>> UpdateMenu(int leftNavMenuId, LeftNavMenuAddEdit menu,
+            CancellationToken ct = default)
+        {
+            var updated = await _leftNavService.UpdateMenuAsync(leftNavMenuId, menu, ct);
+            if (updated == null)
+            {
+                return NotFound();
+            }
+            return updated;
+        }
+
+        // PUT /api/cms/left-navs/5/items — full item list; order follows the array
+        [HttpPut("{leftNavMenuId:int}/items")]
+        public async Task<ActionResult<LeftNavMenuDto>> SaveItems(int leftNavMenuId, List<LeftNavItemEdit> items,
+            CancellationToken ct = default)
+        {
+            if (items.Where(i => i.LeftNavItemId > 0).GroupBy(i => i.LeftNavItemId).Any(g => g.Count() > 1))
+            {
+                return BadRequest("Duplicate item ids are not allowed.");
+            }
+
+            var updated = await _leftNavService.SaveItemsAsync(leftNavMenuId, items, ct);
+            if (updated == null)
+            {
+                return NotFound();
+            }
+            return updated;
+        }
+
+        // DELETE /api/cms/left-navs/5 — deletes the menu and all items (no soft delete, matching legacy)
+        [HttpDelete("{leftNavMenuId:int}")]
+        public async Task<IActionResult> DeleteMenu(int leftNavMenuId, CancellationToken ct = default)
+        {
+            return await _leftNavService.DeleteMenuAsync(leftNavMenuId, ct) ? NoContent() : NotFound();
+        }
+    }
+}

--- a/web/Areas/CMS/Data/LeftNavMenu.cs
+++ b/web/Areas/CMS/Data/LeftNavMenu.cs
@@ -50,9 +50,11 @@ namespace Viper.Areas.CMS.Data
             List<NavMenu> cmsMenus = new();
             foreach (var m in menus)
             {
-                //by default, filter items based on user permissions
+                //by default, filter items based on user permissions; items with no
+                //permissions are visible to any logged-in user (legacy CMS behavior)
                 List<NavMenuItem> items = m.LeftNavItems
                     .Where(item => !filterItemsByPermissions
+                        || item.LeftNavItemToPermissions.Count == 0
                         || item.LeftNavItemToPermissions.Any(p => UserHelper.HasPermission(_rapsContext, currentUser, p.Permission)))
                     .Select(item => new NavMenuItem(item))
                     .ToList();

--- a/web/Areas/CMS/Models/CMSBlockAddEdit.cs
+++ b/web/Areas/CMS/Models/CMSBlockAddEdit.cs
@@ -23,5 +23,13 @@ namespace Viper.Areas.CMS.Models
         public required bool AllowPublicAccess { get; set; }
 
         public ICollection<string> Permissions { get; set; } = new List<string>();
+
+        public List<Guid> FileGuids { get; set; } = new();
+
+        /// <summary>
+        /// ModifiedOn value the client loaded; updates with a stale value get 409 Conflict.
+        /// Required for updates (null gets 400); ignored on create.
+        /// </summary>
+        public DateTime? LastModifiedOn { get; set; }
     }
 }

--- a/web/Areas/CMS/Models/CmsContentBlockMapper.cs
+++ b/web/Areas/CMS/Models/CmsContentBlockMapper.cs
@@ -1,0 +1,31 @@
+using Riok.Mapperly.Abstractions;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Models.VIPER;
+
+namespace Viper.Areas.CMS.Models
+{
+    [Mapper(RequiredMappingStrategy = RequiredMappingStrategy.None)]
+    public static partial class CmsContentBlockMapper
+    {
+        public static ContentBlockDto ToDto(ContentBlock block)
+        {
+            var dto = ToDtoBase(block);
+            dto.Permissions = block.ContentBlockToPermissions.Select(p => p.Permission).OrderBy(p => p).ToList();
+            dto.Files = block.ContentBlockToFiles
+                .Where(f => f.File != null)
+                .Select(f => new ContentBlockFileDto
+                {
+                    FileGuid = f.FileGuid,
+                    FriendlyName = f.File.FriendlyName,
+                    Url = Data.CMS.GetFriendlyURL(f.File.FriendlyName, f.File.AllowPublicAccess)
+                })
+                .OrderBy(f => f.FriendlyName)
+                .ToList();
+            return dto;
+        }
+
+        [MapperIgnoreTarget(nameof(ContentBlockDto.Permissions))]
+        [MapperIgnoreTarget(nameof(ContentBlockDto.Files))]
+        private static partial ContentBlockDto ToDtoBase(ContentBlock block);
+    }
+}

--- a/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
+++ b/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
@@ -1,0 +1,40 @@
+namespace Viper.Areas.CMS.Models.DTOs
+{
+    public class ContentBlockDto
+    {
+        public int ContentBlockId { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public string? Title { get; set; }
+        public string System { get; set; } = string.Empty;
+        public string? Application { get; set; }
+        public string? Page { get; set; }
+        public string? ViperSectionPath { get; set; }
+        public int? BlockOrder { get; set; }
+        public string? FriendlyName { get; set; }
+        public bool AllowPublicAccess { get; set; }
+        public DateTime ModifiedOn { get; set; }
+        public string ModifiedBy { get; set; } = string.Empty;
+        public DateTime? DeletedOn { get; set; }
+        public List<string> Permissions { get; set; } = new();
+        public List<ContentBlockFileDto> Files { get; set; } = new();
+    }
+
+    public class ContentBlockFileDto
+    {
+        public Guid FileGuid { get; set; }
+        public string FriendlyName { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+    }
+
+    public class ContentHistoryListItemDto
+    {
+        public int ContentHistoryId { get; set; }
+        public DateTime? ModifiedOn { get; set; }
+        public string? ModifiedBy { get; set; }
+    }
+
+    public class ContentHistoryDto : ContentHistoryListItemDto
+    {
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
+++ b/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using Areas.CMS.Validation;
+
+namespace Viper.Areas.CMS.Models.DTOs
+{
+    public class LeftNavMenuDto
+    {
+        public int LeftNavMenuId { get; set; }
+        public string? MenuHeaderText { get; set; }
+        public string System { get; set; } = string.Empty;
+        public string? ViperSectionPath { get; set; }
+        public string? Page { get; set; }
+        public string? FriendlyName { get; set; }
+        public DateTime ModifiedOn { get; set; }
+        public string ModifiedBy { get; set; } = string.Empty;
+        public List<LeftNavItemDto> Items { get; set; } = new();
+    }
+
+    public class LeftNavItemDto
+    {
+        public int LeftNavItemId { get; set; }
+        public string? MenuItemText { get; set; }
+        public bool IsHeader { get; set; }
+        public string? Url { get; set; }
+        public int? DisplayOrder { get; set; }
+        public List<string> Permissions { get; set; } = new();
+    }
+
+    public class LeftNavMenuAddEdit
+    {
+        [Required]
+        [MaxLength(500)]
+        public string MenuHeaderText { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(50)]
+        public string System { get; set; } = "Viper";
+
+        [MaxLength(250)]
+        public string? ViperSectionPath { get; set; }
+
+        [MaxLength(250)]
+        public string? Page { get; set; }
+
+        [MaxLength(250)]
+        public string? FriendlyName { get; set; }
+    }
+
+    /// <summary>
+    /// Full item list for a menu; saving replaces the menu's items (new items have id 0,
+    /// omitted ids are deleted, order follows the array).
+    /// </summary>
+    public class LeftNavItemEdit
+    {
+        public int LeftNavItemId { get; set; }
+
+        [Required]
+        [MaxLength(500)]
+        public string MenuItemText { get; set; } = string.Empty;
+
+        public bool IsHeader { get; set; }
+
+        [MaxLength(1000)]
+        [SafeUrl(AllowRelative = true)]
+        public string? Url { get; set; }
+
+        public List<string> Permissions { get; set; } = new();
+    }
+}

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -1,0 +1,466 @@
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Models;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
+using Viper.Services;
+
+namespace Viper.Areas.CMS.Services
+{
+    /// <summary>
+    /// Thrown when an update is based on a stale copy of a block (someone else saved since
+    /// the editor loaded it). Controllers translate this to 409 Conflict.
+    /// </summary>
+    public class CmsConcurrencyException : InvalidOperationException
+    {
+        public CmsConcurrencyException(string message) : base(message) { }
+    }
+
+    public interface ICmsContentBlockService
+    {
+        Task<List<ContentBlockDto>> GetContentBlocksAsync(string status, string? system, string? viperSectionPath,
+            string? search, CancellationToken ct = default);
+
+        Task<ContentBlockDto?> GetContentBlockAsync(int contentBlockId, CancellationToken ct = default);
+
+        Task<ContentBlockDto> CreateContentBlockAsync(CMSBlockAddEdit request, CancellationToken ct = default);
+
+        Task<ContentBlockDto?> UpdateContentBlockAsync(int contentBlockId, CMSBlockAddEdit request, CancellationToken ct = default);
+
+        Task<ContentBlockDto?> UpdateContentOnlyAsync(int contentBlockId, string content, DateTime? lastModifiedOn, CancellationToken ct = default);
+
+        Task<bool> SoftDeleteAsync(int contentBlockId, CancellationToken ct = default);
+
+        Task<bool> RestoreAsync(int contentBlockId, CancellationToken ct = default);
+
+        Task<bool> PermanentlyDeleteAsync(int contentBlockId, CancellationToken ct = default);
+
+        Task<List<ContentHistoryListItemDto>> GetHistoryAsync(int contentBlockId, CancellationToken ct = default);
+
+        Task<ContentHistoryDto?> GetHistoryVersionAsync(int contentBlockId, int contentHistoryId, CancellationToken ct = default);
+
+        Task<List<string>> GetViperSectionPathsAsync(CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Management operations for CMS content blocks. Mirrors legacy ColdFusion
+    /// ContentBlocks.cfc semantics: content is stored raw and sanitized on render,
+    /// and ContentHistory receives the PREVIOUS content/author before each update
+    /// so history entries are the older versions, not copies of the current one.
+    /// </summary>
+    public class CmsContentBlockService : ICmsContentBlockService
+    {
+        private readonly VIPERContext _context;
+        private readonly IHtmlSanitizerService _sanitizer;
+        private readonly IUserHelper _userHelper;
+
+        public CmsContentBlockService(VIPERContext context, IHtmlSanitizerService sanitizer, IUserHelper userHelper)
+        {
+            _context = context;
+            _sanitizer = sanitizer;
+            _userHelper = userHelper;
+        }
+
+        public async Task<List<ContentBlockDto>> GetContentBlocksAsync(string status, string? system,
+            string? viperSectionPath, string? search, CancellationToken ct = default)
+        {
+            var query = _context.ContentBlocks
+                .AsNoTracking()
+                .AsSplitQuery()
+                .TagWith("CmsContentBlockService.GetContentBlocks")
+                .AsQueryable();
+
+            query = status.ToLowerInvariant() switch
+            {
+                "active" => query.Where(b => b.DeletedOn == null),
+                "deleted" => query.Where(b => b.DeletedOn != null),
+                _ => query
+            };
+
+            if (!string.IsNullOrEmpty(system))
+            {
+                query = query.Where(b => b.System == system);
+            }
+            if (!string.IsNullOrEmpty(viperSectionPath))
+            {
+                query = query.Where(b => b.ViperSectionPath == viperSectionPath);
+            }
+            if (!string.IsNullOrEmpty(search))
+            {
+                query = query.Where(b => (b.Title != null && b.Title.Contains(search))
+                    || (b.FriendlyName != null && b.FriendlyName.Contains(search))
+                    || (b.Page != null && b.Page.Contains(search))
+                    || b.Content.Contains(search));
+            }
+
+            // List view: project without Content (it can be large) — the editor loads the full
+            // block. Two stages because GetFriendlyURL reads HttpContext and can't translate to SQL.
+            var blocks = await query
+                .OrderBy(b => b.Title)
+                .Select(b => new
+                {
+                    b.ContentBlockId,
+                    b.Title,
+                    b.System,
+                    b.Application,
+                    b.Page,
+                    b.ViperSectionPath,
+                    b.BlockOrder,
+                    b.FriendlyName,
+                    b.AllowPublicAccess,
+                    b.ModifiedOn,
+                    b.ModifiedBy,
+                    b.DeletedOn,
+                    Permissions = b.ContentBlockToPermissions
+                        .Select(p => p.Permission)
+                        .OrderBy(p => p)
+                        .ToList(),
+                    Files = b.ContentBlockToFiles
+                        .Where(f => f.File != null)
+                        .Select(f => new
+                        {
+                            f.FileGuid,
+                            f.File.FriendlyName,
+                            f.File.AllowPublicAccess
+                        })
+                        .OrderBy(f => f.FriendlyName)
+                        .ToList()
+                })
+                .ToListAsync(ct);
+
+            return blocks.Select(b => new ContentBlockDto
+            {
+                ContentBlockId = b.ContentBlockId,
+                Title = b.Title,
+                System = b.System,
+                Application = b.Application,
+                Page = b.Page,
+                ViperSectionPath = b.ViperSectionPath,
+                BlockOrder = b.BlockOrder,
+                FriendlyName = b.FriendlyName,
+                AllowPublicAccess = b.AllowPublicAccess,
+                ModifiedOn = b.ModifiedOn,
+                ModifiedBy = b.ModifiedBy,
+                DeletedOn = b.DeletedOn,
+                Permissions = b.Permissions,
+                Files = b.Files.Select(f => new ContentBlockFileDto
+                {
+                    FileGuid = f.FileGuid,
+                    FriendlyName = f.FriendlyName,
+                    Url = Data.CMS.GetFriendlyURL(f.FriendlyName, f.AllowPublicAccess)
+                }).ToList()
+            }).ToList();
+        }
+
+        public async Task<ContentBlockDto?> GetContentBlockAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var block = await LoadBlockAsync(contentBlockId, tracking: false, ct);
+            if (block == null)
+            {
+                return null;
+            }
+            var dto = CmsContentBlockMapper.ToDto(block);
+            // Sanitize for the editor with the same policy used on render, so what the
+            // editor shows matches what viewers will see.
+            dto.Content = _sanitizer.Sanitize(dto.Content);
+            return dto;
+        }
+
+        public async Task<ContentBlockDto> CreateContentBlockAsync(CMSBlockAddEdit request, CancellationToken ct = default)
+        {
+            await AssertFriendlyNameUniqueAsync(request.FriendlyName, null, ct);
+            var fileGuids = request.FileGuids.Distinct().ToList();
+            await AssertFilesExistAsync(fileGuids, ct);
+
+            var block = new ContentBlock();
+            ApplyScalarFields(block, request);
+            block.ModifiedOn = DateTime.Now;
+            block.ModifiedBy = CurrentLoginId();
+
+            foreach (var permission in CleanList(request.Permissions))
+            {
+                block.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = permission });
+            }
+            foreach (var fileGuid in fileGuids)
+            {
+                block.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = fileGuid });
+            }
+
+            _context.ContentBlocks.Add(block);
+            await _context.SaveChangesAsync(ct);
+
+            return (await GetContentBlockAsync(block.ContentBlockId, ct))!;
+        }
+
+        public async Task<ContentBlockDto?> UpdateContentBlockAsync(int contentBlockId, CMSBlockAddEdit request, CancellationToken ct = default)
+        {
+            var block = await LoadBlockAsync(contentBlockId, tracking: true, ct);
+            if (block == null)
+            {
+                return null;
+            }
+
+            AssertNotStale(block, request.LastModifiedOn);
+            await AssertFriendlyNameUniqueAsync(request.FriendlyName, contentBlockId, ct);
+            var fileGuids = request.FileGuids.Distinct().ToList();
+            await AssertFilesExistAsync(fileGuids, ct);
+
+            SavePreviousVersionToHistory(block);
+            ApplyScalarFields(block, request);
+            block.ModifiedOn = DateTime.Now;
+            block.ModifiedBy = CurrentLoginId();
+
+            ApplyPermissionDeltas(block, CleanList(request.Permissions));
+            ApplyFileDeltas(block, fileGuids);
+
+            await _context.SaveChangesAsync(ct);
+            return await GetContentBlockAsync(contentBlockId, ct);
+        }
+
+        public async Task<ContentBlockDto?> UpdateContentOnlyAsync(int contentBlockId, string content,
+            DateTime? lastModifiedOn, CancellationToken ct = default)
+        {
+            var block = await LoadBlockAsync(contentBlockId, tracking: true, ct);
+            if (block == null)
+            {
+                return null;
+            }
+
+            AssertNotStale(block, lastModifiedOn);
+            SavePreviousVersionToHistory(block);
+            block.Content = content;
+            block.ModifiedOn = DateTime.Now;
+            block.ModifiedBy = CurrentLoginId();
+
+            await _context.SaveChangesAsync(ct);
+            return await GetContentBlockAsync(contentBlockId, ct);
+        }
+
+        public async Task<bool> SoftDeleteAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var block = await _context.ContentBlocks.FindAsync(new object[] { contentBlockId }, ct);
+            if (block == null)
+            {
+                return false;
+            }
+            block.DeletedOn = DateTime.Now;
+            block.ModifiedOn = DateTime.Now;
+            block.ModifiedBy = CurrentLoginId();
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<bool> RestoreAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var block = await _context.ContentBlocks.FindAsync(new object[] { contentBlockId }, ct);
+            if (block == null)
+            {
+                return false;
+            }
+            block.DeletedOn = null;
+            block.ModifiedOn = DateTime.Now;
+            block.ModifiedBy = CurrentLoginId();
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<bool> PermanentlyDeleteAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var block = await _context.ContentBlocks
+                .Include(b => b.ContentBlockToPermissions)
+                .Include(b => b.ContentBlockToFiles)
+                .Include(b => b.ContentHistories)
+                .AsSplitQuery()
+                .FirstOrDefaultAsync(b => b.ContentBlockId == contentBlockId, ct);
+            if (block == null)
+            {
+                return false;
+            }
+
+            _context.RemoveRange(block.ContentHistories);
+            _context.RemoveRange(block.ContentBlockToFiles);
+            _context.RemoveRange(block.ContentBlockToPermissions);
+            _context.Remove(block);
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<List<ContentHistoryListItemDto>> GetHistoryAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            return await _context.ContentHistories
+                .AsNoTracking()
+                .Where(h => h.ContentBlockId == contentBlockId)
+                .OrderByDescending(h => h.ModifiedOn)
+                .ThenByDescending(h => h.ContentHistoryId)
+                .Select(h => new ContentHistoryListItemDto
+                {
+                    ContentHistoryId = h.ContentHistoryId,
+                    ModifiedOn = h.ModifiedOn,
+                    ModifiedBy = h.ModifiedBy
+                })
+                .ToListAsync(ct);
+        }
+
+        public async Task<ContentHistoryDto?> GetHistoryVersionAsync(int contentBlockId, int contentHistoryId, CancellationToken ct = default)
+        {
+            var history = await _context.ContentHistories
+                .AsNoTracking()
+                .FirstOrDefaultAsync(h => h.ContentBlockId == contentBlockId && h.ContentHistoryId == contentHistoryId, ct);
+            if (history == null)
+            {
+                return null;
+            }
+            return new ContentHistoryDto
+            {
+                ContentHistoryId = history.ContentHistoryId,
+                ModifiedOn = history.ModifiedOn,
+                ModifiedBy = history.ModifiedBy,
+                Content = _sanitizer.Sanitize(history.ContentBlockContent)
+            };
+        }
+
+        public async Task<List<string>> GetViperSectionPathsAsync(CancellationToken ct = default)
+        {
+            return await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.ViperSectionPath != null && b.ViperSectionPath != "")
+                .Select(b => b.ViperSectionPath!)
+                .Distinct()
+                .OrderBy(p => p)
+                .ToListAsync(ct);
+        }
+
+        private async Task<ContentBlock?> LoadBlockAsync(int contentBlockId, bool tracking, CancellationToken ct)
+        {
+            var query = _context.ContentBlocks
+                .Include(b => b.ContentBlockToPermissions)
+                .Include(b => b.ContentBlockToFiles)
+                    .ThenInclude(f => f.File)
+                .AsSplitQuery();
+            if (!tracking)
+            {
+                query = query.AsNoTracking();
+            }
+            return await query.FirstOrDefaultAsync(b => b.ContentBlockId == contentBlockId, ct);
+        }
+
+        private static void AssertNotStale(ContentBlock block, DateTime? lastModifiedOn)
+        {
+            if (lastModifiedOn == null)
+            {
+                throw new ArgumentException("LastModifiedOn is required so concurrent edits can be detected.");
+            }
+            // Compare to the second: serialized timestamps lose sub-second precision round-tripping
+            // through the client.
+            if (Math.Abs((block.ModifiedOn - lastModifiedOn.Value).TotalSeconds) >= 1)
+            {
+                throw new CmsConcurrencyException(
+                    $"This content block was modified by {block.ModifiedBy} on {block.ModifiedOn:g}. Reload to get the latest version.");
+            }
+        }
+
+        private async Task AssertFilesExistAsync(List<Guid> fileGuids, CancellationToken ct)
+        {
+            if (fileGuids.Count == 0)
+            {
+                return;
+            }
+            int existing = await _context.Files.CountAsync(f => fileGuids.Contains(f.FileGuid), ct);
+            if (existing != fileGuids.Count)
+            {
+                throw new ArgumentException("One or more attached files do not exist.");
+            }
+        }
+
+        private async Task AssertFriendlyNameUniqueAsync(string? friendlyName, int? exceptBlockId, CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(friendlyName))
+            {
+                return;
+            }
+            bool taken = await _context.ContentBlocks
+                .AnyAsync(b => b.FriendlyName == friendlyName && (exceptBlockId == null || b.ContentBlockId != exceptBlockId), ct);
+            if (taken)
+            {
+                throw new ArgumentException("Friendly name must be unique");
+            }
+        }
+
+        private void SavePreviousVersionToHistory(ContentBlock block)
+        {
+            // Store the version being replaced, stamped with ITS author/time (legacy semantics).
+            _context.ContentHistories.Add(new ContentHistory
+            {
+                ContentBlockId = block.ContentBlockId,
+                ContentBlockContent = block.Content,
+                ModifiedOn = block.ModifiedOn,
+                ModifiedBy = block.ModifiedBy
+            });
+        }
+
+        private static void ApplyScalarFields(ContentBlock block, CMSBlockAddEdit request)
+        {
+            block.Title = request.Title;
+            block.Content = request.Content;
+            block.FriendlyName = request.FriendlyName;
+            block.System = request.System;
+            block.Application = request.Application;
+            block.Page = request.Page;
+            block.ViperSectionPath = request.ViperSectionPath;
+            block.AllowPublicAccess = request.AllowPublicAccess;
+            block.BlockOrder = request.BlockOrder;
+        }
+
+        private void ApplyPermissionDeltas(ContentBlock block, List<string> requested)
+        {
+            var existing = block.ContentBlockToPermissions.ToList();
+            foreach (var cbp in existing.Where(cbp => !requested.Contains(cbp.Permission, StringComparer.OrdinalIgnoreCase)))
+            {
+                block.ContentBlockToPermissions.Remove(cbp);
+                _context.Remove(cbp);
+            }
+            var existingNames = existing.Select(p => p.Permission).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var permission in requested.Where(p => !existingNames.Contains(p)))
+            {
+                block.ContentBlockToPermissions.Add(new ContentBlockToPermission
+                {
+                    ContentBlockId = block.ContentBlockId,
+                    Permission = permission
+                });
+            }
+        }
+
+        private void ApplyFileDeltas(ContentBlock block, List<Guid> requested)
+        {
+            var existing = block.ContentBlockToFiles.ToList();
+            foreach (var cbf in existing.Where(cbf => !requested.Contains(cbf.FileGuid)))
+            {
+                block.ContentBlockToFiles.Remove(cbf);
+                _context.Remove(cbf);
+            }
+            var existingGuids = existing.Select(f => f.FileGuid).ToHashSet();
+            foreach (var fileGuid in requested.Where(g => !existingGuids.Contains(g)))
+            {
+                block.ContentBlockToFiles.Add(new ContentBlockToFile
+                {
+                    ContentBlockId = block.ContentBlockId,
+                    FileGuid = fileGuid
+                });
+            }
+        }
+
+        private string CurrentLoginId()
+        {
+            return _userHelper.GetCurrentUser()?.LoginId ?? "unknown";
+        }
+
+        private static List<string> CleanList(ICollection<string> values)
+        {
+            return values
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsLeftNavService.cs
+++ b/web/Areas/CMS/Services/CmsLeftNavService.cs
@@ -1,0 +1,265 @@
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.CMS.Models.DTOs;
+using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
+
+namespace Viper.Areas.CMS.Services
+{
+    public interface ICmsLeftNavService
+    {
+        Task<List<LeftNavMenuDto>> GetMenusAsync(string? system, string? viperSectionPath, string? search, CancellationToken ct = default);
+
+        Task<LeftNavMenuDto?> GetMenuAsync(int leftNavMenuId, CancellationToken ct = default);
+
+        Task<LeftNavMenuDto> CreateMenuAsync(LeftNavMenuAddEdit request, CancellationToken ct = default);
+
+        Task<LeftNavMenuDto?> UpdateMenuAsync(int leftNavMenuId, LeftNavMenuAddEdit request, CancellationToken ct = default);
+
+        Task<bool> DeleteMenuAsync(int leftNavMenuId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Replace the menu's items with the supplied list: items with id 0 are added,
+        /// existing ids are updated, omitted ids are deleted, and DisplayOrder follows
+        /// the array order. Matches the legacy editor's batch save.
+        /// </summary>
+        Task<LeftNavMenuDto?> SaveItemsAsync(int leftNavMenuId, List<LeftNavItemEdit> items, CancellationToken ct = default);
+    }
+
+    /// <summary>
+    /// Management operations for CMS left navigation menus (legacy LeftNavs.cfc /
+    /// LeftNavAjax.cfc). Menu deletes cascade to items and item permissions; there is
+    /// no soft delete for menus, matching legacy.
+    /// </summary>
+    public class CmsLeftNavService : ICmsLeftNavService
+    {
+        private readonly VIPERContext _context;
+        private readonly IUserHelper _userHelper;
+
+        public CmsLeftNavService(VIPERContext context, IUserHelper userHelper)
+        {
+            _context = context;
+            _userHelper = userHelper;
+        }
+
+        public async Task<List<LeftNavMenuDto>> GetMenusAsync(string? system, string? viperSectionPath, string? search, CancellationToken ct = default)
+        {
+            var query = _context.LeftNavMenus
+                .AsNoTracking()
+                .Include(m => m.LeftNavItems)
+                    .ThenInclude(i => i.LeftNavItemToPermissions)
+                .AsSplitQuery()
+                .TagWith("CmsLeftNavService.GetMenus")
+                .AsQueryable();
+
+            if (!string.IsNullOrEmpty(system))
+            {
+                query = query.Where(m => m.System == system);
+            }
+            if (!string.IsNullOrEmpty(viperSectionPath))
+            {
+                query = query.Where(m => m.ViperSectionPath == viperSectionPath);
+            }
+            if (!string.IsNullOrEmpty(search))
+            {
+                query = query.Where(m => (m.MenuHeaderText != null && m.MenuHeaderText.Contains(search))
+                    || (m.FriendlyName != null && m.FriendlyName.Contains(search))
+                    || (m.Page != null && m.Page.Contains(search)));
+            }
+
+            var menus = await query
+                .OrderBy(m => m.MenuHeaderText)
+                .ToListAsync(ct);
+            return menus.Select(ToDto).ToList();
+        }
+
+        public async Task<LeftNavMenuDto?> GetMenuAsync(int leftNavMenuId, CancellationToken ct = default)
+        {
+            var menu = await LoadMenuAsync(leftNavMenuId, tracking: false, ct);
+            return menu == null ? null : ToDto(menu);
+        }
+
+        public async Task<LeftNavMenuDto> CreateMenuAsync(LeftNavMenuAddEdit request, CancellationToken ct = default)
+        {
+            var menu = new LeftNavMenu();
+            ApplyMenuFields(menu, request);
+            menu.ModifiedOn = DateTime.Now;
+            menu.ModifiedBy = CurrentLoginId();
+
+            _context.LeftNavMenus.Add(menu);
+            await _context.SaveChangesAsync(ct);
+            return ToDto(menu);
+        }
+
+        public async Task<LeftNavMenuDto?> UpdateMenuAsync(int leftNavMenuId, LeftNavMenuAddEdit request, CancellationToken ct = default)
+        {
+            var menu = await LoadMenuAsync(leftNavMenuId, tracking: true, ct);
+            if (menu == null)
+            {
+                return null;
+            }
+
+            ApplyMenuFields(menu, request);
+            menu.ModifiedOn = DateTime.Now;
+            menu.ModifiedBy = CurrentLoginId();
+
+            await _context.SaveChangesAsync(ct);
+            return ToDto(menu);
+        }
+
+        public async Task<bool> DeleteMenuAsync(int leftNavMenuId, CancellationToken ct = default)
+        {
+            var menu = await LoadMenuAsync(leftNavMenuId, tracking: true, ct);
+            if (menu == null)
+            {
+                return false;
+            }
+
+            foreach (var item in menu.LeftNavItems)
+            {
+                _context.RemoveRange(item.LeftNavItemToPermissions);
+            }
+            _context.RemoveRange(menu.LeftNavItems);
+            _context.Remove(menu);
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<LeftNavMenuDto?> SaveItemsAsync(int leftNavMenuId, List<LeftNavItemEdit> items, CancellationToken ct = default)
+        {
+            var menu = await LoadMenuAsync(leftNavMenuId, tracking: true, ct);
+            if (menu == null)
+            {
+                return null;
+            }
+
+            var requestedIds = items.Where(i => i.LeftNavItemId > 0).Select(i => i.LeftNavItemId).ToHashSet();
+
+            // Delete items not present in the request.
+            foreach (var item in menu.LeftNavItems.Where(i => !requestedIds.Contains(i.LeftNavItemId)).ToList())
+            {
+                _context.RemoveRange(item.LeftNavItemToPermissions);
+                _context.Remove(item);
+                menu.LeftNavItems.Remove(item);
+            }
+
+            var existingById = menu.LeftNavItems.ToDictionary(i => i.LeftNavItemId);
+            int order = 1;
+            foreach (var requested in items)
+            {
+                if (requested.LeftNavItemId > 0 && existingById.TryGetValue(requested.LeftNavItemId, out var existing))
+                {
+                    existing.MenuItemText = requested.MenuItemText;
+                    existing.IsHeader = requested.IsHeader;
+                    existing.Url = requested.IsHeader ? null : requested.Url;
+                    existing.DisplayOrder = order;
+                    ApplyItemPermissionDeltas(existing, CleanList(requested.Permissions));
+                }
+                else
+                {
+                    var newItem = new LeftNavItem
+                    {
+                        LeftNavMenuId = leftNavMenuId,
+                        MenuItemText = requested.MenuItemText,
+                        IsHeader = requested.IsHeader,
+                        Url = requested.IsHeader ? null : requested.Url,
+                        DisplayOrder = order
+                    };
+                    foreach (var permission in CleanList(requested.Permissions))
+                    {
+                        newItem.LeftNavItemToPermissions.Add(new LeftNavItemToPermission { Permission = permission });
+                    }
+                    menu.LeftNavItems.Add(newItem);
+                }
+                order++;
+            }
+
+            menu.ModifiedOn = DateTime.Now;
+            menu.ModifiedBy = CurrentLoginId();
+
+            await _context.SaveChangesAsync(ct);
+            return await GetMenuAsync(leftNavMenuId, ct);
+        }
+
+        private async Task<LeftNavMenu?> LoadMenuAsync(int leftNavMenuId, bool tracking, CancellationToken ct)
+        {
+            var query = _context.LeftNavMenus
+                .Include(m => m.LeftNavItems)
+                    .ThenInclude(i => i.LeftNavItemToPermissions)
+                .AsSplitQuery();
+            if (!tracking)
+            {
+                query = query.AsNoTracking();
+            }
+            return await query.FirstOrDefaultAsync(m => m.LeftNavMenuId == leftNavMenuId, ct);
+        }
+
+        private void ApplyItemPermissionDeltas(LeftNavItem item, List<string> requested)
+        {
+            var existing = item.LeftNavItemToPermissions.ToList();
+            foreach (var p in existing.Where(p => !requested.Contains(p.Permission, StringComparer.OrdinalIgnoreCase)))
+            {
+                item.LeftNavItemToPermissions.Remove(p);
+                _context.Remove(p);
+            }
+            var existingNames = existing.Select(p => p.Permission).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var permission in requested.Where(p => !existingNames.Contains(p)))
+            {
+                item.LeftNavItemToPermissions.Add(new LeftNavItemToPermission
+                {
+                    LeftNavItemId = item.LeftNavItemId,
+                    Permission = permission
+                });
+            }
+        }
+
+        private static void ApplyMenuFields(LeftNavMenu menu, LeftNavMenuAddEdit request)
+        {
+            menu.MenuHeaderText = request.MenuHeaderText;
+            menu.System = request.System;
+            menu.ViperSectionPath = request.ViperSectionPath;
+            menu.Page = request.Page;
+            menu.FriendlyName = request.FriendlyName;
+        }
+
+        private static LeftNavMenuDto ToDto(LeftNavMenu menu)
+        {
+            return new LeftNavMenuDto
+            {
+                LeftNavMenuId = menu.LeftNavMenuId,
+                MenuHeaderText = menu.MenuHeaderText,
+                System = menu.System,
+                ViperSectionPath = menu.ViperSectionPath,
+                Page = menu.Page,
+                FriendlyName = menu.FriendlyName,
+                ModifiedOn = menu.ModifiedOn,
+                ModifiedBy = menu.ModifiedBy,
+                Items = menu.LeftNavItems
+                    .OrderBy(i => i.DisplayOrder)
+                    .Select(i => new LeftNavItemDto
+                    {
+                        LeftNavItemId = i.LeftNavItemId,
+                        MenuItemText = i.MenuItemText,
+                        IsHeader = i.IsHeader,
+                        Url = i.Url,
+                        DisplayOrder = i.DisplayOrder,
+                        Permissions = i.LeftNavItemToPermissions.Select(p => p.Permission).OrderBy(p => p).ToList()
+                    })
+                    .ToList()
+            };
+        }
+
+        private string CurrentLoginId()
+        {
+            return _userHelper.GetCurrentUser()?.LoginId ?? "unknown";
+        }
+
+        private static List<string> CleanList(List<string> values)
+        {
+            return values
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/web/Areas/CMS/Validation/SafeUrlAttribute.cs
+++ b/web/Areas/CMS/Validation/SafeUrlAttribute.cs
@@ -7,6 +7,12 @@ public sealed class SafeUrlAttribute : ValidationAttribute
 {
     private static readonly string[] AllowedSchemes = { "http", "https", "mailto", "tel" };
 
+    /// <summary>
+    /// Also accept relative URLs (e.g. "/CMS/files", "~/page", "page.cfm?x=1").
+    /// Anything a browser could parse as a scheme is still restricted to the allowlist.
+    /// </summary>
+    public bool AllowRelative { get; set; }
+
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         if (value is not string url || string.IsNullOrEmpty(url))
@@ -14,16 +20,27 @@ public sealed class SafeUrlAttribute : ValidationAttribute
             return ValidationResult.Success;
         }
 
-        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+        url = url.Trim();
+
+        // Browsers strip tabs/newlines when parsing hrefs, so "java\tscript:" still runs
+        if (url.Any(char.IsControl))
         {
-            return new ValidationResult("URL must be a full address starting with http, https, mailto, or tel.");
+            return new ValidationResult("URL contains invalid characters.");
         }
 
-        if (!AllowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase))
+        // A colon in the first path segment is what browsers parse as a scheme;
+        // checking it directly avoids Uri's platform-dependent handling of
+        // rooted paths like "/CMS/files" (parsed as file:// on Unix)
+        if (!url.Split('/', '?', '#')[0].Contains(':'))
         {
-            return new ValidationResult("URL protocol must be http, https, mailto, or tel.");
+            return AllowRelative
+                ? ValidationResult.Success
+                : new ValidationResult("URL must be a full address starting with http, https, mailto, or tel.");
         }
 
-        return ValidationResult.Success;
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            && AllowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase)
+            ? ValidationResult.Success
+            : new ValidationResult("URL protocol must be http, https, mailto, or tel.");
     }
 }


### PR DESCRIPTION
Part 2 of 6 (stacks on #245 — the diff below shows only this slice).

**Scope**
- Content blocks: `CmsContentBlockService` + rebuilt `CMSContentController` (filters, history list/restore, section paths, permanent delete admin-gated, content PATCH, attached-file GUID deltas, ModifiedOn 409 concurrency). Fixes two legacy-divergence bugs in history writing: create wrote a history row with id 0, and update stored the NEW content instead of the previous version.
- UI: `ContentBlocks.vue` list + `ContentBlockEdit.vue` (QEditor, version dropdown, attach files via search), shared `PermissionChips`/`DeleteRestoreButtons`.
- Left nav: `CmsLeftNavService` + `CMSLeftNavController` (menu CRUD, batch item save with ordering, per-item permissions, cascade delete) + `LeftNavMenus.vue`/`LeftNavEdit.vue` (drag + arrow reorder, batch save/revert).
- Display-parity fix in `Data/LeftNavMenu`: permission-less items are visible to all logged-in users, matching legacy (affects Layout/Home/Students nav rendering).
