### PR TITLE
VPR-59 [6/6] CMS migration: hardening, concurrency guards, review fixes

### DIFF
--- a/VueApp/src/CMS/__tests__/cms-home.test.ts
+++ b/VueApp/src/CMS/__tests__/cms-home.test.ts
@@ -1,0 +1,78 @@
+import CmsHome from "@/CMS/pages/CmsHome.vue"
+import { useUserStore } from "@/store/UserStore"
+import { mountCms, flushPromises } from "./test-utils"
+
+/**
+ * CmsHome is the permission-gated hub: each tool card (and each action inside a card) only shows
+ * when the user holds one of its permissions, the recent-activity rail mirrors the manage
+ * permissions, and users with no CMS access get an explanatory banner instead. RecentActivity is
+ * stubbed (it fetches its own data); these tests only assert which props gate its panels.
+ */
+
+const recentActivityStub = {
+    name: "RecentActivity",
+    props: ["showBlocks", "showFiles", "showLeftNavs"],
+    template: "<div class='recent-activity-stub' />",
+}
+
+// MountCms seeds the full CMS admin permission set; narrower personas are applied afterwards
+// through the same user store the page reads reactively.
+async function mountHome(permissions?: string[]) {
+    const wrapper = mountCms(CmsHome, { global: { stubs: { RecentActivity: recentActivityStub } } })
+    if (permissions) {
+        useUserStore().setPermissions(permissions)
+        await flushPromises()
+    }
+    await flushPromises()
+    return wrapper
+}
+
+function actionLabels(wrapper: Awaited<ReturnType<typeof mountHome>>): string[] {
+    return wrapper.findAllComponents({ name: "QBtn" }).map((b) => b.props("label") as string)
+}
+
+describe("CmsHome.vue - permission-gated sections", () => {
+    it("shows every tool card and the full activity rail for a CMS admin", async () => {
+        const wrapper = await mountHome()
+
+        for (const title of ["Files", "Content Blocks", "Link Collections", "Left Navigation"]) {
+            expect(wrapper.text()).toContain(title)
+        }
+        const rail = wrapper.findComponent({ name: "RecentActivity" })
+        expect(rail.props("showBlocks")).toBeTruthy()
+        expect(rail.props("showFiles")).toBeTruthy()
+        expect(rail.props("showLeftNavs")).toBeTruthy()
+    })
+
+    it("shows a create-only user just the Content Blocks card with only the Add action", async () => {
+        const wrapper = await mountHome(["SVMSecure.CMS", "SVMSecure.CMS.CreateContentBlock"])
+
+        expect(wrapper.text()).toContain("Content Blocks")
+        expect(wrapper.text()).not.toContain("Link Collections")
+        expect(wrapper.text()).not.toContain("Left Navigation")
+        // Manage/History require ManageContentBlocks even inside a visible section.
+        expect(actionLabels(wrapper)).toEqual(["Add Content Block"])
+        // No manage permission at all: the activity rail is hidden entirely.
+        expect(wrapper.findComponent({ name: "RecentActivity" }).exists()).toBeFalsy()
+    })
+
+    it("shows a files-only user the Files card, including the pre-filtered Trash deep-link", async () => {
+        const wrapper = await mountHome(["SVMSecure.CMS", "SVMSecure.CMS.AllFiles"])
+
+        expect(actionLabels(wrapper)).toEqual(["Manage Files", "Trash", "Audit Trail"])
+        const trash = wrapper.findAllComponents({ name: "QBtn" }).find((b) => b.props("label") === "Trash")!
+        expect(trash.props("to")).toEqual({ name: "CmsFiles", query: { status: "deleted" } })
+
+        const rail = wrapper.findComponent({ name: "RecentActivity" })
+        expect(rail.props("showFiles")).toBeTruthy()
+        expect(rail.props("showBlocks")).toBeFalsy()
+        expect(rail.props("showLeftNavs")).toBeFalsy()
+    })
+
+    it("tells a user with no CMS tool permissions that they have no access", async () => {
+        const wrapper = await mountHome(["SVMSecure.CMS"])
+
+        expect(wrapper.text()).toContain("Your account does not have access to any CMS tools.")
+        expect(wrapper.findAllComponents({ name: "QBtn" })).toHaveLength(0)
+    })
+})

--- a/VueApp/src/CMS/__tests__/cms-home.test.ts
+++ b/VueApp/src/CMS/__tests__/cms-home.test.ts
@@ -2,6 +2,33 @@ import CmsHome from "@/CMS/pages/CmsHome.vue"
 import { useUserStore } from "@/store/UserStore"
 import { mountCms, flushPromises } from "./test-utils"
 
+// The hub checks the trash for files nearing the purge cutoff (file managers only).
+const getMock = vi.fn<(...args: unknown[]) => Promise<{ success: boolean; result: unknown[] }>>(() =>
+    Promise.resolve({ success: true, result: [] }),
+)
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: getMock,
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+function trashedFile(friendlyName: string, purgeOn: string) {
+    return { fileGuid: `g-${friendlyName}`, friendlyName, purgeOn, deletedOn: "2024-01-01T00:00:00" }
+}
+
+function daysFromNow(days: number): string {
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+}
+
 /**
  * CmsHome is the permission-gated hub: each tool card (and each action inside a card) only shows
  * when the user holds one of its permissions, the recent-activity rail mirrors the manage
@@ -31,13 +58,19 @@ function actionLabels(wrapper: Awaited<ReturnType<typeof mountHome>>): string[] 
     return wrapper.findAllComponents({ name: "QBtn" }).map((b) => b.props("label") as string)
 }
 
-describe("CmsHome.vue - permission-gated sections", () => {
+describe("cmsHome.vue - permission-gated sections", () => {
     it("shows every tool card and the full activity rail for a CMS admin", async () => {
         const wrapper = await mountHome()
 
-        for (const title of ["Files", "Content Blocks", "Link Collections", "Left Navigation"]) {
-            expect(wrapper.text()).toContain(title)
-        }
+        // One box per left-nav group, in the nav's order (Link Collections is an action
+        // inside Content Blocks, mirroring CmsNavMenu.cs).
+        // h2 text includes the leading icon ligature name in happy-dom, hence stringContaining.
+        expect(wrapper.findAll("h2").map((h) => h.text())).toStrictEqual([
+            expect.stringContaining("Content Blocks"),
+            expect.stringContaining("Files"),
+            expect.stringContaining("Left Navigation"),
+        ])
+        expect(actionLabels(wrapper)).toContain("Manage Link Collections")
         const rail = wrapper.findComponent({ name: "RecentActivity" })
         expect(rail.props("showBlocks")).toBeTruthy()
         expect(rail.props("showFiles")).toBeTruthy()
@@ -51,7 +84,7 @@ describe("CmsHome.vue - permission-gated sections", () => {
         expect(wrapper.text()).not.toContain("Link Collections")
         expect(wrapper.text()).not.toContain("Left Navigation")
         // Manage/History require ManageContentBlocks even inside a visible section.
-        expect(actionLabels(wrapper)).toEqual(["Add Content Block"])
+        expect(actionLabels(wrapper)).toStrictEqual(["Add Content Block"])
         // No manage permission at all: the activity rail is hidden entirely.
         expect(wrapper.findComponent({ name: "RecentActivity" }).exists()).toBeFalsy()
     })
@@ -59,14 +92,43 @@ describe("CmsHome.vue - permission-gated sections", () => {
     it("shows a files-only user the Files card, including the pre-filtered Trash deep-link", async () => {
         const wrapper = await mountHome(["SVMSecure.CMS", "SVMSecure.CMS.AllFiles"])
 
-        expect(actionLabels(wrapper)).toEqual(["Manage Files", "Trash", "Audit Trail"])
+        expect(actionLabels(wrapper)).toStrictEqual(["Manage Files", "Add File", "Audit Trail", "Trash"])
+        const addFile = wrapper.findAllComponents({ name: "QBtn" }).find((b) => b.props("label") === "Add File")!
+        expect(addFile.props("to")).toStrictEqual({ name: "CmsFiles", query: { upload: "1" } })
         const trash = wrapper.findAllComponents({ name: "QBtn" }).find((b) => b.props("label") === "Trash")!
-        expect(trash.props("to")).toEqual({ name: "CmsFiles", query: { status: "deleted" } })
+        expect(trash.props("to")).toStrictEqual({ name: "CmsFiles", query: { status: "deleted" } })
 
         const rail = wrapper.findComponent({ name: "RecentActivity" })
         expect(rail.props("showFiles")).toBeTruthy()
         expect(rail.props("showBlocks")).toBeFalsy()
         expect(rail.props("showLeftNavs")).toBeFalsy()
+    })
+
+    it("warns file managers when trashed files purge within a week, linking to the Trash", async () => {
+        getMock.mockResolvedValueOnce({
+            success: true,
+            result: [
+                trashedFile("soon.pdf", daysFromNow(2)),
+                trashedFile("soon2.pdf", daysFromNow(6)),
+                trashedFile("later.pdf", daysFromNow(20)),
+            ],
+        })
+        const wrapper = await mountHome()
+
+        expect(wrapper.text()).toContain("2 trashed files will be permanently deleted within 7 days.")
+        expect(wrapper.find("a[href*='status=deleted']").exists()).toBeTruthy()
+        const trashFetch = getMock.mock.calls
+            .map((c) => c[0] as unknown as string)
+            .find((u) => u.includes("status=deleted"))!
+        expect(trashFetch).toContain("sortBy=deletedOn")
+        expect(trashFetch).toContain("descending=false")
+    })
+
+    it("shows no purge warning when nothing in the trash purges soon", async () => {
+        getMock.mockResolvedValueOnce({ success: true, result: [trashedFile("later.pdf", daysFromNow(20))] })
+        const wrapper = await mountHome()
+
+        expect(wrapper.text()).not.toContain("permanently deleted within")
     })
 
     it("tells a user with no CMS tool permissions that they have no access", async () => {

--- a/VueApp/src/CMS/__tests__/content-block-edit-save.test.ts
+++ b/VueApp/src/CMS/__tests__/content-block-edit-save.test.ts
@@ -1,0 +1,378 @@
+import ContentBlockEdit from "@/CMS/pages/ContentBlockEdit.vue"
+import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
+
+/**
+ * ContentBlockEdit save flow: staged inline uploads commit BEFORE the block save (so their GUIDs
+ * ride along in fileGuids), the save payload carries the full block shape with lastModifiedOn as
+ * the concurrency stamp (null on create), a 409 rolls freshly-created files back and offers a
+ * reload, other failures roll back and show a banner, and success notifies + refreshes history.
+ * Mock ViperFetch; the inline uploader is stubbed with a controllable commit().
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
+const mockPut = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        post: (...args: unknown[]) => mockPost(...args),
+        put: (...args: unknown[]) => mockPut(...args),
+        del: (...args: unknown[]) => mockDel(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+const BLOCK = {
+    contentBlockId: 7,
+    content: "<p>hello</p>",
+    title: "Welcome",
+    system: "Viper",
+    application: null,
+    page: "home",
+    viperSectionPath: "/apps",
+    blockOrder: 2,
+    friendlyName: "welcome",
+    allowPublicAccess: false,
+    modifiedOn: "2024-03-01T12:00:00",
+    modifiedBy: "editor",
+    deletedOn: null,
+    permissions: ["SVMSecure.CMS"],
+    files: [{ fileGuid: "f1", friendlyName: "a.pdf", url: "/files/a.pdf" }],
+}
+
+// The payload buildSavePayload derives from BLOCK (files flattened to fileGuids, modifiedOn
+// becoming the lastModifiedOn concurrency stamp).
+const EXPECTED_PUT_PAYLOAD = {
+    contentBlockId: 7,
+    content: "<p>hello</p>",
+    title: "Welcome",
+    system: "Viper",
+    application: null,
+    page: "home",
+    viperSectionPath: "/apps",
+    blockOrder: 2,
+    friendlyName: "welcome",
+    allowPublicAccess: false,
+    permissions: ["SVMSecure.CMS"],
+    fileGuids: ["f1"],
+    lastModifiedOn: "2024-03-01T12:00:00",
+}
+
+const UPLOADED_FILE = { fileGuid: "f2", friendlyName: "b.pdf", friendlyUrl: "/files/b.pdf" }
+
+function routeGet(block: Record<string, unknown> = BLOCK) {
+    mockGet.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string
+        if (url.endsWith("/folders")) {
+            return Promise.resolve({ success: true, result: ["/apps", "/students"] })
+        }
+        if (url.includes("/history")) {
+            return Promise.resolve({ success: true, result: [] })
+        }
+        if (url.includes("cms/files/")) {
+            return Promise.resolve({ success: true, result: [] })
+        }
+        // The single-block load (.../content/7); deep-copied so tests can't cross-mutate BLOCK.
+        return Promise.resolve({ success: true, result: structuredClone(block) })
+    })
+}
+
+function blockLoadCount(): number {
+    return mockGet.mock.calls.map((c) => c[0] as string).filter((u) => u.endsWith("CMS/content/7")).length
+}
+
+// QEditor relies on document.execCommand and rich-text DOM that happy-dom lacks; stub it with a
+// minimal v-model textarea so block.content still binds without exercising the real editor.
+const qEditorStub = {
+    name: "QEditor",
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+    methods: {
+        getContentEl() {
+            return null
+        },
+    },
+    template: `<textarea :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+}
+
+// The inline uploader stages files client-side; the page only calls its exposed commit() during
+// save. Stub it with a controllable commit so the tests drive each staged-upload outcome.
+const mockCommit = vi.fn<() => Promise<{ attached: unknown[]; createdGuids: string[] }>>()
+const inlineUploadStub = {
+    name: "InlineFileUpload",
+    props: ["folder", "permissions", "allowPublicAccess"],
+    emits: ["staged-count"],
+    template: "<div class='inline-upload-stub' />",
+    methods: {
+        commit() {
+            return mockCommit()
+        },
+    },
+}
+
+async function mountEdit(routeArgs: { params?: Record<string, string> } = { params: { id: "7" } }) {
+    const router = createTestRouter()
+    await router.push({ name: "CmsContentBlockEdit", params: routeArgs.params ?? {} })
+    await router.isReady()
+    const wrapper = mountCms(
+        ContentBlockEdit,
+        { global: { stubs: { QEditor: qEditorStub, InlineFileUpload: inlineUploadStub } } },
+        router,
+    )
+    await flushPromises()
+    await flushPromises()
+    return { wrapper, router }
+}
+
+async function submitForm(wrapper: Awaited<ReturnType<typeof mountEdit>>["wrapper"]): Promise<void> {
+    await wrapper.findComponent({ name: "QForm" }).find("form").trigger("submit")
+    await flushPromises()
+    await flushPromises()
+}
+
+// Quasar plugin dialogs ($q.dialog) and notifications teleport to document.body, outside the
+// wrapper. Click the LAST match: a dismissed dialog's portal can linger mid-transition, so the
+// newest dialog is always the live one. The body is never wiped between tests (Quasar caches its
+// notification container there), so assertions use per-test-unique messages.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button in the dialog`).toBeTruthy()
+    btn!.click()
+}
+
+beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDel.mockReset()
+    mockCommit.mockReset()
+    mockCommit.mockResolvedValue({ attached: [], createdGuids: [] })
+    routeGet()
+})
+
+describe("ContentBlockEdit.vue - save payload", () => {
+    it("edit-mode save PUTs the full block payload with lastModifiedOn as the concurrency stamp", async () => {
+        mockPut.mockResolvedValue({ success: true, result: { ...BLOCK } })
+        const { wrapper } = await mountEdit()
+
+        await submitForm(wrapper)
+
+        expect(mockPut).toHaveBeenCalledOnce()
+        const [url, payload] = mockPut.mock.calls[0]!
+        expect(url).toContain("CMS/content/7")
+        expect(payload).toEqual(EXPECTED_PUT_PAYLOAD)
+        expect(document.body.textContent).toContain("Content block saved")
+    })
+
+    it("create-mode save POSTs with a null lastModifiedOn and empty friendlyName collapsed to null", async () => {
+        mockPost.mockResolvedValue({ success: true, result: { ...BLOCK, contentBlockId: 42, files: [] } })
+        const { wrapper, router } = await mountEdit({ params: {} })
+
+        wrapper.findAllComponents({ name: "QInput" })[0]!.vm.$emit("update:modelValue", "New block")
+        wrapper
+            .findAllComponents({ name: "QSelect" })
+            .find((s) => s.props("label") === "VIPER section path")!
+            .vm.$emit("update:modelValue", "/apps")
+        // Let the v-models propagate back into the inputs' props before submit-time validation.
+        await flushPromises()
+        await submitForm(wrapper)
+
+        expect(mockPost).toHaveBeenCalledOnce()
+        const [, payload] = mockPost.mock.calls[0]!
+        expect(payload).toMatchObject({
+            contentBlockId: 0,
+            title: "New block",
+            viperSectionPath: "/apps",
+            friendlyName: null,
+            lastModifiedOn: null,
+            fileGuids: [],
+        })
+        expect(document.body.textContent).toContain("Content block created")
+
+        // Success navigates from the create form to the new block's edit route.
+        await flushRouter()
+        expect(router.currentRoute.value.params.id).toBe("42")
+    })
+
+    it("blocks submit and shows the required-fields banner when validation fails", async () => {
+        const { wrapper } = await mountEdit({ params: {} })
+
+        await submitForm(wrapper)
+
+        expect(mockPost).not.toHaveBeenCalled()
+        expect(wrapper.text()).toContain("Please complete the required fields before creating this content block.")
+    })
+})
+
+describe("ContentBlockEdit.vue - staged upload commit", () => {
+    it("commits staged uploads before the save and includes the new GUIDs in fileGuids", async () => {
+        mockCommit.mockResolvedValue({ attached: [UPLOADED_FILE], createdGuids: ["f2"] })
+        mockPut.mockResolvedValue({ success: true, result: { ...BLOCK } })
+        const { wrapper } = await mountEdit()
+
+        await submitForm(wrapper)
+
+        expect(mockCommit.mock.invocationCallOrder[0]!).toBeLessThan(mockPut.mock.invocationCallOrder[0]!)
+        const [, payload] = mockPut.mock.calls[0]!
+        expect((payload as { fileGuids: string[] }).fileGuids).toEqual(["f1", "f2"])
+    })
+
+    it("aborts the save with a banner when a staged upload fails, leaving the block unsaved", async () => {
+        mockCommit.mockRejectedValue(new Error("upload boom"))
+        const { wrapper } = await mountEdit()
+
+        await submitForm(wrapper)
+
+        expect(mockPut).not.toHaveBeenCalled()
+        expect(wrapper.text()).toContain("upload boom")
+    })
+
+    it("rolls back freshly-created files and shows the error when the save fails", async () => {
+        mockCommit.mockResolvedValue({ attached: [UPLOADED_FILE], createdGuids: ["f2"] })
+        mockPut.mockResolvedValue({ success: false, errors: ["Friendly name already in use"] })
+        const { wrapper } = await mountEdit()
+
+        await submitForm(wrapper)
+
+        // The new upload is soft-deleted and detached again; the pre-existing file stays.
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/f2")
+        expect(wrapper.text()).toContain("Friendly name already in use")
+        expect(wrapper.text()).toContain("a.pdf")
+        expect(wrapper.text()).not.toContain("b.pdf")
+        expect(document.body.textContent).not.toContain("Edit Conflict")
+    })
+})
+
+describe("ContentBlockEdit.vue - 409 conflict handling", () => {
+    it("rolls back new files and offers to reload the latest version on a 409", async () => {
+        mockCommit.mockResolvedValue({ attached: [UPLOADED_FILE], createdGuids: ["f2"] })
+        mockPut.mockResolvedValue({ success: false, status: 409, errors: ["Someone else saved this block."] })
+        const { wrapper } = await mountEdit()
+        const loadsBefore = blockLoadCount()
+
+        await submitForm(wrapper)
+
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/f2")
+        expect(document.body.textContent).toContain("Edit Conflict")
+        expect(document.body.textContent).toContain("Someone else saved this block.")
+
+        clickBodyButton("Reload")
+        await flushPromises()
+        await flushPromises()
+        expect(blockLoadCount()).toBe(loadsBefore + 1)
+    })
+
+    it("keeps the user's edits when they dismiss the conflict dialog", async () => {
+        mockPut.mockResolvedValue({ success: false, status: 409, errors: ["Someone else saved this block."] })
+        const { wrapper } = await mountEdit()
+        const loadsBefore = blockLoadCount()
+
+        await submitForm(wrapper)
+        clickBodyButton("Keep editing")
+        await flushPromises()
+
+        expect(blockLoadCount()).toBe(loadsBefore)
+    })
+})
+
+// Like routeGet, but the file-search endpoint returns a catalog including one already-attached
+// file (f1) and one new candidate (f9).
+function routeGetWithFileSearch() {
+    mockGet.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string
+        if (url.includes("cms/files/")) {
+            return Promise.resolve({
+                success: true,
+                result: [
+                    { fileGuid: "f1", friendlyName: "a.pdf", friendlyUrl: "/files/a.pdf" },
+                    { fileGuid: "f9", friendlyName: "new.pdf", friendlyUrl: "/files/new.pdf" },
+                ],
+            })
+        }
+        if (url.includes("/history")) {
+            return Promise.resolve({ success: true, result: [] })
+        }
+        return Promise.resolve({ success: true, result: structuredClone(BLOCK) })
+    })
+}
+
+describe("ContentBlockEdit.vue - attached files", () => {
+    it("searches active files (excluding already-attached ones) and attaches the selection", async () => {
+        routeGetWithFileSearch()
+        const { wrapper } = await mountEdit()
+
+        const attachSelect = wrapper
+            .findAllComponents({ name: "QSelect" })
+            .find((s) => s.props("label") === "Attach a file")!
+        attachSelect.vm.$emit("filter", "pdf", (fn: () => void) => fn())
+        await flushPromises()
+        await flushPromises()
+
+        const fileSearch = mockGet.mock.calls.map((c) => c[0] as string).find((u) => u.includes("cms/files/?"))
+        expect(fileSearch).toContain("search=pdf")
+        expect(fileSearch).toContain("status=active")
+        // The already-attached f1 is excluded from the options.
+        const options = attachSelect.props("options") as { fileGuid: string }[]
+        expect(options.map((o) => o.fileGuid)).toEqual(["f9"])
+
+        attachSelect.vm.$emit("update:modelValue", options[0])
+        await flushPromises()
+        expect(wrapper.text()).toContain("new.pdf")
+    })
+
+    it("detaching a file removes it from the attachment list and the next save payload", async () => {
+        mockPut.mockResolvedValue({ success: true, result: { ...BLOCK } })
+        const { wrapper } = await mountEdit()
+
+        await wrapper.find("[aria-label='Detach file']").trigger("click")
+        expect(wrapper.text()).not.toContain("a.pdf")
+
+        await submitForm(wrapper)
+        const [, payload] = mockPut.mock.calls[0]!
+        expect((payload as { fileGuids: string[] }).fileGuids).toEqual([])
+    })
+})
+
+describe("ContentBlockEdit.vue - system/public-access coupling and restore", () => {
+    it("switching the system to Public auto-enables public access and explains why", async () => {
+        const { wrapper } = await mountEdit()
+
+        wrapper
+            .findAllComponents({ name: "QSelect" })
+            .find((s) => s.props("label") === "System")!
+            .vm.$emit("update:modelValue", "Public")
+        await flushPromises()
+
+        expect(wrapper.findComponent({ name: "QToggle" }).props("modelValue")).toBeTruthy()
+        expect(wrapper.text()).toContain("we turned on Public access")
+    })
+
+    it("restores a deleted block via the banner action and reloads it", async () => {
+        routeGet({ ...BLOCK, deletedOn: "2024-04-01T00:00:00" })
+        mockPost.mockResolvedValue({ success: true, result: null })
+        const { wrapper } = await mountEdit()
+        const loadsBefore = blockLoadCount()
+        expect(wrapper.text()).toContain("marked as deleted")
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.text().includes("Restore"))!
+            .trigger("click")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockPost.mock.calls[0]![0]).toContain("CMS/content/7/restore")
+        expect(document.body.textContent).toContain("Content block restored")
+        expect(blockLoadCount()).toBe(loadsBefore + 1)
+    })
+})

--- a/VueApp/src/CMS/__tests__/content-blocks.test.ts
+++ b/VueApp/src/CMS/__tests__/content-blocks.test.ts
@@ -8,11 +8,13 @@ import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-u
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: (...args: unknown[]) => mockGet(...args),
-        del: vi.fn<(...args: unknown[]) => unknown>(),
-        post: vi.fn<(...args: unknown[]) => unknown>(),
+        del: (...args: unknown[]) => mockDel(...args),
+        post: (...args: unknown[]) => mockPost(...args),
         createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
             const params = new URLSearchParams()
             for (const [k, v] of Object.entries(obj)) {
@@ -43,6 +45,8 @@ const BLOCK_ROW = {
 // The list endpoint is the one without "/section-paths"; route by URL.
 function routeGet(blockRows: unknown[] = [BLOCK_ROW]) {
     mockGet.mockReset()
+    mockDel.mockReset()
+    mockPost.mockReset()
     mockGet.mockImplementation((...args: unknown[]) => {
         const url = args[0] as string
         if (url.includes("/section-paths")) {
@@ -139,5 +143,106 @@ describe("ContentBlocks.vue - URL filter sync", () => {
         expect(router.currentRoute.value.query.search).toBe("welcome")
         expect(router.currentRoute.value.query.status).toBeUndefined()
         expect(router.currentRoute.value.query.public).toBeUndefined()
+    })
+
+    it("re-syncs filters and refetches when in-app navigation changes the query", async () => {
+        const { router } = await mountPage()
+        const before = mockGet.mock.calls.length
+
+        await router.push({ path: "/CMS/ManageContentBlocks", query: { status: "deleted", search: "old" } })
+        await flushRouter()
+
+        expect(mockGet.mock.calls.length).toBeGreaterThan(before)
+        const url = lastListUrl()
+        expect(url).toContain("status=deleted")
+        expect(url).toContain("search=old")
+    })
+})
+
+// Quasar plugin dialogs ($q.dialog) and notifications teleport to document.body. Click the LAST
+// match: a dismissed dialog's portal can linger mid-transition, so the newest dialog is the live
+// one. The body is never wiped between tests (Quasar caches its notification container there),
+// so toast assertions use per-test-unique messages.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button in the dialog`).toBeTruthy()
+    btn!.click()
+}
+
+function listCallCount(): number {
+    return mockGet.mock.calls.map((c) => c[0] as string).filter((u) => !u.includes("/section-paths")).length
+}
+
+describe("ContentBlocks.vue - delete and restore actions", () => {
+    beforeEach(() => routeGet())
+
+    it("soft-deletes the block and reloads the list once the confirm dialog is accepted", async () => {
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const { wrapper } = await mountPage()
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        expect(document.body.textContent).toContain('Mark "Welcome" as deleted?')
+
+        clickBodyButton("Delete")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("CMS/content/1")
+        expect(document.body.textContent).toContain("Content block marked as deleted")
+        expect(listCallCount()).toBeGreaterThan(before)
+    })
+
+    it("does not delete when the confirm dialog is cancelled", async () => {
+        const { wrapper } = await mountPage()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        clickBodyButton("Cancel")
+        await flushPromises()
+
+        expect(mockDel).not.toHaveBeenCalled()
+    })
+
+    it("notifies when the delete fails", async () => {
+        mockDel.mockResolvedValue({ success: false, errors: ["nope"] })
+        const { wrapper } = await mountPage()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        clickBodyButton("Delete")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to delete content block")
+    })
+
+    it("restores a deleted block and reloads the list", async () => {
+        routeGet([{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }])
+        mockPost.mockResolvedValue({ success: true, result: null })
+        const { wrapper } = await mountPage()
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("restore")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockPost.mock.calls[0]![0]).toContain("CMS/content/1/restore")
+        expect(document.body.textContent).toContain("Content block restored")
+        expect(listCallCount()).toBeGreaterThan(before)
+    })
+
+    it("notifies when the restore fails", async () => {
+        routeGet([{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }])
+        mockPost.mockResolvedValue({ success: false, errors: ["nope"] })
+        const { wrapper } = await mountPage()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("restore")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to restore content block")
     })
 })

--- a/VueApp/src/CMS/__tests__/content-blocks.test.ts
+++ b/VueApp/src/CMS/__tests__/content-blocks.test.ts
@@ -2,9 +2,10 @@ import ContentBlocks from "@/CMS/pages/ContentBlocks.vue"
 import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
 
 /**
- * Representative page filter-state test: filter inputs must drive the right query params on the
- * list request, and returned rows must bind to the table. Mock ViperFetch; section-paths and
- * block list both go through get().
+ * ContentBlocks is a server-paged list (like Files): filter inputs must drive the right query
+ * params on the paged list request, page/sort ride through onRequest, and rowsNumber binds from
+ * the response pagination envelope. Mock ViperFetch; section-paths and the paged list both go
+ * through get(), routed by URL.
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
@@ -42,8 +43,10 @@ const BLOCK_ROW = {
     modifiedBy: "u",
 }
 
-// The list endpoint is the one without "/section-paths"; route by URL.
-function routeGet(blockRows: unknown[] = [BLOCK_ROW]) {
+// The list endpoint is the one without "/section-paths"; route by URL. Returns a paged
+// envelope carrying totalRecords when a total is given (else falls back to row count).
+function routeGet(opts: { rows?: unknown[]; total?: number } = {}) {
+    const rows = opts.rows ?? [BLOCK_ROW]
     mockGet.mockReset()
     mockDel.mockReset()
     mockPost.mockReset()
@@ -52,7 +55,11 @@ function routeGet(blockRows: unknown[] = [BLOCK_ROW]) {
         if (url.includes("/section-paths")) {
             return Promise.resolve({ success: true, result: ["/a", "/b"] })
         }
-        return Promise.resolve({ success: true, result: blockRows })
+        return Promise.resolve({
+            success: true,
+            result: rows,
+            pagination: opts.total === undefined ? undefined : { totalRecords: opts.total },
+        })
     })
 }
 
@@ -72,14 +79,27 @@ async function mountPage(query: Record<string, string> = {}) {
 }
 
 describe("ContentBlocks.vue - filter-driven query params", () => {
-    beforeEach(() => routeGet())
+    beforeEach(() => routeGet({ total: 42 }))
 
-    it("requests with the default active status on mount and binds returned rows", async () => {
+    it("requests page 1 with default sort and active status on mount, binding rows and rowsNumber", async () => {
         const { wrapper } = await mountPage()
-        expect(lastListUrl()).toContain("status=active")
-        // Returned row binds to the table.
+        const url = lastListUrl()
+        expect(url).toContain("status=active")
+        expect(url).toContain("page=1")
+        expect(url).toContain("perPage=50")
+        expect(url).toContain("sortBy=title")
+        // Returned row binds to the table, and rowsNumber comes from the pagination envelope.
         expect(wrapper.findComponent({ name: "QTable" }).props("rows")).toHaveLength(1)
         expect(wrapper.text()).toContain("Welcome")
+        const pag = wrapper.findComponent({ name: "QTable" }).props("pagination") as { rowsNumber: number }
+        expect(pag.rowsNumber).toBe(42)
+    })
+
+    it("falls back to result length for rowsNumber when no pagination envelope is returned", async () => {
+        routeGet({ rows: [BLOCK_ROW, { ...BLOCK_ROW, contentBlockId: 2 }] })
+        const { wrapper } = await mountPage()
+        const pag = wrapper.findComponent({ name: "QTable" }).props("pagination") as { rowsNumber: number }
+        expect(pag.rowsNumber).toBe(2)
     })
 
     it("includes the search term in the query when the search field changes", async () => {
@@ -159,6 +179,23 @@ describe("ContentBlocks.vue - URL filter sync", () => {
     })
 })
 
+describe("ContentBlocks.vue - onRequest pagination passthrough", () => {
+    beforeEach(() => routeGet({ total: 200 }))
+
+    it("uses the sort/descending/page from a table request", async () => {
+        const { wrapper } = await mountPage()
+        await wrapper.findComponent({ name: "QTable" }).vm.$emit("request", {
+            pagination: { page: 3, rowsPerPage: 25, sortBy: "modifiedOn", descending: true },
+        })
+        await flushPromises()
+        const url = lastListUrl()
+        expect(url).toContain("page=3")
+        expect(url).toContain("perPage=25")
+        expect(url).toContain("sortBy=modifiedOn")
+        expect(url).toContain("descending=true")
+    })
+})
+
 // Quasar plugin dialogs ($q.dialog) and notifications teleport to document.body. Click the LAST
 // match: a dismissed dialog's portal can linger mid-transition, so the newest dialog is the live
 // one. The body is never wiped between tests (Quasar caches its notification container there),
@@ -220,7 +257,7 @@ describe("ContentBlocks.vue - delete and restore actions", () => {
     })
 
     it("restores a deleted block and reloads the list", async () => {
-        routeGet([{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }])
+        routeGet({ rows: [{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }] })
         mockPost.mockResolvedValue({ success: true, result: null })
         const { wrapper } = await mountPage()
         const before = listCallCount()
@@ -235,7 +272,7 @@ describe("ContentBlocks.vue - delete and restore actions", () => {
     })
 
     it("notifies when the restore fails", async () => {
-        routeGet([{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }])
+        routeGet({ rows: [{ ...BLOCK_ROW, deletedOn: "2024-02-01T00:00:00" }] })
         mockPost.mockResolvedValue({ success: false, errors: ["nope"] })
         const { wrapper } = await mountPage()
 

--- a/VueApp/src/CMS/__tests__/content-blocks.test.ts
+++ b/VueApp/src/CMS/__tests__/content-blocks.test.ts
@@ -121,10 +121,9 @@ describe("ContentBlocks.vue - URL filter sync", () => {
     beforeEach(() => routeGet())
 
     it("initializes filters from the URL query (deep-link) and reflects them in the request", async () => {
-        await mountPage({ status: "deleted", system: "CTS", section: "courses", search: "welcome", public: "1" })
+        await mountPage({ status: "deleted", section: "courses", search: "welcome", public: "1" })
         const url = lastListUrl()
         expect(url).toContain("status=deleted")
-        expect(url).toContain("system=CTS")
         expect(url).toContain("viperSectionPath=courses")
         expect(url).toContain("search=welcome")
         expect(url).toContain("isPublic=true")

--- a/VueApp/src/CMS/__tests__/file-form-dialog-conflict.test.ts
+++ b/VueApp/src/CMS/__tests__/file-form-dialog-conflict.test.ts
@@ -1,0 +1,278 @@
+import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
+import type { CmsFile } from "@/CMS/types"
+import { mountCms, flushPromises } from "./test-utils"
+
+/**
+ * FileFormDialog upload outcomes: a clean add POSTs the form with folder/flags, a taken name
+ * prompts for rename vs overwrite (PUT to the existing record's guid, or POST with the overwrite
+ * flag when only an orphaned disk file exists), a failed conflict upload arrives as a toast with
+ * the conflict dialog kept open, and copy-link notifies on success/failure.
+ *
+ * Separate from file-form-dialog.test.ts: these tests assert Quasar toasts, and that spec wipes
+ * document.body between tests, which detaches Quasar's cached notification container. Here the
+ * body is never wiped and every asserted message is unique per test.
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPostForm = vi.fn<(...args: unknown[]) => unknown>()
+const mockPutForm = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        postForm: (...args: unknown[]) => mockPostForm(...args),
+        putForm: (...args: unknown[]) => mockPutForm(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+// Stub the async selectors so they don't make their own fetches; their v-model still flows.
+const selectorStub = {
+    props: ["modelValue", "label"],
+    emits: ["update:modelValue"],
+    template: "<div class='selector-stub' />",
+}
+
+function existingFile(overrides: Partial<CmsFile> = {}): CmsFile {
+    return {
+        fileGuid: "guid-123",
+        fileName: "report.pdf",
+        folder: "Apps",
+        friendlyName: "report.pdf",
+        encrypted: false,
+        description: "A report",
+        allowPublicAccess: false,
+        oldUrl: "/old/report.pdf",
+        modifiedOn: "2024-01-01T00:00:00",
+        modifiedBy: "u",
+        deletedOn: null,
+        purgeOn: null,
+        permissions: ["SVMSecure.CMS"],
+        people: [{ iamId: "iam1", name: "Person One" }],
+        url: "/files/guid-123",
+        friendlyUrl: "/Apps/report.pdf",
+        ...overrides,
+    }
+}
+
+function mountDialog(props: { modelValue: boolean; folders: string[]; file: CmsFile | null }) {
+    return mountCms(FileFormDialog, {
+        props,
+        global: {
+            stubs: { PermissionSelector: selectorStub, PersonSelector: selectorStub },
+        },
+    })
+}
+
+// QDialog and notifications teleport to document.body.
+function bodyText(): string {
+    return document.body.textContent ?? ""
+}
+
+async function submitDialogForm(wrapper: ReturnType<typeof mountDialog>): Promise<void> {
+    await wrapper.findComponent({ name: "QForm" }).find("form").trigger("submit")
+}
+
+// Fills the add form (file + folder are the required fields) so a submit passes validation.
+async function fillAddForm(wrapper: ReturnType<typeof mountDialog>, fileName = "report.pdf") {
+    wrapper.findComponent({ name: "QFile" }).vm.$emit("update:modelValue", new File(["data"], fileName))
+    wrapper.findComponent({ name: "QSelect" }).vm.$emit("update:modelValue", "Apps")
+    await flushPromises()
+}
+
+// Click the LAST matching button: a dismissed dialog's portal can linger mid-transition, so the
+// newest dialog is always the live one.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button`).toBeTruthy()
+    btn!.click()
+}
+
+const NAME_FREE = { success: true, result: { inUse: false } }
+const NAME_TAKEN = {
+    success: true,
+    result: {
+        inUse: true,
+        suggestedName: "report_1.pdf",
+        existingFileGuid: "eg9",
+        existingFriendlyName: "report.pdf",
+        existingDeleted: false,
+    },
+}
+
+beforeEach(() => {
+    mockGet.mockReset()
+    mockPostForm.mockReset()
+    mockPutForm.mockReset()
+})
+
+describe("FileFormDialog.vue - add-mode upload", () => {
+    it("checks the destination name, then POSTs the upload with folder, flags, and toggles", async () => {
+        mockGet.mockResolvedValue(NAME_FREE)
+        mockPostForm.mockResolvedValue({ success: true, result: existingFile() })
+        const wrapper = mountDialog({ modelValue: true, folders: ["Apps"], file: null })
+        await flushPromises()
+        await fillAddForm(wrapper)
+        const [publicToggle, encryptToggle] = wrapper.findAllComponents({ name: "QToggle" })
+        publicToggle!.vm.$emit("update:modelValue", true)
+        encryptToggle!.vm.$emit("update:modelValue", true)
+        await flushPromises()
+
+        await submitDialogForm(wrapper)
+        await flushPromises()
+
+        const checkUrl = mockGet.mock.calls[0]![0] as string
+        expect(checkUrl).toContain("check-name")
+        expect(checkUrl).toContain("folder=Apps")
+        expect(checkUrl).toContain("fileName=report.pdf")
+
+        const [, body] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect((body.get("file") as File).name).toBe("report.pdf")
+        expect(body.get("folder")).toBe("Apps")
+        expect(body.get("allowPublicAccess")).toBe("true")
+        expect(body.get("encrypt")).toBe("true")
+        expect(body.has("fileName")).toBeFalsy()
+        expect(body.has("overwrite")).toBeFalsy()
+
+        expect(bodyText()).toContain("File uploaded")
+        expect(wrapper.emitted("saved")).toBeTruthy()
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([false])
+    })
+})
+
+describe("FileFormDialog.vue - name conflict resolution", () => {
+    async function openConflict() {
+        mockGet.mockResolvedValue(NAME_TAKEN)
+        const wrapper = mountDialog({ modelValue: true, folders: ["Apps"], file: null })
+        await flushPromises()
+        await fillAddForm(wrapper)
+        await submitDialogForm(wrapper)
+        await flushPromises()
+        expect(bodyText()).toContain("File name already exists")
+        return wrapper
+    }
+
+    it("prompts on a taken name instead of uploading, prefilling the suggested rename", async () => {
+        const wrapper = await openConflict()
+        expect(mockPostForm).not.toHaveBeenCalled()
+        // Rename is the default choice and the input is prefilled with the server's suggestion.
+        const renameInput = wrapper
+            .findAllComponents({ name: "QInput" })
+            .find((i) => i.props("label") === "New file name")!
+        expect(renameInput.props("modelValue")).toBe("report_1.pdf")
+    })
+
+    it("uploads under the new name when rename is confirmed", async () => {
+        const wrapper = await openConflict()
+        mockPostForm.mockResolvedValue({ success: true, result: existingFile() })
+
+        clickBodyButton("Upload with new name")
+        await flushPromises()
+        await flushPromises()
+
+        const [, body] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(body.get("fileName")).toBe("report_1.pdf")
+        expect(body.has("overwrite")).toBeFalsy()
+        expect(bodyText()).toContain("File uploaded")
+        expect(wrapper.emitted("saved")).toBeTruthy()
+    })
+
+    it("PUTs to the existing record's guid when overwrite is chosen for a managed file", async () => {
+        const wrapper = await openConflict()
+        mockPutForm.mockResolvedValue({ success: true, result: existingFile() })
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "overwrite")
+        await flushPromises()
+        clickBodyButton("Overwrite")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockPostForm).not.toHaveBeenCalled()
+        const [url, body] = mockPutForm.mock.calls[0]! as [string, FormData]
+        expect(url).toContain("cms/files/eg9")
+        // Overwriting a managed record replaces content in place; no folder/new-name fields.
+        expect(body.has("folder")).toBeFalsy()
+        expect(bodyText()).toContain("File overwritten")
+    })
+
+    it("POSTs with the overwrite flag when the conflicting name has no managed record", async () => {
+        mockGet.mockResolvedValue({
+            ...NAME_TAKEN,
+            result: { ...NAME_TAKEN.result, existingFileGuid: null, existingFriendlyName: null },
+        })
+        const wrapper = mountDialog({ modelValue: true, folders: ["Apps"], file: null })
+        await flushPromises()
+        await fillAddForm(wrapper)
+        await submitDialogForm(wrapper)
+        await flushPromises()
+        mockPostForm.mockResolvedValue({ success: true, result: existingFile() })
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "overwrite")
+        await flushPromises()
+        clickBodyButton("Overwrite")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockPutForm).not.toHaveBeenCalled()
+        const [, body] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(body.get("overwrite")).toBe("true")
+    })
+
+    it("reports a failed upload as a toast and keeps the conflict dialog open for a retry", async () => {
+        const wrapper = await openConflict()
+        mockPostForm.mockResolvedValue({ success: false, errors: ["disk full"] })
+
+        clickBodyButton("Upload with new name")
+        await flushPromises()
+        await flushPromises()
+
+        // The user is in the conflict sub-dialog, so the error arrives as a notification...
+        expect(bodyText()).toContain("disk full")
+        // ...and the conflict dialog stays open rather than stranding them on the form.
+        expect(bodyText()).toContain("File name already exists")
+        expect(wrapper.emitted("saved")).toBeFalsy()
+    })
+})
+
+describe("FileFormDialog.vue - copy link", () => {
+    function stubClipboard(writeText: (text: string) => Promise<void>) {
+        Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true })
+    }
+
+    it("copies the friendly URL and confirms", async () => {
+        const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+        stubClipboard(writeText)
+        const wrapper = mountDialog({ modelValue: true, folders: ["Apps"], file: existingFile() })
+        await flushPromises()
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.attributes("aria-label") === "Copy link")!
+            .trigger("click")
+        await flushPromises()
+
+        expect(writeText).toHaveBeenCalledWith("/Apps/report.pdf")
+        expect(bodyText()).toContain("Link copied")
+    })
+
+    it("notifies when the clipboard write fails", async () => {
+        stubClipboard(vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("denied")))
+        const wrapper = mountDialog({ modelValue: true, folders: ["Apps"], file: existingFile() })
+        await flushPromises()
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.attributes("aria-label") === "Copy link")!
+            .trigger("click")
+        await flushPromises()
+
+        expect(bodyText()).toContain("Failed to copy link")
+    })
+})

--- a/VueApp/src/CMS/__tests__/file-form-dialog.test.ts
+++ b/VueApp/src/CMS/__tests__/file-form-dialog.test.ts
@@ -79,7 +79,7 @@ async function submitDialogForm(wrapper: ReturnType<typeof mountDialog>): Promis
     await wrapper.findComponent({ name: "QForm" }).find("form").trigger("submit")
 }
 
-describe("FileFormDialog.vue - add vs edit mode", () => {
+describe("fileFormDialog.vue - add vs edit mode", () => {
     beforeEach(() => {
         mockGet.mockReset()
         mockPostForm.mockReset()
@@ -129,7 +129,7 @@ describe("FileFormDialog.vue - add vs edit mode", () => {
     })
 })
 
-describe("FileFormDialog.vue - required-field enforcement (add mode)", () => {
+describe("fileFormDialog.vue - required-field enforcement (add mode)", () => {
     beforeEach(() => {
         mockGet.mockReset()
         mockPostForm.mockReset()
@@ -151,7 +151,7 @@ describe("FileFormDialog.vue - required-field enforcement (add mode)", () => {
     })
 })
 
-describe("FileFormDialog.vue - save payload", () => {
+describe("fileFormDialog.vue - save payload", () => {
     beforeEach(() => {
         mockGet.mockReset()
         mockPostForm.mockReset()
@@ -180,8 +180,45 @@ describe("FileFormDialog.vue - save payload", () => {
         expect((body as FormData).has("folder")).toBeFalsy()
         expect((body as FormData).get("allowPublicAccess")).toBe("false")
         expect((body as FormData).get("encrypt")).toBe("false")
+        // Stale-edit guard: the save presents the ModifiedOn the dialog loaded.
+        expect((body as FormData).get("lastModifiedOn")).toBe("2024-01-01T00:00:00")
         expect(wrapper.emitted("saved")).toBeTruthy()
-        expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([false])
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toStrictEqual([false])
+    })
+
+    it("edit-mode 409 opens the Edit Conflict dialog; Reload pulls the latest version", async () => {
+        const file = existingFile()
+        mockPutForm.mockResolvedValueOnce({
+            success: false,
+            errors: ["This file was modified by admin on 7/2/2026 1:00 PM. Reload to get the latest version."],
+            status: 409,
+        })
+        const latest = existingFile({ description: "Their newer desc", modifiedOn: "2024-02-02T00:00:00" })
+        mockGet.mockResolvedValue({ success: true, result: latest })
+        const wrapper = mountDialog({ modelValue: false, folders: ["Apps"], file })
+        await wrapper.setProps({ modelValue: true })
+        await flushPromises()
+
+        await submitDialogForm(wrapper)
+        await flushPromises()
+
+        // Conflict dialog names who saved and offers Reload / Keep editing; nothing was saved.
+        expect(bodyText()).toContain("Edit Conflict")
+        expect(bodyText()).toContain("modified by admin")
+        expect(bodyText()).toContain("Keep editing")
+        expect(wrapper.emitted("saved")).toBeFalsy()
+
+        // Reload fetches the record and a resubmit presents the reloaded ModifiedOn.
+        const reload = [...document.querySelectorAll("button")].find((b) => b.textContent?.includes("Reload"))!
+        reload.click()
+        await flushPromises()
+        expect(mockGet).toHaveBeenCalledWith(expect.stringContaining("cms/files/guid-123"))
+
+        mockPutForm.mockResolvedValueOnce({ success: true, result: latest })
+        await submitDialogForm(wrapper)
+        await flushPromises()
+        const [, body] = mockPutForm.mock.calls[1]!
+        expect((body as FormData).get("lastModifiedOn")).toBe("2024-02-02T00:00:00")
     })
 
     it("edit-mode save surfaces the server error on the form banner and does not emit saved", async () => {
@@ -194,5 +231,51 @@ describe("FileFormDialog.vue - save payload", () => {
 
         expect(bodyText()).toContain("Name already taken")
         expect(wrapper.emitted("saved")).toBeFalsy()
+    })
+})
+
+describe("fileFormDialog.vue - unsaved changes guard", () => {
+    beforeEach(() => {
+        mockGet.mockReset()
+        mockPostForm.mockReset()
+        mockPutForm.mockReset()
+        document.body.innerHTML = ""
+    })
+
+    function closeDialog() {
+        const closeBtn = document.body.querySelector<HTMLButtonElement>('button[aria-label="Close dialog"]')
+        expect(closeBtn, "expected the file dialog close (X) button").toBeTruthy()
+        closeBtn!.click()
+    }
+
+    it("prompts before discarding a selected file, since a File serializes to '{}' and would otherwise look clean", async () => {
+        // The form is populated (and the dirty baseline captured) by the open watcher
+        // (modelValue false -> true), so open via a prop toggle rather than mounting
+        // already-open, which would never call setInitialState.
+        const wrapper = mountDialog({ modelValue: false, folders: ["Apps"], file: null })
+        await wrapper.setProps({ modelValue: true })
+        await flushPromises()
+
+        const selected = new File(["contents"], "photo.jpg", { type: "image/jpeg" })
+        await wrapper.findComponent({ name: "QFile" }).setValue(selected)
+        await flushPromises()
+
+        closeDialog()
+        await flushPromises()
+
+        expect(bodyText()).toContain("Unsaved Changes")
+        expect(wrapper.emitted("update:modelValue")).toBeFalsy()
+    })
+
+    it("closes immediately (no guard prompt) when no file has been selected", async () => {
+        const wrapper = mountDialog({ modelValue: false, folders: ["Apps"], file: null })
+        await wrapper.setProps({ modelValue: true })
+        await flushPromises()
+
+        closeDialog()
+        await flushPromises()
+
+        expect(bodyText()).not.toContain("Unsaved Changes")
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toStrictEqual([false])
     })
 })

--- a/VueApp/src/CMS/__tests__/file-form-dialog.test.ts
+++ b/VueApp/src/CMS/__tests__/file-form-dialog.test.ts
@@ -49,6 +49,7 @@ function existingFile(overrides: Partial<CmsFile> = {}): CmsFile {
         modifiedOn: "2024-01-01T00:00:00",
         modifiedBy: "u",
         deletedOn: null,
+        purgeOn: null,
         permissions: ["SVMSecure.CMS"],
         people: [{ iamId: "iam1", name: "Person One" }],
         url: "/files/guid-123",

--- a/VueApp/src/CMS/__tests__/files.test.ts
+++ b/VueApp/src/CMS/__tests__/files.test.ts
@@ -268,11 +268,14 @@ describe("Files.vue - row presentation", () => {
 describe("Files.vue - URL and query watcher", () => {
     beforeEach(() => routeGet())
 
-    it("opens the upload dialog when mounted with the ?upload=1 deep-link", async () => {
-        const { wrapper } = await mountPageWithRouter({ upload: "1" })
+    it("opens the upload dialog when mounted with the ?upload=1 deep-link and strips the flag", async () => {
+        const { wrapper, router } = await mountPageWithRouter({ upload: "1" })
         await flushRouter()
 
         expect(wrapper.findComponent({ name: "FileFormDialog" }).props("modelValue")).toBeTruthy()
+        // The on-mount filter sync races the upload-watcher's strip; the flag must not
+        // survive either write, so re-clicking the nav link can re-open the dialog later.
+        expect(router.currentRoute.value.query.upload).toBeUndefined()
     })
 
     it("re-opens the upload dialog when navigation adds ?upload=1, consuming the flag", async () => {

--- a/VueApp/src/CMS/__tests__/files.test.ts
+++ b/VueApp/src/CMS/__tests__/files.test.ts
@@ -1,5 +1,5 @@
 import Files from "@/CMS/pages/Files.vue"
-import { mountCms, flushPromises, createTestRouter } from "./test-utils"
+import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
 
 /**
  * Files is a server-paged list. Its filters initialize from the URL (deep-link), onRequest builds
@@ -8,11 +8,13 @@ import { mountCms, flushPromises, createTestRouter } from "./test-utils"
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: (...args: unknown[]) => mockGet(...args),
-        del: vi.fn<(...args: unknown[]) => unknown>(),
-        post: vi.fn<(...args: unknown[]) => unknown>(),
+        del: (...args: unknown[]) => mockDel(...args),
+        post: (...args: unknown[]) => mockPost(...args),
         createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
             const params = new URLSearchParams()
             for (const [k, v] of Object.entries(obj)) {
@@ -53,6 +55,8 @@ function lastListUrl(): string {
 function routeGet(opts: { rows?: unknown[]; total?: number } = {}) {
     const rows = opts.rows ?? [FILE_ROW]
     mockGet.mockReset()
+    mockDel.mockReset()
+    mockPost.mockReset()
     mockGet.mockImplementation((...args: unknown[]) => {
         const url = args[0] as string
         if (url.includes("folder-counts")) {
@@ -70,14 +74,32 @@ function routeGet(opts: { rows?: unknown[]; total?: number } = {}) {
     })
 }
 
-async function mountPage(query: Record<string, string> = {}) {
+async function mountPageWithRouter(query: Record<string, string> = {}) {
     const router = createTestRouter()
     await router.push({ path: "/CMS/ManageFiles", query })
     await router.isReady()
     const wrapper = mountCms(Files, {}, router)
     await flushPromises()
     await flushPromises()
-    return wrapper
+    return { wrapper, router }
+}
+
+async function mountPage(query: Record<string, string> = {}) {
+    return (await mountPageWithRouter(query)).wrapper
+}
+
+function listCallCount(): number {
+    return mockGet.mock.calls.map((c) => c[0] as string).filter((u) => u.includes("cms/files/?")).length
+}
+
+// Quasar plugin dialogs ($q.dialog) and notifications teleport to document.body. Click the LAST
+// match: a dismissed dialog's portal can linger mid-transition, so the newest dialog is the live
+// one. The body is never wiped between tests (Quasar caches its notification container there),
+// so toast assertions use per-test-unique messages.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button in the dialog`).toBeTruthy()
+    btn!.click()
 }
 
 describe("Files.vue - query param construction", () => {
@@ -133,5 +155,160 @@ describe("Files.vue - onRequest pagination passthrough", () => {
         expect(url).toContain("perPage=25")
         expect(url).toContain("sortBy=modifiedOn")
         expect(url).toContain("descending=true")
+    })
+})
+
+describe("Files.vue - delete and restore actions", () => {
+    beforeEach(() => routeGet())
+
+    it("soft-deletes the file and reloads the list once the confirm dialog is accepted", async () => {
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const wrapper = await mountPage()
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        expect(document.body.textContent).toContain('Mark "a.pdf" as deleted?')
+
+        clickBodyButton("Delete")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/g1")
+        expect(document.body.textContent).toContain("File marked as deleted")
+        expect(listCallCount()).toBeGreaterThan(before)
+    })
+
+    it("does not delete when the confirm dialog is cancelled", async () => {
+        const wrapper = await mountPage()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        clickBodyButton("Cancel")
+        await flushPromises()
+
+        expect(mockDel).not.toHaveBeenCalled()
+    })
+
+    it("notifies and keeps the list when the delete fails", async () => {
+        mockDel.mockResolvedValue({ success: false, errors: ["nope"] })
+        const wrapper = await mountPage()
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("delete")
+        await flushPromises()
+        clickBodyButton("Delete")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to delete file")
+        expect(listCallCount()).toBe(before)
+    })
+
+    it("restores a deleted file and reloads the list", async () => {
+        routeGet({ rows: [{ ...FILE_ROW, deletedOn: "2024-02-01T00:00:00" }] })
+        mockPost.mockResolvedValue({ success: true, result: null })
+        const wrapper = await mountPage()
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("restore")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockPost).toHaveBeenCalledOnce()
+        expect(mockPost.mock.calls[0]![0]).toContain("cms/files/g1/restore")
+        expect(document.body.textContent).toContain("File restored")
+        expect(listCallCount()).toBeGreaterThan(before)
+    })
+
+    it("notifies when the restore fails", async () => {
+        routeGet({ rows: [{ ...FILE_ROW, deletedOn: "2024-02-01T00:00:00" }] })
+        mockPost.mockResolvedValue({ success: false, errors: ["nope"] })
+        const wrapper = await mountPage()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("restore")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to restore file")
+    })
+})
+
+describe("Files.vue - row presentation", () => {
+    beforeEach(() => routeGet())
+    afterEach(() => vi.unstubAllEnvs())
+
+    it("labels a trashed file with its deletion and auto-purge dates", async () => {
+        routeGet({ rows: [{ ...FILE_ROW, deletedOn: "2024-02-01T00:00:00", purgeOn: "2024-03-02T00:00:00" }] })
+        const wrapper = await mountPage()
+
+        const deletedIcon = wrapper
+            .findAllComponents({ name: "StatusIcon" })
+            .find((c) => (c.props("label") as string).startsWith("Deleted"))!
+        expect(deletedIcon.props("label")).toBe("Deleted 02/01/24 · purges 03/02/24")
+    })
+
+    it("links the old URL on the VIPER 1 host so legacy links are exercised end to end", async () => {
+        vi.stubEnv("VITE_VIPER_1_HOME", "http://v1.local/")
+        routeGet({ rows: [{ ...FILE_ROW, oldUrl: "/old/report.pdf" }] })
+        const wrapper = await mountPage()
+
+        expect(wrapper.find('a[href="http://v1.local/old/report.pdf"]').exists()).toBeTruthy()
+    })
+
+    it("builds the folder filter options with per-folder counts and an All total", async () => {
+        const wrapper = await mountPage()
+
+        const options = wrapper.findAllComponents({ name: "QSelect" })[0]!.props("options") as { label: string }[]
+        expect(options.map((o) => o.label)).toEqual(["All (3)", "Apps (3)", "Reports (0)"])
+    })
+})
+
+describe("Files.vue - URL and query watcher", () => {
+    beforeEach(() => routeGet())
+
+    it("opens the upload dialog when mounted with the ?upload=1 deep-link", async () => {
+        const { wrapper } = await mountPageWithRouter({ upload: "1" })
+        await flushRouter()
+
+        expect(wrapper.findComponent({ name: "FileFormDialog" }).props("modelValue")).toBeTruthy()
+    })
+
+    it("re-opens the upload dialog when navigation adds ?upload=1, consuming the flag", async () => {
+        const { wrapper, router } = await mountPageWithRouter()
+        expect(wrapper.findComponent({ name: "FileFormDialog" }).props("modelValue")).toBeFalsy()
+
+        await router.push({ path: "/CMS/ManageFiles", query: { upload: "1" } })
+        await flushRouter()
+
+        expect(wrapper.findComponent({ name: "FileFormDialog" }).props("modelValue")).toBeTruthy()
+        // The flag is stripped so re-clicking the nav link can re-open the dialog later.
+        expect(router.currentRoute.value.query.upload).toBeUndefined()
+    })
+
+    it("re-syncs filters and refetches when in-app navigation changes the query", async () => {
+        const { router } = await mountPageWithRouter()
+        const before = listCallCount()
+
+        await router.push({ path: "/CMS/ManageFiles", query: { folder: "Reports", status: "deleted" } })
+        await flushRouter()
+
+        expect(listCallCount()).toBeGreaterThan(before)
+        const url = lastListUrl()
+        expect(url).toContain("folder=Reports")
+        expect(url).toContain("status=deleted")
+    })
+
+    it("does not refetch when the watcher sees our own URL sync (equality guard)", async () => {
+        const { wrapper } = await mountPageWithRouter()
+
+        wrapper.findComponent({ name: "QInput" }).vm.$emit("update:modelValue", "report")
+        await flushPromises()
+        const afterFilterChange = listCallCount()
+
+        // The filter change itself fetched once; the router.replace it triggered must not re-fetch.
+        await flushRouter()
+        expect(listCallCount()).toBe(afterFilterChange)
     })
 })

--- a/VueApp/src/CMS/__tests__/files.test.ts
+++ b/VueApp/src/CMS/__tests__/files.test.ts
@@ -37,6 +37,7 @@ const FILE_ROW = {
     modifiedOn: "2024-01-01T00:00:00",
     modifiedBy: "u",
     deletedOn: null,
+    purgeOn: null,
     permissions: [],
     people: [],
     url: "/files/g1",

--- a/VueApp/src/CMS/__tests__/inline-file-upload.test.ts
+++ b/VueApp/src/CMS/__tests__/inline-file-upload.test.ts
@@ -1,0 +1,335 @@
+import InlineFileUpload from "@/CMS/components/InlineFileUpload.vue"
+import type { CmsFile } from "@/CMS/types"
+import { mountCms, flushPromises } from "./test-utils"
+
+/**
+ * InlineFileUpload stages files client-side (validating the extension and checking the name for
+ * conflicts) and only creates anything server-side when the parent calls the exposed commit().
+ * Each staged file commits per its chosen conflict action: new upload / rename (POST, rolled back
+ * on later failure), overwrite-in-place (PUT, never rolled back), or attach-existing (GET only).
+ * Mock ViperFetch; the file picker (VueUse useFileDialog) is mocked at the browser boundary so
+ * tests can hand the component a File directly.
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPostForm = vi.fn<(...args: unknown[]) => unknown>()
+const mockPutForm = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        postForm: (...args: unknown[]) => mockPostForm(...args),
+        putForm: (...args: unknown[]) => mockPutForm(...args),
+        del: (...args: unknown[]) => mockDel(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+// Mock the file dialog at the browser boundary: capture the onChange callback so tests can
+// "pick" a file. The drop zone needs real pointer events, so it is inert here (staging via
+// drag and via the picker share stageFile).
+const fileDialogState = vi.hoisted(() => ({
+    onChange: undefined as ((files: File[] | null) => void) | undefined,
+    open: (() => undefined) as () => void,
+}))
+vi.mock("@vueuse/core", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@vueuse/core")>()
+    const { ref } = await import("vue")
+    return {
+        ...actual,
+        useFileDialog: () => ({
+            open: fileDialogState.open,
+            onChange: (cb: (files: File[] | null) => void) => {
+                fileDialogState.onChange = cb
+            },
+        }),
+        useDropZone: () => ({ isOverDropZone: ref(false) }),
+    }
+})
+
+type NameCheck = {
+    inUse: boolean
+    suggestedName: string
+    existingFileGuid: string | null
+    existingFriendlyName: string | null
+    existingDeleted: boolean
+}
+
+const NO_CONFLICT: NameCheck = {
+    inUse: false,
+    suggestedName: "",
+    existingFileGuid: null,
+    existingFriendlyName: null,
+    existingDeleted: false,
+}
+
+const CONFLICT: NameCheck = {
+    inUse: true,
+    suggestedName: "report_1.pdf",
+    existingFileGuid: "eg1",
+    existingFriendlyName: "report.pdf",
+    existingDeleted: false,
+}
+
+function cmsFile(fileGuid: string, friendlyName: string): CmsFile {
+    return {
+        fileGuid,
+        fileName: friendlyName,
+        folder: "Apps",
+        friendlyName,
+        encrypted: false,
+        description: "",
+        allowPublicAccess: false,
+        oldUrl: null,
+        modifiedOn: "2024-01-01T00:00:00",
+        modifiedBy: "u",
+        deletedOn: null,
+        purgeOn: null,
+        permissions: [],
+        people: [],
+        url: `/files/${fileGuid}`,
+        friendlyUrl: `/Apps/${friendlyName}`,
+    }
+}
+
+// Routes the check-name probe; other get() calls (attach-existing) are configured per test.
+function routeCheckName(check: NameCheck) {
+    mockGet.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string
+        if (url.includes("check-name")) {
+            return Promise.resolve({ success: true, result: check })
+        }
+        return Promise.resolve({ success: true, result: cmsFile("eg1", "report.pdf") })
+    })
+}
+
+function mountUpload(props: Partial<{ folder: string | null; allowPublicAccess: boolean }> = {}) {
+    return mountCms(InlineFileUpload, {
+        props: {
+            folder: "Apps",
+            permissions: ["SVMSecure.CMS", "SVMSecure.CMS.AllFiles"],
+            allowPublicAccess: false,
+            ...props,
+        },
+    })
+}
+
+async function stage(fileName: string) {
+    fileDialogState.onChange!([new File(["data"], fileName)])
+    await flushPromises()
+    await flushPromises()
+}
+
+function commitOf(wrapper: ReturnType<typeof mountUpload>) {
+    return (wrapper.vm as unknown as { commit: () => Promise<{ attached: CmsFile[]; createdGuids: string[] }> }).commit
+}
+
+beforeEach(() => {
+    mockGet.mockReset()
+    mockPostForm.mockReset()
+    mockPutForm.mockReset()
+    mockDel.mockReset()
+    routeCheckName(NO_CONFLICT)
+})
+
+describe("inlineFileUpload.vue - staging", () => {
+    it("rejects a file type outside the allow-list without checking its name", async () => {
+        const wrapper = mountUpload()
+        await stage("script.bat")
+
+        expect(wrapper.text()).toContain("Files of type .bat aren't allowed.")
+        expect(wrapper.find(".staged-file").exists()).toBeFalsy()
+        expect(mockGet).not.toHaveBeenCalled()
+    })
+
+    it("checks the name in the block's folder and stages an allowed file, reporting the count", async () => {
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        const checkUrl = mockGet.mock.calls[0]![0] as string
+        expect(checkUrl).toContain("check-name")
+        expect(checkUrl).toContain("folder=Apps")
+        expect(checkUrl).toContain("fileName=report.pdf")
+        expect(wrapper.find(".staged-file").text()).toContain("report.pdf")
+        expect(wrapper.emitted("staged-count")?.at(-1)).toStrictEqual([1])
+    })
+
+    it("offers rename, overwrite, and use-existing choices when the name belongs to an existing record", async () => {
+        routeCheckName(CONFLICT)
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        const options = wrapper.findComponent({ name: "QOptionGroup" }).props("options") as { label: string }[]
+        expect(options).toHaveLength(3)
+        expect(options[0]!.label).toContain("report_1.pdf")
+        expect(options.map((o) => o.label).join(",")).toContain("Use the existing file instead")
+    })
+
+    it("omits the use-existing choice when the conflicting name has no file record", async () => {
+        routeCheckName({ ...CONFLICT, existingFileGuid: null })
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        const options = wrapper.findComponent({ name: "QOptionGroup" }).props("options") as { label: string }[]
+        expect(options.map((o) => o.label)).toStrictEqual([
+            "Upload under a new name (report_1.pdf)",
+            "Overwrite the existing file",
+        ])
+    })
+
+    it("removes a staged file and reports the new count", async () => {
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        await wrapper.find("[aria-label='Remove report.pdf']").trigger("click")
+
+        expect(wrapper.find(".staged-file").exists()).toBeFalsy()
+        expect(wrapper.emitted("staged-count")?.at(-1)).toStrictEqual([0])
+    })
+
+    it("ignores picked files while no folder is set (staging is disabled)", async () => {
+        const wrapper = mountUpload({ folder: null })
+        await stage("report.pdf")
+
+        expect(wrapper.find(".staged-file").exists()).toBeFalsy()
+        expect(mockGet).not.toHaveBeenCalled()
+        expect(wrapper.text()).toContain("Set a VIPER section path")
+    })
+})
+
+describe("inlineFileUpload.vue - commit", () => {
+    it("resolves empty without any requests when nothing is staged", async () => {
+        const wrapper = mountUpload()
+        await expect(commitOf(wrapper)()).resolves.toStrictEqual({ attached: [], createdGuids: [] })
+        expect(mockPostForm).not.toHaveBeenCalled()
+    })
+
+    it("uploads a new file with the block's folder, permissions, and public flag, marking it created", async () => {
+        mockPostForm.mockResolvedValue({ success: true, result: cmsFile("n1", "report.pdf") })
+        const wrapper = mountUpload({ allowPublicAccess: true })
+        await stage("report.pdf")
+
+        const result = await commitOf(wrapper)()
+
+        expect(mockPostForm).toHaveBeenCalledOnce()
+        const [url, data] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(url).toContain("cms/files/")
+        expect((data.get("file") as File).name).toBe("report.pdf")
+        expect(data.get("folder")).toBe("Apps")
+        expect(data.get("allowPublicAccess")).toBe("true")
+        expect(data.getAll("permissions")).toStrictEqual(["SVMSecure.CMS", "SVMSecure.CMS.AllFiles"])
+        expect(data.has("fileName")).toBeFalsy()
+        expect(data.has("overwrite")).toBeFalsy()
+
+        expect(result.attached.map((f) => f.fileGuid)).toStrictEqual(["n1"])
+        expect(result.createdGuids).toStrictEqual(["n1"])
+        // The staged list is cleared once everything committed.
+        expect(wrapper.emitted("staged-count")?.at(-1)).toStrictEqual([0])
+    })
+
+    it("uploads under the suggested name when rename is chosen for a conflict", async () => {
+        routeCheckName(CONFLICT)
+        mockPostForm.mockResolvedValue({ success: true, result: cmsFile("n2", "report_1.pdf") })
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        // Rename is the default conflict action.
+        const result = await commitOf(wrapper)()
+
+        const [, data] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(data.get("fileName")).toBe("report_1.pdf")
+        expect(data.has("overwrite")).toBeFalsy()
+        expect(result.createdGuids).toStrictEqual(["n2"])
+    })
+
+    it("overwrites the existing record in place via PUT and does not mark it for rollback", async () => {
+        routeCheckName(CONFLICT)
+        mockPutForm.mockResolvedValue({ success: true, result: cmsFile("eg1", "report.pdf") })
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "overwrite")
+        const result = await commitOf(wrapper)()
+
+        expect(mockPostForm).not.toHaveBeenCalled()
+        const [url, data] = mockPutForm.mock.calls[0]! as [string, FormData]
+        expect(url).toContain("cms/files/eg1")
+        // Overwrite-in-place reuses the record; no folder/new-name fields.
+        expect(data.has("folder")).toBeFalsy()
+        expect(result.attached.map((f) => f.fileGuid)).toStrictEqual(["eg1"])
+        expect(result.createdGuids).toStrictEqual([])
+    })
+
+    it("pOSTs with the overwrite flag when overwriting an on-disk file that has no record", async () => {
+        routeCheckName({ ...CONFLICT, existingFileGuid: null })
+        mockPostForm.mockResolvedValue({ success: true, result: cmsFile("n3", "report.pdf") })
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "overwrite")
+        const result = await commitOf(wrapper)()
+
+        expect(mockPutForm).not.toHaveBeenCalled()
+        const [, data] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(data.get("overwrite")).toBe("true")
+        // A NEW record was created for the orphan, so it is rollback-safe.
+        expect(result.createdGuids).toStrictEqual(["n3"])
+    })
+
+    it("attaches the existing file without uploading when use-existing is chosen", async () => {
+        routeCheckName(CONFLICT)
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "existing")
+        const result = await commitOf(wrapper)()
+
+        expect(mockPostForm).not.toHaveBeenCalled()
+        expect(mockPutForm).not.toHaveBeenCalled()
+        const fileFetch = mockGet.mock.calls.map((c) => c[0] as string).find((u) => !u.includes("check-name"))
+        expect(fileFetch).toContain("cms/files/eg1")
+        expect(result.attached.map((f) => f.fileGuid)).toStrictEqual(["eg1"])
+        expect(result.createdGuids).toStrictEqual([])
+    })
+
+    it("aborts the commit with the load error when the existing file cannot be fetched", async () => {
+        mockGet.mockImplementation((...args: unknown[]) => {
+            const url = args[0] as string
+            if (url.includes("check-name")) {
+                return Promise.resolve({ success: true, result: CONFLICT })
+            }
+            return Promise.resolve({ success: false, errors: ["gone"] })
+        })
+        const wrapper = mountUpload()
+        await stage("report.pdf")
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "existing")
+        await expect(commitOf(wrapper)()).rejects.toThrow("gone")
+    })
+
+    it("rolls back files created earlier in the batch when a later upload fails, keeping them staged", async () => {
+        mockPostForm
+            .mockResolvedValueOnce({ success: true, result: cmsFile("n1", "a.pdf") })
+            .mockResolvedValueOnce({ success: false, errors: ["disk full"] })
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const wrapper = mountUpload()
+        await stage("a.pdf")
+        await stage("b.pdf")
+
+        await expect(commitOf(wrapper)()).rejects.toThrow("disk full")
+
+        // The first (created) upload is soft-deleted so nothing new is stranded.
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/n1")
+        // The staged list is NOT cleared, so the user can retry the save.
+        expect(wrapper.findAll(".staged-file")).toHaveLength(2)
+    })
+})

--- a/VueApp/src/CMS/__tests__/left-nav-menus.test.ts
+++ b/VueApp/src/CMS/__tests__/left-nav-menus.test.ts
@@ -1,5 +1,5 @@
 import LeftNavMenus from "@/CMS/pages/LeftNavMenus.vue"
-import { mountCms, flushPromises, createTestRouter } from "./test-utils"
+import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
 
 /**
  * LeftNavMenus list: filter inputs drive system/search query params, returned rows bind to the
@@ -7,10 +7,11 @@ import { mountCms, flushPromises, createTestRouter } from "./test-utils"
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: (...args: unknown[]) => mockGet(...args),
-        del: vi.fn<(...args: unknown[]) => unknown>(),
+        del: (...args: unknown[]) => mockDel(...args),
         post: vi.fn<(...args: unknown[]) => unknown>(),
         createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
             const params = new URLSearchParams()
@@ -38,6 +39,7 @@ const MENU_ROW = {
 
 function routeGet(rows: unknown[] = [MENU_ROW]) {
     mockGet.mockReset()
+    mockDel.mockReset()
     mockGet.mockResolvedValue({ success: true, result: rows })
 }
 
@@ -45,14 +47,28 @@ function lastUrl(): string {
     return (mockGet.mock.calls.at(-1)?.[0] as string) ?? ""
 }
 
-async function mountPage(query: Record<string, string> = {}) {
+async function mountPageWithRouter(query: Record<string, string> = {}) {
     const router = createTestRouter()
     await router.push({ path: "/CMS/ManageLeftNav", query })
     await router.isReady()
     const wrapper = mountCms(LeftNavMenus, {}, router)
     await flushPromises()
     await flushPromises()
-    return wrapper
+    return { wrapper, router }
+}
+
+async function mountPage(query: Record<string, string> = {}) {
+    return (await mountPageWithRouter(query)).wrapper
+}
+
+// Quasar plugin dialogs ($q.dialog) and notifications teleport to document.body. Click the LAST
+// match: a dismissed dialog's portal can linger mid-transition, so the newest dialog is the live
+// one. The body is never wiped between tests (Quasar caches its notification container there),
+// so toast assertions use per-test-unique messages.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button in the dialog`).toBeTruthy()
+    btn!.click()
 }
 
 describe("LeftNavMenus.vue", () => {
@@ -89,5 +105,72 @@ describe("LeftNavMenus.vue", () => {
     it("leaves the add dialog closed without ?add=1", async () => {
         const wrapper = await mountPage()
         expect(wrapper.findComponent({ name: "LeftNavMenuDialog" }).props("modelValue")).toBeFalsy()
+    })
+
+    it("clears the table and notifies when loading menus fails", async () => {
+        mockGet.mockReset()
+        mockGet.mockResolvedValue({ success: false, errors: ["nav service down"] })
+        const wrapper = await mountPage()
+
+        expect(wrapper.findComponent({ name: "QTable" }).props("rows")).toEqual([])
+        expect(document.body.textContent).toContain("nav service down")
+    })
+
+    it("navigates to the new menu's item editor after the add dialog reports a create", async () => {
+        const { wrapper, router } = await mountPageWithRouter()
+
+        wrapper.findComponent({ name: "LeftNavMenuDialog" }).vm.$emit("created", 33)
+        await flushRouter()
+
+        expect(router.currentRoute.value.name).toBe("CmsLeftNavEdit")
+        expect(router.currentRoute.value.params.id).toBe("33")
+    })
+})
+
+describe("LeftNavMenus.vue - delete", () => {
+    beforeEach(() => routeGet())
+
+    it("permanently deletes the menu and reloads once the confirm dialog is accepted", async () => {
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const wrapper = await mountPage()
+        const before = mockGet.mock.calls.length
+
+        await wrapper.find("[aria-label='Delete menu']").trigger("click")
+        await flushPromises()
+        // The confirmation spells out the item count so the loss is clear.
+        expect(document.body.textContent).toContain('Permanently delete "Main" and its 1 item?')
+
+        clickBodyButton("Delete Menu")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/left-navs/1")
+        expect(document.body.textContent).toContain("Menu deleted")
+        expect(mockGet.mock.calls.length).toBeGreaterThan(before)
+    })
+
+    it("does not delete when the confirm dialog is cancelled", async () => {
+        const wrapper = await mountPage()
+
+        await wrapper.find("[aria-label='Delete menu']").trigger("click")
+        await flushPromises()
+        clickBodyButton("Cancel")
+        await flushPromises()
+
+        expect(mockDel).not.toHaveBeenCalled()
+    })
+
+    it("notifies when the delete fails", async () => {
+        mockDel.mockResolvedValue({ success: false, errors: ["in use"] })
+        const wrapper = await mountPage()
+
+        await wrapper.find("[aria-label='Delete menu']").trigger("click")
+        await flushPromises()
+        clickBodyButton("Delete Menu")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to delete menu")
     })
 })

--- a/VueApp/src/CMS/__tests__/link-collections.test.ts
+++ b/VueApp/src/CMS/__tests__/link-collections.test.ts
@@ -176,26 +176,21 @@ describe("LinkCollections.vue - tag category filter", () => {
 describe("LinkCollections.vue - group by tag category", () => {
     beforeEach(() => primeFetch())
 
-    it("getInGroup returns only links whose group tag matches the group value", async () => {
+    it("buckets links by their value in the group-by tag category", async () => {
         const wrapper = await mountLoaded({ linkCollectionName: "Resources", groupByTagCategory: "Subject" })
-        const vm = wrapper.vm as unknown as {
-            getInGroup: (links: Link[], group: string) => Link[]
-            filteredLinks: Link[]
-        }
-        const anatomy = vm.getInGroup(vm.filteredLinks, "Anatomy").map((l) => l.title)
+        const vm = wrapper.vm as unknown as { groupedLinks: Map<string, Link[]> }
+        const anatomy = (vm.groupedLinks.get("Anatomy") ?? []).map((l) => l.title)
         expect(anatomy.toSorted()).toEqual(["Anatomy Atlas", "Anatomy Guide"])
-        const pharm = vm.getInGroup(vm.filteredLinks, "Pharmacology").map((l) => l.title)
+        const pharm = (vm.groupedLinks.get("Pharmacology") ?? []).map((l) => l.title)
         expect(pharm).toEqual(["Pharmacology Notes"])
     })
 
-    it("getInGroup returns all links unchanged when no group category is set", async () => {
+    it("renders all links and builds no buckets when no group category is set", async () => {
         primeFetch()
         const wrapper = await mountLoaded({ linkCollectionName: "Resources" })
-        const vm = wrapper.vm as unknown as {
-            getInGroup: (links: Link[], group: string) => Link[]
-            filteredLinks: Link[]
-        }
-        expect(vm.getInGroup(vm.filteredLinks, "anything")).toHaveLength(3)
+        expect(linkCardTitles(wrapper)).toHaveLength(3)
+        const vm = wrapper.vm as unknown as { groupedLinks: Map<string, Link[]> }
+        expect(vm.groupedLinks.size).toBe(0)
     })
 
     it("computes the sorted set of group header values", async () => {

--- a/VueApp/src/CMS/__tests__/link-collections.test.ts
+++ b/VueApp/src/CMS/__tests__/link-collections.test.ts
@@ -1,4 +1,5 @@
 import LinkCollections from "@/CMS/components/LinkCollections.vue"
+import ManageLinkCollections from "@/CMS/pages/ManageLinkCollections.vue"
 import type { Link, LinkCollection } from "@/CMS/types"
 import { mountCms, flushPromises } from "./test-utils"
 
@@ -7,12 +8,20 @@ import { mountCms, flushPromises } from "./test-utils"
  * its links, derives tag-category filters, then filters (search across title/description/tags,
  * case-insensitive; plus per-category tag select) and optionally groups links by a category.
  * These tests mock ViperFetch to seed deterministic data and assert the filter/group output.
+ * The ManageLinkCollections admin page (same domain) is also exercised here for its
+ * unsaved-changes guard on the Edit Collection dialog.
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPut = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: (...args: unknown[]) => mockGet(...args),
+        put: (...args: unknown[]) => mockPut(...args),
+        post: (...args: unknown[]) => mockPost(...args),
+        del: (...args: unknown[]) => mockDel(...args),
         createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
             const params = new URLSearchParams()
             for (const [k, v] of Object.entries(obj)) {
@@ -197,5 +206,88 @@ describe("LinkCollections.vue - group by tag category", () => {
         const wrapper = await mountLoaded({ linkCollectionName: "Resources", groupByTagCategory: "Subject" })
         const vm = wrapper.vm as unknown as { groupByValues: string[] }
         expect(vm.groupByValues).toEqual(["Anatomy", "Pharmacology"])
+    })
+})
+
+// Quasar plugin dialogs teleport to document.body; click the LAST matching button since a
+// dismissed dialog's portal can briefly linger mid-transition.
+function clickBodyButton(label: string) {
+    const btn = [...document.body.querySelectorAll("button")].filter((b) => b.textContent?.includes(label)).at(-1)
+    expect(btn, `expected a "${label}" button`).toBeTruthy()
+    btn!.click()
+}
+
+const MANAGE_COLLECTION = { linkCollectionId: 7, linkCollection: "Resources" }
+const MANAGE_TAGS = [{ linkCollectionTagCategoryId: 1, linkCollectionTagCategory: "Type", sortOrder: 1 }]
+
+// The manage page fans out to the collection list, then the selected collection's links + tags.
+function primeManageFetch() {
+    mockGet.mockReset()
+    mockPut.mockReset()
+    mockPost.mockReset()
+    mockDel.mockReset()
+    mockGet.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string
+        if (url.includes("/links")) return Promise.resolve({ success: true, result: [] })
+        if (url.includes("/tags")) return Promise.resolve({ success: true, result: MANAGE_TAGS })
+        return Promise.resolve({ success: true, result: [MANAGE_COLLECTION] })
+    })
+}
+
+type ManageVm = {
+    showCollectionDialog: boolean
+    draftTags: { linkCollectionTagCategoryId: number; linkCollectionTagCategory: string; sortOrder: number }[]
+}
+
+describe("ManageLinkCollections.vue - Edit Collection dialog unsaved-changes guard", () => {
+    beforeEach(() => primeManageFetch())
+
+    async function mountManage() {
+        const wrapper = mountCms(ManageLinkCollections)
+        await flushPromises()
+        await flushPromises()
+        return wrapper
+    }
+
+    function closeCollectionDialog() {
+        const closeBtn = document.body.querySelector<HTMLButtonElement>('button[aria-label="Close dialog"]')
+        expect(closeBtn, "expected the collection dialog close (X) button").toBeTruthy()
+        closeBtn!.click()
+    }
+
+    it("prompts before discarding staged tag edits, then discards on confirm", async () => {
+        const wrapper = await mountManage()
+        const vm = wrapper.vm as unknown as ManageVm
+
+        vm.showCollectionDialog = true
+        await flushPromises()
+        // Stage a new tag category so the dialog is dirty.
+        vm.draftTags.push({ linkCollectionTagCategoryId: -1, linkCollectionTagCategory: "New", sortOrder: 2 })
+        await flushPromises()
+
+        closeCollectionDialog()
+        await flushPromises()
+        // The guard intercepts the close instead of silently discarding the staged edits.
+        expect(document.body.textContent).toContain("Unsaved Changes")
+        expect(vm.showCollectionDialog).toBe(true)
+
+        clickBodyButton("Discard Changes")
+        await flushPromises()
+        await flushPromises()
+        expect(vm.showCollectionDialog).toBe(false)
+    })
+
+    it("closes without prompting when nothing was edited", async () => {
+        const wrapper = await mountManage()
+        const vm = wrapper.vm as unknown as ManageVm
+
+        vm.showCollectionDialog = true
+        await flushPromises()
+
+        closeCollectionDialog()
+        await flushPromises()
+        await flushPromises()
+        // Clean dialog: confirmClose resolves immediately, so the dialog just closes.
+        expect(vm.showCollectionDialog).toBe(false)
     })
 })

--- a/VueApp/src/CMS/__tests__/link.test.ts
+++ b/VueApp/src/CMS/__tests__/link.test.ts
@@ -65,8 +65,9 @@ describe("Link.vue - URL safety", () => {
 })
 
 describe("Link.vue - tag badge color cycling", () => {
-    // The palette has 6 entries; the component maps sortOrder n -> index (n-1) % 6.
-    // sortOrder 1 -> warning/dark, 2 -> secondary/white, 7 -> wraps back to warning/dark.
+    // The categorical palette has 5 non-semantic entries; the component maps
+    // sortOrder n -> index (n-1) % 5. sortOrder 1 -> primary/white,
+    // 2 -> arboretum/dark, 6 -> wraps back to primary/white.
     function mountWithTag(categorySortOrder: number) {
         const categoryId = 1
         const collection: LinkCollection = {
@@ -88,30 +89,30 @@ describe("Link.vue - tag badge color cycling", () => {
         return mountCms(LinkComponent, { props: { link, linkCollection: collection } })
     }
 
-    it("uses the first palette entry (warning) for sortOrder 1", () => {
+    it("uses the first palette entry (primary) for sortOrder 1", () => {
         const wrapper = mountWithTag(1)
         const badge = wrapper.findComponent({ name: "QBadge" })
         expect(badge.exists()).toBeTruthy()
-        expect(badge.props("color")).toBe("warning")
-        expect(badge.props("textColor")).toBe("dark")
+        expect(badge.props("color")).toBe("primary")
+        expect(badge.props("textColor")).toBe("white")
         expect(badge.text()).toContain("TagValue")
     })
 
-    it("uses the second palette entry (secondary) for sortOrder 2", () => {
+    it("uses the second palette entry (arboretum) for sortOrder 2, paired with dark text", () => {
         const badge = mountWithTag(2).findComponent({ name: "QBadge" })
-        expect(badge.props("color")).toBe("secondary")
-        expect(badge.props("textColor")).toBe("white")
+        expect(badge.props("color")).toBe("arboretum")
+        expect(badge.props("textColor")).toBe("dark")
     })
 
-    it("wraps modulo the palette length so sortOrder 7 matches sortOrder 1", () => {
-        const badge = mountWithTag(7).findComponent({ name: "QBadge" })
-        expect(badge.props("color")).toBe("warning")
-        expect(badge.props("textColor")).toBe("dark")
+    it("wraps modulo the palette length so sortOrder 6 matches sortOrder 1", () => {
+        const badge = mountWithTag(6).findComponent({ name: "QBadge" })
+        expect(badge.props("color")).toBe("primary")
+        expect(badge.props("textColor")).toBe("white")
     })
 
     it("falls back to the first entry for a non-positive sortOrder", () => {
         const badge = mountWithTag(0).findComponent({ name: "QBadge" })
-        expect(badge.props("color")).toBe("warning")
+        expect(badge.props("color")).toBe("primary")
     })
 
     it("only renders badges for tags whose category matches the collection category", () => {

--- a/VueApp/src/CMS/__tests__/person-selector.test.ts
+++ b/VueApp/src/CMS/__tests__/person-selector.test.ts
@@ -84,6 +84,37 @@ describe("PersonSelector.vue", () => {
         expect(currentOptions(wrapper)).toEqual([])
     })
 
+    it("ignores a stale response that resolves after a newer search (out-of-order guard)", async () => {
+        const wrapper = mountSelector()
+        let resolveFirst!: (v: unknown) => void
+        let resolveSecond!: (v: unknown) => void
+        mockGet
+            .mockImplementationOnce(
+                () =>
+                    new Promise((r) => {
+                        resolveFirst = r
+                    }),
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise((r) => {
+                        resolveSecond = r
+                    }),
+            )
+
+        const select = wrapper.findComponent({ name: "QSelect" })
+        select.vm.$emit("filter", "jane", runUpdate)
+        select.vm.$emit("filter", "janet", runUpdate)
+
+        // The newer search answers first; the older one lands afterwards and must be dropped.
+        resolveSecond({ success: true, result: [PEOPLE[1]] })
+        await flushPromises()
+        resolveFirst({ success: true, result: [PEOPLE[0]] })
+        await flushPromises()
+
+        expect(currentOptions(wrapper)).toEqual([PEOPLE[1]])
+    })
+
     it("emits the selected people array on update and coerces null to []", async () => {
         const wrapper = mountSelector()
         const select = wrapper.findComponent({ name: "QSelect" })

--- a/VueApp/src/CMS/__tests__/recent-activity.test.ts
+++ b/VueApp/src/CMS/__tests__/recent-activity.test.ts
@@ -1,5 +1,5 @@
 import RecentActivity from "@/CMS/components/RecentActivity.vue"
-import { mountCms, flushPromises } from "./test-utils"
+import { createTestRouter, mountCms, flushPromises, flushRouter } from "./test-utils"
 
 /**
  * RecentActivity merges up to three sources (content blocks, files, left-nav menus), each
@@ -9,9 +9,11 @@ import { mountCms, flushPromises } from "./test-utils"
  */
 
 const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: (...args: unknown[]) => mockGet(...args),
+        post: (...args: unknown[]) => mockPost(...args),
         createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
             const params = new URLSearchParams()
             for (const [k, v] of Object.entries(obj)) {
@@ -35,12 +37,35 @@ function leftNav(id: number, modifiedOn: string, menuHeaderText = `Menu ${id}`) 
 }
 
 // Routes requests to the right canned response based on the URL the component builds.
-function routeGet(handlers: { blocks?: unknown; files?: unknown; leftNavs?: unknown }) {
+// The trash source defaults to an empty success so pre-existing tests keep their exact
+// call semantics; tests exercising deletions or all-source failure pass it explicitly.
+// The latest-change diff is a POST (current content vs newest history row) and answers
+// from historyDiff.
+function routeGet(handlers: {
+    blocks?: unknown
+    blockDetail?: unknown
+    files?: unknown
+    deletedFiles?: unknown
+    historyList?: unknown
+    historyDiff?: unknown
+    leftNavs?: unknown
+}) {
+    mockPost.mockReset()
+    mockPost.mockResolvedValue(handlers.historyDiff)
     mockGet.mockReset()
     mockGet.mockImplementation((...args: unknown[]) => {
         const url = args[0] as string
+        if (url.includes("CMS/content/history")) {
+            return Promise.resolve(handlers.historyList)
+        }
+        if (/CMS\/content\/\d+$/u.test(url)) {
+            return Promise.resolve(handlers.blockDetail)
+        }
         if (url.includes("CMS/content")) {
             return Promise.resolve(handlers.blocks)
+        }
+        if (url.includes("cms/files") && url.includes("status=deleted")) {
+            return Promise.resolve(handlers.deletedFiles ?? { success: true, result: [] })
         }
         if (url.includes("cms/files")) {
             return Promise.resolve(handlers.files)
@@ -87,7 +112,8 @@ describe("recentActivity.vue - source gating", () => {
             leftNavs: { success: true, result: [leftNav(1, "2024-01-01T00:00:00")] },
         })
         await mountActivity({ showBlocks: true, showFiles: true, showLeftNavs: true })
-        expect(mockGet).toHaveBeenCalledTimes(3)
+        // ShowFiles drives two fetches: active files and recently deleted (trash) files.
+        expect(mockGet).toHaveBeenCalledTimes(4)
     })
 })
 
@@ -145,8 +171,127 @@ describe("recentActivity.vue - partial failure semantics", () => {
         routeGet({
             blocks: { success: false, result: [] },
             files: { success: false, result: [] },
+            deletedFiles: { success: false, result: [] },
         })
         const wrapper = await mountActivity({ showBlocks: true, showFiles: true })
         expect(wrapper.text()).toContain("Couldn't load recent activity.")
+    })
+})
+
+describe("recentActivity.vue - deleted files and item actions", () => {
+    it("shows recently deleted files with a deleted verb and a trash deep-link", async () => {
+        routeGet({
+            files: { success: true, result: [] },
+            deletedFiles: {
+                success: true,
+                result: [{ ...file("g9", "2024-05-01T00:00:00", "Gone file"), deletedOn: "2024-05-02T00:00:00" }],
+            },
+        })
+        const wrapper = await mountActivity({ showFiles: true })
+
+        expect(wrapper.text()).toContain("Gone file")
+        expect(wrapper.text()).toContain("deleted")
+        const item = wrapper.findAllComponents({ name: "QItem" }).find((i) => i.text().includes("Gone file"))!
+        expect(item.props("to")).toStrictEqual({
+            name: "CmsFiles",
+            query: { status: "deleted", search: "Gone file" },
+        })
+        const deletedFetch = mockGet.mock.calls.map((c) => c[0] as string).find((u) => u.includes("status=deleted"))!
+        expect(deletedFetch).toContain("sortBy=deletedOn")
+        expect(deletedFetch).toContain("descending=true")
+    })
+
+    it("links block items to their edit history and files to their audit trail", async () => {
+        routeGet({
+            blocks: { success: true, result: [block(7, "2024-01-02T00:00:00")] },
+            files: { success: true, result: [file("g1", "2024-01-01T00:00:00")] },
+        })
+        const wrapper = await mountActivity({ showBlocks: true, showFiles: true })
+
+        const buttons = wrapper.findAllComponents({ name: "QBtn" })
+        const history = buttons.find((b) => b.props("icon") === "history")!
+        expect(history.props("to")).toStrictEqual({
+            name: "CmsContentBlockHistory",
+            query: { contentBlockId: "7" },
+        })
+        const audit = buttons.find((b) => b.props("icon") === "fact_check")!
+        expect(audit.props("to")).toStrictEqual({ name: "CmsFileAudit", query: { fileGuid: "g1" } })
+    })
+
+    // Guards the click handling: a preventDefault on to-actions would make QBtn cancel its own
+    // router navigation, and a missing .stop would let the row's edit link hijack the click.
+    it("navigates to the block's edit history when its history action is clicked", async () => {
+        routeGet({ blocks: { success: true, result: [block(7, "2024-01-02T00:00:00")] } })
+        const router = createTestRouter()
+        const wrapper = mountCms(RecentActivity, { props: { showBlocks: true } }, router)
+        await flushPromises()
+        await flushPromises()
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.props("icon") === "history")!
+            .trigger("click")
+        await flushRouter()
+
+        expect(router.currentRoute.value.name).toBe("CmsContentBlockHistory")
+        expect(router.currentRoute.value.query).toStrictEqual({ contentBlockId: "7" })
+    })
+
+    it("opens the latest-change diff inline from a block item", async () => {
+        routeGet({
+            blocks: { success: true, result: [block(7, "2024-01-02T00:00:00", "Diffable block")] },
+            blockDetail: {
+                success: true,
+                result: { ...block(7, "2024-01-02T00:00:00", "Diffable block"), content: "<p>now</p>" },
+            },
+            historyList: { success: true, result: [{ contentHistoryId: 42, contentBlockId: 7 }] },
+            historyDiff: {
+                success: true,
+                result: {
+                    content: "<p>diff <ins>added</ins></p>",
+                    hasComparison: true,
+                    hasChanges: true,
+                    oldModifiedOn: "2024-01-01T00:00:00",
+                    oldModifiedBy: "before",
+                    newModifiedOn: null,
+                    newModifiedBy: null,
+                },
+            },
+        })
+        const wrapper = await mountActivity({ showBlocks: true })
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.props("icon") === "difference")!
+            .trigger("click")
+        await flushPromises()
+
+        const dialog = wrapper.findComponent({ name: "ContentDiffDialog" })
+        expect(dialog.props("modelValue")).toBeTruthy()
+        expect(dialog.props("diffHtml")).toContain("added")
+        // The latest change is live content vs the newest history row, so it must go through
+        // the POST diff (history rows only hold superseded versions) with the current content.
+        expect(mockPost).toHaveBeenCalledOnce()
+        const [diffUrl, diffBody] = mockPost.mock.calls[0] as [string, unknown]
+        expect(diffUrl).toContain("CMS/content/7/history/42/diff")
+        expect(diffBody).toStrictEqual({ content: "<p>now</p>" })
+    })
+
+    it("closes the diff viewer and notifies when the block has no history", async () => {
+        routeGet({
+            blocks: { success: true, result: [block(7, "2024-01-02T00:00:00")] },
+            blockDetail: { success: true, result: { ...block(7, "2024-01-02T00:00:00"), content: "<p>now</p>" } },
+            historyList: { success: true, result: [] },
+        })
+        const wrapper = await mountActivity({ showBlocks: true })
+
+        await wrapper
+            .findAllComponents({ name: "QBtn" })
+            .find((b) => b.props("icon") === "difference")!
+            .trigger("click")
+        await flushPromises()
+
+        expect(wrapper.findComponent({ name: "ContentDiffDialog" }).props("modelValue")).toBeFalsy()
+        expect(mockPost).not.toHaveBeenCalled()
     })
 })

--- a/VueApp/src/CMS/__tests__/recent-activity.test.ts
+++ b/VueApp/src/CMS/__tests__/recent-activity.test.ts
@@ -191,8 +191,10 @@ describe("recentActivity.vue - deleted files and item actions", () => {
 
         expect(wrapper.text()).toContain("Gone file")
         expect(wrapper.text()).toContain("deleted")
+        // The row's single anchor is the stretched title link (controls must not nest in an anchor).
         const item = wrapper.findAllComponents({ name: "QItem" }).find((i) => i.text().includes("Gone file"))!
-        expect(item.props("to")).toStrictEqual({
+        const titleLink = item.findComponent({ name: "RouterLink" })
+        expect(titleLink.props("to")).toStrictEqual({
             name: "CmsFiles",
             query: { status: "deleted", search: "Gone file" },
         })

--- a/VueApp/src/CMS/__tests__/recent-activity.test.ts
+++ b/VueApp/src/CMS/__tests__/recent-activity.test.ts
@@ -59,7 +59,7 @@ async function mountActivity(props: Record<string, boolean>) {
     return wrapper
 }
 
-describe("RecentActivity.vue - source gating", () => {
+describe("recentActivity.vue - source gating", () => {
     it("loads no sources and shows the empty message when all flags are off", async () => {
         routeGet({})
         const wrapper = await mountActivity({})
@@ -71,7 +71,13 @@ describe("RecentActivity.vue - source gating", () => {
         routeGet({ blocks: { success: true, result: [block(1, "2024-01-01T00:00:00")] } })
         await mountActivity({ showBlocks: true })
         expect(mockGet).toHaveBeenCalledOnce()
-        expect(mockGet.mock.calls[0]![0]).toContain("CMS/content")
+        const url = mockGet.mock.calls[0]![0] as string
+        expect(url).toContain("CMS/content")
+        // Recency must be resolved server-side: a client-side sort of the default page can
+        // only ever see the first alphabetical page of blocks.
+        expect(url).toContain("sortBy=modifiedOn")
+        expect(url).toContain("descending=true")
+        expect(url).toContain("perPage=5")
     })
 
     it("loads all three sources when every flag is set", async () => {
@@ -85,7 +91,7 @@ describe("RecentActivity.vue - source gating", () => {
     })
 })
 
-describe("RecentActivity.vue - merge, sort, cap", () => {
+describe("recentActivity.vue - merge, sort, cap", () => {
     it("merges sources and sorts by modifiedOn descending", async () => {
         routeGet({
             blocks: { success: true, result: [block(1, "2024-01-01T00:00:00", "Old block")] },
@@ -124,7 +130,7 @@ describe("RecentActivity.vue - merge, sort, cap", () => {
     })
 })
 
-describe("RecentActivity.vue - partial failure semantics", () => {
+describe("recentActivity.vue - partial failure semantics", () => {
     it("does NOT mark failed when one source rejects but another succeeds", async () => {
         routeGet({
             blocks: { success: false, result: [] }, // LoadBlocks throws on !success

--- a/VueApp/src/CMS/__tests__/router-canonicalization.test.ts
+++ b/VueApp/src/CMS/__tests__/router-canonicalization.test.ts
@@ -1,0 +1,50 @@
+import { createPinia, setActivePinia } from "pinia"
+import { useUserStore } from "@/store/UserStore"
+import { cmsRouter } from "@/CMS/router"
+
+// The real beforeEach guard calls requireLogin, which hits the network and needs a Quasar/inject
+// context. Stub it (Vitest hoists this above the imports) so the test exercises only the
+// permission-driven canonicalization, not the auth plumbing.
+vi.mock("@/composables/RequireLogin", () => ({
+    useRequireLogin: () => ({ requireLogin: () => Promise.resolve(true) }),
+    getLoginUrl: () => ({ value: "" }),
+}))
+
+// Park on a neutral route first so the push to the area root is never a redundant navigation
+// (which would resolve to a NavigationFailure and leave currentRoute unchanged).
+async function goToAreaRoot(): Promise<void> {
+    await cmsRouter.push("/__reset__")
+    await cmsRouter.push("/CMS/")
+}
+
+describe("CMS area-root canonicalization", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    it("redirects base SVMSecure.CMS users from /CMS/ to the Home hub", async () => {
+        useUserStore().setPermissions(["SVMSecure.CMS"])
+
+        await goToAreaRoot()
+
+        expect(cmsRouter.currentRoute.value.name).toBe("CmsHome")
+    })
+
+    it("redirects granular-only users (no base SVMSecure.CMS) to the Home hub", async () => {
+        // The regression: AllFiles/ManageNavigation/etc. users can enter the area but used to be
+        // stranded on /CMS/ because canonicalization only checked the base permission.
+        useUserStore().setPermissions(["SVMSecure.CMS.AllFiles"])
+
+        await goToAreaRoot()
+
+        expect(cmsRouter.currentRoute.value.name).toBe("CmsHome")
+    })
+
+    it("leaves visitors with no CMS permissions on the CmsAuth landing", async () => {
+        useUserStore().setPermissions([])
+
+        await goToAreaRoot()
+
+        expect(cmsRouter.currentRoute.value.name).toBe("CmsAuth")
+    })
+})

--- a/VueApp/src/CMS/__tests__/test-utils.ts
+++ b/VueApp/src/CMS/__tests__/test-utils.ts
@@ -3,19 +3,32 @@ import type { ComponentMountingOptions } from "@vue/test-utils"
 import { createRouter, createWebHistory } from "vue-router"
 import type { Router, RouteRecordRaw } from "vue-router"
 import { Quasar, Notify, Dialog } from "quasar"
+import { createPinia, setActivePinia } from "pinia"
 import { nextTick } from "vue"
+import { useUserStore } from "@/store/UserStore"
 
 /**
  * Shared test utilities for CMS component/page tests.
  *
- * CMS has no Pinia store (state is local to each component), so these helpers
- * only need a Quasar plugin set, a test router, and an "apiURL" provide value
- * that mirrors what cms.ts injects at runtime.
+ * CMS keeps page state local, but some pages read the signed-in user's permissions from the
+ * shared user store (e.g. ContentBlockEdit gates its section-path and file pickers). So the
+ * helpers install Pinia and seed a full CMS admin so mounted pages behave as they would for a
+ * manager (the role these tests assume).
  */
 
 // Components build request URLs as inject("apiURL") + "cms/...". Tests assert against
 // this prefix, so keep it stable and obvious.
 const TEST_API_URL = "/api/"
+
+// The CMS area's full permission set; mounted pages default to this so existing tests see the
+// same UI a manager would. Mirrors the route meta in src/CMS/router/routes.ts.
+const CMS_ADMIN_PERMISSIONS = [
+    "SVMSecure.CMS",
+    "SVMSecure.CMS.ManageContentBlocks",
+    "SVMSecure.CMS.CreateContentBlock",
+    "SVMSecure.CMS.AllFiles",
+    "SVMSecure.CMS.ManageNavigation",
+]
 
 // Route table mirroring the real CMS route names/paths (src/CMS/router/routes.ts) so
 // router-link :to and programmatic navigation resolve exactly as they do in production.
@@ -41,9 +54,13 @@ function createTestRouter(): Router {
 }
 
 // Generic mount wrapper: registers Quasar (with Notify + Dialog so components that call
-// $q.notify / $q.dialog don't blow up), a router, and the apiURL provide.
+// $q.notify / $q.dialog don't blow up), Pinia (seeded as a CMS admin), a router, and the
+// apiURL provide.
 function mountCms<T>(component: T, options: ComponentMountingOptions<T> = {}, router?: Router) {
     const testRouter = router ?? createTestRouter()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useUserStore().setPermissions(CMS_ADMIN_PERMISSIONS)
     const { global: globalOptions = {}, ...rest } = options as Record<string, unknown> & {
         global?: Record<string, unknown>
     }
@@ -52,7 +69,7 @@ function mountCms<T>(component: T, options: ComponentMountingOptions<T> = {}, ro
         {
             ...rest,
             global: {
-                plugins: [[Quasar, { plugins: { Notify, Dialog } }], testRouter],
+                plugins: [[Quasar, { plugins: { Notify, Dialog } }], testRouter, pinia],
                 provide: { apiURL: TEST_API_URL },
                 ...globalOptions,
             },

--- a/VueApp/src/CMS/__tests__/use-server-table.test.ts
+++ b/VueApp/src/CMS/__tests__/use-server-table.test.ts
@@ -3,7 +3,7 @@ import { useServerTable } from "@/CMS/composables/use-server-table"
 import { mountCms, flushPromises } from "./test-utils"
 
 /**
- * useServerTable is the server-paged QTable core shared by the CMS list pages: onRequest issues
+ * UseServerTable is the server-paged QTable core shared by the CMS list pages: onRequest issues
  * the GET built from buildParams, binds rows and rowsNumber (falling back to the row count when
  * the API returns no pagination envelope), copies the request pagination into state, and notifies
  * on failure. Direct spec so regressions surface here rather than in every list page.
@@ -68,7 +68,7 @@ describe("useServerTable", () => {
         await table.onRequest(request(2, { sortBy: "modifiedOn", descending: true }))
 
         expect(mockGet.mock.calls[0]![0]).toBe("/api/things?page=2&perPage=25&sortBy=modifiedOn&descending=true")
-        expect(table.rows.value).toEqual([{ id: 1 }])
+        expect(table.rows.value).toStrictEqual([{ id: 1 }])
         expect(table.pagination.value).toMatchObject({
             rowsNumber: 91,
             page: 2,
@@ -98,7 +98,7 @@ describe("useServerTable", () => {
 
         // The notification teleports to document.body.
         expect(document.body.textContent).toContain("backend exploded")
-        expect(table.rows.value).toEqual([{ id: 1 }])
+        expect(table.rows.value).toStrictEqual([{ id: 1 }])
         expect(table.loading.value).toBeFalsy()
     })
 
@@ -110,6 +110,27 @@ describe("useServerTable", () => {
         await flushPromises()
 
         expect(document.body.textContent).toContain("Failed to load things")
+    })
+
+    it("drops a stale response that resolves after a newer request", async () => {
+        // First request resolves LAST (slow); second request resolves first. The slow
+        // first response must not clobber the rows/pagination of the newer request.
+        let resolveFirst!: (value: unknown) => void
+        mockGet.mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+        mockGet.mockResolvedValueOnce({ success: true, result: [{ id: 2 }], pagination: { totalRecords: 1 } })
+        const table = mountTable()
+
+        const first = table.onRequest(request(1))
+        const second = table.onRequest(request(2))
+        await second
+
+        resolveFirst({ success: true, result: [{ id: 99 }], pagination: { totalRecords: 999 } })
+        await first
+        await flushPromises()
+
+        expect(table.rows.value).toStrictEqual([{ id: 2 }])
+        expect(table.pagination.value.rowsNumber).toBe(1)
+        expect(table.pagination.value.page).toBe(2)
     })
 
     it("reloadFirstPage re-requests page 1 while keeping the current sort and page size", async () => {

--- a/VueApp/src/CMS/__tests__/use-server-table.test.ts
+++ b/VueApp/src/CMS/__tests__/use-server-table.test.ts
@@ -1,0 +1,128 @@
+import { defineComponent } from "vue"
+import { useServerTable } from "@/CMS/composables/use-server-table"
+import { mountCms, flushPromises } from "./test-utils"
+
+/**
+ * useServerTable is the server-paged QTable core shared by the CMS list pages: onRequest issues
+ * the GET built from buildParams, binds rows and rowsNumber (falling back to the row count when
+ * the API returns no pagination envelope), copies the request pagination into state, and notifies
+ * on failure. Direct spec so regressions surface here rather than in every list page.
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+type Row = { id: number }
+
+// The composable needs a component context for useQuasar/useFetch; host it in a renderless
+// component and drive it through its returned API (the same surface the pages use).
+function mountTable(options: { errorMessage?: string } = {}) {
+    let table!: ReturnType<typeof useServerTable<Row>>
+    const Host = defineComponent({
+        name: "ServerTableHost",
+        setup() {
+            table = useServerTable<Row>({
+                url: "/api/things",
+                errorMessage: options.errorMessage,
+                pagination: { sortBy: "name", descending: false, rowsPerPage: 25 },
+                buildParams: (p) => ({
+                    page: p.page,
+                    perPage: p.rowsPerPage,
+                    sortBy: p.sortBy,
+                    descending: p.descending ? "true" : "false",
+                }),
+            })
+            return () => null
+        },
+    })
+    mountCms(Host)
+    return table
+}
+
+const request = (page: number, overrides: Partial<{ sortBy: string; descending: boolean }> = {}) => ({
+    pagination: { page, rowsPerPage: 25, sortBy: "name", descending: false, ...overrides },
+})
+
+beforeEach(() => {
+    mockGet.mockReset()
+})
+
+describe("useServerTable", () => {
+    it("binds rows and takes rowsNumber from the response pagination envelope", async () => {
+        mockGet.mockResolvedValue({ success: true, result: [{ id: 1 }], pagination: { totalRecords: 91 } })
+        const table = mountTable()
+
+        await table.onRequest(request(2, { sortBy: "modifiedOn", descending: true }))
+
+        expect(mockGet.mock.calls[0]![0]).toBe("/api/things?page=2&perPage=25&sortBy=modifiedOn&descending=true")
+        expect(table.rows.value).toEqual([{ id: 1 }])
+        expect(table.pagination.value).toMatchObject({
+            rowsNumber: 91,
+            page: 2,
+            sortBy: "modifiedOn",
+            descending: true,
+        })
+        expect(table.loading.value).toBeFalsy()
+    })
+
+    it("falls back to the returned row count for rowsNumber when no envelope is present", async () => {
+        mockGet.mockResolvedValue({ success: true, result: [{ id: 1 }, { id: 2 }, { id: 3 }] })
+        const table = mountTable()
+
+        await table.onRequest(request(1))
+
+        expect(table.pagination.value.rowsNumber).toBe(3)
+    })
+
+    it("notifies with the server error and keeps the previous rows when the request fails", async () => {
+        mockGet.mockResolvedValueOnce({ success: true, result: [{ id: 1 }] })
+        const table = mountTable()
+        await table.onRequest(request(1))
+
+        mockGet.mockResolvedValueOnce({ success: false, errors: ["backend exploded"] })
+        await table.onRequest(request(2))
+        await flushPromises()
+
+        // The notification teleports to document.body.
+        expect(document.body.textContent).toContain("backend exploded")
+        expect(table.rows.value).toEqual([{ id: 1 }])
+        expect(table.loading.value).toBeFalsy()
+    })
+
+    it("falls back to the caller's errorMessage when a failure carries no errors", async () => {
+        mockGet.mockResolvedValue({ success: false, errors: null })
+        const table = mountTable({ errorMessage: "Failed to load things" })
+
+        await table.onRequest(request(1))
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to load things")
+    })
+
+    it("reloadFirstPage re-requests page 1 while keeping the current sort and page size", async () => {
+        mockGet.mockResolvedValue({ success: true, result: [], pagination: { totalRecords: 0 } })
+        const table = mountTable()
+        await table.onRequest(request(3, { sortBy: "modifiedOn", descending: true }))
+
+        await table.reloadFirstPage()
+        await flushPromises()
+
+        const lastUrl = mockGet.mock.calls.at(-1)![0] as string
+        expect(lastUrl).toContain("page=1")
+        expect(lastUrl).toContain("sortBy=modifiedOn")
+        expect(lastUrl).toContain("descending=true")
+    })
+})

--- a/VueApp/src/CMS/__tests__/use-url-filtered-table.test.ts
+++ b/VueApp/src/CMS/__tests__/use-url-filtered-table.test.ts
@@ -1,0 +1,133 @@
+import { defineComponent } from "vue"
+import { useUrlFilteredTable } from "@/CMS/composables/use-url-filtered-table"
+import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
+
+/**
+ * useUrlFilteredTable layers URL sync onto useServerTable: filters and the primary deep-link id
+ * initialize from route.query, reload() reflects them back (empties omitted) and refetches page 1,
+ * clearPrimaryFilter drops the id chip, and the route.query watcher re-syncs on external
+ * navigation while its equality guard skips the composable's own URL writes.
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+type Row = { id: number }
+type Filters = { search: string; from: string }
+
+async function mountTable(query: Record<string, string> = {}) {
+    const router = createTestRouter()
+    await router.push({ path: "/CMS/ManageFiles/Audit", query })
+    await router.isReady()
+
+    let table!: ReturnType<typeof useUrlFilteredTable<Row, Filters>>
+    const Host = defineComponent({
+        name: "UrlFilteredTableHost",
+        setup() {
+            table = useUrlFilteredTable<Row, Filters>({
+                url: "/api/audit",
+                errorMessage: "Failed to load audit",
+                primaryKey: "fileGuid",
+                defaultFilters: () => ({ search: "", from: "" }),
+                pagination: { sortBy: "when", descending: true },
+            })
+            return () => null
+        },
+    })
+    mountCms(Host, {}, router)
+    return { table, router }
+}
+
+function lastUrl(): string {
+    return (mockGet.mock.calls.at(-1)?.[0] as string) ?? ""
+}
+
+beforeEach(() => {
+    mockGet.mockReset()
+    mockGet.mockResolvedValue({ success: true, result: [], pagination: { totalRecords: 0 } })
+})
+
+describe("useUrlFilteredTable", () => {
+    it("initializes the primary id and filters from route.query and sends them, omitting empties", async () => {
+        const { table } = await mountTable({ fileGuid: "g1", search: "report" })
+
+        table.reload()
+        await flushPromises()
+
+        const url = lastUrl()
+        expect(url).toContain("fileGuid=g1")
+        expect(url).toContain("search=report")
+        expect(url).toContain("page=1")
+        expect(url).toContain("perPage=50")
+        // The untouched "from" filter is blank and must not be serialized at all.
+        expect(url).not.toContain("from=")
+    })
+
+    it("reload writes the active filters back to the URL, omitting empty ones", async () => {
+        const { table, router } = await mountTable()
+
+        table.filters.value.search = "hello"
+        table.reload()
+        await flushRouter()
+
+        expect(router.currentRoute.value.query.search).toBe("hello")
+        expect(router.currentRoute.value.query.from).toBeUndefined()
+        expect(router.currentRoute.value.query.fileGuid).toBeUndefined()
+    })
+
+    it("clearPrimaryFilter drops the deep-link id from the request and the URL, then refetches", async () => {
+        const { table, router } = await mountTable({ fileGuid: "g1" })
+        table.reload()
+        await flushRouter()
+        const before = mockGet.mock.calls.length
+
+        table.clearPrimaryFilter()
+        await flushRouter()
+
+        expect(table.primary.value).toBeNull()
+        expect(mockGet.mock.calls.length).toBeGreaterThan(before)
+        expect(lastUrl()).not.toContain("fileGuid=")
+        expect(router.currentRoute.value.query.fileGuid).toBeUndefined()
+    })
+
+    it("re-syncs filters and refetches when external navigation changes the query", async () => {
+        const { table, router } = await mountTable()
+        table.reload()
+        await flushRouter()
+        const before = mockGet.mock.calls.length
+
+        await router.push({ path: "/CMS/ManageFiles/Audit", query: { search: "changed", fileGuid: "g2" } })
+        await flushRouter()
+
+        expect(mockGet.mock.calls.length).toBe(before + 1)
+        expect(table.filters.value.search).toBe("changed")
+        expect(table.primary.value).toBe("g2")
+        expect(lastUrl()).toContain("search=changed")
+    })
+
+    it("does not double-fetch when the watcher sees the composable's own URL write (equality guard)", async () => {
+        const { table } = await mountTable()
+
+        table.filters.value.search = "abc"
+        table.reload()
+        await flushPromises()
+        const afterReload = mockGet.mock.calls.length
+
+        // Reload's router.replace triggers the route.query watcher; state already matches.
+        await flushRouter()
+        expect(mockGet.mock.calls.length).toBe(afterReload)
+    })
+})

--- a/VueApp/src/CMS/components/ActivityRow.vue
+++ b/VueApp/src/CMS/components/ActivityRow.vue
@@ -1,0 +1,107 @@
+<template>
+    <q-item
+        clickable
+        :to="item.to"
+        class="q-px-none"
+    >
+        <q-item-section side>
+            <q-icon
+                :name="item.icon"
+                :aria-label="item.typeLabel"
+                color="secondary"
+                size="sm"
+            />
+        </q-item-section>
+        <q-item-section>
+            <q-item-label lines="1">{{ item.label }}</q-item-label>
+            <q-item-label
+                caption
+                :title="formatFullDate(item.modifiedOn)"
+            >
+                {{ item.typeLabel }} &middot; {{ item.verb ? item.verb + " " : ""
+                }}{{ formatTimeAgo(new Date(item.modifiedOn)) }} by
+                {{ item.modifiedBy }}
+            </q-item-label>
+        </q-item-section>
+        <q-item-section
+            v-if="item.actions?.length"
+            side
+            class="activity-actions"
+        >
+            <div class="row no-wrap">
+                <q-btn
+                    v-for="action in item.actions"
+                    :key="action.icon"
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    color="primary"
+                    :icon="action.icon"
+                    :aria-label="action.label"
+                    :to="action.to"
+                    @click.stop="runAction(action, $event)"
+                >
+                    <q-tooltip>{{ action.label }}</q-tooltip>
+                </q-btn>
+            </div>
+        </q-item-section>
+    </q-item>
+</template>
+
+<script setup lang="ts">
+import { formatTimeAgo } from "@vueuse/core"
+import type { ActivityItem, RailAction } from "@/CMS/types/"
+
+defineProps<{
+    item: ActivityItem
+}>()
+
+function formatFullDate(value: string): string {
+    return new Date(value).toLocaleString()
+}
+
+// Row-level navigation must not fire for action clicks (`.stop` in the template). Actions with
+// their own `to` navigate via QBtn; only run-actions preventDefault, both to keep the row's
+// anchor inert and because a prevented default makes QBtn cancel its router navigation.
+function runAction(action: RailAction, event: Event) {
+    if (!action.run) return
+    event.preventDefault()
+    action.run()
+}
+</script>
+
+<style scoped>
+/* Keep the two icon actions from inflating the dense rows; the buttons carry their own
+   padding and get the standard 44px targets on coarse pointers via base.css. */
+.activity-actions {
+    padding-left: 0;
+}
+
+/* Quiet the rail: row actions fade in on row hover or keyboard focus. Opacity (not display)
+   keeps the buttons in the layout and the tab order, so rows never shift and focus reveals
+   them for keyboard users. */
+.activity-actions .q-btn {
+    opacity: 0;
+    transition: opacity 0.15s ease-out;
+}
+
+.q-item:hover .activity-actions .q-btn,
+.q-item:focus-within .activity-actions .q-btn {
+    opacity: 1;
+}
+
+/* No hover on touch: keep the actions always visible so they don't need a discovery tap
+   that would fight the row's own navigation. */
+@media (pointer: coarse) {
+    .activity-actions .q-btn {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .activity-actions .q-btn {
+        transition: none;
+    }
+}
+</style>

--- a/VueApp/src/CMS/components/ActivityRow.vue
+++ b/VueApp/src/CMS/components/ActivityRow.vue
@@ -1,9 +1,5 @@
 <template>
-    <q-item
-        clickable
-        :to="item.to"
-        class="q-px-none"
-    >
+    <q-item class="q-px-none activity-row">
         <q-item-section side>
             <q-icon
                 :name="item.icon"
@@ -13,7 +9,13 @@
             />
         </q-item-section>
         <q-item-section>
-            <q-item-label lines="1">{{ item.label }}</q-item-label>
+            <q-item-label lines="1">
+                <router-link
+                    :to="item.to"
+                    class="activity-link"
+                    >{{ item.label }}</router-link
+                >
+            </q-item-label>
             <q-item-label
                 caption
                 :title="formatFullDate(item.modifiedOn)"
@@ -40,7 +42,7 @@
                     :icon="action.icon"
                     :aria-label="action.label"
                     :to="action.to"
-                    @click.stop="runAction(action, $event)"
+                    @click="runAction(action)"
                 >
                     <q-tooltip>{{ action.label }}</q-tooltip>
                 </q-btn>
@@ -61,21 +63,48 @@ function formatFullDate(value: string): string {
     return new Date(value).toLocaleString()
 }
 
-// Row-level navigation must not fire for action clicks (`.stop` in the template). Actions with
-// their own `to` navigate via QBtn; only run-actions preventDefault, both to keep the row's
-// anchor inert and because a prevented default makes QBtn cancel its router navigation.
-function runAction(action: RailAction, event: Event) {
-    if (!action.run) return
-    event.preventDefault()
-    action.run()
+// Actions with their own `to` navigate via QBtn; run-actions just run. The stretched
+// title link sits below the action buttons (z-index), so a button click can't reach it.
+function runAction(action: RailAction) {
+    action.run?.()
 }
 </script>
 
 <style scoped>
+/* Whole-row clickability without nesting controls inside an anchor (invalid HTML, ambiguous
+   for AT): the title is the only row link, stretched over the row via ::after, and the action
+   buttons sit above the overlay. Screen readers announce one link named by the title. */
+.activity-row {
+    position: relative;
+}
+
+.activity-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.activity-link::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+}
+
+.activity-link:hover,
+.activity-link:focus-visible {
+    text-decoration: underline;
+}
+
+.activity-row:hover,
+.activity-row:focus-within {
+    background: var(--surface-tint);
+}
+
 /* Keep the two icon actions from inflating the dense rows; the buttons carry their own
    padding and get the standard 44px targets on coarse pointers via base.css. */
 .activity-actions {
     padding-left: 0;
+    position: relative;
+    z-index: 1;
 }
 
 /* Quiet the rail: row actions fade in on row hover or keyboard focus. Opacity (not display)

--- a/VueApp/src/CMS/components/ContentBlock.vue
+++ b/VueApp/src/CMS/components/ContentBlock.vue
@@ -23,33 +23,12 @@ const contentBlock: Ref<ContentBlock | null> = ref(null)
 async function loadContentBlock() {
     const { get } = useFetch()
     const r = await get(import.meta.env.VITE_API_URL + "cms/content/fn/" + props.contentBlockName)
-    contentBlock.value = r.result
+    contentBlock.value = r.success ? r.result : null
 }
 
-watch(
-    () => props,
-    () => {
-        loadContentBlock()
-    },
-    { immediate: true, deep: true },
-)
-
-loadContentBlock()
+// Reload only when the block name changes. props is reactive, so watching the
+// specific source (instead of a deep watch on props) avoids the duplicate
+// immediate fetch and unrelated re-runs. Headings for the sanitized HTML are
+// styled globally in styles/base.css (shared with the diff view).
+watch(() => props.contentBlockName, loadContentBlock, { immediate: true })
 </script>
-
-<style>
-.content-block h1 {
-    font-size: 2rem;
-    line-height: 2rem;
-}
-
-.content-block h2 {
-    font-size: 2rem;
-    line-height: 2rem;
-}
-
-.content-block h3 {
-    font-size: 2rem;
-    line-height: 2rem;
-}
-</style>

--- a/VueApp/src/CMS/components/ContentDiffDialog.vue
+++ b/VueApp/src/CMS/components/ContentDiffDialog.vue
@@ -124,7 +124,7 @@ const emit = defineEmits<{ "update:modelValue": [value: boolean] }>()
 .cms-diff :deep(ins.diffins),
 .cms-diff :deep(ins.diffmod),
 .cms-diff-legend ins {
-    background-color: #d7efdb;
+    background-color: var(--diff-add);
     color: var(--q-dark);
     text-decoration: underline;
 }
@@ -132,7 +132,7 @@ const emit = defineEmits<{ "update:modelValue": [value: boolean] }>()
 .cms-diff :deep(del.diffdel),
 .cms-diff :deep(del.diffmod),
 .cms-diff-legend del {
-    background-color: #f6d9dc;
+    background-color: var(--diff-remove);
     color: var(--q-dark);
     text-decoration: line-through;
 }

--- a/VueApp/src/CMS/components/FileFormDialog.vue
+++ b/VueApp/src/CMS/components/FileFormDialog.vue
@@ -236,6 +236,7 @@ import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
 import PersonSelector from "@/CMS/components/PersonSelector.vue"
 import StatusBanner from "@/components/StatusBanner.vue"
+import { CMS_ACCEPTED_EXTENSIONS } from "@/CMS/file-types"
 import type { CmsFile, CmsFilePerson } from "@/CMS/types/"
 
 const props = defineProps<{
@@ -253,8 +254,7 @@ const apiURL = inject("apiURL") + "cms/files/"
 const $q = useQuasar()
 const { get, postForm, putForm, createUrlSearchParams } = useFetch()
 
-const acceptedExtensions =
-    ".pdf,.docx,.doc,.xls,.xlsx,.csv,.ppt,.pptx,.pptm,.txt,.html,.gif,.png,.jpg,.jpeg,.tiff,.mp3,.wav,.mp4,.webm,.oft,.eps,.zip,.7z,.dmg,.exe"
+const acceptedExtensions = CMS_ACCEPTED_EXTENSIONS
 
 const isEdit = computed(() => props.file !== null)
 const formRef = ref()

--- a/VueApp/src/CMS/components/FileFormDialog.vue
+++ b/VueApp/src/CMS/components/FileFormDialog.vue
@@ -229,6 +229,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; submitSave is split into small helpers below.
+// fallow-ignore-file complexity
 import { computed, inject, ref, watch } from "vue"
 import { useQuasar } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
@@ -440,37 +442,42 @@ async function resolveConflict() {
     if (await submitSave(opts)) showConflict.value = false
 }
 
+// Edit updates the current record; overwriteGuid replaces an existing managed file's content and
+// details; otherwise this is a new upload.
+function sendSave(opts: SubmitOptions) {
+    if (isEdit.value) return putForm(apiURL + props.file!.fileGuid, buildFormData())
+    if (opts.overwriteGuid) return putForm(apiURL + opts.overwriteGuid, buildFormData(opts))
+    return postForm(apiURL, buildFormData(opts))
+}
+
+// During conflict resolution the user is in the conflict sub-dialog, so a toast is the only place
+// they'd see the error; otherwise surface it on the main form banner.
+function reportSaveError(res: { errors: string[] | null }) {
+    const message = res.errors?.[0] ?? `Failed to ${isEdit.value ? "save" : "upload"} file`
+    if (showConflict.value) {
+        $q.notify({ type: "negative", message })
+    } else {
+        formError.value = message
+    }
+}
+
+function saveSuccessMessage(opts: SubmitOptions): string {
+    if (isEdit.value) return "File updated"
+    return opts.overwrite || opts.overwriteGuid ? "File overwritten" : "File uploaded"
+}
+
 async function submitSave(opts: SubmitOptions = {}): Promise<boolean> {
     if (saving.value) return false
     saving.value = true
-    let res
-    if (isEdit.value) {
-        res = await putForm(apiURL + props.file!.fileGuid, buildFormData())
-    } else if (opts.overwriteGuid) {
-        // Overwriting a managed file replaces the existing record's content and details.
-        res = await putForm(apiURL + opts.overwriteGuid, buildFormData(opts))
-    } else {
-        res = await postForm(apiURL, buildFormData(opts))
-    }
+    const res = await sendSave(opts)
     saving.value = false
 
     if (!res.success) {
-        const message = res.errors?.[0] ?? `Failed to ${isEdit.value ? "save" : "upload"} file`
-        // During conflict resolution the user is in the conflict sub-dialog, so a toast is the
-        // only place they'd see the error; otherwise surface it on the main form banner.
-        if (showConflict.value) {
-            $q.notify({ type: "negative", message })
-        } else {
-            formError.value = message
-        }
+        reportSaveError(res)
         return false
     }
 
-    const overwrote = opts.overwrite || opts.overwriteGuid
-    $q.notify({
-        type: "positive",
-        message: isEdit.value ? "File updated" : overwrote ? "File overwritten" : "File uploaded",
-    })
+    $q.notify({ type: "positive", message: saveSuccessMessage(opts) })
     emit("saved", res.result)
     emit("update:modelValue", false)
     return true

--- a/VueApp/src/CMS/components/FileFormDialog.vue
+++ b/VueApp/src/CMS/components/FileFormDialog.vue
@@ -149,7 +149,15 @@
                         dense
                         no-caps
                         :loading="saving"
-                    />
+                    >
+                        <template #loading>
+                            <q-spinner
+                                size="1em"
+                                class="q-mr-sm"
+                            />
+                            {{ isEdit ? "Save Changes" : "Upload" }}
+                        </template>
+                    </q-btn>
                 </q-card-actions>
             </q-form>
 
@@ -204,7 +212,15 @@
                             :label="conflictChoice === 'rename' ? 'Upload with new name' : 'Overwrite'"
                             :loading="saving"
                             @click="resolveConflict"
-                        />
+                        >
+                            <template #loading>
+                                <q-spinner
+                                    size="1em"
+                                    class="q-mr-sm"
+                                />
+                                {{ conflictChoice === "rename" ? "Upload with new name" : "Overwrite" }}
+                            </template>
+                        </q-btn>
                     </q-card-actions>
                 </q-card>
             </q-dialog>

--- a/VueApp/src/CMS/components/FileFormDialog.vue
+++ b/VueApp/src/CMS/components/FileFormDialog.vue
@@ -280,6 +280,7 @@ type NameCheck = {
     existingFileGuid: string | null
     existingFriendlyName: string | null
     existingDeleted: boolean
+    existingModifiedOn: string | null
 }
 
 const emptyForm = (): FileForm => ({
@@ -295,7 +296,15 @@ const emptyForm = (): FileForm => ({
 
 const form = ref<FileForm>(emptyForm())
 
-const { setInitialState, confirmClose } = useUnsavedChanges(form)
+// useUnsavedChanges compares JSON.stringify snapshots, but a File's properties are prototype
+// getters, so it serializes to "{}" and choosing one leaves the form looking clean. Swap it for
+// a name+size identity so a selection is visible to the dirty check.
+const dirtySnapshot = computed(() => ({
+    ...form.value,
+    upload: form.value.upload ? `${form.value.upload.name}:${form.value.upload.size}` : null,
+}))
+
+const { setInitialState, confirmClose } = useUnsavedChanges(dirtySnapshot)
 
 const conflict = ref<NameCheck | null>(null)
 const showConflict = ref(false)
@@ -317,24 +326,34 @@ const conflictDetail = computed(() => {
     return ` (${conflict.value.existingFriendlyName}${conflict.value.existingDeleted ? ", deleted" : ""})`
 })
 
+// The record being edited. Starts as the parent's row but diverges when an edit-conflict
+// "Reload" pulls the latest version: its modifiedOn is what the save presents as
+// lastModifiedOn for the 409 stale-edit guard.
+const latestFile = ref<CmsFile | null>(null)
+
+function populateForm(file: CmsFile | null) {
+    if (file) {
+        form.value = {
+            upload: null,
+            folder: file.folder,
+            description: file.description ?? "",
+            oldUrl: file.oldUrl ?? "",
+            allowPublicAccess: file.allowPublicAccess,
+            encrypt: file.encrypted,
+            permissions: [...file.permissions],
+            people: file.people.map((p) => ({ ...p })),
+        }
+    } else {
+        form.value = emptyForm()
+    }
+}
+
 watch(
     () => [props.modelValue, props.file] as const,
     ([open]) => {
         if (!open) return
-        if (props.file) {
-            form.value = {
-                upload: null,
-                folder: props.file.folder,
-                description: props.file.description ?? "",
-                oldUrl: props.file.oldUrl ?? "",
-                allowPublicAccess: props.file.allowPublicAccess,
-                encrypt: props.file.encrypted,
-                permissions: [...props.file.permissions],
-                people: props.file.people.map((p) => ({ ...p })),
-            }
-        } else {
-            form.value = emptyForm()
-        }
+        latestFile.value = props.file
+        populateForm(props.file)
         formError.value = ""
         setInitialState()
     },
@@ -391,6 +410,13 @@ function buildFormData(opts: SubmitOptions = {}): FormData {
         if (opts.overwrite) {
             data.append("overwrite", "true")
         }
+    }
+    // Updates must present the ModifiedOn they loaded; a stale value gets a 409 so a
+    // concurrent edit (or a record that changed after the overwrite prompt) isn't clobbered.
+    if (isEdit.value && latestFile.value) {
+        data.append("lastModifiedOn", latestFile.value.modifiedOn)
+    } else if (opts.overwriteGuid && conflict.value?.existingModifiedOn) {
+        data.append("lastModifiedOn", conflict.value.existingModifiedOn)
     }
     data.append("description", form.value.description)
     data.append("oldUrl", form.value.oldUrl)
@@ -450,6 +476,55 @@ function sendSave(opts: SubmitOptions) {
     return postForm(apiURL, buildFormData(opts))
 }
 
+// A 409 means the record changed since we loaded it. For an edit, offer to reload the latest
+// version into the form (mirrors ContentBlockEdit's conflict dialog). For an overwrite-by-upload,
+// refresh the name-check data so the retry presents the record's current ModifiedOn.
+async function handleSaveConflict(res: { errors: string[] | null }) {
+    if (showConflict.value) {
+        await refreshOverwriteConflict()
+        $q.notify({
+            type: "negative",
+            message:
+                (res.errors?.[0] ?? "The existing file was changed by someone else.") +
+                " Overwrite again to replace the latest version.",
+        })
+        return
+    }
+    $q.dialog({
+        title: "Edit Conflict",
+        message:
+            (res.errors?.[0] ?? "This file was changed by someone else.") +
+            " Reload the latest version? Your unsaved changes will be lost.",
+        cancel: { label: "Keep editing", flat: true },
+        persistent: true,
+        ok: { label: "Reload", color: "primary", unelevated: true },
+    }).onOk(() => void reloadLatest())
+}
+
+async function reloadLatest() {
+    if (!props.file) return
+    const res = await get(apiURL + props.file.fileGuid)
+    if (!res.success || !res.result) {
+        $q.notify({ type: "negative", message: "Failed to reload the file" })
+        return
+    }
+    latestFile.value = res.result
+    populateForm(res.result)
+    formError.value = ""
+    setInitialState()
+}
+
+// Re-run the pre-upload name check so conflict.existingModifiedOn (and the named record)
+// reflect the current state; without this a retry would 409 forever on the old timestamp.
+async function refreshOverwriteConflict() {
+    if (!form.value.upload || !form.value.folder) return
+    const params = createUrlSearchParams({ folder: form.value.folder, fileName: form.value.upload.name })
+    const check = await get(apiURL + "check-name?" + params)
+    if (check.success && check.result.inUse) {
+        conflict.value = check.result
+    }
+}
+
 // During conflict resolution the user is in the conflict sub-dialog, so a toast is the only place
 // they'd see the error; otherwise surface it on the main form banner.
 function reportSaveError(res: { errors: string[] | null }) {
@@ -472,6 +547,10 @@ async function submitSave(opts: SubmitOptions = {}): Promise<boolean> {
     const res = await sendSave(opts)
     saving.value = false
 
+    if (res.status === 409) {
+        await handleSaveConflict(res)
+        return false
+    }
     if (!res.success) {
         reportSaveError(res)
         return false

--- a/VueApp/src/CMS/components/InlineFileUpload.vue
+++ b/VueApp/src/CMS/components/InlineFileUpload.vue
@@ -1,0 +1,329 @@
+<template>
+    <div>
+        <button
+            ref="dropZoneRef"
+            type="button"
+            class="inline-upload"
+            :class="{ 'inline-upload--over': isOverDropZone && !disabled }"
+            :disabled="disabled"
+            :aria-label="ariaLabel"
+            @click="activate"
+        >
+            <q-spinner
+                v-if="busy"
+                size="24px"
+                color="primary"
+            />
+            <q-icon
+                v-else
+                :name="folder ? 'upload_file' : 'block'"
+                size="24px"
+                class="inline-upload__icon"
+            />
+            <span class="inline-upload__text">
+                <template v-if="!folder">{{ disabledHint }}</template>
+                <template v-else>Drag a file here, or click to choose one. It uploads when you save.</template>
+            </span>
+        </button>
+
+        <!-- Files staged for upload on Save. Nothing is created on the server until the block is saved. -->
+        <div
+            v-for="item in staged"
+            :key="item.key"
+            class="staged-file q-mt-sm"
+        >
+            <div class="row items-center no-wrap">
+                <q-icon
+                    :name="item.conflict ? 'warning' : 'schedule'"
+                    :color="item.conflict ? 'warning' : 'grey-7'"
+                    size="xs"
+                    class="q-mr-sm"
+                />
+                <span class="col ellipsis">{{ item.file.name }}</span>
+                <q-btn
+                    flat
+                    dense
+                    size="sm"
+                    icon="close"
+                    color="negative"
+                    :aria-label="`Remove ${item.file.name}`"
+                    @click="removeStaged(item.key)"
+                >
+                    <q-tooltip>Remove</q-tooltip>
+                </q-btn>
+            </div>
+
+            <div
+                v-if="item.conflict"
+                class="staged-file__conflict"
+            >
+                <div class="text-caption text-warning">
+                    A file named "{{ item.file.name }}" already exists in {{ folder }}. Choose what to do:
+                </div>
+                <q-option-group
+                    v-model="item.action"
+                    :options="conflictOptions(item)"
+                    type="radio"
+                    dense
+                    class="q-mt-xs"
+                />
+            </div>
+        </div>
+
+        <StatusBanner
+            v-if="error"
+            type="error"
+            class="q-mt-sm"
+        >
+            {{ error }}
+        </StatusBanner>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, watch } from "vue"
+import { useDropZone, useFileDialog } from "@vueuse/core"
+import { useFetch } from "@/composables/ViperFetch"
+import StatusBanner from "@/components/StatusBanner.vue"
+import { CMS_ACCEPTED_EXTENSIONS } from "@/CMS/file-types"
+import type { CmsFile } from "@/CMS/types/"
+
+// Stages files for upload on the block's Save (nothing is created server-side until then), using the
+// block's own folder + permissions. On a name conflict the user picks per file: overwrite the
+// existing file, upload under a new name, or attach the existing file as-is (legacy's three options).
+const props = defineProps<{
+    folder: string | null
+    permissions: string[]
+    // Uploaded files inherit the block's public-access flag: a file on a public block must itself be
+    // publicly downloadable, or anonymous viewers get a broken/denied link.
+    allowPublicAccess?: boolean
+}>()
+
+const emit = defineEmits<{ "staged-count": [count: number] }>()
+
+const apiURL = inject("apiURL") + "cms/files/"
+const { get, postForm, putForm, del, createUrlSearchParams } = useFetch()
+
+type NameCheck = {
+    inUse: boolean
+    suggestedName: string
+    existingFileGuid: string | null
+    existingFriendlyName: string | null
+    existingDeleted: boolean
+}
+type StagedFile = {
+    key: string
+    file: File
+    conflict: NameCheck | null
+    action: "rename" | "overwrite" | "existing"
+}
+
+const dropZoneRef = ref<HTMLElement | null>(null)
+const staged = ref<StagedFile[]>([])
+const busy = ref(false)
+const error = ref("")
+let keyCounter = 0
+
+const disabled = computed(() => !props.folder || busy.value)
+const disabledHint = "Set a VIPER section path to upload files for this block."
+const ariaLabel = computed(() =>
+    props.folder ? "Add a file to upload when the block is saved, by clicking or dragging" : disabledHint,
+)
+
+watch(
+    () => staged.value.length,
+    (n) => emit("staged-count", n),
+)
+
+const { open: openFileDialog, onChange: onFileDialogChange } = useFileDialog({
+    accept: CMS_ACCEPTED_EXTENSIONS,
+    multiple: false,
+})
+onFileDialogChange((files) => stageFile(files?.[0]))
+const { isOverDropZone } = useDropZone(dropZoneRef, {
+    multiple: false,
+    onDrop: (files) => stageFile(files?.[0]),
+})
+
+function activate() {
+    if (disabled.value) return
+    openFileDialog()
+}
+
+function conflictOptions(item: StagedFile) {
+    const opts = [
+        { label: `Upload under a new name (${item.conflict!.suggestedName})`, value: "rename" },
+        { label: "Overwrite the existing file", value: "overwrite" },
+    ]
+    // "Use existing" only works when the conflict is a real file record we can attach.
+    if (item.conflict!.existingFileGuid) {
+        opts.push({ label: "Use the existing file instead (don't upload)", value: "existing" })
+    }
+    return opts
+}
+
+async function stageFile(file: File | null | undefined) {
+    if (!file || disabled.value) return
+    error.value = ""
+
+    // Drag-drop bypasses the picker's accept filter, so validate the extension ourselves.
+    const ext = "." + (file.name.split(".").pop() ?? "").toLowerCase()
+    if (!CMS_ACCEPTED_EXTENSIONS.split(",").includes(ext)) {
+        error.value = `Files of type ${ext} aren't allowed.`
+        return
+    }
+
+    busy.value = true
+    try {
+        const params = createUrlSearchParams({ folder: props.folder!, fileName: file.name })
+        const check = await get(apiURL + "check-name?" + params)
+        const conflict: NameCheck | null = check.success && check.result.inUse ? check.result : null
+        staged.value.push({ key: String(++keyCounter), file, conflict, action: "rename" })
+    } finally {
+        busy.value = false
+    }
+}
+
+function removeStaged(key: string) {
+    staged.value = staged.value.filter((s) => s.key !== key)
+}
+
+// Uploads (or resolves) every staged file per its chosen action. Returns the files to attach plus
+// the GUIDs that were newly created (new uploads/renames) so the parent can roll them back if the
+// block save then fails. Called as part of Save; throws on the first failure so the save aborts,
+// after rolling back files created earlier in the batch (soft delete, same as the parent's
+// rollbackFiles) so a partial failure doesn't strand new uploads attached to nothing.
+async function commit(): Promise<{ attached: CmsFile[]; createdGuids: string[] }> {
+    if (staged.value.length === 0) return { attached: [], createdGuids: [] }
+    busy.value = true
+    const attached: CmsFile[] = []
+    const createdGuids: string[] = []
+    try {
+        for (const item of staged.value) {
+            const { file, created } = await commitOne(item)
+            attached.push(file)
+            if (created) createdGuids.push(file.fileGuid)
+        }
+        staged.value = []
+        return { attached, createdGuids }
+    } catch (e) {
+        for (const guid of createdGuids) {
+            await del(apiURL + guid)
+        }
+        throw e
+    } finally {
+        busy.value = false
+    }
+}
+
+// Returns the resulting file and whether a NEW record was created (true = safe to roll back).
+async function commitOne(item: StagedFile): Promise<{ file: CmsFile; created: boolean }> {
+    // Attach the existing file without uploading anything - never roll this back, it pre-existed.
+    if (item.conflict && item.action === "existing" && item.conflict.existingFileGuid) {
+        const res = await get(apiURL + item.conflict.existingFileGuid)
+        if (!res.success) throw new Error(res.errors?.[0] ?? `Could not load ${item.conflict.existingFriendlyName}`)
+        return { file: res.result as CmsFile, created: false }
+    }
+
+    const data = new FormData()
+    data.append("file", item.file)
+    data.append("allowPublicAccess", String(props.allowPublicAccess ?? false))
+    for (const permission of props.permissions) {
+        data.append("permissions", permission)
+    }
+
+    // Overwrite replaces an existing record's content in place (legacy editFile), keeping its GUID.
+    // It is destructive to a pre-existing file and can't be un-done, so it is NOT rolled back.
+    if (item.conflict && item.action === "overwrite" && item.conflict.existingFileGuid) {
+        const res = await putForm(apiURL + item.conflict.existingFileGuid, data)
+        if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to overwrite ${item.file.name}`)
+        return { file: res.result as CmsFile, created: false }
+    }
+
+    // New record created (new upload, rename, or overwriting an orphaned on-disk file with no
+    // record); folder is required. This is safe to roll back on a failed save.
+    data.append("folder", props.folder!)
+    if (item.conflict && item.action === "overwrite") {
+        data.append("overwrite", "true")
+    } else if (item.conflict && item.action === "rename") {
+        data.append("fileName", item.conflict.suggestedName)
+    }
+    const res = await postForm(apiURL, data)
+    if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to upload ${item.file.name}`)
+    return { file: res.result as CmsFile, created: true }
+}
+
+defineExpose({ commit })
+</script>
+
+<style scoped>
+.inline-upload {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 16px;
+    text-align: center;
+    border: 2px dashed var(--q-primary);
+    border-radius: 4px;
+    background-color: transparent;
+    font: inherit;
+    color: var(--ucdavis-black-60);
+    cursor: pointer;
+    appearance: none;
+    transition:
+        box-shadow 0.15s ease,
+        border-style 0.15s ease;
+}
+
+/* Emphasise via the border/ring rather than a fill so the hint text keeps its AA
+   contrast against the dialog background in every state. */
+.inline-upload--over {
+    border-style: solid;
+    box-shadow: 0 0 0 2px var(--ucdavis-blue-20);
+}
+
+.inline-upload:focus-visible {
+    outline: none;
+    box-shadow:
+        0 0 0 0.1rem white,
+        0 0 0 0.25rem #258cfb;
+}
+
+.inline-upload:disabled {
+    border-color: var(--ucdavis-black-60);
+    cursor: not-allowed;
+    opacity: 0.85;
+}
+
+.inline-upload__icon {
+    color: var(--q-primary);
+}
+
+.inline-upload:disabled .inline-upload__icon {
+    color: var(--ucdavis-black-60);
+}
+
+.inline-upload__text {
+    font-size: 0.85rem;
+}
+
+.staged-file {
+    border: 1px solid var(--ucdavis-blue-20);
+    border-radius: 4px;
+    padding: 8px;
+}
+
+.staged-file__conflict {
+    margin-top: 4px;
+    padding-left: 24px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .inline-upload {
+        transition: none;
+    }
+}
+</style>

--- a/VueApp/src/CMS/components/InlineFileUpload.vue
+++ b/VueApp/src/CMS/components/InlineFileUpload.vue
@@ -81,6 +81,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; the upload logic is split into small helpers below.
+// fallow-ignore-file complexity
 import { computed, inject, ref, watch } from "vue"
 import { useDropZone, useFileDialog } from "@vueuse/core"
 import { useFetch } from "@/composables/ViperFetch"
@@ -216,32 +218,37 @@ async function commit(): Promise<{ attached: CmsFile[]; createdGuids: string[] }
     }
 }
 
-// Returns the resulting file and whether a NEW record was created (true = safe to roll back).
-async function commitOne(item: StagedFile): Promise<{ file: CmsFile; created: boolean }> {
-    // Attach the existing file without uploading anything - never roll this back, it pre-existed.
-    if (item.conflict && item.action === "existing" && item.conflict.existingFileGuid) {
-        const res = await get(apiURL + item.conflict.existingFileGuid)
-        if (!res.success) throw new Error(res.errors?.[0] ?? `Could not load ${item.conflict.existingFriendlyName}`)
-        return { file: res.result as CmsFile, created: false }
-    }
+type CommitResult = { file: CmsFile; created: boolean }
 
+// Attach the existing file without uploading anything - never rolled back, it pre-existed.
+async function attachExisting(item: StagedFile): Promise<CommitResult> {
+    const res = await get(apiURL + item.conflict!.existingFileGuid)
+    if (!res.success) throw new Error(res.errors?.[0] ?? `Could not load ${item.conflict!.existingFriendlyName}`)
+    return { file: res.result as CmsFile, created: false }
+}
+
+// Shared multipart body: the file plus the block's public-access flag and permissions.
+function buildUploadData(item: StagedFile): FormData {
     const data = new FormData()
     data.append("file", item.file)
     data.append("allowPublicAccess", String(props.allowPublicAccess ?? false))
     for (const permission of props.permissions) {
         data.append("permissions", permission)
     }
+    return data
+}
 
-    // Overwrite replaces an existing record's content in place (legacy editFile), keeping its GUID.
-    // It is destructive to a pre-existing file and can't be un-done, so it is NOT rolled back.
-    if (item.conflict && item.action === "overwrite" && item.conflict.existingFileGuid) {
-        const res = await putForm(apiURL + item.conflict.existingFileGuid, data)
-        if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to overwrite ${item.file.name}`)
-        return { file: res.result as CmsFile, created: false }
-    }
+// Overwrite replaces an existing record's content in place (legacy editFile), keeping its GUID.
+// It is destructive to a pre-existing file and can't be un-done, so it is NOT rolled back.
+async function overwriteInPlace(item: StagedFile, data: FormData): Promise<CommitResult> {
+    const res = await putForm(apiURL + item.conflict!.existingFileGuid, data)
+    if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to overwrite ${item.file.name}`)
+    return { file: res.result as CmsFile, created: false }
+}
 
-    // New record created (new upload, rename, or overwriting an orphaned on-disk file with no
-    // record); folder is required. This is safe to roll back on a failed save.
+// New record created (new upload, rename, or overwriting an orphaned on-disk file with no
+// record); folder is required. This is safe to roll back on a failed save.
+async function uploadNew(item: StagedFile, data: FormData): Promise<CommitResult> {
     data.append("folder", props.folder!)
     if (item.conflict && item.action === "overwrite") {
         data.append("overwrite", "true")
@@ -251,6 +258,18 @@ async function commitOne(item: StagedFile): Promise<{ file: CmsFile; created: bo
     const res = await postForm(apiURL, data)
     if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to upload ${item.file.name}`)
     return { file: res.result as CmsFile, created: true }
+}
+
+// Returns the resulting file and whether a NEW record was created (true = safe to roll back).
+async function commitOne(item: StagedFile): Promise<CommitResult> {
+    if (item.conflict && item.action === "existing" && item.conflict.existingFileGuid) {
+        return attachExisting(item)
+    }
+    const data = buildUploadData(item)
+    if (item.conflict && item.action === "overwrite" && item.conflict.existingFileGuid) {
+        return overwriteInPlace(item, data)
+    }
+    return uploadNew(item, data)
 }
 
 defineExpose({ commit })

--- a/VueApp/src/CMS/components/InlineFileUpload.vue
+++ b/VueApp/src/CMS/components/InlineFileUpload.vue
@@ -282,11 +282,11 @@ defineExpose({ commit })
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 4px;
-    padding: 16px;
+    gap: 0.25rem;
+    padding: 1rem;
     text-align: center;
     border: 2px dashed var(--q-primary);
-    border-radius: 4px;
+    border-radius: 0.25rem;
     background-color: transparent;
     font: inherit;
     color: var(--ucdavis-black-60);
@@ -308,7 +308,7 @@ defineExpose({ commit })
     outline: none;
     box-shadow:
         0 0 0 0.1rem white,
-        0 0 0 0.25rem #258cfb;
+        0 0 0 0.25rem var(--focus-ring-color);
 }
 
 .inline-upload:disabled {

--- a/VueApp/src/CMS/components/InlineFileUpload.vue
+++ b/VueApp/src/CMS/components/InlineFileUpload.vue
@@ -11,13 +11,13 @@
         >
             <q-spinner
                 v-if="busy"
-                size="24px"
+                size="sm"
                 color="primary"
             />
             <q-icon
                 v-else
                 :name="folder ? 'upload_file' : 'block'"
-                size="24px"
+                size="sm"
                 class="inline-upload__icon"
             />
             <span class="inline-upload__text">
@@ -331,13 +331,13 @@ defineExpose({ commit })
 
 .staged-file {
     border: 1px solid var(--ucdavis-blue-20);
-    border-radius: 4px;
-    padding: 8px;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
 }
 
 .staged-file__conflict {
-    margin-top: 4px;
-    padding-left: 24px;
+    margin-top: 0.25rem;
+    padding-left: 1.5rem;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/VueApp/src/CMS/components/Link.vue
+++ b/VueApp/src/CMS/components/Link.vue
@@ -57,10 +57,13 @@ const props = defineProps<{
 const hrefForLink = computed(() => safeHref(props.link.url))
 const isSafe = computed(() => hrefForLink.value !== "#")
 
-// Each tag category's sortOrder (1-based) indexes this palette of Quasar brand
-// roles. StatusBadge derives the WCAG-AA text color for each (dark on the light
-// warning/info tints, white on the rest).
-const TAG_COLORS = ["warning", "secondary", "negative", "positive", "info", "primary"] as const
+// Each tag category's sortOrder (1-based) indexes this categorical palette. It is
+// built from non-semantic brand roles only (Aggie Blue, the secondary-palette
+// arboretum/cabernet accents, Blue 70, and Ink) so status colors — positive,
+// negative, warning, info — keep their meaning and never read as a tag category.
+// StatusBadge derives the WCAG-AA text color for each (dark on arboretum, white
+// on the rest).
+const TAG_COLORS = ["primary", "arboretum", "cabernet", "secondary", "dark"] as const
 
 function getTagColor(order: number) {
     const idx = order >= 1 ? (order - 1) % TAG_COLORS.length : 0

--- a/VueApp/src/CMS/components/Link.vue
+++ b/VueApp/src/CMS/components/Link.vue
@@ -31,14 +31,13 @@
                     v-for="tag in props.link.linkTags"
                     :key="tag.linkTagId"
                 >
-                    <q-badge
+                    <StatusBadge
                         v-if="tag.linkCollectionTagCategoryId == lct.linkCollectionTagCategoryId"
-                        :color="getTagStyle(lct.sortOrder).color"
-                        :text-color="getTagStyle(lct.sortOrder).textColor"
-                        class="link-tag q-px-sm"
+                        :color="getTagColor(lct.sortOrder)"
+                        class="q-px-sm q-mr-xs"
                     >
                         {{ tag.value }}
-                    </q-badge>
+                    </StatusBadge>
                 </template>
             </template>
         </q-card-section>
@@ -49,6 +48,7 @@
 import { computed } from "vue"
 import type { Link, LinkCollection } from "@/CMS/types"
 import { safeHref } from "@/CMS/utils/url"
+import StatusBadge from "@/components/StatusBadge.vue"
 const props = defineProps<{
     link: Link
     linkCollection: LinkCollection
@@ -57,35 +57,25 @@ const props = defineProps<{
 const hrefForLink = computed(() => safeHref(props.link.url))
 const isSafe = computed(() => hrefForLink.value !== "#")
 
-// Each tag category's sortOrder (1-based) indexes this palette. Gold and Tahoe
-// are light enough to require dark text for WCAG AA contrast (≥4.5:1).
-const TAG_STYLES: ReadonlyArray<{ color: string; textColor: string }> = [
-    { color: "warning", textColor: "dark" },
-    { color: "secondary", textColor: "white" },
-    { color: "negative", textColor: "white" },
-    { color: "positive", textColor: "white" },
-    { color: "info", textColor: "dark" },
-    { color: "primary", textColor: "white" },
-]
+// Each tag category's sortOrder (1-based) indexes this palette of Quasar brand
+// roles. StatusBadge derives the WCAG-AA text color for each (dark on the light
+// warning/info tints, white on the rest).
+const TAG_COLORS = ["warning", "secondary", "negative", "positive", "info", "primary"] as const
 
-function getTagStyle(order: number) {
-    const idx = order >= 1 ? (order - 1) % TAG_STYLES.length : 0
-    return TAG_STYLES[idx]!
+function getTagColor(order: number) {
+    const idx = order >= 1 ? (order - 1) % TAG_COLORS.length : 0
+    return TAG_COLORS[idx]
 }
 </script>
 
 <style scoped>
 .link-card {
-    max-width: 350px;
+    max-width: 21.875rem;
     width: 100%;
 }
 
 .link-card a {
     text-decoration: none;
     color: inherit;
-}
-
-.link-tag {
-    margin-right: 2px;
 }
 </style>

--- a/VueApp/src/CMS/components/LinkCollections.vue
+++ b/VueApp/src/CMS/components/LinkCollections.vue
@@ -250,13 +250,13 @@ function applyFilters() {
     }
 }
 
-watch(
-    tagFilters,
-    () => {
-        applyFilters()
-    },
-    { deep: true },
-)
+// Re-filter only when a selection or the search term changes. Watching the
+// mapped selected values (not the whole tagFilters tree) avoids re-running
+// applyFilters for every option pushed onto a filter during loadFilters.
+const selectedTagValues = computed(() => tagFilters.value.map((tf) => tf.selected))
+watch(selectedTagValues, () => {
+    applyFilters()
+})
 watch(search, () => {
     applyFilters()
 })

--- a/VueApp/src/CMS/components/LinkCollections.vue
+++ b/VueApp/src/CMS/components/LinkCollections.vue
@@ -17,8 +17,7 @@
             v-model="filtersExpandedComputed"
             icon="filter_list"
             label="Filters"
-            header-class="bg-grey-2 lt-md"
-            :header-style="$q.screen.gt.xs ? 'display: none' : ''"
+            header-class="bg-grey-2 lt-sm"
             class="q-mb-md"
         >
             <q-form>
@@ -81,27 +80,25 @@
             </div>
         </template>
         <template v-else-if="linkCollection != null">
-            <div
-                class="q-pa-md row q-gutter-md"
+            <template
                 v-for="groupBy in groupByValues"
                 :key="groupBy"
             >
                 <div
-                    class="col-12"
-                    v-if="getInGroup(filteredLinks, groupBy).length > 0"
+                    v-if="(groupedLinks.get(groupBy)?.length ?? 0) > 0"
+                    class="q-pa-md row q-gutter-md"
                 >
-                    <h3 class="q-mt-lg q-mb-sm">{{ groupBy }}</h3>
-                </div>
-                <template
-                    v-for="li in getInGroup(filteredLinks, groupBy)"
-                    :key="li.linkId"
-                >
+                    <div class="col-12">
+                        <h3 class="q-mt-lg q-mb-sm">{{ groupBy }}</h3>
+                    </div>
                     <LinkComponent
+                        v-for="li in groupedLinks.get(groupBy)"
+                        :key="li.linkId"
                         :link="li"
                         :link-collection="linkCollection"
-                    ></LinkComponent>
-                </template>
-            </div>
+                    />
+                </div>
+            </template>
         </template>
     </template>
 </template>
@@ -149,7 +146,7 @@ async function getLinkCollection() {
     const { get } = useFetch()
     const baseUrl = import.meta.env.VITE_API_URL + "cms/linkcollections/"
     const r = await get(baseUrl + "?linkCollectionName=" + encodeURIComponent(props.linkCollectionName))
-    linkCollection.value = r.result[0] as LinkCollection
+    linkCollection.value = r.success && Array.isArray(r.result) ? ((r.result[0] as LinkCollection) ?? null) : null
     if (linkCollection.value) {
         await loadLinks(linkCollection.value.linkCollectionId)
         await loadFilters()
@@ -171,7 +168,7 @@ async function loadLinks(collectionId: number) {
 
 function loadFilters() {
     if (linkCollection.value !== null) {
-        for (var tagCat of linkCollection.value.linkCollectionTagCategories) {
+        for (const tagCat of linkCollection.value.linkCollectionTagCategories) {
             tagFilters.value.push({
                 linkCollectionTagCategoryId: tagCat.linkCollectionTagCategoryId,
                 linkCollectionTagCategory: tagCat.linkCollectionTagCategory,
@@ -179,19 +176,21 @@ function loadFilters() {
                 selected: null,
             })
         }
-        for (var l of links.value) {
-            for (var lt of l.linkTags) {
-                var t = tagFilters.value.find((t) => t.linkCollectionTagCategoryId === lt.linkCollectionTagCategoryId)
-                if (t) {
-                    t.options.push(lt.value)
+        for (const l of links.value) {
+            for (const lt of l.linkTags) {
+                const filter = tagFilters.value.find(
+                    (f) => f.linkCollectionTagCategoryId === lt.linkCollectionTagCategoryId,
+                )
+                if (filter) {
+                    filter.options.push(lt.value)
                 }
             }
         }
-        for (var tf of tagFilters.value) {
+        for (const tf of tagFilters.value) {
             tf.options = tf.options.sort()
         }
 
-        for (var tagOptions of tagFilters.value) {
+        for (const tagOptions of tagFilters.value) {
             tagOptions.options = [...new Set(tagOptions.options)]
             if (
                 props.groupByTagCategory !== null &&
@@ -204,21 +203,32 @@ function loadFilters() {
     }
 }
 
-function getInGroup(linksIn: Link[], groupByValue: string) {
-    if (props.groupByTagCategory === null || props.groupByTagCategory.length === 0 || groupById.value === null) {
-        return linksIn
+// Bucket the filtered links by their value in the group-by category once per render,
+// so the template does an O(1) Map.get per group instead of re-filtering every link
+// (twice) for every group.
+const groupedLinks = computed(() => {
+    const buckets = new Map<string, Link[]>()
+    if (groupById.value === null) {
+        return buckets
     }
-    return linksIn.filter((l) => {
-        const findTag = l.linkTags.find((lt) => {
-            return lt.linkCollectionTagCategoryId === groupById.value && lt.value === groupByValue
-        })
-        return findTag !== undefined
-    })
-}
+    for (const value of groupByValues.value) {
+        buckets.set(value, [])
+    }
+    for (const link of filteredLinks.value) {
+        const seen = new Set<string>()
+        for (const tag of link.linkTags) {
+            if (tag.linkCollectionTagCategoryId === groupById.value && !seen.has(tag.value)) {
+                seen.add(tag.value)
+                buckets.get(tag.value)?.push(link)
+            }
+        }
+    }
+    return buckets
+})
 
 function applyFilters() {
     filteredLinks.value = links.value
-    for (var tf of tagFilters.value) {
+    for (const tf of tagFilters.value) {
         if (tf.selected !== null && tf.selected !== "") {
             filteredLinks.value = filteredLinks.value.filter((fl: Link) => {
                 const findTag = fl.linkTags.find((lt: LinkTag) => {
@@ -253,19 +263,3 @@ watch(search, () => {
 
 getLinkCollection()
 </script>
-
-<style scoped>
-.link-card {
-    max-width: 350px;
-    width: 100%;
-}
-
-.link-card a {
-    text-decoration: none;
-    color: inherit;
-}
-
-.link-tag {
-    margin-right: 2px;
-}
-</style>

--- a/VueApp/src/CMS/components/LinkCollections.vue
+++ b/VueApp/src/CMS/components/LinkCollections.vue
@@ -162,7 +162,7 @@ async function loadLinks(collectionId: number) {
     }
 
     const r = await get(baseUrl)
-    links.value = r.result as Link[]
+    links.value = r.success && Array.isArray(r.result) ? (r.result as Link[]) : []
     filteredLinks.value = links.value
 }
 

--- a/VueApp/src/CMS/components/PermissionChips.vue
+++ b/VueApp/src/CMS/components/PermissionChips.vue
@@ -1,40 +1,42 @@
 <template>
-    <template v-if="permissions.length || peopleCount > 0">
-        <q-chip
-            v-for="p in permissions.slice(0, maxShown)"
-            :key="p"
-            dense
-            square
-            size="sm"
+    <div :class="stacked ? 'column items-start chips-stacked' : ''">
+        <template v-if="permissions.length || peopleCount > 0">
+            <q-chip
+                v-for="p in permissions.slice(0, maxShown)"
+                :key="p"
+                dense
+                square
+                size="sm"
+            >
+                {{ p }}
+            </q-chip>
+            <q-chip
+                v-if="permissions.length > maxShown"
+                dense
+                square
+                size="sm"
+                color="grey-4"
+            >
+                +{{ permissions.length - maxShown }} more
+            </q-chip>
+            <q-chip
+                v-if="peopleCount > 0"
+                dense
+                square
+                size="sm"
+                icon="person"
+                color="grey-4"
+            >
+                {{ peopleCount }}
+            </q-chip>
+        </template>
+        <span
+            v-else
+            class="text-grey-7"
         >
-            {{ p }}
-        </q-chip>
-        <q-chip
-            v-if="permissions.length > maxShown"
-            dense
-            square
-            size="sm"
-            color="grey-4"
-        >
-            +{{ permissions.length - maxShown }} more
-        </q-chip>
-        <q-chip
-            v-if="peopleCount > 0"
-            dense
-            square
-            size="sm"
-            icon="person"
-            color="grey-4"
-        >
-            {{ peopleCount }}
-        </q-chip>
-    </template>
-    <span
-        v-else
-        class="text-grey-7"
-    >
-        All VIPER users
-    </span>
+            All VIPER users
+        </span>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -43,7 +45,18 @@ withDefaults(
         permissions: string[]
         peopleCount?: number
         maxShown?: number
+        // Stack chips vertically (for narrow table columns) instead of flowing inline.
+        stacked?: boolean
     }>(),
-    { peopleCount: 0, maxShown: 2 },
+    { peopleCount: 0, maxShown: 2, stacked: false },
 )
 </script>
+
+<style scoped>
+/* When stacked, drop the chips' horizontal margins so they sit flush-left
+   and tighten the vertical rhythm. */
+.chips-stacked .q-chip {
+    margin-left: 0;
+    margin-right: 0;
+}
+</style>

--- a/VueApp/src/CMS/components/RecentActivity.vue
+++ b/VueApp/src/CMS/components/RecentActivity.vue
@@ -1,6 +1,8 @@
 <template>
     <section aria-label="Recent activity">
-        <h2 class="text-h6 text-primary q-my-none">Recent activity</h2>
+        <!-- Bare h2: the compressed-heading rule renders it 1.2rem bold, matching the hub's
+             primary card title (text-h6 would drop it to 1rem regular, weaker than the rows). -->
+        <h2 class="text-primary q-my-none">Recent activity</h2>
 
         <template v-if="loading">
             <q-skeleton
@@ -100,20 +102,26 @@ function formatFullDate(value: string): string {
 }
 
 async function loadBlocks(): Promise<ActivityItem[]> {
-    const res = await get(apiURL + "CMS/content?" + createUrlSearchParams({ status: "active" }))
+    // Sort/limit server-side like loadFiles: sorting a default page client-side would only
+    // ever surface the recent-most of the first alphabetical page of blocks.
+    const params = createUrlSearchParams({
+        status: "active",
+        page: 1,
+        perPage: PER_SOURCE,
+        sortBy: "modifiedOn",
+        descending: "true",
+    })
+    const res = await get(apiURL + "CMS/content?" + params)
     if (!res.success) throw new Error("blocks")
-    return [...((res.result ?? []) as CmsContentBlock[])]
-        .sort((a, b) => new Date(b.modifiedOn).getTime() - new Date(a.modifiedOn).getTime())
-        .slice(0, PER_SOURCE)
-        .map((b) => ({
-            key: "block-" + b.contentBlockId,
-            icon: "article",
-            typeLabel: "Content block",
-            label: b.title || b.friendlyName || "(untitled)",
-            to: { name: "CmsContentBlockEdit", params: { id: b.contentBlockId } },
-            modifiedOn: b.modifiedOn,
-            modifiedBy: b.modifiedBy,
-        }))
+    return ((res.result ?? []) as CmsContentBlock[]).map((b) => ({
+        key: "block-" + b.contentBlockId,
+        icon: "article",
+        typeLabel: "Content block",
+        label: b.title || b.friendlyName || "(untitled)",
+        to: { name: "CmsContentBlockEdit", params: { id: b.contentBlockId } },
+        modifiedOn: b.modifiedOn,
+        modifiedBy: b.modifiedBy,
+    }))
 }
 
 async function loadFiles(): Promise<ActivityItem[]> {

--- a/VueApp/src/CMS/components/RecentActivity.vue
+++ b/VueApp/src/CMS/components/RecentActivity.vue
@@ -31,56 +31,11 @@
             v-else
             dense
         >
-            <q-item
+            <ActivityRow
                 v-for="item in items"
                 :key="item.key"
-                clickable
-                :to="item.to"
-                class="q-px-none"
-            >
-                <q-item-section side>
-                    <q-icon
-                        :name="item.icon"
-                        :aria-label="item.typeLabel"
-                        color="secondary"
-                        size="sm"
-                    />
-                </q-item-section>
-                <q-item-section>
-                    <q-item-label lines="1">{{ item.label }}</q-item-label>
-                    <q-item-label
-                        caption
-                        :title="formatFullDate(item.modifiedOn)"
-                    >
-                        {{ item.typeLabel }} &middot; {{ item.verb ? item.verb + " " : ""
-                        }}{{ formatTimeAgo(new Date(item.modifiedOn)) }} by
-                        {{ item.modifiedBy }}
-                    </q-item-label>
-                </q-item-section>
-                <q-item-section
-                    v-if="item.actions?.length"
-                    side
-                    class="activity-actions"
-                >
-                    <div class="row no-wrap">
-                        <q-btn
-                            v-for="action in item.actions"
-                            :key="action.icon"
-                            flat
-                            dense
-                            round
-                            size="sm"
-                            color="primary"
-                            :icon="action.icon"
-                            :aria-label="action.label"
-                            :to="action.to"
-                            @click.stop="runAction(action, $event)"
-                        >
-                            <q-tooltip>{{ action.label }}</q-tooltip>
-                        </q-btn>
-                    </div>
-                </q-item-section>
-            </q-item>
+                :item="item"
+            />
         </q-list>
 
         <ContentDiffDialog
@@ -98,16 +53,18 @@
 <script setup lang="ts">
 import { inject, onMounted, ref } from "vue"
 import { useQuasar } from "quasar"
-import { formatTimeAgo } from "@vueuse/core"
 import { useFetch } from "@/composables/ViperFetch"
 import { useContentDiffViewer } from "@/CMS/composables/use-content-diff-viewer"
+import ActivityRow from "@/CMS/components/ActivityRow.vue"
 import ContentDiffDialog from "@/CMS/components/ContentDiffDialog.vue"
 import type {
+    ActivityItem,
     CmsContentBlock,
     CmsContentHistoryAudit,
     CmsContentHistoryDiff,
     CmsFile,
     CmsLeftNavMenu,
+    RailAction,
 } from "@/CMS/types/"
 
 const MAX_ITEMS = 8
@@ -123,26 +80,6 @@ const {
     showLeftNavs?: boolean
 }>()
 
-type RailAction = {
-    icon: string
-    label: string
-    to?: { name: string; query?: Record<string, string> }
-    run?: () => void
-}
-
-type ActivityItem = {
-    key: string
-    icon: string
-    typeLabel: string
-    // Rendered before the time-ago stamp (e.g. "deleted 2 days ago"); empty means plain recency.
-    verb?: string
-    label: string
-    to: { name: string; params?: Record<string, string | number>; query?: Record<string, string> }
-    modifiedOn: string
-    modifiedBy: string
-    actions?: RailAction[]
-}
-
 const $q = useQuasar()
 const apiURL = inject("apiURL")
 const { get, post, createUrlSearchParams } = useFetch()
@@ -151,19 +88,6 @@ const { viewer, openViewer, applyDiff, closeViewer, failViewer, diffStamp } = us
 const loading = ref(true)
 const failed = ref(false)
 const items = ref<ActivityItem[]>([])
-
-function formatFullDate(value: string): string {
-    return new Date(value).toLocaleString()
-}
-
-// Row-level navigation must not fire for action clicks (`.stop` in the template). Actions with
-// their own `to` navigate via QBtn; only run-actions preventDefault, both to keep the row's
-// anchor inert and because a prevented default makes QBtn cancel its router navigation.
-function runAction(action: RailAction, event: Event) {
-    if (!action.run) return
-    event.preventDefault()
-    action.run()
-}
 
 // History rows hold only superseded versions, and the GET diff endpoint compares two of them —
 // so the block's latest change (newest history row -> live content) needs the POST diff with
@@ -331,38 +255,3 @@ onMounted(() => {
     void loadActivity()
 })
 </script>
-
-<style scoped>
-/* Keep the two icon actions from inflating the dense rows; the buttons carry their own
-   padding and get the standard 44px targets on coarse pointers via base.css. */
-.activity-actions {
-    padding-left: 0;
-}
-
-/* Quiet the rail: row actions fade in on row hover or keyboard focus. Opacity (not display)
-   keeps the buttons in the layout and the tab order, so rows never shift and focus reveals
-   them for keyboard users. */
-.activity-actions .q-btn {
-    opacity: 0;
-    transition: opacity 0.15s ease-out;
-}
-
-.q-item:hover .activity-actions .q-btn,
-.q-item:focus-within .activity-actions .q-btn {
-    opacity: 1;
-}
-
-/* No hover on touch: keep the actions always visible so they don't need a discovery tap
-   that would fight the row's own navigation. */
-@media (pointer: coarse) {
-    .activity-actions .q-btn {
-        opacity: 1;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .activity-actions .q-btn {
-        transition: none;
-    }
-}
-</style>

--- a/VueApp/src/CMS/components/RecentActivity.vue
+++ b/VueApp/src/CMS/components/RecentActivity.vue
@@ -52,20 +52,63 @@
                         caption
                         :title="formatFullDate(item.modifiedOn)"
                     >
-                        {{ item.typeLabel }} &middot; {{ formatTimeAgo(new Date(item.modifiedOn)) }} by
+                        {{ item.typeLabel }} &middot; {{ item.verb ? item.verb + " " : ""
+                        }}{{ formatTimeAgo(new Date(item.modifiedOn)) }} by
                         {{ item.modifiedBy }}
                     </q-item-label>
                 </q-item-section>
+                <q-item-section
+                    v-if="item.actions?.length"
+                    side
+                    class="activity-actions"
+                >
+                    <div class="row no-wrap">
+                        <q-btn
+                            v-for="action in item.actions"
+                            :key="action.icon"
+                            flat
+                            dense
+                            round
+                            size="sm"
+                            color="primary"
+                            :icon="action.icon"
+                            :aria-label="action.label"
+                            :to="action.to"
+                            @click.stop="runAction(action, $event)"
+                        >
+                            <q-tooltip>{{ action.label }}</q-tooltip>
+                        </q-btn>
+                    </div>
+                </q-item-section>
             </q-item>
         </q-list>
+
+        <ContentDiffDialog
+            v-model="viewer.open"
+            :loading="viewer.loading"
+            :title="viewer.title"
+            :subtitle="viewer.subtitle"
+            :diff-html="viewer.content"
+            :has-comparison="viewer.hasComparison"
+            :has-changes="viewer.hasChanges"
+        />
     </section>
 </template>
 
 <script setup lang="ts">
 import { inject, onMounted, ref } from "vue"
+import { useQuasar } from "quasar"
 import { formatTimeAgo } from "@vueuse/core"
 import { useFetch } from "@/composables/ViperFetch"
-import type { CmsContentBlock, CmsFile, CmsLeftNavMenu } from "@/CMS/types/"
+import { useContentDiffViewer } from "@/CMS/composables/use-content-diff-viewer"
+import ContentDiffDialog from "@/CMS/components/ContentDiffDialog.vue"
+import type {
+    CmsContentBlock,
+    CmsContentHistoryAudit,
+    CmsContentHistoryDiff,
+    CmsFile,
+    CmsLeftNavMenu,
+} from "@/CMS/types/"
 
 const MAX_ITEMS = 8
 const PER_SOURCE = 5
@@ -80,18 +123,30 @@ const {
     showLeftNavs?: boolean
 }>()
 
+type RailAction = {
+    icon: string
+    label: string
+    to?: { name: string; query?: Record<string, string> }
+    run?: () => void
+}
+
 type ActivityItem = {
     key: string
     icon: string
     typeLabel: string
+    // Rendered before the time-ago stamp (e.g. "deleted 2 days ago"); empty means plain recency.
+    verb?: string
     label: string
     to: { name: string; params?: Record<string, string | number>; query?: Record<string, string> }
     modifiedOn: string
     modifiedBy: string
+    actions?: RailAction[]
 }
 
+const $q = useQuasar()
 const apiURL = inject("apiURL")
-const { get, createUrlSearchParams } = useFetch()
+const { get, post, createUrlSearchParams } = useFetch()
+const { viewer, openViewer, applyDiff, closeViewer, failViewer, diffStamp } = useContentDiffViewer()
 
 const loading = ref(true)
 const failed = ref(false)
@@ -99,6 +154,52 @@ const items = ref<ActivityItem[]>([])
 
 function formatFullDate(value: string): string {
     return new Date(value).toLocaleString()
+}
+
+// Row-level navigation must not fire for action clicks (`.stop` in the template). Actions with
+// their own `to` navigate via QBtn; only run-actions preventDefault, both to keep the row's
+// anchor inert and because a prevented default makes QBtn cancel its router navigation.
+function runAction(action: RailAction, event: Event) {
+    if (!action.run) return
+    event.preventDefault()
+    action.run()
+}
+
+// History rows hold only superseded versions, and the GET diff endpoint compares two of them —
+// so the block's latest change (newest history row -> live content) needs the POST diff with
+// the current content, exactly like the editor's compare-against-draft flow.
+async function openLatestDiff(b: CmsContentBlock, label: string) {
+    openViewer(label)
+    const listParams = createUrlSearchParams({ contentBlockId: b.contentBlockId, page: 1, perPage: 1 })
+    const [blockRes, listRes] = await Promise.all([
+        get(apiURL + "CMS/content/" + b.contentBlockId),
+        get(apiURL + "CMS/content/history?" + listParams),
+    ])
+    const previous = ((listRes.result ?? []) as CmsContentHistoryAudit[])[0]
+    if (listRes.success && !previous) {
+        closeViewer()
+        $q.notify({ type: "info", message: "No edit history for this block yet." })
+        return
+    }
+    if (!listRes.success || !blockRes.success) {
+        failViewer("Failed to load the latest change")
+        return
+    }
+    const res = await post(
+        apiURL + "CMS/content/" + b.contentBlockId + "/history/" + previous.contentHistoryId + "/diff",
+        {
+            content: (blockRes.result as CmsContentBlock).content,
+        },
+    )
+    if (res.success) {
+        const diff = res.result as CmsContentHistoryDiff
+        applyDiff(
+            diff,
+            `Changes from ${diffStamp(diff.oldModifiedOn, diff.oldModifiedBy)} to ${diffStamp(b.modifiedOn, b.modifiedBy)}`,
+        )
+    } else {
+        failViewer(res.errors?.[0] ?? "Failed to load the latest change")
+    }
 }
 
 async function loadBlocks(): Promise<ActivityItem[]> {
@@ -113,15 +214,38 @@ async function loadBlocks(): Promise<ActivityItem[]> {
     })
     const res = await get(apiURL + "CMS/content?" + params)
     if (!res.success) throw new Error("blocks")
-    return ((res.result ?? []) as CmsContentBlock[]).map((b) => ({
-        key: "block-" + b.contentBlockId,
-        icon: "article",
-        typeLabel: "Content block",
-        label: b.title || b.friendlyName || "(untitled)",
-        to: { name: "CmsContentBlockEdit", params: { id: b.contentBlockId } },
-        modifiedOn: b.modifiedOn,
-        modifiedBy: b.modifiedBy,
-    }))
+    return ((res.result ?? []) as CmsContentBlock[]).map((b) => {
+        const label = b.title || b.friendlyName || "(untitled)"
+        return {
+            key: "block-" + b.contentBlockId,
+            icon: "article",
+            typeLabel: "Content block",
+            label,
+            to: { name: "CmsContentBlockEdit", params: { id: b.contentBlockId } },
+            modifiedOn: b.modifiedOn,
+            modifiedBy: b.modifiedBy,
+            actions: [
+                {
+                    icon: "difference",
+                    label: "View latest change",
+                    run: () => void openLatestDiff(b, label),
+                },
+                {
+                    icon: "history",
+                    label: "View edit history",
+                    to: { name: "CmsContentBlockHistory", query: { contentBlockId: String(b.contentBlockId) } },
+                },
+            ],
+        }
+    })
+}
+
+function fileAuditAction(fileGuid: string): RailAction {
+    return {
+        icon: "fact_check",
+        label: "View audit trail",
+        to: { name: "CmsFileAudit", query: { fileGuid } },
+    }
 }
 
 async function loadFiles(): Promise<ActivityItem[]> {
@@ -142,6 +266,31 @@ async function loadFiles(): Promise<ActivityItem[]> {
         to: { name: "CmsFiles", query: { search: f.friendlyName } },
         modifiedOn: f.modifiedOn,
         modifiedBy: f.modifiedBy,
+        actions: [fileAuditAction(f.fileGuid)],
+    }))
+}
+
+async function loadDeletedFiles(): Promise<ActivityItem[]> {
+    const params = createUrlSearchParams({
+        status: "deleted",
+        page: 1,
+        perPage: PER_SOURCE,
+        sortBy: "deletedOn",
+        descending: "true",
+    })
+    const res = await get(apiURL + "cms/files/?" + params)
+    if (!res.success) throw new Error("deletedFiles")
+    return ((res.result ?? []) as CmsFile[]).map((f) => ({
+        key: "trash-" + f.fileGuid,
+        icon: "delete",
+        typeLabel: "File",
+        verb: "deleted",
+        label: f.friendlyName,
+        to: { name: "CmsFiles", query: { status: "deleted", search: f.friendlyName } },
+        // Soft delete stamps ModifiedOn/ModifiedBy alongside DeletedOn, so the deleter is correct.
+        modifiedOn: f.deletedOn ?? f.modifiedOn,
+        modifiedBy: f.modifiedBy,
+        actions: [fileAuditAction(f.fileGuid)],
     }))
 }
 
@@ -166,7 +315,7 @@ async function loadLeftNavs(): Promise<ActivityItem[]> {
 async function loadActivity() {
     const sources = [
         ...(showBlocks ? [loadBlocks()] : []),
-        ...(showFiles ? [loadFiles()] : []),
+        ...(showFiles ? [loadFiles(), loadDeletedFiles()] : []),
         ...(showLeftNavs ? [loadLeftNavs()] : []),
     ]
     const results = await Promise.allSettled(sources)
@@ -182,3 +331,38 @@ onMounted(() => {
     void loadActivity()
 })
 </script>
+
+<style scoped>
+/* Keep the two icon actions from inflating the dense rows; the buttons carry their own
+   padding and get the standard 44px targets on coarse pointers via base.css. */
+.activity-actions {
+    padding-left: 0;
+}
+
+/* Quiet the rail: row actions fade in on row hover or keyboard focus. Opacity (not display)
+   keeps the buttons in the layout and the tab order, so rows never shift and focus reveals
+   them for keyboard users. */
+.activity-actions .q-btn {
+    opacity: 0;
+    transition: opacity 0.15s ease-out;
+}
+
+.q-item:hover .activity-actions .q-btn,
+.q-item:focus-within .activity-actions .q-btn {
+    opacity: 1;
+}
+
+/* No hover on touch: keep the actions always visible so they don't need a discovery tap
+   that would fight the row's own navigation. */
+@media (pointer: coarse) {
+    .activity-actions .q-btn {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .activity-actions .q-btn {
+        transition: none;
+    }
+}
+</style>

--- a/VueApp/src/CMS/components/RecentActivity.vue
+++ b/VueApp/src/CMS/components/RecentActivity.vue
@@ -34,7 +34,6 @@
                 :key="item.key"
                 clickable
                 :to="item.to"
-                role="link"
                 class="q-px-none"
             >
                 <q-item-section side>

--- a/VueApp/src/CMS/components/StatusIcon.vue
+++ b/VueApp/src/CMS/components/StatusIcon.vue
@@ -2,6 +2,7 @@
     <q-icon
         :name="icon"
         :color="color"
+        aria-hidden="true"
     >
         <q-tooltip>{{ label }}</q-tooltip>
     </q-icon>

--- a/VueApp/src/CMS/composables/use-content-diff-viewer.ts
+++ b/VueApp/src/CMS/composables/use-content-diff-viewer.ts
@@ -1,0 +1,68 @@
+import { ref } from "vue"
+import { useQuasar } from "quasar"
+import { useDateFunctions } from "@/composables/DateFunctions"
+import type { CmsContentHistoryDiff } from "@/CMS/types/"
+
+// Shared state and helpers for every ContentDiffDialog consumer (history page, block editor,
+// recent-activity rail): one open/reset shape, one way to apply a diff response, one error
+// path, and the shared "date by author" stamp wording for subtitles.
+export function useContentDiffViewer() {
+    const $q = useQuasar()
+    const { formatDateTime } = useDateFunctions()
+
+    const viewer = ref({
+        open: false,
+        loading: false,
+        title: "",
+        subtitle: "",
+        content: "",
+        hasComparison: true,
+        hasChanges: true,
+    })
+
+    function openViewer(title: string) {
+        viewer.value = {
+            open: true,
+            loading: true,
+            title,
+            subtitle: "",
+            content: "",
+            hasComparison: true,
+            hasChanges: true,
+        }
+    }
+
+    function applyDiff(diff: CmsContentHistoryDiff, subtitle: string) {
+        viewer.value.content = diff.content
+        viewer.value.hasComparison = diff.hasComparison
+        viewer.value.hasChanges = diff.hasChanges
+        viewer.value.subtitle = subtitle
+        viewer.value.loading = false
+    }
+
+    function closeViewer() {
+        viewer.value.open = false
+        viewer.value.loading = false
+    }
+
+    function failViewer(message: string) {
+        $q.notify({ type: "negative", message })
+        closeViewer()
+    }
+
+    function diffStamp(on: string | null, by: string | null): string {
+        return (
+            (on ? formatDateTime(on, { dateStyle: "short", timeStyle: "short" }) : "unknown date") +
+            (by ? ` by ${by}` : "")
+        )
+    }
+
+    // Subtitle for a saved-version diff (GET .../diff): direction reads old version -> new version.
+    function savedDiffSubtitle(diff: CmsContentHistoryDiff): string {
+        return diff.hasComparison
+            ? `Changes from ${diffStamp(diff.oldModifiedOn, diff.oldModifiedBy)} to ${diffStamp(diff.newModifiedOn, diff.newModifiedBy)}`
+            : `Original version, ${diffStamp(diff.newModifiedOn, diff.newModifiedBy)}`
+    }
+
+    return { viewer, openViewer, applyDiff, closeViewer, failViewer, diffStamp, savedDiffSubtitle }
+}

--- a/VueApp/src/CMS/composables/use-server-table.ts
+++ b/VueApp/src/CMS/composables/use-server-table.ts
@@ -52,11 +52,21 @@ export function useServerTable<TRow>(options: ServerTableOptions) {
         ...options.pagination,
     })
 
+    // Monotonic sequence guarding against out-of-order responses: rapid filter changes
+    // fire overlapping GETs, and a slow earlier response must not clobber the rows of
+    // the request issued after it (same pattern as PersonSelector's searchSeq).
+    let requestSeq = 0
+
     async function onRequest(request: TableRequest) {
         const { page, rowsPerPage, sortBy, descending } = request.pagination
+        requestSeq += 1
+        const seq = requestSeq
         loading.value = true
         const params = createUrlSearchParams(options.buildParams(request.pagination))
         const res = await get(`${options.url}?${params}`)
+        if (seq !== requestSeq) {
+            return
+        }
         if (res.success) {
             rows.value = res.result
             pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length

--- a/VueApp/src/CMS/composables/use-server-table.ts
+++ b/VueApp/src/CMS/composables/use-server-table.ts
@@ -1,0 +1,78 @@
+import type { Ref } from "vue"
+import { ref } from "vue"
+import { useQuasar } from "quasar"
+import { useFetch } from "@/composables/ViperFetch"
+
+type ServerTablePagination = {
+    sortBy: string
+    descending: boolean
+    page: number
+    rowsPerPage: number
+    rowsNumber: number
+}
+
+// Quasar's QTable @request emits pagination without a guaranteed rowsNumber.
+type TableRequestPagination = {
+    sortBy: string
+    descending: boolean
+    page: number
+    rowsPerPage: number
+    rowsNumber?: number
+}
+
+type TableRequest = { pagination: TableRequestPagination }
+
+type TableQueryParams = Record<string, string | number | null | undefined>
+
+type ServerTableOptions = {
+    url: string
+    // Build the query params for one page request from the table's current pagination.
+    buildParams: (pagination: TableRequestPagination) => TableQueryParams
+    errorMessage?: string
+    pagination?: Partial<ServerTablePagination>
+}
+
+// Server-side paged QTable core shared by the CMS list pages: owns rows/loading/pagination, issues
+// the GET on @request, and binds rowsNumber from the response envelope (falling back to the row
+// count when the API returns none). Callers supply the URL and a params builder, keeping each
+// page's filter mapping local while the fetch/pagination plumbing lives here once.
+export function useServerTable<TRow>(options: ServerTableOptions) {
+    const $q = useQuasar()
+    const { get, createUrlSearchParams } = useFetch()
+    const failureMessage = options.errorMessage ?? "Failed to load"
+
+    const rows = ref([]) as Ref<TRow[]>
+    const loading = ref(false)
+    const pagination = ref<ServerTablePagination>({
+        sortBy: "",
+        descending: false,
+        page: 1,
+        rowsPerPage: 50,
+        rowsNumber: 0,
+        ...options.pagination,
+    })
+
+    async function onRequest(request: TableRequest) {
+        const { page, rowsPerPage, sortBy, descending } = request.pagination
+        loading.value = true
+        const params = createUrlSearchParams(options.buildParams(request.pagination))
+        const res = await get(`${options.url}?${params}`)
+        if (res.success) {
+            rows.value = res.result
+            pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
+            pagination.value.page = page
+            pagination.value.rowsPerPage = rowsPerPage
+            pagination.value.sortBy = sortBy
+            pagination.value.descending = descending
+        } else {
+            $q.notify({ type: "negative", message: res.errors?.[0] ?? failureMessage })
+        }
+        loading.value = false
+    }
+
+    function reloadFirstPage() {
+        return onRequest({ pagination: { ...pagination.value, page: 1 } })
+    }
+
+    return { rows, loading, pagination, onRequest, reloadFirstPage }
+}

--- a/VueApp/src/CMS/composables/use-url-filtered-table.ts
+++ b/VueApp/src/CMS/composables/use-url-filtered-table.ts
@@ -1,0 +1,111 @@
+import type { Ref } from "vue"
+import type { LocationQuery, LocationQueryRaw } from "vue-router"
+import { ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useServerTable } from "./use-server-table"
+
+type UrlFilters = Record<string, string | null>
+
+type UrlFilteredTableOptions<F extends UrlFilters> = {
+    url: string
+    errorMessage: string
+    // The single deep-link id filter shown as a removable chip (e.g. fileGuid, contentBlockId).
+    primaryKey: string
+    // Default (empty) value for each synced filter; also defines the filter key set and order.
+    defaultFilters: () => F
+    pagination: { sortBy: string; descending: boolean }
+}
+
+// "" and null both mean "unset": collapse to null so query params and the URL omit them.
+function blankToNull(value: string | null): string | null {
+    return value || null
+}
+
+function readString(query: LocationQuery, key: string, fallback: string | null): string | null {
+    return typeof query[key] === "string" ? (query[key] as string) : fallback
+}
+
+// A URL-synced, server-paged filter table shared by the CMS audit/history views. Filters and the
+// primary id deep-link from route.query and reflect back on change (empties omitted). When in-app
+// navigation reuses the view with a different query, the watcher re-syncs and re-fetches; its
+// equality guard skips our own syncFiltersToUrl writes so they don't trigger a redundant fetch.
+export function useUrlFilteredTable<TRow, F extends UrlFilters>(options: UrlFilteredTableOptions<F>) {
+    const route = useRoute()
+    const router = useRouter()
+
+    function readFilters(query: LocationQuery): F {
+        const defaults = options.defaultFilters()
+        const next = { ...defaults }
+        for (const key of Object.keys(defaults) as (keyof F)[]) {
+            next[key] = readString(query, key as string, defaults[key]) as F[keyof F]
+        }
+        return next
+    }
+
+    const primary = ref(readString(route.query, options.primaryKey, null)) as Ref<string | null>
+    const filters = ref(readFilters(route.query)) as Ref<F>
+
+    const table = useServerTable<TRow>({
+        url: options.url,
+        errorMessage: options.errorMessage,
+        pagination: options.pagination,
+        buildParams: (p) => {
+            const params: Record<string, string | number | null | undefined> = {
+                [options.primaryKey]: primary.value,
+            }
+            for (const [key, value] of Object.entries(filters.value)) {
+                params[key] = blankToNull(value)
+            }
+            params.page = p.page
+            params.perPage = p.rowsPerPage
+            return params
+        },
+    })
+
+    function syncFiltersToUrl() {
+        const query: LocationQueryRaw = { [options.primaryKey]: primary.value || undefined }
+        for (const [key, value] of Object.entries(filters.value)) {
+            query[key] = value || undefined
+        }
+        router.replace({ query })
+    }
+
+    function reload() {
+        syncFiltersToUrl()
+        table.reloadFirstPage()
+    }
+
+    function clearPrimaryFilter() {
+        primary.value = null
+        reload()
+    }
+
+    function filtersMatch(next: F): boolean {
+        return Object.keys(next).every((key) => next[key as keyof F] === filters.value[key as keyof F])
+    }
+
+    watch(
+        () => route.query,
+        (query) => {
+            const nextPrimary = readString(query, options.primaryKey, null)
+            const next = readFilters(query)
+            if (nextPrimary === primary.value && filtersMatch(next)) {
+                return
+            }
+            primary.value = nextPrimary
+            filters.value = next
+            table.reloadFirstPage()
+        },
+    )
+
+    return {
+        rows: table.rows,
+        loading: table.loading,
+        pagination: table.pagination,
+        onRequest: table.onRequest,
+        filters,
+        primary,
+        reload,
+        clearPrimaryFilter,
+    }
+}

--- a/VueApp/src/CMS/file-types.ts
+++ b/VueApp/src/CMS/file-types.ts
@@ -1,0 +1,5 @@
+// File extensions the CMS accepts for upload. Shared by the file manager's upload dialog and the
+// content block's inline uploader so the allow-list stays in one place. Mirrors the backend's
+// CmsFileTypes allow-list; keep the two in sync.
+export const CMS_ACCEPTED_EXTENSIONS =
+    ".pdf,.docx,.doc,.xls,.xlsx,.csv,.ppt,.pptx,.pptm,.txt,.html,.gif,.png,.jpg,.jpeg,.tiff,.mp3,.wav,.mp4,.webm,.oft,.eps,.zip,.7z,.dmg,.exe"

--- a/VueApp/src/CMS/pages/BulkEncrypt.vue
+++ b/VueApp/src/CMS/pages/BulkEncrypt.vue
@@ -17,6 +17,7 @@
                     v-model="filters.folder"
                     dense
                     options-dense
+                    outlined
                     emit-value
                     map-options
                     label="VIPER app"
@@ -29,6 +30,7 @@
                     v-model="filters.search"
                     dense
                     clearable
+                    outlined
                     debounce="400"
                     label="Search"
                     @update:model-value="reload"

--- a/VueApp/src/CMS/pages/BulkEncrypt.vue
+++ b/VueApp/src/CMS/pages/BulkEncrypt.vue
@@ -137,10 +137,13 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; the page's data logic lives in useServerTable.
+// fallow-ignore-file complexity
 import { inject, onMounted, ref } from "vue"
 import { inflect } from "inflection"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
+import { useServerTable } from "@/CMS/composables/use-server-table"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import ListCard from "@/CMS/components/ListCard.vue"
 import ListCardField from "@/CMS/components/ListCardField.vue"
@@ -156,30 +159,20 @@ type BulkEncryptResult = {
 
 const apiURL = inject("apiURL") + "cms/files/"
 const $q = useQuasar()
-const { get, post, createUrlSearchParams } = useFetch()
+const { get, post } = useFetch()
 
 type FolderOption = { label: string; value: string }
 
 const ALL_FOLDERS = "All"
 
-const files = ref<CmsFile[]>([])
 const folderOptions = ref<FolderOption[]>([{ label: ALL_FOLDERS, value: ALL_FOLDERS }])
 const selected = ref<CmsFile[]>([])
 const results = ref<BulkEncryptResult[]>([])
-const loading = ref(false)
 const encrypting = ref(false)
 
 const filters = ref({
     folder: ALL_FOLDERS,
     search: "",
-})
-
-const pagination = ref({
-    sortBy: "friendlyName",
-    descending: false,
-    page: 1,
-    rowsPerPage: 50,
-    rowsNumber: 0,
 })
 
 const columns: QTableProps["columns"] = [
@@ -188,44 +181,31 @@ const columns: QTableProps["columns"] = [
     { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
 ]
 
-type TableRequestPagination = {
-    sortBy: string
-    descending: boolean
-    page: number
-    rowsPerPage: number
-    rowsNumber?: number
-}
-
-async function onRequest(requestProps: { pagination: TableRequestPagination }) {
-    const { page, rowsPerPage, sortBy, descending } = requestProps.pagination
-    loading.value = true
-    const params = createUrlSearchParams({
+const {
+    rows: files,
+    loading,
+    pagination,
+    onRequest,
+    reloadFirstPage,
+} = useServerTable<CmsFile>({
+    url: apiURL,
+    errorMessage: "Failed to load files",
+    pagination: { sortBy: "friendlyName", descending: false },
+    buildParams: (p) => ({
         folder: filters.value.folder !== ALL_FOLDERS ? filters.value.folder : null,
         status: "active",
         encrypted: "false",
         search: filters.value.search || null,
-        page,
-        perPage: rowsPerPage,
-        sortBy: sortBy ?? "friendlyName",
-        descending: descending.toString(),
-    })
-    const res = await get(apiURL + "?" + params)
-    if (res.success) {
-        files.value = res.result
-        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
-        pagination.value.page = page
-        pagination.value.rowsPerPage = rowsPerPage
-        pagination.value.sortBy = sortBy
-        pagination.value.descending = descending
-    } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load files" })
-    }
-    loading.value = false
-}
+        page: p.page,
+        perPage: p.rowsPerPage,
+        sortBy: p.sortBy ?? "friendlyName",
+        descending: p.descending.toString(),
+    }),
+})
 
 function reload() {
     selected.value = []
-    void onRequest({ pagination: { ...pagination.value, page: 1 } })
+    void reloadFirstPage()
 }
 
 async function loadFolders() {

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -9,6 +9,16 @@
             Your account does not have access to any CMS tools. Contact the VIPER team if you need access.
         </StatusBanner>
 
+        <StatusBanner
+            v-if="purgeSoonCount > 0"
+            type="warning"
+            class="q-mb-md"
+        >
+            {{ purgeWarningText }}
+            <router-link :to="{ name: 'CmsFiles', query: { status: 'deleted' } }">Review the Trash</router-link>
+            to restore anything still needed.
+        </StatusBanner>
+
         <div class="row q-col-gutter-lg cms-home-grid">
             <div class="col-12 col-lg-8">
                 <div class="cms-home-cards">
@@ -59,12 +69,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue"
+import { computed, inject, ref, watch } from "vue"
+import { inflect } from "inflection"
 import { useUserStore } from "@/store/UserStore"
+import { useFetch } from "@/composables/ViperFetch"
 import StatusBanner from "@/components/StatusBanner.vue"
 import RecentActivity from "@/CMS/components/RecentActivity.vue"
+import type { CmsFile } from "@/CMS/types/"
 
 const userStore = useUserStore()
+const apiURL = inject("apiURL")
+const { get, createUrlSearchParams } = useFetch()
 
 type Action = {
     label: string
@@ -82,25 +97,14 @@ type Section = {
     actions: Action[]
 }
 
+// One box per left-nav group, in the nav's order (CmsNavMenu.cs: Content Blocks, Files,
+// Left Navigation Menus), with Manage Link Collections inside Content Blocks like the nav.
 const sections: Section[] = [
-    {
-        title: "Files",
-        icon: "folder",
-        description:
-            "Store files for VIPER pages and share them through permission-checked download links. Every download is logged.",
-        permissions: ["SVMSecure.CMS.AllFiles"],
-        actions: [
-            { label: "Manage Files", to: { name: "CmsFiles" } },
-            // File managers see their own deleted files here; admins see the whole trash (scoped by
-            // the API). Inherits the section's AllFiles gate.
-            { label: "Trash", to: { name: "CmsFiles", query: { status: "deleted" } } },
-            { label: "Audit Trail", to: { name: "CmsFileAudit" } },
-        ],
-    },
     {
         title: "Content Blocks",
         icon: "article",
-        description: "Edit the text and images displayed on VIPER pages. Every change is kept in version history.",
+        description:
+            "Edit the text, images, and tagged link lists displayed on VIPER pages. Every change is kept in version history.",
         permissions: ["SVMSecure.CMS.ManageContentBlocks", "SVMSecure.CMS.CreateContentBlock"],
         actions: [
             {
@@ -114,21 +118,39 @@ const sections: Section[] = [
                 to: { name: "CmsContentBlockHistory" },
                 permissions: ["SVMSecure.CMS.ManageContentBlocks"],
             },
+            {
+                label: "Manage Link Collections",
+                to: { name: "ManageLinkCollections" },
+                permissions: ["SVMSecure.CMS.ManageContentBlocks"],
+            },
         ],
     },
     {
-        title: "Link Collections",
-        icon: "link",
-        description: "Maintain the tagged link lists displayed on VIPER pages.",
-        permissions: ["SVMSecure.CMS.ManageContentBlocks"],
-        actions: [{ label: "Manage Link Collections", to: { name: "ManageLinkCollections" } }],
+        title: "Files",
+        icon: "folder",
+        description:
+            "Store files for VIPER pages and share them through permission-checked download links. Every download is logged.",
+        permissions: ["SVMSecure.CMS.AllFiles"],
+        actions: [
+            { label: "Manage Files", to: { name: "CmsFiles" } },
+            // Mirrors the nav's ManageFiles?upload=1 deep-link: opens the upload dialog on arrival.
+            { label: "Add File", to: { name: "CmsFiles", query: { upload: "1" } } },
+            { label: "Audit Trail", to: { name: "CmsFileAudit" } },
+            // Home-only extra (not in the nav): file managers see their own deleted files here;
+            // admins see the whole trash (scoped by the API). Inherits the section's AllFiles gate.
+            { label: "Trash", to: { name: "CmsFiles", query: { status: "deleted" } } },
+        ],
     },
     {
-        title: "Left Navigation",
+        title: "Left Navigation Menus",
         icon: "menu",
         description: "Control the left-hand menus shown on VIPER sections and pages.",
         permissions: ["SVMSecure.CMS.ManageNavigation"],
-        actions: [{ label: "Manage Left-Nav Menus", to: { name: "CmsLeftNavMenus" } }],
+        actions: [
+            { label: "Manage Left-Nav Menus", to: { name: "CmsLeftNavMenus" } },
+            // Mirrors the nav's ManageLeftNav?add=1 deep-link: opens the create dialog on arrival.
+            { label: "Add Left-Nav Menu", to: { name: "CmsLeftNavMenus", query: { add: "1" } } },
+        ],
     },
 ]
 
@@ -143,37 +165,58 @@ const canManageBlocks = computed(() => userStore.userInfo.permissions.includes("
 const canManageFiles = computed(() => userStore.userInfo.permissions.includes("SVMSecure.CMS.AllFiles"))
 const canManageNav = computed(() => userStore.userInfo.permissions.includes("SVMSecure.CMS.ManageNavigation"))
 const showRecentActivity = computed(() => canManageBlocks.value || canManageFiles.value || canManageNav.value)
+
+// Warn file managers when trashed files approach the purge cutoff. PurgeOn comes from the API
+// (deletedOn + retention), so the warning stays correct if the retention window ever changes.
+// One ascending page bounds the check; a trash deeper than one page still warns correctly
+// because the soonest-purging files sort first.
+const PURGE_WARNING_DAYS = 7
+const purgeSoonCount = ref(0)
+
+watch(
+    canManageFiles,
+    async (canManage) => {
+        if (!canManage) {
+            purgeSoonCount.value = 0
+            return
+        }
+        const params = createUrlSearchParams({
+            status: "deleted",
+            page: 1,
+            perPage: 50,
+            sortBy: "deletedOn",
+            descending: "false",
+        })
+        const res = await get(`${apiURL}cms/files/?${params}`)
+        if (!res.success) {
+            return
+        }
+        const cutoff = Date.now() + PURGE_WARNING_DAYS * 24 * 60 * 60 * 1000
+        purgeSoonCount.value = ((res.result ?? []) as CmsFile[]).filter(
+            (f) => f.purgeOn !== null && new Date(f.purgeOn).getTime() <= cutoff,
+        ).length
+    },
+    { immediate: true },
+)
+
+const purgeWarningText = computed(
+    () =>
+        `${purgeSoonCount.value} trashed ${inflect("file", purgeSoonCount.value)} will be permanently ` +
+        `deleted within ${PURGE_WARNING_DAYS} days.`,
+)
 </script>
 
 <style scoped>
-/* Cards as a 2x2 grid with the activity rail beside them; cap the width
-   so neither stretches into low-density slabs on wide monitors. */
+/* One full-width card per nav group, stacked in the nav's top-to-bottom order, with the
+   activity rail beside them; cap the width so neither stretches into low-density slabs
+   on wide monitors. */
 .cms-home-grid {
     max-width: 80rem;
 }
 
-/* Fixed two-column grid so cards always tile evenly (4 -> 2x2) instead of
-   reflowing to 3x1 at wider widths; equal rows keep tiles the same size
-   regardless of description length. Collapses to one column when narrow. */
 .cms-home-cards {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-auto-rows: 1fr;
-    gap: 1rem;
-}
-
-@media (max-width: 599.98px) {
-    .cms-home-cards {
-        grid-template-columns: 1fr;
-    }
-}
-
-.cms-home-cards .q-card {
     display: flex;
     flex-direction: column;
-}
-
-.cms-home-cards .q-card .q-card__actions {
-    margin-top: auto;
+    gap: 1rem;
 }
 </style>

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -155,7 +155,7 @@ const showRecentActivity = computed(() => canManageBlocks.value || canManageFile
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
     grid-auto-rows: 1fr;
-    gap: 16px;
+    gap: 1rem;
 }
 
 .cms-home-cards .q-card {

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -91,6 +91,9 @@ const sections: Section[] = [
         permissions: ["SVMSecure.CMS.AllFiles"],
         actions: [
             { label: "Manage Files", to: { name: "CmsFiles" } },
+            // File managers see their own deleted files here; admins see the whole trash (scoped by
+            // the API). Inherits the section's AllFiles gate.
+            { label: "Trash", to: { name: "CmsFiles", query: { status: "deleted" } } },
             { label: "Audit Trail", to: { name: "CmsFileAudit" } },
         ],
     },
@@ -149,13 +152,20 @@ const showRecentActivity = computed(() => canManageBlocks.value || canManageFile
     max-width: 80rem;
 }
 
-/* CSS grid with equal rows so all four cards render as same-size tiles
-   regardless of description length; collapses to one column when narrow. */
+/* Fixed two-column grid so cards always tile evenly (4 -> 2x2) instead of
+   reflowing to 3x1 at wider widths; equal rows keep tiles the same size
+   regardless of description length. Collapses to one column when narrow. */
 .cms-home-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-auto-rows: 1fr;
     gap: 1rem;
+}
+
+@media (max-width: 599.98px) {
+    .cms-home-cards {
+        grid-template-columns: 1fr;
+    }
 }
 
 .cms-home-cards .q-card {

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -327,6 +327,7 @@
             </div>
         </q-form>
 
+        <!-- Always diffs the editor's current content against an existing history entry, so a comparison always exists -->
         <ContentDiffDialog
             v-model="diffViewer.open"
             :loading="diffViewer.loading"
@@ -334,6 +335,7 @@
             :subtitle="diffViewer.subtitle"
             :diff-html="diffViewer.content"
             :has-changes="diffViewer.hasChanges"
+            :has-comparison="true"
         />
     </div>
 </template>

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -31,7 +31,7 @@
             @validation-error="onValidationError"
         >
             <div class="row q-col-gutter-lg">
-                <div class="col-12 col-lg-8">
+                <div class="col-12">
                     <q-input
                         v-model="block.title"
                         dense
@@ -52,6 +52,8 @@
                     <q-editor
                         ref="contentEditorRef"
                         v-model="block.content"
+                        dense
+                        class="content-editor"
                         min-height="20rem"
                         :toolbar="editorToolbar"
                         :definitions="{}"
@@ -115,7 +117,7 @@
                     </div>
                 </div>
 
-                <div class="col-12 col-lg-4">
+                <div class="col-12">
                     <q-card
                         flat
                         bordered
@@ -139,18 +141,40 @@
                             />
 
                             <q-select
+                                v-if="isNew"
                                 v-model="block.viperSectionPath"
                                 dense
                                 options-dense
                                 outlined
-                                clearable
-                                use-input
-                                new-value-mode="add-unique"
-                                input-debounce="0"
                                 label="VIPER section path"
-                                hint="Pick an existing section or type a new one"
-                                :options="sectionPaths"
+                                class="required-field"
+                                :options="folders"
+                                :rules="[(v: string | null) => !!v || 'A VIPER section path is required']"
+                                aria-required="true"
+                                hint="The VIPER app folder this block's files are stored in; it can't be changed later."
                             />
+                            <q-input
+                                v-else
+                                :model-value="block.viperSectionPath"
+                                dense
+                                outlined
+                                readonly
+                                label="VIPER section path"
+                            >
+                                <template #append>
+                                    <q-icon
+                                        name="help"
+                                        size="xs"
+                                        tabindex="0"
+                                        role="img"
+                                        aria-label="The section path can't be edited after the block is created"
+                                    >
+                                        <q-tooltip>
+                                            The section path can't be edited after the block is created.
+                                        </q-tooltip>
+                                    </q-icon>
+                                </template>
+                            </q-input>
 
                             <q-input
                                 v-model="block.page"
@@ -225,6 +249,7 @@
                                     <span class="sr-only">(opens in new window)</span>
                                 </a>
                                 <q-btn
+                                    v-if="canAccessFiles"
                                     dense
                                     flat
                                     size="sm"
@@ -251,6 +276,15 @@
                                 :loading="searchingFiles"
                                 @filter="searchFiles"
                                 @update:model-value="attachFile"
+                            />
+                            <InlineFileUpload
+                                v-if="canAccessFiles"
+                                ref="inlineUploadRef"
+                                class="q-mt-sm"
+                                :folder="block.viperSectionPath"
+                                :permissions="block.permissions"
+                                :allow-public-access="block.allowPublicAccess"
+                                @staged-count="stagedCount = $event"
                             />
                         </q-card-section>
                     </q-card>
@@ -313,6 +347,7 @@ import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
+import InlineFileUpload from "@/CMS/components/InlineFileUpload.vue"
 import StatusBanner from "@/components/StatusBanner.vue"
 import ContentDiffDialog from "@/CMS/components/ContentDiffDialog.vue"
 import type {
@@ -328,12 +363,11 @@ const filesApiURL = inject("apiURL") + "cms/files/"
 const route = useRoute()
 const router = useRouter()
 const $q = useQuasar()
-const { get, post, put, createUrlSearchParams } = useFetch()
+const { get, post, put, del, createUrlSearchParams } = useFetch()
 
-// This route also admits CreateContentBlock-only users, but the section-path list and the file
-// catalog APIs require ManageContentBlocks / AllFiles. Gate those calls so a create-only user
-// doesn't fire requests that can only 403 (the section field still accepts a typed-in path).
-const canManageContent = checkHasOnePermission(["SVMSecure.CMS.ManageContentBlocks"])
+// This route also admits CreateContentBlock-only users. The folder list (for the section path)
+// is served by a content-scoped endpoint they can reach; the file catalog (attach/upload) still
+// requires AllFiles, so gate only those.
 const canAccessFiles = checkHasOnePermission(["SVMSecure.CMS.AllFiles"])
 
 const blockId = computed(() => (route.params.id ? Number(route.params.id) : null))
@@ -352,7 +386,7 @@ const emptyBlock = (): CmsContentBlock => ({
     application: null,
     page: null,
     viperSectionPath: null,
-    blockOrder: 1,
+    blockOrder: 0,
     friendlyName: null,
     allowPublicAccess: false,
     modifiedOn: "",
@@ -364,12 +398,20 @@ const emptyBlock = (): CmsContentBlock => ({
 
 const block = ref<CmsContentBlock>(emptyBlock())
 
-const { setInitialState, resetDirtyState, confirmClose } = useUnsavedChanges(block)
+// Files chosen in the inline uploader are staged client-side and only uploaded on Save. Fold their
+// count into the dirty state so staging alone trips the unsaved-changes guard.
+const inlineUploadRef = ref<{
+    commit: () => Promise<{ attached: CmsFile[]; createdGuids: string[] }>
+} | null>(null)
+const stagedCount = ref(0)
+const dirtyState = computed(() => ({ block: block.value, staged: stagedCount.value }))
+
+const { setInitialState, resetDirtyState, confirmClose } = useUnsavedChanges(dirtyState)
 
 // Prompt before leaving with unsaved edits, matching the Effort forms' guard.
 onBeforeRouteLeave(async () => await confirmClose())
 
-const sectionPaths = ref<string[]>([])
+const folders = ref<string[]>([])
 const history = ref<CmsContentHistoryItem[]>([])
 const selectedHistory = ref<CmsContentHistoryItem | null>(null)
 const viewingVersion = ref(false)
@@ -408,9 +450,12 @@ async function loadHistory() {
     history.value = res.success ? res.result : []
 }
 
-async function loadSectionPaths() {
-    const res = await get(apiURL + "/section-paths")
-    sectionPaths.value = res.success ? res.result : []
+// The section path IS a file folder (legacy parity): a block can only point at a real upload
+// folder, so its files always land somewhere valid. Sourced from a content-scoped endpoint so
+// create-only users (who lack AllFiles) can still populate it.
+async function loadFolders() {
+    const res = await get(apiURL + "/folders")
+    folders.value = res.success ? res.result : []
 }
 
 function historyLabel(h: CmsContentHistoryItem): string {
@@ -498,6 +543,17 @@ function attachFile() {
     fileToAttach.value = null
 }
 
+// Add a file that was just committed (uploaded/overwritten/reused) by the inline uploader to the
+// block's attachment list, de-duping by GUID.
+function attachUploadedFile(file: CmsFile) {
+    if (block.value.files.some((f) => f.fileGuid === file.fileGuid)) return
+    block.value.files.push({
+        fileGuid: file.fileGuid,
+        friendlyName: file.friendlyName,
+        url: file.friendlyUrl,
+    })
+}
+
 function detachFile(file: CmsContentBlockFile) {
     block.value.files = block.value.files.filter((f) => f.fileGuid !== file.fileGuid)
 }
@@ -523,10 +579,40 @@ function onValidationError() {
         : "Please complete the required fields before saving your changes."
 }
 
+// Roll back files freshly created during a Save that then failed, so a failed save leaves nothing
+// attached. The files go to the trash (soft-delete); the trash-purge job clears them later, and
+// they're recoverable meanwhile. Overwritten or reused existing files are never in this list - see
+// InlineFileUpload.commit.
+async function rollbackFiles(createdGuids: string[]) {
+    if (createdGuids.length === 0) return
+    for (const guid of createdGuids) {
+        await del(filesApiURL + guid)
+    }
+    const removed = new Set(createdGuids)
+    block.value.files = block.value.files.filter((f) => !removed.has(f.fileGuid))
+}
+
 async function saveBlock() {
     formError.value = ""
 
     saving.value = true
+
+    // Commit any staged inline uploads first (this is when they're actually created on the server),
+    // then attach them so they're included in fileGuids below. Abort the save if an upload fails.
+    // Track freshly-created files so we can roll them back if the block save itself then fails.
+    let rollbackGuids: string[] = []
+    if (inlineUploadRef.value) {
+        try {
+            const { attached, createdGuids } = await inlineUploadRef.value.commit()
+            attached.forEach(attachUploadedFile)
+            rollbackGuids = createdGuids
+        } catch (e) {
+            saving.value = false
+            formError.value = e instanceof Error ? e.message : "Failed to upload one or more files."
+            return
+        }
+    }
+
     const payload = {
         contentBlockId: block.value.contentBlockId,
         content: block.value.content,
@@ -549,6 +635,7 @@ async function saveBlock() {
     saving.value = false
 
     if (res.status === 409) {
+        await rollbackFiles(rollbackGuids)
         $q.dialog({
             title: "Edit Conflict",
             message:
@@ -566,6 +653,7 @@ async function saveBlock() {
     }
 
     if (!res.success) {
+        await rollbackFiles(rollbackGuids)
         formError.value = res.errors?.[0] ?? "Failed to save content block"
         return
     }
@@ -599,7 +687,8 @@ onMounted(() => {
     // QEditor renders the focusable contenteditable as an inner element, so its accessible
     // name has to be set there rather than on the wrapper the "Content" label sits beside.
     contentEditorRef.value?.getContentEl()?.setAttribute("aria-labelledby", "content-editor-label")
-    if (canManageContent) loadSectionPaths()
+    // Only the create form offers the (editable) section-path select; on edit it's read-only.
+    if (isNew.value) loadFolders()
     loadBlock()
     // loadBlock sets the baseline for an existing block after it loads; a brand-new form's
     // baseline is just the empty block, so capture it synchronously here.
@@ -613,5 +702,25 @@ onMounted(() => {
 .required-field :deep(.q-field__label)::after {
     content: " *";
     color: var(--q-negative);
+}
+
+/* Let the editor toolbar wrap onto multiple rows on narrow screens instead of
+   scrolling horizontally; `dense` keeps each button group intact so groups wrap
+   as whole units rather than splitting mid-group. */
+.content-editor :deep(.q-editor__toolbar) {
+    flex-wrap: wrap;
+}
+
+/* On phones, trim the inter-button and inter-group gaps so the toolbar packs
+   into two rows instead of three. Only the gaps shrink - the buttons keep their
+   size, so touch targets are unchanged. */
+@media (width <= 599.98px) {
+    .content-editor :deep(.q-editor__toolbar-group) {
+        margin: 0 2px;
+    }
+
+    .content-editor :deep(.q-editor__toolbar .q-btn) {
+        margin: 2px;
+    }
 }
 </style>

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -346,6 +346,7 @@ import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import { useContentDiffViewer } from "@/CMS/composables/use-content-diff-viewer"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
@@ -481,41 +482,25 @@ async function loadHistoryVersion() {
     }
 }
 
-const diffViewer = ref({
-    open: false,
-    loading: false,
-    title: "",
-    subtitle: "",
-    content: "",
-    hasChanges: true,
-})
+const { viewer: diffViewer, openViewer: openDiffViewer, applyDiff, failViewer } = useContentDiffViewer()
 
 // Compare the editor's current content (the "new" side) against the selected historical version
 // (the "old" side). The current content is posted because it may include unsaved edits.
 async function diffAgainstCurrent() {
     if (!selectedHistory.value) return
-    diffViewer.value = {
-        open: true,
-        loading: true,
-        title: "Current editor content vs previous version",
-        subtitle: "",
-        content: "",
-        hasChanges: true,
-    }
+    openDiffViewer("Current editor content vs previous version")
     const res = await post(
         apiURL + "/" + blockId.value + "/history/" + selectedHistory.value.contentHistoryId + "/diff",
         { content: block.value.content },
     )
     if (res.success) {
-        const diff = res.result as CmsContentHistoryDiff
-        diffViewer.value.content = diff.content
-        diffViewer.value.hasChanges = diff.hasChanges
-        diffViewer.value.subtitle = `Changes from ${historyLabel(selectedHistory.value)} to your current editor content`
+        applyDiff(
+            res.result as CmsContentHistoryDiff,
+            `Changes from ${historyLabel(selectedHistory.value)} to your current editor content`,
+        )
     } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to build the diff" })
-        diffViewer.value.open = false
+        failViewer(res.errors?.[0] ?? "Failed to build the diff")
     }
-    diffViewer.value.loading = false
 }
 
 async function searchFiles(val: string, update: (fn: () => void) => void) {

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -105,9 +105,9 @@
                             class="col-auto"
                         >
                             <q-chip
-                                color="orange-2"
                                 dense
                                 square
+                                class="bg-warning text-dark"
                             >
                                 Viewing an old version, save to restore it
                             </q-chip>
@@ -204,6 +204,7 @@
                     </q-card>
 
                     <q-card
+                        v-if="canAccessFiles || block.files.length > 0"
                         flat
                         bordered
                     >
@@ -236,6 +237,7 @@
                                 </q-btn>
                             </div>
                             <q-select
+                                v-if="canAccessFiles"
                                 v-model="fileToAttach"
                                 dense
                                 options-dense
@@ -308,6 +310,7 @@ import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
+import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import PermissionSelector from "@/CMS/components/PermissionSelector.vue"
 import StatusBanner from "@/components/StatusBanner.vue"
@@ -326,6 +329,12 @@ const route = useRoute()
 const router = useRouter()
 const $q = useQuasar()
 const { get, post, put, createUrlSearchParams } = useFetch()
+
+// This route also admits CreateContentBlock-only users, but the section-path list and the file
+// catalog APIs require ManageContentBlocks / AllFiles. Gate those calls so a create-only user
+// doesn't fire requests that can only 403 (the section field still accepts a typed-in path).
+const canManageContent = checkHasOnePermission(["SVMSecure.CMS.ManageContentBlocks"])
+const canAccessFiles = checkHasOnePermission(["SVMSecure.CMS.AllFiles"])
 
 const blockId = computed(() => (route.params.id ? Number(route.params.id) : null))
 const isNew = computed(() => blockId.value === null)
@@ -590,7 +599,7 @@ onMounted(() => {
     // QEditor renders the focusable contenteditable as an inner element, so its accessible
     // name has to be set there rather than on the wrapper the "Content" label sits beside.
     contentEditorRef.value?.getContentEl()?.setAttribute("aria-labelledby", "content-editor-label")
-    loadSectionPaths()
+    if (canManageContent) loadSectionPaths()
     loadBlock()
     // loadBlock sets the baseline for an existing block after it loads; a brand-new form's
     // baseline is just the empty block, so capture it synchronously here.

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -339,6 +339,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; saveBlock is split into small helpers below.
+// fallow-ignore-file complexity
 import { computed, inject, onMounted, ref } from "vue"
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
@@ -592,28 +594,18 @@ async function rollbackFiles(createdGuids: string[]) {
     block.value.files = block.value.files.filter((f) => !removed.has(f.fileGuid))
 }
 
-async function saveBlock() {
-    formError.value = ""
+// Commit any staged inline uploads first (this is when they're actually created on the server),
+// then attach them so they're included in fileGuids. Returns the freshly-created GUIDs so a failed
+// block save can roll them back; throws if an upload fails so the caller aborts the save.
+async function commitStagedUploads(): Promise<string[]> {
+    if (!inlineUploadRef.value) return []
+    const { attached, createdGuids } = await inlineUploadRef.value.commit()
+    attached.forEach(attachUploadedFile)
+    return createdGuids
+}
 
-    saving.value = true
-
-    // Commit any staged inline uploads first (this is when they're actually created on the server),
-    // then attach them so they're included in fileGuids below. Abort the save if an upload fails.
-    // Track freshly-created files so we can roll them back if the block save itself then fails.
-    let rollbackGuids: string[] = []
-    if (inlineUploadRef.value) {
-        try {
-            const { attached, createdGuids } = await inlineUploadRef.value.commit()
-            attached.forEach(attachUploadedFile)
-            rollbackGuids = createdGuids
-        } catch (e) {
-            saving.value = false
-            formError.value = e instanceof Error ? e.message : "Failed to upload one or more files."
-            return
-        }
-    }
-
-    const payload = {
+function buildSavePayload() {
+    return {
         contentBlockId: block.value.contentBlockId,
         content: block.value.content,
         title: block.value.title,
@@ -628,51 +620,68 @@ async function saveBlock() {
         fileGuids: block.value.files.map((f) => f.fileGuid),
         lastModifiedOn: isNew.value ? null : block.value.modifiedOn,
     }
+}
 
+// A 409 means someone else saved first; roll back our new files and offer to reload their version.
+async function handleSaveConflict(res: { errors: string[] | null }, rollbackGuids: string[]) {
+    await rollbackFiles(rollbackGuids)
+    $q.dialog({
+        title: "Edit Conflict",
+        message:
+            (res.errors?.[0] ?? "This content block was changed by someone else.") +
+            " Reload the latest version? Your unsaved changes will be lost.",
+        cancel: { label: "Keep editing", flat: true },
+        persistent: true,
+        ok: { label: "Reload", color: "primary", unelevated: true },
+    }).onOk(() => {
+        void loadBlock()
+        viewingVersion.value = false
+        selectedHistory.value = null
+    })
+}
+
+async function applySaveSuccess(res: { result: CmsContentBlock }) {
+    $q.notify({ type: "positive", message: isNew.value ? "Content block created" : "Content block saved" })
+    viewingVersion.value = false
+    selectedHistory.value = null
+    autoEnabledPublicAccess.value = false
+    if (isNew.value) {
+        void router.push({ name: "CmsContentBlockEdit", params: { id: res.result.contentBlockId } })
+    }
+    block.value = res.result
+    resetDirtyState()
+    await loadHistory()
+}
+
+async function saveBlock() {
+    formError.value = ""
+    saving.value = true
+
+    let rollbackGuids: string[]
+    try {
+        rollbackGuids = await commitStagedUploads()
+    } catch (e) {
+        saving.value = false
+        formError.value = e instanceof Error ? e.message : "Failed to upload one or more files."
+        return
+    }
+
+    const payload = buildSavePayload()
     const res = isNew.value
         ? await post(apiURL, payload)
         : await put(apiURL + "/" + block.value.contentBlockId, payload)
     saving.value = false
 
     if (res.status === 409) {
-        await rollbackFiles(rollbackGuids)
-        $q.dialog({
-            title: "Edit Conflict",
-            message:
-                (res.errors?.[0] ?? "This content block was changed by someone else.") +
-                " Reload the latest version? Your unsaved changes will be lost.",
-            cancel: { label: "Keep editing", flat: true },
-            persistent: true,
-            ok: { label: "Reload", color: "primary", unelevated: true },
-        }).onOk(() => {
-            void loadBlock()
-            viewingVersion.value = false
-            selectedHistory.value = null
-        })
+        await handleSaveConflict(res, rollbackGuids)
         return
     }
-
     if (!res.success) {
         await rollbackFiles(rollbackGuids)
         formError.value = res.errors?.[0] ?? "Failed to save content block"
         return
     }
-
-    $q.notify({ type: "positive", message: isNew.value ? "Content block created" : "Content block saved" })
-    viewingVersion.value = false
-    selectedHistory.value = null
-    autoEnabledPublicAccess.value = false
-
-    if (isNew.value) {
-        void router.push({ name: "CmsContentBlockEdit", params: { id: res.result.contentBlockId } })
-        block.value = res.result
-        resetDirtyState()
-        await loadHistory()
-    } else {
-        block.value = res.result
-        resetDirtyState()
-        await loadHistory()
-    }
+    await applySaveSuccess(res)
 }
 
 async function restoreBlock() {

--- a/VueApp/src/CMS/pages/ContentBlockHistory.vue
+++ b/VueApp/src/CMS/pages/ContentBlockHistory.vue
@@ -87,7 +87,7 @@
                     <router-link :to="{ name: 'CmsContentBlockEdit', params: { id: cellProps.row.contentBlockId } }">
                         {{ blockLabel(cellProps.row) }}
                     </router-link>
-                    <q-badge
+                    <StatusBadge
                         v-if="cellProps.row.blockDeleted"
                         color="negative"
                         class="q-ml-sm"
@@ -129,7 +129,7 @@
                             >
                                 {{ blockLabel(row) }}
                             </router-link>
-                            <q-badge
+                            <StatusBadge
                                 v-if="row.blockDeleted"
                                 color="negative"
                                 label="deleted"
@@ -192,6 +192,7 @@ import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useDateFunctions } from "@/composables/DateFunctions"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
+import StatusBadge from "@/components/StatusBadge.vue"
 import DateRangeFilter from "@/CMS/components/DateRangeFilter.vue"
 import ContentDiffDialog from "@/CMS/components/ContentDiffDialog.vue"
 import ListCard from "@/CMS/components/ListCard.vue"

--- a/VueApp/src/CMS/pages/ContentBlockHistory.vue
+++ b/VueApp/src/CMS/pages/ContentBlockHistory.vue
@@ -186,11 +186,11 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onMounted, ref, watch } from "vue"
-import { useRoute, useRouter } from "vue-router"
+import { inject, onMounted, ref } from "vue"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useDateFunctions } from "@/composables/DateFunctions"
+import { useUrlFilteredTable } from "@/CMS/composables/use-url-filtered-table"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import StatusBadge from "@/components/StatusBadge.vue"
 import DateRangeFilter from "@/CMS/components/DateRangeFilter.vue"
@@ -200,45 +200,9 @@ import ListCardField from "@/CMS/components/ListCardField.vue"
 import type { CmsContentHistoryAudit, CmsContentHistoryDiff } from "@/CMS/types/"
 
 const apiBase = inject("apiURL")
-const listUrl = apiBase + "CMS/content/history"
 const $q = useQuasar()
-const route = useRoute()
-const router = useRouter()
-const { get, createUrlSearchParams } = useFetch()
+const { get } = useFetch()
 const { formatDateTime } = useDateFunctions()
-
-const entries = ref<CmsContentHistoryAudit[]>([])
-const loading = ref(false)
-const contentBlockId = ref<string | null>((route.query.contentBlockId as string) || null)
-
-// Filters initialize from the URL so filtered views can be shared/deep-linked.
-const filters = ref({
-    modifiedBy: typeof route.query.modifiedBy === "string" ? route.query.modifiedBy : "",
-    from: typeof route.query.from === "string" ? route.query.from : "",
-    to: typeof route.query.to === "string" ? route.query.to : "",
-    search: typeof route.query.search === "string" ? route.query.search : "",
-})
-
-// Reflect the active filters back into the URL (empty values are omitted).
-function syncFiltersToUrl() {
-    void router.replace({
-        query: {
-            contentBlockId: contentBlockId.value || undefined,
-            modifiedBy: filters.value.modifiedBy || undefined,
-            from: filters.value.from || undefined,
-            to: filters.value.to || undefined,
-            search: filters.value.search || undefined,
-        },
-    })
-}
-
-const pagination = ref({
-    sortBy: "modifiedOn",
-    descending: true,
-    page: 1,
-    rowsPerPage: 50,
-    rowsNumber: 0,
-})
 
 const columns: QTableProps["columns"] = [
     { name: "modifiedOn", label: "Date", field: "modifiedOn", align: "left" },
@@ -251,47 +215,24 @@ function blockLabel(row: CmsContentHistoryAudit): string {
     return row.title || row.friendlyName || "(untitled)"
 }
 
-type TableRequestPagination = {
-    sortBy: string
-    descending: boolean
-    page: number
-    rowsPerPage: number
-    rowsNumber?: number
-}
-
-async function onRequest(requestProps: { pagination: TableRequestPagination }) {
-    const { page, rowsPerPage } = requestProps.pagination
-    loading.value = true
-    const params = createUrlSearchParams({
-        contentBlockId: contentBlockId.value,
-        modifiedBy: filters.value.modifiedBy || null,
-        from: filters.value.from || null,
-        to: filters.value.to || null,
-        search: filters.value.search || null,
-        page,
-        perPage: rowsPerPage,
-    })
-    const res = await get(listUrl + "?" + params)
-    if (res.success) {
-        entries.value = res.result
-        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
-        pagination.value.page = page
-        pagination.value.rowsPerPage = rowsPerPage
-    } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load edit history" })
-    }
-    loading.value = false
-}
-
-function reload() {
-    syncFiltersToUrl()
-    void onRequest({ pagination: { ...pagination.value, page: 1 } })
-}
-
-function clearBlockFilter() {
-    contentBlockId.value = null
-    reload()
-}
+// Filters + the per-block deep-link (?contentBlockId) sync to the URL and drive the server-paged
+// fetch; see useUrlFilteredTable.
+const {
+    rows: entries,
+    loading,
+    pagination,
+    onRequest,
+    filters,
+    primary: contentBlockId,
+    reload,
+    clearPrimaryFilter: clearBlockFilter,
+} = useUrlFilteredTable<CmsContentHistoryAudit, { modifiedBy: string; from: string; to: string; search: string }>({
+    url: apiBase + "CMS/content/history",
+    errorMessage: "Failed to load edit history",
+    primaryKey: "contentBlockId",
+    defaultFilters: () => ({ modifiedBy: "", from: "", to: "", search: "" }),
+    pagination: { sortBy: "modifiedOn", descending: true },
+})
 
 const viewer = ref({
     open: false,
@@ -334,35 +275,6 @@ async function viewDiff(row: CmsContentHistoryAudit) {
     }
     viewer.value.loading = false
 }
-
-// Re-sync filters from the URL when in-app navigation reuses this view with a different
-// query (e.g. a per-block ?contentBlockId deep-link). The equality guard skips our own
-// syncFiltersToUrl write so it doesn't double-fetch.
-watch(
-    () => route.query,
-    (query) => {
-        const nextBlock = typeof query.contentBlockId === "string" ? query.contentBlockId : null
-        const next = {
-            modifiedBy: typeof query.modifiedBy === "string" ? query.modifiedBy : "",
-            from: typeof query.from === "string" ? query.from : "",
-            to: typeof query.to === "string" ? query.to : "",
-            search: typeof query.search === "string" ? query.search : "",
-        }
-        const f = filters.value
-        if (
-            nextBlock === contentBlockId.value &&
-            next.modifiedBy === f.modifiedBy &&
-            next.from === f.from &&
-            next.to === f.to &&
-            next.search === f.search
-        ) {
-            return
-        }
-        contentBlockId.value = nextBlock
-        filters.value = next
-        void onRequest({ pagination: { ...pagination.value, page: 1 } })
-    },
-)
 
 onMounted(reload)
 </script>

--- a/VueApp/src/CMS/pages/ContentBlockHistory.vue
+++ b/VueApp/src/CMS/pages/ContentBlockHistory.vue
@@ -186,10 +186,11 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onMounted, ref } from "vue"
+import { inject, onMounted } from "vue"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useDateFunctions } from "@/composables/DateFunctions"
+import { useContentDiffViewer } from "@/CMS/composables/use-content-diff-viewer"
 import { useUrlFilteredTable } from "@/CMS/composables/use-url-filtered-table"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import StatusBadge from "@/components/StatusBadge.vue"
@@ -234,46 +235,17 @@ const {
     pagination: { sortBy: "modifiedOn", descending: true },
 })
 
-const viewer = ref({
-    open: false,
-    loading: false,
-    title: "",
-    subtitle: "",
-    content: "",
-    hasComparison: true,
-    hasChanges: true,
-})
-
-function diffStamp(on: string | null, by: string | null): string {
-    return (
-        (on ? formatDateTime(on, { dateStyle: "short", timeStyle: "short" }) : "unknown date") + (by ? ` by ${by}` : "")
-    )
-}
+const { viewer, openViewer, applyDiff, failViewer, savedDiffSubtitle } = useContentDiffViewer()
 
 async function viewDiff(row: CmsContentHistoryAudit) {
-    viewer.value = {
-        open: true,
-        loading: true,
-        title: blockLabel(row),
-        subtitle: "",
-        content: "",
-        hasComparison: true,
-        hasChanges: true,
-    }
+    openViewer(blockLabel(row))
     const res = await get(apiBase + "CMS/content/" + row.contentBlockId + "/history/" + row.contentHistoryId + "/diff")
     if (res.success) {
         const diff = res.result as CmsContentHistoryDiff
-        viewer.value.content = diff.content
-        viewer.value.hasComparison = diff.hasComparison
-        viewer.value.hasChanges = diff.hasChanges
-        viewer.value.subtitle = diff.hasComparison
-            ? `Changes from ${diffStamp(diff.oldModifiedOn, diff.oldModifiedBy)} to ${diffStamp(diff.newModifiedOn, diff.newModifiedBy)}`
-            : `Original version, ${diffStamp(diff.newModifiedOn, diff.newModifiedBy)}`
+        applyDiff(diff, savedDiffSubtitle(diff))
     } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load this version" })
-        viewer.value.open = false
+        failViewer(res.errors?.[0] ?? "Failed to load this version")
     }
-    viewer.value.loading = false
 }
 
 onMounted(reload)

--- a/VueApp/src/CMS/pages/ContentBlocks.vue
+++ b/VueApp/src/CMS/pages/ContentBlocks.vue
@@ -19,6 +19,7 @@
                     v-model="filters.status"
                     dense
                     options-dense
+                    outlined
                     emit-value
                     map-options
                     label="Status"
@@ -31,6 +32,7 @@
                     v-model="filters.viperSectionPath"
                     dense
                     options-dense
+                    outlined
                     clearable
                     label="VIPER section"
                     :options="sectionPaths"
@@ -42,6 +44,7 @@
                     v-model="filters.search"
                     dense
                     clearable
+                    outlined
                     debounce="400"
                     label="Search title, name, page, or content"
                     @update:model-value="reload"
@@ -61,17 +64,20 @@
             </div>
         </div>
 
+        <!-- Server-paged like Files: rows come back one page at a time, so no "All" (0) option.
+             Card mode at lt.sm matches Files (both have six columns), not the old lt.md. -->
         <q-table
             :rows="blocks"
             :columns="columns"
             row-key="contentBlockId"
             :loading="loading"
-            :pagination="{ rowsPerPage: 50, sortBy: 'title' }"
-            :rows-per-page-options="[25, 50, 100, 0]"
-            :grid="$q.screen.lt.md"
+            v-model:pagination="pagination"
+            :rows-per-page-options="[25, 50, 100, 250]"
+            :grid="$q.screen.lt.sm"
             dense
             flat
             bordered
+            @request="onRequest"
         >
             <template #body-cell-title="cellProps">
                 <q-td :props="cellProps">
@@ -199,6 +205,7 @@ import { inject, onMounted, ref, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
+import { useServerTable } from "@/CMS/composables/use-server-table"
 import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
 import EditButton from "@/CMS/components/EditButton.vue"
 import ListCard from "@/CMS/components/ListCard.vue"
@@ -212,11 +219,9 @@ const apiURL = inject("apiURL") + "CMS/content"
 const route = useRoute()
 const router = useRouter()
 const $q = useQuasar()
-const { get, del, post, createUrlSearchParams } = useFetch()
+const { get, del, post } = useFetch()
 
-const blocks = ref<CmsContentBlock[]>([])
 const sectionPaths = ref<string[]>([])
-const loading = ref(false)
 
 // Filters initialize from the URL so views can be shared/deep-linked, matching
 // the Files list and audit trail.
@@ -255,24 +260,35 @@ const columns: QTableProps["columns"] = [
     { name: "actions", label: "Actions", field: "contentBlockId", align: "center" },
 ]
 
-async function loadBlocks() {
-    loading.value = true
-    const params = createUrlSearchParams({
+// Server-paged list, mirroring Files: useServerTable owns rows/loading/pagination and
+// issues the GET on @request; buildParams maps the current filters + page/sort each request.
+const {
+    rows: blocks,
+    loading,
+    pagination,
+    onRequest,
+    reloadFirstPage,
+} = useServerTable<CmsContentBlock>({
+    url: apiURL,
+    errorMessage: "Failed to load content blocks",
+    pagination: { sortBy: "title", descending: false },
+    buildParams: (p) => ({
         status: filters.value.status,
         viperSectionPath: filters.value.viperSectionPath,
         search: filters.value.search || null,
         isPublic: filters.value.publicOnly ? "true" : null,
-    })
-    const res = await get(apiURL + "?" + params)
-    blocks.value = res.success ? res.result : []
-    loading.value = false
-}
+        page: p.page,
+        perPage: p.rowsPerPage,
+        sortBy: p.sortBy ?? "title",
+        descending: p.descending ? "true" : "false",
+    }),
+})
 
-// Filter changes both reload the list and update the URL; the route watcher
+// Filter changes both reload the list (from page 1) and update the URL; the route watcher
 // guards against re-fetching on our own URL write.
 function reload() {
     syncFiltersToUrl()
-    loadBlocks()
+    void reloadFirstPage()
 }
 
 async function loadSectionPaths() {
@@ -300,7 +316,7 @@ async function deleteBlock(block: CmsContentBlock) {
         return
     }
     $q.notify({ type: "positive", message: "Content block marked as deleted" })
-    loadBlocks()
+    reload()
 }
 
 async function restoreBlock(block: CmsContentBlock) {
@@ -310,7 +326,7 @@ async function restoreBlock(block: CmsContentBlock) {
         return
     }
     $q.notify({ type: "positive", message: "Content block restored" })
-    loadBlocks()
+    reload()
 }
 
 // Re-sync filters when in-app navigation reuses this view with a different query
@@ -335,12 +351,12 @@ watch(
             return
         }
         filters.value = next
-        loadBlocks()
+        void reloadFirstPage()
     },
 )
 
 onMounted(() => {
     loadSectionPaths()
-    loadBlocks()
+    reload()
 })
 </script>

--- a/VueApp/src/CMS/pages/ContentBlocks.vue
+++ b/VueApp/src/CMS/pages/ContentBlocks.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <div class="row items-center q-mb-md">
+        <div class="row items-center q-mb-md list-page-header">
             <h1 class="q-my-none">Manage Content Blocks</h1>
             <q-space />
             <q-btn
@@ -23,18 +23,6 @@
                     map-options
                     label="Status"
                     :options="statusOptions"
-                    @update:model-value="reload"
-                />
-            </div>
-            <div class="col-12 col-sm-3 col-lg-2">
-                <q-select
-                    v-model="filters.system"
-                    dense
-                    options-dense
-                    emit-value
-                    map-options
-                    label="System"
-                    :options="systemOptions"
                     @update:model-value="reload"
                 />
             </div>
@@ -80,7 +68,7 @@
             :loading="loading"
             :pagination="{ rowsPerPage: 50, sortBy: 'title' }"
             :rows-per-page-options="[25, 50, 100, 0]"
-            :grid="$q.screen.lt.sm"
+            :grid="$q.screen.lt.md"
             dense
             flat
             bordered
@@ -112,7 +100,10 @@
 
             <template #body-cell-permissions="cellProps">
                 <q-td :props="cellProps">
-                    <PermissionChips :permissions="cellProps.row.permissions" />
+                    <PermissionChips
+                        :permissions="cellProps.row.permissions"
+                        stacked
+                    />
                 </q-td>
             </template>
 
@@ -167,10 +158,6 @@
                     </template>
 
                     <ListCardField
-                        label="System"
-                        :value="row.system"
-                    />
-                    <ListCardField
                         v-if="row.viperSectionPath"
                         label="VIPER section"
                         :value="row.viperSectionPath"
@@ -179,10 +166,6 @@
                         v-if="row.page"
                         label="Page"
                         :value="row.page"
-                    />
-                    <ListCardField
-                        label="Order"
-                        :value="row.blockOrder"
                     />
                     <ListCardField label="Access">
                         <PermissionChips :permissions="row.permissions" />
@@ -237,7 +220,6 @@ const loading = ref(false)
 // the Files list and audit trail.
 const filters = ref({
     status: typeof route.query.status === "string" ? route.query.status : "active",
-    system: typeof route.query.system === "string" ? route.query.system : null,
     viperSectionPath: typeof route.query.section === "string" ? route.query.section : null,
     search: typeof route.query.search === "string" ? route.query.search : "",
     publicOnly: route.query.public === "1",
@@ -249,7 +231,6 @@ function syncFiltersToUrl() {
         query: {
             ...route.query,
             status: filters.value.status !== "active" ? filters.value.status : undefined,
-            system: filters.value.system || undefined,
             section: filters.value.viperSectionPath || undefined,
             search: filters.value.search || undefined,
             public: filters.value.publicOnly ? "1" : undefined,
@@ -263,18 +244,10 @@ const statusOptions = [
     { label: "All", value: "all" },
 ]
 
-const systemOptions = [
-    { label: "All", value: null },
-    { label: "Viper", value: "Viper" },
-    { label: "Public", value: "Public" },
-]
-
 const columns: QTableProps["columns"] = [
     { name: "title", label: "Title", field: "title", align: "left", sortable: true },
-    { name: "system", label: "System", field: "system", align: "left", sortable: true },
     { name: "viperSectionPath", label: "VIPER section", field: "viperSectionPath", align: "left", sortable: true },
     { name: "page", label: "Page", field: "page", align: "left", sortable: true },
-    { name: "blockOrder", label: "Order", field: "blockOrder", align: "center", sortable: true },
     { name: "permissions", label: "Access", field: "permissions", align: "left" },
     { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
     { name: "actions", label: "Actions", field: "contentBlockId", align: "center" },
@@ -284,7 +257,6 @@ async function loadBlocks() {
     loading.value = true
     const params = createUrlSearchParams({
         status: filters.value.status,
-        system: filters.value.system,
         viperSectionPath: filters.value.viperSectionPath,
         search: filters.value.search || null,
         isPublic: filters.value.publicOnly ? "true" : null,
@@ -347,7 +319,6 @@ watch(
     (query) => {
         const next = {
             status: typeof query.status === "string" ? query.status : "active",
-            system: typeof query.system === "string" ? query.system : null,
             viperSectionPath: typeof query.section === "string" ? query.section : null,
             search: typeof query.search === "string" ? query.search : "",
             publicOnly: query.public === "1",
@@ -355,7 +326,6 @@ watch(
         const f = filters.value
         if (
             next.status === f.status &&
-            next.system === f.system &&
             next.viperSectionPath === f.viperSectionPath &&
             next.search === f.search &&
             next.publicOnly === f.publicOnly

--- a/VueApp/src/CMS/pages/ContentBlocks.vue
+++ b/VueApp/src/CMS/pages/ContentBlocks.vue
@@ -193,6 +193,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only (large filter + table markup); script logic is small.
+// fallow-ignore-file complexity
 import { inject, onMounted, ref, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar, type QTableProps } from "quasar"

--- a/VueApp/src/CMS/pages/FileAuditLog.vue
+++ b/VueApp/src/CMS/pages/FileAuditLog.vue
@@ -138,11 +138,10 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onMounted, ref, watch } from "vue"
-import { useRoute, useRouter } from "vue-router"
+import { inject, onMounted } from "vue"
 import { useQuasar, type QTableProps } from "quasar"
-import { useFetch } from "@/composables/ViperFetch"
 import { useDateFunctions } from "@/composables/DateFunctions"
+import { useUrlFilteredTable } from "@/CMS/composables/use-url-filtered-table"
 import BreadcrumbHeading from "@/components/BreadcrumbHeading.vue"
 import StatusBadge from "@/components/StatusBadge.vue"
 import ListCard from "@/CMS/components/ListCard.vue"
@@ -152,37 +151,7 @@ import type { CmsFileAudit } from "@/CMS/types/"
 
 const apiURL = inject("apiURL") + "cms/files/audit"
 const $q = useQuasar()
-const route = useRoute()
-const router = useRouter()
-const { get, createUrlSearchParams } = useFetch()
 const { formatDateTime } = useDateFunctions()
-
-const entries = ref<CmsFileAudit[]>([])
-const loading = ref(false)
-const fileGuid = ref<string | null>((route.query.fileGuid as string) || null)
-
-// Filters initialize from the URL so filtered views can be shared/deep-linked.
-const filters = ref({
-    action: typeof route.query.action === "string" ? route.query.action : null,
-    loginId: typeof route.query.loginId === "string" ? route.query.loginId : "",
-    from: typeof route.query.from === "string" ? route.query.from : "",
-    to: typeof route.query.to === "string" ? route.query.to : "",
-    search: typeof route.query.search === "string" ? route.query.search : "",
-})
-
-// Reflect the active filters back into the URL (empty values are omitted).
-function syncFiltersToUrl() {
-    void router.replace({
-        query: {
-            fileGuid: fileGuid.value || undefined,
-            action: filters.value.action || undefined,
-            loginId: filters.value.loginId || undefined,
-            from: filters.value.from || undefined,
-            to: filters.value.to || undefined,
-            search: filters.value.search || undefined,
-        },
-    })
-}
 
 const actionOptions = [
     "AccessFile",
@@ -194,14 +163,6 @@ const actionOptions = [
     "CancelDelete",
     "ImportFile",
 ]
-
-const pagination = ref({
-    sortBy: "timestamp",
-    descending: true,
-    page: 1,
-    rowsPerPage: 50,
-    rowsNumber: 0,
-})
 
 // Column order mirrors the Effort audit trail: date, who, what was affected,
 // then the action badge and its detail.
@@ -225,79 +186,27 @@ function getActionColor(action: string): string {
     return "grey-8"
 }
 
-type TableRequestPagination = {
-    sortBy: string
-    descending: boolean
-    page: number
-    rowsPerPage: number
-    rowsNumber?: number
-}
-
-async function onRequest(requestProps: { pagination: TableRequestPagination }) {
-    const { page, rowsPerPage } = requestProps.pagination
-    loading.value = true
-    const params = createUrlSearchParams({
-        fileGuid: fileGuid.value,
-        action: filters.value.action,
-        loginId: filters.value.loginId || null,
-        from: filters.value.from || null,
-        to: filters.value.to || null,
-        search: filters.value.search || null,
-        page,
-        perPage: rowsPerPage,
-    })
-    const res = await get(apiURL + "?" + params)
-    if (res.success) {
-        entries.value = res.result
-        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
-        pagination.value.page = page
-        pagination.value.rowsPerPage = rowsPerPage
-    } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load audit trail" })
-    }
-    loading.value = false
-}
-
-function reload() {
-    syncFiltersToUrl()
-    void onRequest({ pagination: { ...pagination.value, page: 1 } })
-}
-
-function clearFileFilter() {
-    fileGuid.value = null
-    reload()
-}
-
-// Re-sync filters from the URL when in-app navigation reuses this view with a different
-// query (e.g. re-clicking the left-nav link, or a per-file ?fileGuid deep-link). The
-// equality guard skips our own syncFiltersToUrl write so it doesn't double-fetch.
-watch(
-    () => route.query,
-    (query) => {
-        const nextGuid = typeof query.fileGuid === "string" ? query.fileGuid : null
-        const next = {
-            action: typeof query.action === "string" ? query.action : null,
-            loginId: typeof query.loginId === "string" ? query.loginId : "",
-            from: typeof query.from === "string" ? query.from : "",
-            to: typeof query.to === "string" ? query.to : "",
-            search: typeof query.search === "string" ? query.search : "",
-        }
-        const f = filters.value
-        if (
-            nextGuid === fileGuid.value &&
-            next.action === f.action &&
-            next.loginId === f.loginId &&
-            next.from === f.from &&
-            next.to === f.to &&
-            next.search === f.search
-        ) {
-            return
-        }
-        fileGuid.value = nextGuid
-        filters.value = next
-        void onRequest({ pagination: { ...pagination.value, page: 1 } })
-    },
-)
+// Filters + the per-file deep-link (?fileGuid) sync to the URL and drive the server-paged fetch;
+// see useUrlFilteredTable. The action filter defaults to null (unset) to match the clearable select.
+const {
+    rows: entries,
+    loading,
+    pagination,
+    onRequest,
+    filters,
+    primary: fileGuid,
+    reload,
+    clearPrimaryFilter: clearFileFilter,
+} = useUrlFilteredTable<
+    CmsFileAudit,
+    { action: string | null; loginId: string; from: string; to: string; search: string }
+>({
+    url: apiURL,
+    errorMessage: "Failed to load audit trail",
+    primaryKey: "fileGuid",
+    defaultFilters: () => ({ action: null, loginId: "", from: "", to: "", search: "" }),
+    pagination: { sortBy: "timestamp", descending: true },
+})
 
 onMounted(reload)
 </script>

--- a/VueApp/src/CMS/pages/FileAuditLog.vue
+++ b/VueApp/src/CMS/pages/FileAuditLog.vue
@@ -304,7 +304,7 @@ onMounted(reload)
 
 <style scoped>
 .file-path {
-    max-width: 320px;
+    max-width: 20rem;
     display: inline-block;
     vertical-align: middle;
 }

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -45,6 +45,7 @@
                     v-model="filters.folder"
                     dense
                     options-dense
+                    outlined
                     emit-value
                     map-options
                     label="VIPER app"
@@ -57,6 +58,7 @@
                     v-model="filters.status"
                     dense
                     options-dense
+                    outlined
                     emit-value
                     map-options
                     label="Status"
@@ -69,6 +71,7 @@
                     v-model="filters.search"
                     dense
                     clearable
+                    outlined
                     debounce="400"
                     label="Search name, description, or URL"
                     @update:model-value="reload"
@@ -315,6 +318,9 @@ const filters = ref({
 })
 
 // Reflect the active filters back into the URL (defaults are omitted).
+// `upload` is a one-shot action flag, never a persisted filter: strip it here so a
+// filter-sync write that races the upload-watcher's own strip (both fire on mount)
+// can't re-add the stale flag via the ...route.query spread.
 function syncFiltersToUrl() {
     void router.replace({
         query: {
@@ -324,6 +330,7 @@ function syncFiltersToUrl() {
             search: filters.value.search || undefined,
             encrypted: filters.value.encryptedOnly ? "1" : undefined,
             public: filters.value.publicOnly ? "1" : undefined,
+            upload: undefined,
         },
     })
 }

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <div class="row items-center q-mb-md">
+        <div class="row items-center q-mb-md list-page-header">
             <h1 class="q-my-none">Manage Files</h1>
             <q-space />
             <q-btn-dropdown
@@ -136,7 +136,7 @@
                             v-if="cellProps.row.deletedOn"
                             icon="delete_outline"
                             color="negative"
-                            :label="`Deleted ${formatDate(cellProps.row.deletedOn)}`"
+                            :label="deletedLabel(cellProps.row)"
                         />
                     </div>
                 </q-td>
@@ -213,7 +213,7 @@
                                 v-if="row.deletedOn"
                                 icon="delete_outline"
                                 color="negative"
-                                :label="`Deleted ${formatDate(row.deletedOn)}`"
+                                :label="deletedLabel(row)"
                             />
                         </div>
                     </template>
@@ -303,7 +303,8 @@ const showDialog = ref(false)
 const editingFile = ref<CmsFile | null>(null)
 
 // Filters initialize from the URL so views can be shared/deep-linked
-// (the hub's recent-activity rail uses ?search=<file name>).
+// (the hub's recent-activity rail uses ?search=<file name>). The deleted/all views are open to all
+// file managers; the API scopes them to files the user deleted (admins see the whole trash).
 const filters = ref({
     folder: typeof route.query.folder === "string" ? route.query.folder : ALL_FOLDERS,
     status: typeof route.query.status === "string" ? route.query.status : "active",
@@ -489,6 +490,12 @@ async function confirmAction(title: string, message: string, okLabel: string, ok
 function formatDate(value: string | null): string {
     if (!value) return ""
     return new Date(value).toLocaleDateString("en-US", { year: "2-digit", month: "2-digit", day: "2-digit" })
+}
+
+// In the trash, show when the file will be auto-purged so it's clear it isn't kept forever.
+function deletedLabel(row: CmsFile): string {
+    const base = `Deleted ${formatDate(row.deletedOn)}`
+    return row.purgeOn ? `${base} · purges ${formatDate(row.purgeOn)}` : base
 }
 
 // When in-app navigation reuses this view with a different query (e.g. re-clicking the

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -271,10 +271,13 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; the page's data logic lives in useServerTable.
+// fallow-ignore-file complexity
 import { inject, nextTick, onMounted, ref, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
+import { useServerTable } from "@/CMS/composables/use-server-table"
 import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
 import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
 import EditButton from "@/CMS/components/EditButton.vue"
@@ -293,12 +296,10 @@ const { get, del, post, createUrlSearchParams } = useFetch()
 
 const ALL_FOLDERS = "All"
 
-const files = ref<CmsFile[]>([])
 const folders = ref<string[]>([])
 type FolderOption = { label: string; value: string }
 
 const filterFolders = ref<FolderOption[]>([{ label: ALL_FOLDERS, value: ALL_FOLDERS }])
-const loading = ref(false)
 const showDialog = ref(false)
 const editingFile = ref<CmsFile | null>(null)
 
@@ -347,14 +348,6 @@ const fileTools = [
     { label: "Bulk Encrypt", icon: "lock", to: { name: "CmsBulkEncrypt" } },
 ]
 
-const pagination = ref({
-    sortBy: "friendlyName",
-    descending: false,
-    page: 1,
-    rowsPerPage: 50,
-    rowsNumber: 0,
-})
-
 const columns: QTableProps["columns"] = [
     { name: "friendlyName", label: "File", field: "friendlyName", align: "left", sortable: true },
     { name: "folder", label: "VIPER app", field: "folder", align: "left", sortable: true },
@@ -363,6 +356,29 @@ const columns: QTableProps["columns"] = [
     { name: "modifiedOn", label: "Modified", field: "modifiedOn", align: "left", sortable: true },
     { name: "actions", label: "Actions", field: "fileGuid", align: "center" },
 ]
+
+const {
+    rows: files,
+    loading,
+    pagination,
+    onRequest,
+    reloadFirstPage,
+} = useServerTable<CmsFile>({
+    url: apiURL,
+    errorMessage: "Failed to load files",
+    pagination: { sortBy: "friendlyName", descending: false },
+    buildParams: (p) => ({
+        folder: filters.value.folder !== ALL_FOLDERS ? filters.value.folder : null,
+        status: filters.value.status,
+        search: filters.value.search || null,
+        encrypted: filters.value.encryptedOnly ? "true" : null,
+        isPublic: filters.value.publicOnly ? "true" : null,
+        page: p.page,
+        perPage: p.rowsPerPage,
+        sortBy: p.sortBy ?? "friendlyName",
+        descending: p.descending ? "true" : "false",
+    }),
+})
 
 async function loadFolders() {
     // Upload destinations are the disk allow-list; the filter dropdown is built
@@ -393,46 +409,10 @@ async function loadFolderOptions() {
     ]
 }
 
-type TableRequestPagination = {
-    sortBy: string
-    descending: boolean
-    page: number
-    rowsPerPage: number
-    rowsNumber?: number
-}
-
-async function onRequest(requestProps: { pagination: TableRequestPagination }) {
-    const { page, rowsPerPage, sortBy, descending } = requestProps.pagination
-    loading.value = true
-    const params = createUrlSearchParams({
-        folder: filters.value.folder !== ALL_FOLDERS ? filters.value.folder : null,
-        status: filters.value.status,
-        search: filters.value.search || null,
-        encrypted: filters.value.encryptedOnly ? "true" : null,
-        isPublic: filters.value.publicOnly ? "true" : null,
-        page,
-        perPage: rowsPerPage,
-        sortBy: sortBy ?? "friendlyName",
-        descending: descending ? "true" : "false",
-    })
-    const res = await get(apiURL + "?" + params)
-    if (res.success) {
-        files.value = res.result
-        pagination.value.rowsNumber = res.pagination?.totalRecords ?? res.result.length
-        pagination.value.page = page
-        pagination.value.rowsPerPage = rowsPerPage
-        pagination.value.sortBy = sortBy
-        pagination.value.descending = descending
-    } else {
-        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load files" })
-    }
-    loading.value = false
-}
-
 function reload() {
     syncFiltersToUrl()
     void loadFolderOptions()
-    void onRequest({ pagination: { ...pagination.value, page: 1 } })
+    void reloadFirstPage()
 }
 
 function openUploadDialog() {
@@ -524,7 +504,7 @@ watch(
         }
         filters.value = next
         void loadFolderOptions()
-        void onRequest({ pagination: { ...pagination.value, page: 1 } })
+        void reloadFirstPage()
     },
 )
 

--- a/VueApp/src/CMS/pages/ImportFiles.vue
+++ b/VueApp/src/CMS/pages/ImportFiles.vue
@@ -146,7 +146,15 @@
                     :disable="importableCount === 0"
                     :loading="importing"
                     @click="runImport"
-                />
+                >
+                    <template #loading>
+                        <q-spinner
+                            size="1em"
+                            class="q-mr-sm"
+                        />
+                        Importing...
+                    </template>
+                </q-btn>
             </div>
         </template>
 
@@ -240,7 +248,7 @@ const importableCount = computed(() => preview.value?.filter((p) => p.canImport)
 
 function previewStatus(row: ImportPreview) {
     if (!row.canImport) return { icon: "error", color: "negative", label: "Will be skipped" }
-    if (row.message) return { icon: "warning", color: "warning", label: "Ready" }
+    if (row.message) return { icon: "warning", color: "warning", label: "Ready (with note)" }
     return { icon: "check_circle", color: "positive", label: "Ready" }
 }
 

--- a/VueApp/src/CMS/pages/ImportFiles.vue
+++ b/VueApp/src/CMS/pages/ImportFiles.vue
@@ -186,6 +186,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only (large wizard/table markup); script logic is small.
+// fallow-ignore-file complexity
 import { computed, inject, onMounted, ref } from "vue"
 import { inflect } from "inflection"
 import { useQuasar, type QTableProps } from "quasar"

--- a/VueApp/src/CMS/pages/ImportFiles.vue
+++ b/VueApp/src/CMS/pages/ImportFiles.vue
@@ -117,8 +117,10 @@
                 </template>
                 <template #body-cell-fileName="cellProps">
                     <q-td :props="cellProps">
-                        <template v-if="cellProps.row.fileName">
-                            {{ cellProps.row.fileName }}
+                        <!-- Show the friendly name the file will be listed under (folder-name),
+                             matching the post-import "Imported as" column, not the bare disk name. -->
+                        <template v-if="cellProps.row.friendlyName">
+                            {{ cellProps.row.friendlyName }}
                             <div
                                 v-if="cellProps.row.renamedFrom"
                                 class="text-caption text-warning"

--- a/VueApp/src/CMS/pages/LeftNavEdit.vue
+++ b/VueApp/src/CMS/pages/LeftNavEdit.vue
@@ -107,7 +107,11 @@
                             @reorder="onItemsReorder"
                         >
                             <template #row="{ item }">
-                                <div class="menu-item-fields">
+                                <div
+                                    class="menu-item-fields"
+                                    role="group"
+                                    :aria-label="`${item.isHeader ? 'Section header' : 'Menu link'}: ${item.menuItemText || '(untitled)'}`"
+                                >
                                     <div class="menu-item-fields__text">
                                         <q-input
                                             v-model="item.menuItemText"
@@ -471,7 +475,7 @@ onMounted(() => {
 .unsaved-hint {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 0.25rem;
     font-size: 0.8125rem;
     font-weight: 500;
 }
@@ -486,14 +490,14 @@ onMounted(() => {
 .menu-item-fields {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 0.5rem;
 }
 
 @container (min-width: 30rem) {
     .menu-item-fields {
         flex-direction: row;
         align-items: flex-start;
-        gap: 12px;
+        gap: 0.75rem;
     }
 
     .menu-item-fields__text {
@@ -516,8 +520,8 @@ onMounted(() => {
    borderless grouped rows in the panel on desktop. Header rows keep a distinct tint. */
 .menu-items :deep(.sortable-row) {
     border: 1px solid var(--ucdavis-black-10);
-    border-radius: 8px;
-    padding: 12px;
+    border-radius: 0.25rem;
+    padding: 0.75rem;
     background: var(--surface-tint-raised);
 }
 
@@ -534,7 +538,7 @@ onMounted(() => {
         border: none;
         border-bottom: 1px solid var(--ucdavis-black-10);
         border-radius: 0;
-        padding: 12px 8px;
+        padding: 0.75rem 0.5rem;
         background: transparent;
     }
 

--- a/VueApp/src/CMS/pages/LeftNavEdit.vue
+++ b/VueApp/src/CMS/pages/LeftNavEdit.vue
@@ -411,9 +411,10 @@ function onItemsReorder() {
 
 async function saveItems() {
     itemsError.value = ""
-    const emptyItem = items.value.find((i) => !i.menuItemText || i.menuItemText.trim() === "")
-    if (emptyItem) {
-        itemsError.value = "Every item needs text — fill in the empty item before saving."
+    // Headers may be blank (legacy spacer rows still render as an empty divider); links need text.
+    const emptyLink = items.value.find((i) => !i.isHeader && (!i.menuItemText || i.menuItemText.trim() === ""))
+    if (emptyLink) {
+        itemsError.value = "Every link needs text — fill in the empty link before saving."
         return
     }
 

--- a/VueApp/src/CMS/pages/LeftNavEdit.vue
+++ b/VueApp/src/CMS/pages/LeftNavEdit.vue
@@ -217,6 +217,8 @@
 </template>
 
 <script setup lang="ts">
+// Template-size synthetic complexity only; the payload build is extracted from saveMenu below.
+// fallow-ignore-file complexity
 import { computed, inject, onMounted, ref, watch } from "vue"
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
@@ -346,17 +348,21 @@ function onMenuValidationError() {
         : "Please complete the required fields before saving."
 }
 
-async function saveMenu() {
-    menuFormError.value = ""
-
-    savingMenu.value = true
-    const payload = {
+function buildMenuPayload() {
+    return {
         menuHeaderText: menu.value.menuHeaderText,
         system: menu.value.system,
         viperSectionPath: menu.value.viperSectionPath || null,
         page: menu.value.page || null,
         friendlyName: menu.value.friendlyName || null,
     }
+}
+
+async function saveMenu() {
+    menuFormError.value = ""
+
+    savingMenu.value = true
+    const payload = buildMenuPayload()
     const res = isNew.value ? await post(apiURL, payload) : await put(apiURL + "/" + menuId.value, payload)
     savingMenu.value = false
 

--- a/VueApp/src/CMS/pages/LeftNavMenus.vue
+++ b/VueApp/src/CMS/pages/LeftNavMenus.vue
@@ -19,6 +19,7 @@
                     v-model="filters.system"
                     dense
                     options-dense
+                    outlined
                     emit-value
                     map-options
                     label="System"
@@ -31,6 +32,7 @@
                     v-model="filters.search"
                     dense
                     clearable
+                    outlined
                     debounce="400"
                     label="Search header, name, or page"
                     @update:model-value="loadMenus"
@@ -42,13 +44,16 @@
             </div>
         </div>
 
+        <!-- Left-nav menus are a small, bounded set (one row per menu), so the list stays
+             client-side; the "All" (0) rows-per-page option is dropped since even the full
+             list is a short page. -->
         <q-table
             :rows="menus"
             :columns="columns"
             row-key="leftNavMenuId"
             :loading="loading"
             :pagination="{ rowsPerPage: 50, sortBy: 'menuHeaderText' }"
-            :rows-per-page-options="[25, 50, 100, 0]"
+            :rows-per-page-options="[25, 50, 100]"
             :grid="$q.screen.lt.sm"
             dense
             flat

--- a/VueApp/src/CMS/pages/LeftNavMenus.vue
+++ b/VueApp/src/CMS/pages/LeftNavMenus.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="q-pa-md">
-        <div class="row items-center q-mb-md">
+        <div class="row items-center q-mb-md list-page-header">
             <h1 class="q-my-none">Manage Left-Nav Menus</h1>
             <q-space />
             <q-btn

--- a/VueApp/src/CMS/pages/LeftNavMenus.vue
+++ b/VueApp/src/CMS/pages/LeftNavMenus.vue
@@ -149,6 +149,12 @@
                     </template>
                 </ListCard>
             </template>
+
+            <template #no-data>
+                <div class="full-width text-center text-grey-7 q-py-md">
+                    No left-nav menus yet. Use the "Add Left-Nav Menu" button to create one.
+                </div>
+            </template>
         </q-table>
 
         <LeftNavMenuDialog
@@ -162,6 +168,7 @@
 import { inject, onMounted, ref } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useQuasar, type QTableProps } from "quasar"
+import { inflect } from "inflection"
 import { useFetch } from "@/composables/ViperFetch"
 import EditButton from "@/CMS/components/EditButton.vue"
 import LeftNavMenuDialog from "@/CMS/components/LeftNavMenuDialog.vue"
@@ -209,7 +216,12 @@ async function loadMenus() {
         search: filters.value.search || null,
     })
     const res = await get(apiURL + "?" + params)
-    menus.value = res.success ? res.result : []
+    if (res.success) {
+        menus.value = res.result
+    } else {
+        menus.value = []
+        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Failed to load menus" })
+    }
     loading.value = false
 }
 
@@ -217,7 +229,7 @@ async function deleteMenu(menu: CmsLeftNavMenu) {
     const confirmed = await new Promise<boolean>((resolve) => {
         $q.dialog({
             title: "Delete Menu",
-            message: `Permanently delete "${menu.menuHeaderText}" and its ${menu.items.length} items? This cannot be undone.`,
+            message: `Permanently delete "${menu.menuHeaderText || "(untitled)"}" and its ${menu.items.length} ${inflect("item", menu.items.length)}? This cannot be undone.`,
             cancel: { label: "Cancel", flat: true },
             persistent: true,
             ok: { label: "Delete Menu", color: "negative", unelevated: true },

--- a/VueApp/src/CMS/pages/ManageLinkCollections.vue
+++ b/VueApp/src/CMS/pages/ManageLinkCollections.vue
@@ -904,30 +904,6 @@ loadCollections()
     color: var(--q-negative);
 }
 
-.link-form :deep(.q-field--error .q-field__bottom) {
-    padding-top: 0.25rem;
-}
-
-.link-form :deep(.q-field--error .q-field__messages) {
-    display: inline-flex;
-    align-items: center;
-    background: var(--q-negative);
-    color: white;
-    flex: none;
-    width: fit-content;
-    padding: 0.125rem 0.5rem 0.125rem 0.25rem;
-    border-radius: 1rem;
-    font-size: 0.75rem;
-    gap: 0.125rem;
-}
-
-.link-form :deep(.q-field--error .q-field__messages)::before {
-    content: "error";
-    font-family: "Material Icons";
-    font-size: 1rem;
-    line-height: 1;
-}
-
 .tags-fieldset {
     border: 1px solid var(--q-primary);
     border-radius: 0.25rem;

--- a/VueApp/src/CMS/pages/ManageLinkCollections.vue
+++ b/VueApp/src/CMS/pages/ManageLinkCollections.vue
@@ -50,8 +50,9 @@
         <!-- Create/Edit Dialog -->
         <q-dialog
             v-model="showCollectionDialog"
+            persistent
             aria-labelledby="collection-dialog-title"
-            @hide="cancelCollectionDialog"
+            @keydown.escape="handleCollectionClose"
         >
             <q-card class="dialog-card">
                 <q-card-section class="row items-center q-pb-none">
@@ -68,7 +69,7 @@
                         round
                         dense
                         aria-label="Close dialog"
-                        v-close-popup
+                        @click="handleCollectionClose"
                     />
                 </q-card-section>
 
@@ -395,7 +396,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, watch } from "vue"
+import { ref, inject, computed, watch } from "vue"
 import { useQuasar } from "quasar"
 import type { Ref } from "vue"
 import type { LinkCollection, Link, LinkCollectionTagCategory, LinkWithTags } from "@/CMS/types/"
@@ -423,6 +424,19 @@ const addTag: Ref<string> = ref("")
 const draftTags: Ref<LinkCollectionTagCategory[]> = ref([])
 const deletedTagIds: Ref<number[]> = ref([])
 let nextTempTagId = -1
+
+// Guard the collection dialog's editable state (the name plus the staged tag adds,
+// deletes, and reorders) so the X/Escape can't silently discard unsaved tag edits —
+// mirrors the link dialog's unsaved-changes guard on the same page.
+// Iterate the arrays here (map/spread) so the snapshot deep-tracks in-place mutations
+// (SortableList reorder, createTag push, deleteTag splice), not just the ref identity.
+const collectionDialogState = computed(() => ({
+    name: collectionData.value.linkCollection ?? "",
+    draftTags: draftTags.value.map((t) => ({ id: t.linkCollectionTagCategoryId, label: t.linkCollectionTagCategory })),
+    deletedTagIds: [...deletedTagIds.value],
+}))
+const { setInitialState: setCollectionBaseline, confirmClose: confirmCollectionClose } =
+    useUnsavedChanges(collectionDialogState)
 
 const links: Ref<LinkWithTags[]> = ref([])
 const link: Ref<LinkWithTags> = ref({ linkId: 0, url: "", title: "", description: "", tags: {}, sortOrder: 0 })
@@ -588,8 +602,16 @@ watch(showCollectionDialog, (open) => {
         draftTags.value = collectionId.value === null ? [] : collectionTags.value.map((t) => ({ ...t }))
         deletedTagIds.value = []
         addTag.value = ""
+        // Capture the clean baseline after the staged state is reset, for the guard.
+        setCollectionBaseline()
     }
 })
+
+// X/Escape close: confirm before discarding staged name/tag edits, then clean up.
+async function handleCollectionClose() {
+    if (!(await confirmCollectionClose())) return
+    cancelCollectionDialog()
+}
 
 //links
 async function loadLinks() {

--- a/VueApp/src/CMS/pages/ManageLinkCollections.vue
+++ b/VueApp/src/CMS/pages/ManageLinkCollections.vue
@@ -91,6 +91,7 @@
                         <q-input
                             dense
                             v-model="addTag"
+                            label="New tag category"
                             class="col-auto"
                         />
                         <q-btn
@@ -605,7 +606,7 @@ async function loadLinks() {
 
 function getTagRecord(r: Link) {
     let tags: Record<number, string> = {}
-    for (var lt of r.linkTags || []) {
+    for (const lt of r.linkTags || []) {
         if (tags[lt.linkCollectionTagCategoryId] === undefined) {
             tags[lt.linkCollectionTagCategoryId] = lt.value
         } else {
@@ -806,14 +807,15 @@ loadCollections()
 
 <style scoped>
 .dialog-card {
-    min-width: 350px;
+    min-width: 21.875rem;
+    max-width: 95vw;
 }
 
 #allLinks {
     background: var(--surface);
     border: 1px solid var(--ucdavis-black-10);
-    border-radius: 6px;
-    padding: 8px 12px;
+    border-radius: 0.25rem;
+    padding: 0.5rem 0.75rem;
 }
 
 .link-url {
@@ -829,13 +831,13 @@ loadCollections()
     gap: 0;
     width: 100%;
     text-align: left;
-    margin-bottom: 6px;
+    margin-bottom: 0.375rem;
 }
 
 .tag-chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
+    gap: 0.25rem;
     max-width: 100%;
 }
 
@@ -851,7 +853,7 @@ loadCollections()
 }
 
 .tag-row {
-    margin-bottom: 4px;
+    margin-bottom: 0.25rem;
 }
 
 /* The column header only reads as one once the fields line up in a grid (desktop). */
@@ -864,8 +866,8 @@ loadCollections()
 /* Card-per-row on small and medium screens. */
 .links-list :deep(.sortable-row) {
     border: 1px solid var(--ucdavis-black-10);
-    border-radius: 8px;
-    padding: 12px;
+    border-radius: 0.25rem;
+    padding: 0.75rem;
     background: var(--surface-tint-raised);
 }
 
@@ -906,7 +908,7 @@ loadCollections()
 
 .tags-fieldset {
     border: 1px solid var(--q-primary);
-    border-radius: 4px;
+    border-radius: 0.25rem;
     padding: 0.75rem 1rem 0.25rem;
 }
 
@@ -920,7 +922,7 @@ loadCollections()
     .link-grid {
         display: grid;
         grid-template-columns: 2.5fr 1.2fr 2.5fr 1.5fr;
-        column-gap: 12px;
+        column-gap: 0.75rem;
         align-items: start;
     }
 
@@ -936,7 +938,7 @@ loadCollections()
         border: none;
         border-bottom: 1px solid var(--ucdavis-black-10);
         border-radius: 0;
-        padding: 8px 0;
+        padding: 0.5rem 0;
         background: transparent;
     }
 
@@ -957,7 +959,7 @@ loadCollections()
     }
 
     .tag-row {
-        margin-bottom: 6px;
+        margin-bottom: 0.375rem;
     }
 }
 </style>

--- a/VueApp/src/CMS/pages/ManageLinkCollections.vue
+++ b/VueApp/src/CMS/pages/ManageLinkCollections.vue
@@ -618,7 +618,8 @@ async function loadLinks() {
     const { get } = useFetch()
     if (collectionId.value) {
         const res = await get(apiURL + collectionId.value + "/links")
-        links.value = res.result.map((r: any) => {
+        const result = res.success && Array.isArray(res.result) ? res.result : []
+        links.value = result.map((r: any) => {
             return { ...r, tags: getTagRecord(r) }
         })
     } else {
@@ -791,7 +792,7 @@ async function loadTags() {
     const { get } = useFetch()
     if (collectionId.value) {
         const res = await get(apiURL + collectionId.value + "/tags")
-        collectionTags.value = res.result
+        collectionTags.value = res.success && Array.isArray(res.result) ? res.result : []
     } else {
         collectionTags.value = []
     }

--- a/VueApp/src/CMS/router/index.ts
+++ b/VueApp/src/CMS/router/index.ts
@@ -1,5 +1,5 @@
 import { createSpaRouter } from "@/shared/create-spa-router"
-import { routes } from "./routes"
+import { routes, cmsHomePermissions } from "./routes"
 import { useRequireLogin } from "@/composables/RequireLogin"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 
@@ -19,8 +19,10 @@ router.beforeEach(async (to) => {
     }
     // Canonicalize the area root for CMS users so the left nav "Home" link
     // highlights; unauthenticated and permission-less visitors stay on the
-    // CmsAuth landing (redirecting them would force a login or loop).
-    if (to.name === "CmsAuth" && checkHasOnePermission(["SVMSecure.CMS"])) {
+    // CmsAuth landing (redirecting them would force a login or loop). Gate on
+    // the same set as the CmsHome route so granular-only users (no base
+    // SVMSecure.CMS) canonicalize too, instead of being stranded on /CMS/.
+    if (to.name === "CmsAuth" && checkHasOnePermission(cmsHomePermissions)) {
         return { name: "CmsHome" }
     }
 })

--- a/VueApp/src/CMS/router/routes.ts
+++ b/VueApp/src/CMS/router/routes.ts
@@ -2,6 +2,17 @@ import ViperLayout from "@/layouts/ViperLayout.vue"
 import type { RouteLocationNormalized } from "vue-router"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
 
+// Granular CMS permissions that grant the Home hub. The hub adapts to whichever of these the user
+// holds, and CmsNavMenu links it for any of them, so the Home route guard and the area-root
+// canonicalization (router/index.ts) gate on this one shared set rather than two lists that drift.
+const cmsHomePermissions = [
+    "SVMSecure.CMS",
+    "SVMSecure.CMS.ManageContentBlocks",
+    "SVMSecure.CMS.CreateContentBlock",
+    "SVMSecure.CMS.AllFiles",
+    "SVMSecure.CMS.ManageNavigation",
+]
+
 const routes = [
     {
         path: "/CMS/",
@@ -11,7 +22,10 @@ const routes = [
     },
     {
         path: "/CMS/Home",
-        meta: { layout: ViperLayout, permissions: ["SVMSecure.CMS"] },
+        meta: {
+            layout: ViperLayout,
+            permissions: cmsHomePermissions,
+        },
         component: () => import("@/CMS/pages/CmsHome.vue"),
         name: "CmsHome",
     },
@@ -92,4 +106,4 @@ const routes = [
     },
 ]
 
-export { routes }
+export { routes, cmsHomePermissions }

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -75,6 +75,28 @@ type CmsContentHistoryDiff = {
     newModifiedBy: string | null
 }
 
+// One row in the hub's recent-activity rail, normalized across sources (blocks, files,
+// trashed files, left-nav menus); actions are the per-row shortcuts (history, audit, diff).
+type RailAction = {
+    icon: string
+    label: string
+    to?: { name: string; query?: Record<string, string> }
+    run?: () => void
+}
+
+type ActivityItem = {
+    key: string
+    icon: string
+    typeLabel: string
+    // Rendered before the time-ago stamp (e.g. "deleted 2 days ago"); empty means plain recency.
+    verb?: string
+    label: string
+    to: { name: string; params?: Record<string, string | number>; query?: Record<string, string> }
+    modifiedOn: string
+    modifiedBy: string
+    actions?: RailAction[]
+}
+
 type CmsLeftNavMenu = {
     leftNavMenuId: number
     menuHeaderText: string | null
@@ -177,6 +199,8 @@ export type {
     CmsFileAudit,
     CmsContentHistoryAudit,
     CmsContentHistoryDiff,
+    RailAction,
+    ActivityItem,
     LinkCollection,
     LinkCollectionTagCategory,
     Link,

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -16,6 +16,7 @@ type CmsFile = {
     modifiedOn: string
     modifiedBy: string
     deletedOn: string | null
+    purgeOn: string | null
     permissions: string[]
     people: CmsFilePerson[]
     url: string

--- a/VueApp/src/Effort/pages/AuditList.vue
+++ b/VueApp/src/Effort/pages/AuditList.vue
@@ -128,7 +128,9 @@
             </q-card>
         </q-expansion-item>
 
-        <!-- Search box and clear-filters on their own row above the table, matching the CMS audit trail -->
+        <!-- Search box on its own row above the table, matching the CMS audit trail. Unlike the
+             CMS audit (few filters), this page keeps a bulk Clear Filters button: it has nine
+             filters and clearing also reloads the cascading subject/course dropdown options. -->
         <div class="row items-center q-mb-sm">
             <div class="col-12 col-sm-4 col-lg-3">
                 <q-input

--- a/VueApp/src/components/SortableList.vue
+++ b/VueApp/src/components/SortableList.vue
@@ -242,7 +242,7 @@ function onMoveDown(index: number) {
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
-    border-radius: 6px;
+    border-radius: 0.25rem;
 }
 
 .sortable-row--header {
@@ -256,7 +256,7 @@ function onMoveDown(index: number) {
     align-items: center;
     justify-content: center;
     padding-top: 0.375rem;
-    color: var(--ucdavis-black-60, #666);
+    color: var(--ucdavis-black-60);
     cursor: grab;
 }
 
@@ -300,7 +300,7 @@ function onMoveDown(index: number) {
 
 .sortable-row--ghost {
     opacity: 0.5;
-    background: var(--surface-tint, #f5f7fb);
+    background: var(--surface-tint);
 }
 
 /* "Just moved" cue: a brand-blue tint and ring that fade out. It is a colour/shadow
@@ -308,7 +308,7 @@ function onMoveDown(index: number) {
    skipped — keeping a clear signal that something changed. */
 @keyframes sortable-row-flash {
     0% {
-        background-color: var(--ucdavis-blue-10, #cdd6e0);
+        background-color: var(--ucdavis-blue-10);
         box-shadow: inset 0 0 0 0.125rem var(--q-primary);
     }
 

--- a/VueApp/src/components/__tests__/sortable-list.test.ts
+++ b/VueApp/src/components/__tests__/sortable-list.test.ts
@@ -108,6 +108,40 @@ describe("SortableList - move buttons", () => {
     })
 })
 
+describe("SortableList - drag commit", () => {
+    it("announces and emits reorder when a drag ends (the array is already reordered by SortableJS)", async () => {
+        const { wrapper } = mountList(threeItems())
+
+        wrapper.findComponent({ name: "VueDraggable" }).vm.$emit("end", { oldIndex: 0, newIndex: 2 })
+        await nextTick()
+        await nextTick()
+
+        // CommitDrag doesn't move anything itself; it reports the item now sitting at newIndex.
+        const events = wrapper.emitted("reorder")
+        expect(events).toHaveLength(1)
+        expect(events![0]).toEqual([{ id: 3, label: "Charlie" }, 2, 0])
+        expect(wrapper.find('[role="status"]').text()).toBe("Moved to position 3 of 3")
+    })
+
+    it("ignores a drag end without indices (cancelled drag)", async () => {
+        const { wrapper } = mountList(threeItems())
+
+        wrapper.findComponent({ name: "VueDraggable" }).vm.$emit("end", {})
+        await nextTick()
+
+        expect(wrapper.emitted("reorder")).toBeFalsy()
+    })
+
+    it("ignores a drag that ends where it started", async () => {
+        const { wrapper } = mountList(threeItems())
+
+        wrapper.findComponent({ name: "VueDraggable" }).vm.$emit("end", { oldIndex: 1, newIndex: 1 })
+        await nextTick()
+
+        expect(wrapper.emitted("reorder")).toBeFalsy()
+    })
+})
+
 describe("SortableList - accessibility", () => {
     it("announces the move in a polite live region", async () => {
         const { wrapper } = mountList(threeItems())

--- a/VueApp/src/composables/use-route-focus.ts
+++ b/VueApp/src/composables/use-route-focus.ts
@@ -8,9 +8,11 @@ import { nextTick } from "vue"
  */
 export function useRouteFocus(router: Router) {
     router.afterEach((to, from) => {
-        // In-page anchor navigation (skip links): the browser already moved
-        // focus to the fragment target; don't steal it back to <main>.
-        if (to.path === from.path && to.hash) {
+        // Same-path navigations never move focus. In-page anchors (skip links): the
+        // browser already focused the fragment target. Query-only updates (URL-synced
+        // filters, debounced searches): the user is mid-interaction in a control, and
+        // yanking focus to <main> would eat their keystrokes.
+        if (to.path === from.path) {
             return
         }
         nextTick(() => {

--- a/VueApp/src/config/colors.ts
+++ b/VueApp/src/config/colors.ts
@@ -29,7 +29,8 @@ const semanticColors = {
 
 // Quasar/brand colors whose backgrounds are light enough that white foreground
 // text fails WCAG contrast. Pair these with text-color="dark".
-const LIGHT_BACKGROUND_COLORS = new Set(["warning", "info", "accent"])
+// (arboretum #00c4b3: white is 2.2:1, ink is 7.7:1 — needs dark text.)
+const LIGHT_BACKGROUND_COLORS = new Set(["warning", "info", "accent", "arboretum"])
 
 function getAccessibleTextColor(color: string | null | undefined): "dark" | "white" {
     return color && LIGHT_BACKGROUND_COLORS.has(color) ? "dark" : "white"

--- a/VueApp/src/shared/__tests__/create-spa-router.test.ts
+++ b/VueApp/src/shared/__tests__/create-spa-router.test.ts
@@ -15,7 +15,7 @@ describe("createSpaRouter scroll behavior", () => {
     const scrollBehavior = router.options.scrollBehavior!
 
     it("scrolls to top when navigating to a different page", () => {
-        expect(scrollBehavior(route("/b"), route("/a"), null)).toEqual({ left: 0, top: 0 })
+        expect(scrollBehavior(route("/b"), route("/a"), null)).toStrictEqual({ left: 0, top: 0 })
     })
 
     it("keeps scroll position for query-only changes on the same page", () => {
@@ -23,11 +23,11 @@ describe("createSpaRouter scroll behavior", () => {
     })
 
     it("scrolls to the fragment target when navigating to a hash on another page", () => {
-        expect(scrollBehavior(route("/b", "#section"), route("/a"), null)).toEqual({ el: "#section" })
+        expect(scrollBehavior(route("/b", "#section"), route("/a"), null)).toStrictEqual({ el: "#section" })
     })
 
     it("scrolls to the fragment target when the hash changes on the same page", () => {
-        expect(scrollBehavior(route("/a", "#section"), route("/a"), null)).toEqual({ el: "#section" })
+        expect(scrollBehavior(route("/a", "#section"), route("/a"), null)).toStrictEqual({ el: "#section" })
     })
 
     it("keeps scroll position for query-only changes when the hash is unchanged", () => {
@@ -74,6 +74,21 @@ describe("route-change focus management", () => {
         const skipTarget = document.querySelector<HTMLElement>("#leftNavMenu")!
         skipTarget.focus()
         await router.push({ path: "/other", hash: "#leftNavMenu" })
+        await nextTick()
+
+        expect(document.activeElement?.id).toBe("leftNavMenu")
+    })
+
+    it("does not steal focus on query-only navigation (URL-synced filters)", async () => {
+        // Filter changes replace the route with new query params while the user is
+        // typing/selecting in a control; focus must stay in that control.
+        const router = buildRouter()
+        await router.push("/other")
+        await router.isReady()
+
+        const filterControl = document.querySelector<HTMLElement>("#leftNavMenu")!
+        filterControl.focus()
+        await router.replace({ path: "/other", query: { search: "abc" } })
         await nextTick()
 
         expect(document.activeElement?.id).toBe("leftNavMenu")

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -294,14 +294,28 @@ div.breadcrumbs {
     font-weight: bold;
 }
 
-/* Breadcrumb-style parent links inside page headings */
+/* Breadcrumb-style parent links inside page headings. Underlined by default so
+   they read as links: the heading text is black and bold, and the Aggie-Blue
+   link color alone is too close to it to signal a link (WCAG 1.4.1) - and on
+   touch there's no hover to reveal one. */
 .q-page-container h1 a {
-    text-decoration: none;
+    text-decoration: underline;
 }
 
-.q-page-container h1 a:hover,
-.q-page-container h1 a:focus {
-    text-decoration: underline;
+/* List-page header: a page title beside its primary action(s). Inline (title
+   left, action right) on tablet and up; on phones the action drops below the
+   title, both left-aligned - a deliberate stack rather than an incidental wrap.
+   The .q-page-container prefix outweighs Quasar's .row so the direction flips. */
+@media (max-width: 599.98px) {
+    .q-page-container .list-page-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .q-page-container .list-page-header > .q-space {
+        display: none;
+    }
 }
 
 .q-dialog h2,

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -502,11 +502,19 @@ header .q-avatar {
    block (CMS/components/ContentBlock.vue) and the history diff view
    (CMS/components/ContentDiffDialog.vue) so both render block headings the same.
    Declared globally because scoped styles don't reach v-html children. */
-.content-block h1,
-.content-block h2,
-.content-block h3 {
+.content-block h1 {
     font-size: 2rem;
-    line-height: 2rem;
+    line-height: 1.2;
+}
+
+.content-block h2 {
+    font-size: 1.5rem;
+    line-height: 1.25;
+}
+
+.content-block h3 {
+    font-size: 1.25rem;
+    line-height: 1.3;
 }
 
 /* Screen reader only — visually hidden but accessible to assistive technology */

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -484,6 +484,17 @@ header .q-avatar {
     font-size: 1.4rem;
 }
 
+/* Headings inside sanitized CMS content (v-html). Shared by the live content
+   block (CMS/components/ContentBlock.vue) and the history diff view
+   (CMS/components/ContentDiffDialog.vue) so both render block headings the same.
+   Declared globally because scoped styles don't reach v-html children. */
+.content-block h1,
+.content-block h2,
+.content-block h3 {
+    font-size: 2rem;
+    line-height: 2rem;
+}
+
 /* Screen reader only — visually hidden but accessible to assistive technology */
 .sr-only {
     position: absolute;

--- a/VueApp/src/styles/base.css
+++ b/VueApp/src/styles/base.css
@@ -420,6 +420,17 @@ header .q-avatar {
     max-width: 95vw;
 }
 
+/* Quasar caps minimized dialogs at 560px via .q-dialog__inner--minimized > div, which
+   out-specifies the single classes above and silently shrank md/lg dialogs when the
+   inline widths moved here. Lift the cap to each class's declared width. */
+.q-dialog__inner--minimized > .dialog-card-md {
+    max-width: min(600px, 95vw);
+}
+
+.q-dialog__inner--minimized > .dialog-card-lg {
+    max-width: min(900px, 95vw);
+}
+
 /* Skip to content link — visible on focus for keyboard users */
 .skip-to-content {
     position: absolute;

--- a/VueApp/src/styles/colors.css
+++ b/VueApp/src/styles/colors.css
@@ -52,6 +52,17 @@
     --surface: #ffffff;
     --surface-tint: #f5f7fb;
     --surface-tint-raised: #fafbff;
+
+    /* Diff highlight tints — light green/red fills behind <ins>/<del> in the
+       content-history diff. Ink text on these clears WCAG AA; the underline/
+       strikethrough carry the meaning so color is not the only signal. */
+    --diff-add: #d7efdb;
+    --diff-remove: #f6d9dc;
+
+    /* Keyboard focus-ring color. Mirrors the literal used by the shared focus
+       ring in base.css / site.css so components can reference a token instead
+       of repeating the hex. */
+    --focus-ring-color: #258cfb;
 }
 
 /* Background utility classes — UC Davis palette */
@@ -68,6 +79,15 @@
 }
 .bg-ucdavis-gold-20 {
     background-color: var(--ucdavis-gold-20);
+}
+/* Secondary-palette accents for categorical distinction (charts, tags). Exposed as
+   bg-* utilities so Quasar color="arboretum"/"cabernet" resolves on badges/chips,
+   since these are not part of Quasar's registered brand palette. */
+.bg-arboretum {
+    background-color: var(--ucdavis-arboretum);
+}
+.bg-cabernet {
+    background-color: var(--ucdavis-cabernet);
 }
 /* Overrides Quasar's .text-warning; bright gold fails WCAG contrast on white.
    !important required to beat Quasar's own !important. */

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -29,6 +29,7 @@ namespace Viper.test.CMS;
 public sealed class CMSContentControllerTests : IDisposable
 {
     private readonly ICmsContentBlockService _blockService;
+    private readonly ICmsFileStorageService _storage;
     private readonly IUserHelper _userHelper;
     private readonly VIPERContext _context;
     private readonly RAPSContext _rapsContext;
@@ -38,6 +39,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public CMSContentControllerTests()
     {
         _blockService = Substitute.For<ICmsContentBlockService>();
+        _storage = Substitute.For<ICmsFileStorageService>();
         _userHelper = Substitute.For<IUserHelper>();
         _sanitizer = Substitute.For<IHtmlSanitizerService>();
         _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
@@ -45,7 +47,7 @@ public sealed class CMSContentControllerTests : IDisposable
         _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
             .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
 
-        _controller = new CMSContentController(_context, _rapsContext, _sanitizer, _blockService, _userHelper);
+        _controller = new CMSContentController(_context, _rapsContext, _sanitizer, _blockService, _storage, _userHelper);
         SetupControllerContext();
     }
 
@@ -111,6 +113,18 @@ public sealed class CMSContentControllerTests : IDisposable
         Assert.Same(blocks, result.Value);
         await _blockService.Received(1).GetContentBlocksAsync("deleted", "Viper", "cats", "search", true,
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void GetFolders_ReturnsTopLevelUploadFolders()
+    {
+        var folders = new List<string> { "accreditation", "students" };
+        _storage.GetTopLevelFolders().Returns(folders);
+
+        var result = _controller.GetFolders();
+
+        Assert.Same(folders, result.Value);
+        _storage.Received(1).GetTopLevelFolders();
     }
 
     [Fact]

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -104,14 +104,15 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetContentBlocks_PassesFiltersThrough()
     {
         var blocks = new List<ContentBlockDto> { Block() };
-        _blockService.GetContentBlocksAsync("deleted", "Viper", "cats", "search", true, Arg.Any<CancellationToken>())
-            .Returns(blocks);
+        _blockService.GetContentBlocksAsync("deleted", "Viper", "cats", "search", true, 1, 50, "title", false,
+            Arg.Any<CancellationToken>()).Returns((blocks, 1));
 
-        var result = await _controller.GetContentBlocks("deleted", "Viper", "cats", "search", true, TestContext.Current.CancellationToken);
+        var result = await _controller.GetContentBlocks(null, "deleted", "Viper", "cats", "search", true,
+            ct: TestContext.Current.CancellationToken);
 
         Assert.Same(blocks, result.Value);
-        await _blockService.Received(1).GetContentBlocksAsync("deleted", "Viper", "cats", "search", true,
-            Arg.Any<CancellationToken>());
+        await _blockService.Received(1).GetContentBlocksAsync("deleted", "Viper", "cats", "search", true, 1, 50,
+            "title", false, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -205,6 +205,12 @@ public sealed class CMSContentControllerTests : IDisposable
         Assert.DoesNotContain("contentHistories", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("SUPER_SECRET_AES_KEY", json);
         Assert.DoesNotContain(@"S:\Files", json);
+        // No management metadata: the anonymous endpoint must not disclose editor login ids,
+        // permission names, or placement fields (PublicContentBlockDto, not ContentBlockDto).
+        Assert.DoesNotContain("modifiedBy", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("permissions", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"system\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("viperSectionPath", json, StringComparison.OrdinalIgnoreCase);
     }
 
     #endregion

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -33,7 +33,6 @@ public sealed class CMSContentControllerTests : IDisposable
     private readonly IUserHelper _userHelper;
     private readonly VIPERContext _context;
     private readonly RAPSContext _rapsContext;
-    private readonly IHtmlSanitizerService _sanitizer;
     private readonly CMSContentController _controller;
 
     public CMSContentControllerTests()
@@ -41,13 +40,13 @@ public sealed class CMSContentControllerTests : IDisposable
         _blockService = Substitute.For<ICmsContentBlockService>();
         _storage = Substitute.For<ICmsFileStorageService>();
         _userHelper = Substitute.For<IUserHelper>();
-        _sanitizer = Substitute.For<IHtmlSanitizerService>();
+        var sanitizer = Substitute.For<IHtmlSanitizerService>();
         _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
             .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
         _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
             .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
 
-        _controller = new CMSContentController(_context, _rapsContext, _sanitizer, _blockService, _storage, _userHelper);
+        _controller = new CMSContentController(_context, _rapsContext, sanitizer, _blockService, _storage, _userHelper);
         SetupControllerContext();
     }
 

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -147,6 +147,65 @@ public sealed class CMSContentControllerTests : IDisposable
         Assert.IsType<NotFoundResult>(result.Result);
     }
 
+    [Fact]
+    public async Task GetContentBlockByFn_ReturnsNotFound_WhenMissing()
+    {
+        var result = _controller.GetContentBlockByFn("does-not-exist");
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetContentBlockByFn_ProjectsToDto_AndDoesNotLeakEntityInternals()
+    {
+        // Regression: this endpoint is anonymous. It must project to a DTO and never serialize the
+        // raw ContentBlock graph, which would leak each attached file's AES Key and server FilePath,
+        // the full content history, and the block's permission rows.
+        var file = new Models.VIPER.File
+        {
+            FileGuid = Guid.NewGuid(),
+            FriendlyName = "attached-doc",
+            FilePath = @"S:\Files\secret\attached-doc.pdf",
+            Key = "SUPER_SECRET_AES_KEY",
+            Encrypted = true,
+            AllowPublicAccess = true,
+            Description = "internal notes",
+            ModifiedBy = "author"
+        };
+        var block = new Models.VIPER.ContentBlock
+        {
+            Content = "<p>body</p>",
+            Title = "Public Block",
+            System = "Viper",
+            FriendlyName = "public-fn",
+            AllowPublicAccess = true,
+            ModifiedOn = DateTime.Now,
+            ModifiedBy = "author",
+            ContentBlockToFiles = { new Models.VIPER.ContentBlockToFile { FileGuid = file.FileGuid, File = file } },
+            ContentHistories = { new Models.VIPER.ContentHistory { ContentBlockContent = "<p>OLD SECRET VERSION</p>", ModifiedOn = DateTime.Now.AddDays(-1), ModifiedBy = "author" } }
+        };
+        _context.Files.Add(file);
+        _context.ContentBlocks.Add(block);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = _controller.GetContentBlockByFn("public-fn");
+
+        Assert.NotNull(result.Value);
+        var json = System.Text.Json.JsonSerializer.Serialize(result.Value,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+
+        // Consumer contract (VueApp ContentBlock type) preserved.
+        Assert.Contains("\"contentBlockId\"", json);
+        Assert.Contains("\"content\"", json);
+        Assert.Contains("\"title\"", json);
+        // No entity internals or secrets.
+        Assert.DoesNotContain("\"key\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("filePath", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("contentHistories", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("SUPER_SECRET_AES_KEY", json);
+        Assert.DoesNotContain(@"S:\Files", json);
+    }
+
     #endregion
 
     #region Create

--- a/test/CMS/CMSContentPermissionTests.cs
+++ b/test/CMS/CMSContentPermissionTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.CMS.Constants;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
@@ -21,7 +22,6 @@ public sealed class CMSContentPermissionTests : IDisposable
 {
     private readonly VIPERContext _context;
     private readonly RAPSContext _rapsContext;
-    private readonly IHtmlSanitizerService _sanitizer;
     private readonly IUserHelper _userHelper;
     private readonly DataCms _cms;
 
@@ -31,11 +31,11 @@ public sealed class CMSContentPermissionTests : IDisposable
             .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
         _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
             .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
-        _sanitizer = Substitute.For<IHtmlSanitizerService>();
-        _sanitizer.Sanitize(Arg.Any<string>()).Returns(c => c.ArgAt<string>(0));
+        var sanitizer = Substitute.For<IHtmlSanitizerService>();
+        sanitizer.Sanitize(Arg.Any<string>()).Returns(c => c.ArgAt<string>(0));
         _userHelper = Substitute.For<IUserHelper>();
 
-        _cms = new DataCms(_context, _rapsContext, _sanitizer) { UserHelper = _userHelper };
+        _cms = new DataCms(_context, _rapsContext, sanitizer) { UserHelper = _userHelper };
     }
 
     public void Dispose()
@@ -77,13 +77,13 @@ public sealed class CMSContentPermissionTests : IDisposable
     public async Task PublicBlock_ReturnedToAnonymousUser()
     {
         var block = await SeedBlockAsync(allowPublic: true);
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Single(result!);
-        Assert.Equal(block.ContentBlockId, result![0].ContentBlockId);
+        Assert.Single(result);
+        Assert.Equal(block.ContentBlockId, result[0].ContentBlockId);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public sealed class CMSContentPermissionTests : IDisposable
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Empty(result!);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public sealed class CMSContentPermissionTests : IDisposable
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Single(result!);
+        Assert.Single(result);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public sealed class CMSContentPermissionTests : IDisposable
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Single(result!);
+        Assert.Single(result);
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public sealed class CMSContentPermissionTests : IDisposable
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Single(result!);
+        Assert.Single(result);
     }
 
     [Fact]
@@ -161,18 +161,18 @@ public sealed class CMSContentPermissionTests : IDisposable
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Single(result!);
+        Assert.Single(result);
     }
 
     [Fact]
     public async Task RestrictedBlock_WithheldFromAnonymousUser()
     {
         var block = await SeedBlockAsync(allowPublic: false, "SVMSecure.CATS");
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var result = _cms.GetContentBlocksAllowed(null, block.FriendlyName, null, null, null, null, null, 1)?.ToList();
 
         Assert.NotNull(result);
-        Assert.Empty(result!);
+        Assert.Empty(result);
     }
 }

--- a/test/CMS/CMSFilesControllerTests.cs
+++ b/test/CMS/CMSFilesControllerTests.cs
@@ -47,7 +47,14 @@ public sealed class CMSFilesControllerTests : IDisposable
         SetupControllerContext();
     }
 
-    public void Dispose() => _rapsContext.Dispose();
+    // Streams backing form files must outlive the controller call; disposed with the test instance.
+    private readonly List<MemoryStream> _formFileStreams = new();
+
+    public void Dispose()
+    {
+        _rapsContext.Dispose();
+        _formFileStreams.ForEach(s => s.Dispose());
+    }
 
     private void SetupControllerContext()
     {
@@ -66,9 +73,10 @@ public sealed class CMSFilesControllerTests : IDisposable
         Folder = "cats"
     };
 
-    private static IFormFile MakeFormFile(string fileName = "report.pdf", long length = 3)
+    private IFormFile MakeFormFile(string fileName = "report.pdf", long length = 3)
     {
         var stream = new MemoryStream(new byte[length]);
+        _formFileStreams.Add(stream);
         return new FormFile(stream, 0, length, "file", fileName);
     }
 
@@ -125,7 +133,7 @@ public sealed class CMSFilesControllerTests : IDisposable
     public async Task GetAudit_PassesFilterAndPaginationThrough_AndSetsTotal()
     {
         _auditService.GetAuditEntriesAsync(Arg.Any<CmsFileAuditFilter>(), 3, 10, Arg.Any<CancellationToken>())
-            .Returns(new List<Viper.Models.VIPER.FileAudit>());
+            .Returns(new List<Models.VIPER.FileAudit>());
         _auditService.GetAuditEntryCountAsync(Arg.Any<CmsFileAuditFilter>(), Arg.Any<CancellationToken>()).Returns(5);
         var fileGuid = Guid.NewGuid();
         var pagination = new ApiPagination { Page = 3, PerPage = 10 };

--- a/test/CMS/CMSFilesControllerTests.cs
+++ b/test/CMS/CMSFilesControllerTests.cs
@@ -77,9 +77,13 @@ public sealed class CMSFilesControllerTests : IDisposable
     [Fact]
     public async Task GetFiles_PassesFiltersAndPaginationThrough_AndSetsTotal()
     {
+        // An admin sees the whole trash, so the owner restriction passed to the service is null.
+        var user = new AaudUser { AaudUserId = 1, LoginId = "admin" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(true);
         var files = new List<CmsFileDto> { File() };
         _fileService.GetFilesAsync("cats", "deleted", "budget", true, false, 2, 25, "modifiedOn", true,
-            Arg.Any<CancellationToken>()).Returns((files, 42));
+            null, Arg.Any<CancellationToken>()).Returns((files, 42));
         var pagination = new ApiPagination { Page = 2, PerPage = 25 };
 
         var result = await _controller.GetFiles("cats", "budget", true, false, pagination, "deleted", "modifiedOn", true, TestContext.Current.CancellationToken);
@@ -87,19 +91,21 @@ public sealed class CMSFilesControllerTests : IDisposable
         Assert.Same(files, result.Value);
         Assert.Equal(42, pagination.TotalRecords);
         await _fileService.Received(1).GetFilesAsync("cats", "deleted", "budget", true, false, 2, 25, "modifiedOn", true,
-            Arg.Any<CancellationToken>());
+            null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetFiles_DefaultsPageAndPerPage_WhenNoPagination()
     {
+        var user = new AaudUser { AaudUserId = 1, LoginId = "user" };
+        _userHelper.GetCurrentUser().Returns(user);
         _fileService.GetFilesAsync(null, "active", null, null, null, 1, 50, "friendlyName", false,
-            Arg.Any<CancellationToken>()).Returns((new List<CmsFileDto>(), 0));
+            "user", Arg.Any<CancellationToken>()).Returns((new List<CmsFileDto>(), 0));
 
         await _controller.GetFiles(null, null, null, null, null, ct: TestContext.Current.CancellationToken);
 
         await _fileService.Received(1).GetFilesAsync(null, "active", null, null, null, 1, 50, "friendlyName", false,
-            Arg.Any<CancellationToken>());
+            "user", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -291,11 +297,79 @@ public sealed class CMSFilesControllerTests : IDisposable
     public async Task RestoreFile_ReturnsNoContent_WhenRestored()
     {
         var guid = Guid.NewGuid();
+        var user = new AaudUser { AaudUserId = 1, LoginId = "admin" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(true);
         _fileService.RestoreFileAsync(guid, Arg.Any<CancellationToken>()).Returns(true);
 
         var result = await _controller.RestoreFile(guid, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task RestoreFile_AllowsNonAdmin_WhoDeletedTheFile()
+    {
+        var guid = Guid.NewGuid();
+        var user = new AaudUser { AaudUserId = 1, LoginId = "user" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(false);
+        _fileService.GetFileAsync(guid, Arg.Any<CancellationToken>())
+            .Returns(new CmsFileDto { FileGuid = guid, DeletedOn = DateTime.Now, ModifiedBy = "user" });
+        _fileService.RestoreFileAsync(guid, Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await _controller.RestoreFile(guid, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NoContentResult>(result);
+        await _fileService.Received(1).RestoreFileAsync(guid, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RestoreFile_Forbids_WhenNonAdminDidNotDeleteIt()
+    {
+        var guid = Guid.NewGuid();
+        var user = new AaudUser { AaudUserId = 1, LoginId = "user" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(false);
+        _fileService.GetFileAsync(guid, Arg.Any<CancellationToken>())
+            .Returns(new CmsFileDto { FileGuid = guid, DeletedOn = DateTime.Now, ModifiedBy = "someone-else" });
+
+        var result = await _controller.RestoreFile(guid, TestContext.Current.CancellationToken);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+        await _fileService.DidNotReceive().RestoreFileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetFiles_ScopesDeletedToOwner_ForNonAdmin()
+    {
+        var user = new AaudUser { AaudUserId = 1, LoginId = "user" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(false);
+        _fileService.GetFilesAsync(null, "deleted", null, null, null, 1, 50, "friendlyName", false,
+            "user", Arg.Any<CancellationToken>()).Returns((new List<CmsFileDto>(), 0));
+
+        await _controller.GetFiles(null, null, null, null, null, "deleted", ct: TestContext.Current.CancellationToken);
+
+        // A non-admin's trash is scoped to the files they deleted (their login).
+        await _fileService.Received(1).GetFilesAsync(null, "deleted", null, null, null, 1, 50, "friendlyName", false,
+            "user", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetFiles_FailsClosed_WhenUserContextMissing()
+    {
+        _userHelper.GetCurrentUser().ReturnsNull();
+        _fileService.GetFilesAsync(null, "deleted", null, null, null, 1, 50, "friendlyName", false,
+            string.Empty, Arg.Any<CancellationToken>()).Returns((new List<CmsFileDto>(), 0));
+
+        await _controller.GetFiles(null, null, null, null, null, "deleted", ct: TestContext.Current.CancellationToken);
+
+        // A missing user context must scope the trash to nothing, not fall through to the
+        // admin-level unrestricted (null) view.
+        await _fileService.Received(1).GetFilesAsync(null, "deleted", null, null, null, 1, 50, "friendlyName", false,
+            string.Empty, Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/test/CMS/CMSFilesControllerTests.cs
+++ b/test/CMS/CMSFilesControllerTests.cs
@@ -247,6 +247,21 @@ public sealed class CMSFilesControllerTests : IDisposable
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
+    [Fact]
+    public async Task UpdateFile_ReturnsConflict_OnStaleEdit()
+    {
+        // CmsConcurrencyException derives from InvalidOperationException; it must map to 409,
+        // not fall into the generic InvalidOperationException -> 400 handler.
+        var guid = Guid.NewGuid();
+        var request = new CmsFileUpdateRequest { Description = "x", LastModifiedOn = DateTime.Now.AddMinutes(-5) };
+        _fileService.UpdateFileAsync(guid, request, Arg.Any<IFormFile?>(), Arg.Any<CancellationToken>())
+            .Throws(new CmsConcurrencyException("This file was modified by someone on 7/2/2026."));
+
+        var result = await _controller.UpdateFile(guid, request, null, TestContext.Current.CancellationToken);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
     #endregion
 
     #region Delete / Restore

--- a/test/CMS/CMSLeftNavControllerTests.cs
+++ b/test/CMS/CMSLeftNavControllerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReturnsExtensions;
 using Viper.Areas.CMS.Controllers;
 using Viper.Areas.CMS.Models.DTOs;
@@ -114,20 +115,30 @@ public sealed class CMSLeftNavControllerTests
     #region SaveItems
 
     [Fact]
-    public async Task SaveItems_ReturnsBadRequest_OnDuplicateItemIds()
+    public async Task SaveItems_ReturnsBadRequest_OnArgumentException()
     {
-        var items = new List<LeftNavItemEdit>
-        {
-            new() { LeftNavItemId = 2, MenuItemText = "A" },
-            new() { LeftNavItemId = 2, MenuItemText = "B" }
-        };
+        // The duplicate-id guard now lives in the service; the controller maps its ArgumentException to 400.
+        var items = new List<LeftNavItemEdit> { new() { LeftNavItemId = 2, MenuItemText = "A" } };
+        _leftNavService.SaveItemsAsync(5, items, Arg.Any<CancellationToken>())
+            .Throws(new ArgumentException("Duplicate item ids are not allowed."));
 
         var result = await _controller.SaveItems(5, items, TestContext.Current.CancellationToken);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("Duplicate item ids", badRequest.Value?.ToString());
-        await _leftNavService.DidNotReceive().SaveItemsAsync(Arg.Any<int>(), Arg.Any<List<LeftNavItemEdit>>(),
-            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveItems_ReturnsConflict_OnStaleItemId()
+    {
+        var items = new List<LeftNavItemEdit> { new() { LeftNavItemId = 99, MenuItemText = "Stale" } };
+        _leftNavService.SaveItemsAsync(5, items, Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("One or more items no longer exist in this menu. Reload and try again."));
+
+        var result = await _controller.SaveItems(5, items, TestContext.Current.CancellationToken);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result.Result);
+        Assert.Contains("no longer exist", conflict.Value?.ToString());
     }
 
     [Fact]

--- a/test/CMS/CMSLinkCollectionControllerTests.cs
+++ b/test/CMS/CMSLinkCollectionControllerTests.cs
@@ -84,7 +84,7 @@ public sealed class CMSLinkCollectionControllerTests : IDisposable
     [Fact]
     public async Task PostLinkCollection_RejectsDuplicateName()
     {
-        await SeedCollectionAsync("Resources");
+        await SeedCollectionAsync();
 
         var result = await _controller.PostLinkCollection(new CreateLinkCollectionDto { LinkCollection = "Resources" });
 

--- a/test/CMS/CMSUserPhotoControllerTests.cs
+++ b/test/CMS/CMSUserPhotoControllerTests.cs
@@ -10,10 +10,14 @@ namespace Viper.test.CMS;
 /// <summary>
 /// Controller wiring tests for CMSUserPhotoController: each by-id-type endpoint forwards only
 /// its identifier (and the altPhoto flag) to ICmsUserPhotoService and returns the bytes as an
-/// image/jpeg file response with a private cache header.
+/// image/jpeg file response with a private cache header; conditional requests (If-Modified-Since)
+/// short-circuit to 304 per FIX 4.
 /// </summary>
 public sealed class CMSUserPhotoControllerTests
 {
+    private static readonly DateTimeOffset PhotoLastModified =
+        new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
     private readonly ICmsUserPhotoService _photoService;
     private readonly CMSUserPhotoController _controller;
 
@@ -29,54 +33,134 @@ public sealed class CMSUserPhotoControllerTests
         };
     }
 
+    private static CmsUserPhotoResult Result(byte[] bytes) => new(bytes, PhotoLastModified);
+
     [Fact]
     public async Task GetByMailId_ForwardsMailIdOnly()
     {
         var bytes = new byte[] { 1, 2, 3 };
-        _photoService.GetUserPhotoAsync("mail@example.com", null, null, false, Arg.Any<CancellationToken>())
-            .Returns(bytes);
+        _photoService.GetUserPhotoAsync("mail@example.com", null, null, null, false, Arg.Any<CancellationToken>())
+            .Returns(Result(bytes));
 
         var result = await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
 
         var file = Assert.IsType<FileContentResult>(result);
         Assert.Equal("image/jpeg", file.ContentType);
         Assert.Equal(bytes, file.FileContents);
-        await _photoService.Received(1).GetUserPhotoAsync("mail@example.com", null, null, false,
+        await _photoService.Received(1).GetUserPhotoAsync("mail@example.com", null, null, null, false,
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetByLoginId_ForwardsLoginIdAndAltPhotoFlag()
     {
-        _photoService.GetUserPhotoAsync(null, "loginX", null, true, Arg.Any<CancellationToken>())
-            .Returns(new byte[] { 9 });
+        _photoService.GetUserPhotoAsync(null, "loginX", null, null, true, Arg.Any<CancellationToken>())
+            .Returns(Result(new byte[] { 9 }));
 
         var result = await _controller.GetByLoginId("loginX", altPhoto: true, TestContext.Current.CancellationToken);
 
         Assert.IsType<FileContentResult>(result);
-        await _photoService.Received(1).GetUserPhotoAsync(null, "loginX", null, true, Arg.Any<CancellationToken>());
+        await _photoService.Received(1).GetUserPhotoAsync(null, "loginX", null, null, true, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetByIamId_ForwardsIamIdOnly()
     {
-        _photoService.GetUserPhotoAsync(null, null, "1000123", false, Arg.Any<CancellationToken>())
-            .Returns(new byte[] { 7 });
+        _photoService.GetUserPhotoAsync(null, null, "1000123", null, false, Arg.Any<CancellationToken>())
+            .Returns(Result(new byte[] { 7 }));
 
         var result = await _controller.GetByIamId("1000123", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<FileContentResult>(result);
-        await _photoService.Received(1).GetUserPhotoAsync(null, null, "1000123", false, Arg.Any<CancellationToken>());
+        await _photoService.Received(1).GetUserPhotoAsync(null, null, "1000123", null, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetByMothraId_ForwardsMothraIdOnly()
+    {
+        _photoService.GetUserPhotoAsync(null, null, null, "m-9001", false, Arg.Any<CancellationToken>())
+            .Returns(Result(new byte[] { 5 }));
+
+        var result = await _controller.GetByMothraId("m-9001", ct: TestContext.Current.CancellationToken);
+
+        Assert.IsType<FileContentResult>(result);
+        await _photoService.Received(1).GetUserPhotoAsync(null, null, null, "m-9001", false, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ServePhoto_SetsPrivateCacheHeader()
     {
-        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<CancellationToken>()).Returns(new byte[] { 1 });
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(new byte[] { 1 }));
 
         await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
 
-        Assert.Contains("private", _controller.Response.Headers.CacheControl.ToString());
+        var cacheControl = _controller.Response.Headers.CacheControl.ToString();
+        Assert.Contains("private", cacheControl);
+        Assert.Contains("stale-while-revalidate", cacheControl);
+    }
+
+    [Fact]
+    public async Task ServePhoto_SetsLastModifiedHeader()
+    {
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(new byte[] { 1 }));
+
+        await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(PhotoLastModified, _controller.Response.GetTypedHeaders().LastModified);
+    }
+
+    [Fact]
+    public async Task ServePhoto_ReturnsNotModified_WhenIfModifiedSinceCoversLastModified()
+    {
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(new byte[] { 1, 2, 3 }));
+        _controller.Request.GetTypedHeaders().IfModifiedSince = PhotoLastModified;
+
+        var result = await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
+
+        var status = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(StatusCodes.Status304NotModified, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task ServePhoto_ReturnsNotModified_WhenIfModifiedSinceIsAfterLastModified()
+    {
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(new byte[] { 1, 2, 3 }));
+        _controller.Request.GetTypedHeaders().IfModifiedSince = PhotoLastModified.AddDays(1);
+
+        var result = await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
+
+        var status = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(StatusCodes.Status304NotModified, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task ServePhoto_ReturnsFile_WhenIfModifiedSinceIsBeforeLastModified()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(bytes));
+        _controller.Request.GetTypedHeaders().IfModifiedSince = PhotoLastModified.AddDays(-1);
+
+        var result = await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal(bytes, file.FileContents);
+    }
+
+    [Fact]
+    public async Task ServePhoto_ReturnsFile_WhenNoIfModifiedSinceHeaderSent()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        _photoService.GetUserPhotoAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Result(bytes));
+
+        var result = await _controller.GetByMailId("mail@example.com", ct: TestContext.Current.CancellationToken);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal(bytes, file.FileContents);
     }
 }

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -17,7 +17,6 @@ public sealed class CmsContentBlockServiceTests : IDisposable
 {
     private readonly VIPERContext _context;
     private readonly IHtmlSanitizerService _sanitizer;
-    private readonly IUserHelper _userHelper;
     private readonly CmsContentBlockService _service;
 
     public CmsContentBlockServiceTests()
@@ -28,9 +27,8 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         _sanitizer.Sanitize(Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
         // Pass-through so diff tests assert on the real htmldiff.net markers, not a sanitized copy.
         _sanitizer.SanitizeDiff(Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
-        _userHelper = Substitute.For<IUserHelper>();
 
-        _service = new CmsContentBlockService(_context, _sanitizer, _userHelper);
+        _service = new CmsContentBlockService(_context, _sanitizer, Substitute.For<IUserHelper>());
     }
 
     public void Dispose()
@@ -113,7 +111,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         var dto = await _service.GetContentBlockAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
 
         Assert.NotNull(dto);
-        Assert.Equal("<p>original</p>", dto!.Content);
+        Assert.Equal("<p>original</p>", dto.Content);
         Assert.Equal(new List<string> { "SVMSecure.CATS" }, dto.Permissions);
     }
 
@@ -230,7 +228,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     [Fact]
     public async Task Update_AppliesPermissionAndFileDeltas()
     {
-        var file = new Viper.Models.VIPER.File
+        var file = new Models.VIPER.File
         {
             FileGuid = Guid.NewGuid(),
             FilePath = @"C:\FakeRoot\cats\attach.pdf",
@@ -438,7 +436,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(diff);
-        Assert.True(diff!.HasComparison);
+        Assert.True(diff.HasComparison);
         Assert.True(diff.HasChanges);
         Assert.Equal("originalAuthor", diff.OldModifiedBy);
         Assert.Contains("<ins", diff.Content);
@@ -461,7 +459,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(diff);
-        Assert.False(diff!.HasComparison);
+        Assert.False(diff.HasComparison);
         Assert.Equal("<p>original</p>", diff.Content);
         Assert.DoesNotContain("<ins", diff.Content);
     }
@@ -490,7 +488,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
             "<p>current draft</p>", TestContext.Current.CancellationToken);
 
         Assert.NotNull(diff);
-        Assert.True(diff!.HasComparison);
+        Assert.True(diff.HasComparison);
         Assert.True(diff.HasChanges);
         Assert.Equal("originalAuthor", diff.OldModifiedBy);
         Assert.Contains("<ins", diff.Content);
@@ -511,7 +509,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
             "<p>original</p>", TestContext.Current.CancellationToken);
 
         Assert.NotNull(diff);
-        Assert.True(diff!.HasComparison);
+        Assert.True(diff.HasComparison);
         Assert.False(diff.HasChanges);
         Assert.DoesNotContain("<ins", diff.Content);
         Assert.DoesNotContain("<del", diff.Content);

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -83,13 +83,37 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         await SeedBlockAsync();
         await SeedBlockAsync(b => b.DeletedOn = DateTime.Now);
 
-        var active = await _service.GetContentBlocksAsync("active", null, null, null, ct: TestContext.Current.CancellationToken);
-        var deleted = await _service.GetContentBlocksAsync("deleted", null, null, null, ct: TestContext.Current.CancellationToken);
-        var all = await _service.GetContentBlocksAsync("all", null, null, null, ct: TestContext.Current.CancellationToken);
+        var active = await _service.GetContentBlocksAsync("active", null, null, null, null, 1, 50, "title", false, TestContext.Current.CancellationToken);
+        var deleted = await _service.GetContentBlocksAsync("deleted", null, null, null, null, 1, 50, "title", false, TestContext.Current.CancellationToken);
+        var all = await _service.GetContentBlocksAsync("all", null, null, null, null, 1, 50, "title", false, TestContext.Current.CancellationToken);
 
-        Assert.Single(active);
-        Assert.Single(deleted);
-        Assert.Equal(2, all.Count);
+        Assert.Single(active.Blocks);
+        Assert.Single(deleted.Blocks);
+        Assert.Equal(2, all.Blocks.Count);
+        Assert.Equal(2, all.Total);
+    }
+
+    [Fact]
+    public async Task GetContentBlocks_PagesSortsAndReturnsTotal()
+    {
+        await SeedBlockAsync(b => b.Title = "Charlie");
+        await SeedBlockAsync(b => b.Title = "Alpha");
+        await SeedBlockAsync(b => b.Title = "Bravo");
+
+        var page1 = await _service.GetContentBlocksAsync("active", null, null, null, null, 1, 2, "title", false,
+            TestContext.Current.CancellationToken);
+        var page2 = await _service.GetContentBlocksAsync("active", null, null, null, null, 2, 2, "title", false,
+            TestContext.Current.CancellationToken);
+
+        // Total counts all matches; the page returns only its slice, sorted by title across pages.
+        Assert.Equal(3, page1.Total);
+        Assert.Equal(new[] { "Alpha", "Bravo" }, page1.Blocks.Select(b => b.Title));
+        Assert.Single(page2.Blocks);
+        Assert.Equal("Charlie", page2.Blocks[0].Title);
+
+        var desc = await _service.GetContentBlocksAsync("active", null, null, null, null, 1, 1, "title", true,
+            TestContext.Current.CancellationToken);
+        Assert.Equal("Charlie", desc.Blocks[0].Title);
     }
 
     [Fact]
@@ -97,9 +121,9 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     {
         await SeedBlockAsync();
 
-        var list = await _service.GetContentBlocksAsync("active", null, null, null, ct: TestContext.Current.CancellationToken);
+        var list = await _service.GetContentBlocksAsync("active", null, null, null, null, 1, 50, "title", false, TestContext.Current.CancellationToken);
 
-        Assert.Equal(string.Empty, list[0].Content);
+        Assert.Equal(string.Empty, list.Blocks[0].Content);
     }
 
     [Fact]

--- a/test/CMS/CmsFileImportServiceTests.cs
+++ b/test/CMS/CmsFileImportServiceTests.cs
@@ -334,15 +334,19 @@ public sealed class CmsFileImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Preview_TwoLinesSameFinalName_NonBlockingMessageOnSecond()
+    public async Task Preview_TwoLinesSameBasename_SecondPreviewsImportRenamedName()
     {
         CreateWebrootFile(@"cats\docs\manual.pdf");
         // A second file in a different sub-path that produces the same final name after rename.
         Directory.CreateDirectory(Path.Join(_webroot, "cats", "other"));
         CreateWebrootFile(@"cats\other\manual.pdf");
 
-        // Stub storage to always return the same available name so both resolve to "manual.pdf".
+        // Disk/DB alone leaves the name free, so both lines resolve to "manual.pdf" on their own.
         _storage.GetAvailableFileName("cats", "manual.pdf").Returns("manual.pdf");
+        // But once the first line reserves "manual.pdf", the import would rename the second; the
+        // preview must reserve names across the batch and show that same renamed name up front.
+        _storage.GetAvailableFileName("cats", "manual.pdf",
+            Arg.Is<IReadOnlySet<string>?>(s => s != null && s.Contains("manual.pdf"))).Returns("manual_0.pdf");
 
         var request = new CmsFileImportRequest
         {
@@ -357,11 +361,16 @@ public sealed class CmsFileImportServiceTests : IDisposable
         var results = await _service.PreviewImportAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, results.Count);
-        // First entry: CanImport true, no message.
+        // First entry: keeps the name, no message.
         Assert.True(results[0].CanImport);
+        Assert.Equal("manual.pdf", results[0].FileName);
         Assert.Null(results[0].Message);
-        // Second entry: CanImport true (non-blocking), but has a message about renaming.
+        // Second entry: previews the exact renamed name the import will assign (not the colliding
+        // name), with a non-blocking message explaining the rename.
         Assert.True(results[1].CanImport);
+        Assert.Equal("manual_0.pdf", results[1].FileName);
+        Assert.Equal("manual.pdf", results[1].RenamedFrom);
+        Assert.Equal("cats-manual_0.pdf", results[1].FriendlyName);
         Assert.NotNull(results[1].Message);
         Assert.Contains("renamed", results[1].Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/test/CMS/CmsFileImportServiceTests.cs
+++ b/test/CMS/CmsFileImportServiceTests.cs
@@ -66,7 +66,11 @@ public sealed class CmsFileImportServiceTests : IDisposable
 
     private string CreateWebrootFile(string relativePath, string contents = "legacy file")
     {
-        var path = Path.Join(_webroot, relativePath);
+        // Split on both separator styles: on Linux a raw @"cats\docs\x.pdf" would otherwise
+        // become one literal file name in the webroot root instead of a nested path.
+        var segments = relativePath.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var path = Path.Join(_webroot, Path.Join(segments));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, contents);
         return path;
     }

--- a/test/CMS/CmsFileResponseTests.cs
+++ b/test/CMS/CmsFileResponseTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Http;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Services;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for the /CMS/Files download-response hardening: X-Content-Type-Options: nosniff on every
+/// file response, and forcing inline-unsafe types (html/svg) to download instead of rendering in
+/// the app origin (stored-XSS guard). Legacy .html files stay downloadable, just never inline.
+/// </summary>
+public sealed class CmsFileResponseTests
+{
+    [Fact]
+    public void SetNoSniff_SetsHeader()
+    {
+        var response = new DefaultHttpContext().Response;
+
+        CmsFileResponse.SetNoSniff(response);
+
+        Assert.Equal("nosniff", response.Headers["X-Content-Type-Options"]);
+    }
+
+    [Theory]
+    [InlineData("page.html")]
+    [InlineData("PAGE.HTM")]
+    [InlineData("doc.xhtml")]
+    [InlineData("logo.svg")]
+    [InlineData(@"S:\Files\cats\evil.HTML")]
+    public void DispositionType_InlineUnsafe_ForcesAttachment(string fileName)
+    {
+        Assert.Equal("attachment", CmsFileResponse.DispositionType(fileName));
+        Assert.True(CmsFileTypes.ShouldForceAttachment(fileName));
+    }
+
+    [Theory]
+    [InlineData("report.pdf")]
+    [InlineData("image.png")]
+    [InlineData("notes.txt")]
+    [InlineData("sheet.xlsx")]
+    [InlineData("noextension")]
+    public void DispositionType_SafeTypes_StayInline(string fileName)
+    {
+        Assert.Equal("inline", CmsFileResponse.DispositionType(fileName));
+        Assert.False(CmsFileTypes.ShouldForceAttachment(fileName));
+    }
+}

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -822,6 +822,31 @@ public sealed class CmsFileServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetFiles_SortsByDeletedOn_OldestFirstForPurgeViews()
+    {
+        await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-newer.pdf";
+            f.FilePath = @"C:\FakeRoot\cats\newer.pdf";
+            f.DeletedOn = DateTime.Now.AddDays(-1);
+        });
+        await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-older.pdf";
+            f.FilePath = @"C:\FakeRoot\cats\older.pdf";
+            f.DeletedOn = DateTime.Now.AddDays(-20);
+        });
+
+        var (ascending, _) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50,
+            "deletedOn", false, ct: TestContext.Current.CancellationToken);
+        var (descending, _) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50,
+            "deletedOn", true, ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(new[] { "cats-older.pdf", "cats-newer.pdf" }, ascending.Select(f => f.FriendlyName));
+        Assert.Equal(new[] { "cats-newer.pdf", "cats-older.pdf" }, descending.Select(f => f.FriendlyName));
+    }
+
+    [Fact]
     public async Task GetFiles_Deleted_ScopedToOwner_ReturnsOnlyFilesTheyDeleted()
     {
         var mine = await SeedFileAsync(f =>

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using Viper.Areas.CMS.Models.DTOs;
 using Viper.Areas.CMS.Services;
 using Viper.Classes.SQLContext;
+using Viper.Models.VIPER;
 using File = Viper.Models.VIPER.File;
 
 namespace Viper.test.CMS;
@@ -25,6 +26,7 @@ public sealed class CmsFileServiceTests : IDisposable
     private readonly IUserHelper _userHelper;
     private readonly CmsFileService _service;
     private readonly List<VIPERContext> _extraContexts = new();
+    private readonly List<MemoryStream> _formFileStreams = new();
 
     public CmsFileServiceTests()
     {
@@ -37,7 +39,7 @@ public sealed class CmsFileServiceTests : IDisposable
         _storage.RootFolder.Returns(@"C:\FakeRoot");
         _storage.IsValidFolder(Arg.Any<string>()).Returns(true);
         _storage.SaveToTempAsync(Arg.Any<IFormFile>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo => Task.FromResult(@"C:\FakeTemp\" + Guid.NewGuid().ToString("N")));
+            .Returns(_ => Task.FromResult(@"C:\FakeTemp\" + Guid.NewGuid().ToString("N")));
         _storage.MoveIntoPlace(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
             .Returns(callInfo => Path.Join(@"C:\FakeRoot", callInfo.ArgAt<string>(1), Path.GetFileName(callInfo.ArgAt<string>(2))));
 
@@ -59,11 +61,17 @@ public sealed class CmsFileServiceTests : IDisposable
         {
             ctx.Dispose();
         }
+        foreach (var stream in _formFileStreams)
+        {
+            stream.Dispose();
+        }
     }
 
-    private static IFormFile MakeFormFile(string fileName = "report.pdf")
+    private IFormFile MakeFormFile(string fileName = "report.pdf")
     {
+        // Tracked so the backing stream is disposed in Dispose rather than left to the GC.
         var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        _formFileStreams.Add(stream);
         return new FormFile(stream, 0, stream.Length, "file", fileName);
     }
 
@@ -209,9 +217,9 @@ public sealed class CmsFileServiceTests : IDisposable
         var request = new CmsFileCreateRequest { Folder = "cats" };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateFileAsync(request, MakeFormFile("report.pdf"), TestContext.Current.CancellationToken));
+            () => _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken));
 
-        _storage.Received(1).DeleteManagedFile(@"C:\FakeRoot\cats\report.pdf");
+        _storage.Received(1).DeleteManagedFile(Path.Join(@"C:\FakeRoot", "cats", "report.pdf"));
     }
 
     [Fact]
@@ -255,7 +263,7 @@ public sealed class CmsFileServiceTests : IDisposable
 
         var request = new CmsFileCreateRequest { Folder = "cats", Overwrite = true };
 
-        await _service.CreateFileAsync(request, MakeFormFile("report.pdf"), TestContext.Current.CancellationToken);
+        await _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken);
 
         _storage.Received(1).ReplaceInPlace(Arg.Any<string>(), targetPath);
         _storage.DidNotReceive().MoveIntoPlace(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
@@ -280,7 +288,7 @@ public sealed class CmsFileServiceTests : IDisposable
         var request = new CmsFileCreateRequest { Folder = "cats", Overwrite = true };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateFileAsync(request, MakeFormFile("report.pdf"), TestContext.Current.CancellationToken));
+            () => _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken));
 
         _storage.DidNotReceive().ReplaceInPlace(Arg.Any<string>(), Arg.Any<string>());
     }
@@ -290,7 +298,7 @@ public sealed class CmsFileServiceTests : IDisposable
     {
         var request = new CmsFileCreateRequest { Folder = "cats", Overwrite = true };
 
-        await _service.CreateFileAsync(request, MakeFormFile("report.pdf"), TestContext.Current.CancellationToken);
+        await _service.CreateFileAsync(request, MakeFormFile(), TestContext.Current.CancellationToken);
 
         _storage.Received(1).MoveIntoPlace(Arg.Any<string>(), "cats", "report.pdf", Arg.Any<bool>());
         _storage.DidNotReceive().ReplaceInPlace(Arg.Any<string>(), Arg.Any<string>());
@@ -365,8 +373,8 @@ public sealed class CmsFileServiceTests : IDisposable
     {
         var file = await SeedFileAsync(f =>
         {
-            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Old" });
-            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Keep" });
+            f.FileToPermissions.Add(new FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Old" });
+            f.FileToPermissions.Add(new FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure.Keep" });
         });
         var request = new CmsFileUpdateRequest
         {
@@ -377,7 +385,7 @@ public sealed class CmsFileServiceTests : IDisposable
         var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
 
         Assert.NotNull(dto);
-        Assert.Equal(new List<string> { "SVMSecure.Keep", "SVMSecure.New" }, dto!.Permissions);
+        Assert.Equal(new List<string> { "SVMSecure.Keep", "SVMSecure.New" }, dto.Permissions);
         _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.EditFile,
             Arg.Is<string>(d => d.Contains("Permission removed: SVMSecure.Old") && d.Contains("Permission added: SVMSecure.New")));
     }
@@ -386,7 +394,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task UpdateFile_AppliesPersonDeltas()
     {
         var file = await SeedFileAsync(f =>
-            f.FileToPeople.Add(new Viper.Models.VIPER.FileToPerson { FileGuid = f.FileGuid, IamId = "100OLD" }));
+            f.FileToPeople.Add(new FileToPerson { FileGuid = f.FileGuid, IamId = "100OLD" }));
         var request = new CmsFileUpdateRequest
         {
             Description = "seeded",
@@ -396,7 +404,7 @@ public sealed class CmsFileServiceTests : IDisposable
         var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
 
         Assert.NotNull(dto);
-        Assert.Single(dto!.People);
+        Assert.Single(dto.People);
         Assert.Equal("100NEW", dto.People[0].IamId);
     }
 
@@ -634,7 +642,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task PermanentDelete_RemovesRowAndDiskFile()
     {
         var file = await SeedFileAsync(f =>
-            f.FileToPermissions.Add(new Viper.Models.VIPER.FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure" }));
+            f.FileToPermissions.Add(new FileToPermission { FileGuid = f.FileGuid, Permission = "SVMSecure" }));
         _storage.ManagedFileExists(file.FilePath).Returns(true);
 
         var result = await _service.PermanentlyDeleteFileAsync(file.FileGuid, TestContext.Current.CancellationToken);
@@ -681,7 +689,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task PurgeDeletedFiles_DetachesFromContentBlocks()
     {
         var file = await SeedFileAsync(f => f.DeletedOn = DateTime.Now.AddDays(-40));
-        _context.ContentBlockToFiles.Add(new Viper.Models.VIPER.ContentBlockToFile
+        _context.ContentBlockToFiles.Add(new ContentBlockToFile
         {
             ContentBlockId = 1,
             FileGuid = file.FileGuid

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -67,6 +67,18 @@ public sealed class CmsFileServiceTests : IDisposable
         return new FormFile(stream, 0, stream.Length, "file", fileName);
     }
 
+    /// <summary>
+    /// Writes a real temp file to stand in for a backup the service returns from BackupManagedFile.
+    /// A real path lets the cleanup branch (System.IO.File.Exists/Delete) actually execute rather
+    /// than short-circuiting on a fake path that never exists. Callers delete it in a finally.
+    /// </summary>
+    private static string MakeRealBackupFile()
+    {
+        string path = Path.Join(Path.GetTempPath(), "Viper-CMS-Test-" + Guid.NewGuid().ToString("N"));
+        System.IO.File.WriteAllBytes(path, new byte[] { 9, 9, 9 });
+        return path;
+    }
+
     private async Task<File> SeedFileAsync(Action<File>? customize = null)
     {
         var file = new File
@@ -284,6 +296,66 @@ public sealed class CmsFileServiceTests : IDisposable
         _storage.DidNotReceive().ReplaceInPlace(Arg.Any<string>(), Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task CreateFile_OverwriteOrphan_SaveFails_RestoresOriginalFile()
+    {
+        const string targetPath = @"C:\FakeRoot\cats\orphan.pdf";
+        const string backupPath = @"C:\FakeTemp\backup-orphan";
+        _storage.FileNameInUse("cats", "orphan.pdf").Returns(true);
+        _storage.BuildManagedPath("cats", "orphan.pdf").Returns(targetPath);
+        _storage.ManagedFileExists(targetPath).Returns(true);
+        _storage.BackupManagedFile(targetPath).Returns(backupPath);
+
+        var (service, _, _) = await BuildServiceOverFailingSaveAsync();
+        var request = new CmsFileCreateRequest { Folder = "cats", Overwrite = true };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.CreateFileAsync(request, MakeFormFile("orphan.pdf"), TestContext.Current.CancellationToken));
+
+        // The orphaned original (no DB row) was overwritten on disk; the failed save must move the
+        // pre-overwrite backup back into place rather than deleting it, so the file isn't lost.
+        _storage.Received(1).BackupManagedFile(targetPath);
+        _storage.Received(1).ReplaceInPlace(backupPath, targetPath);
+        _storage.DidNotReceive().DeleteManagedFile(targetPath);
+    }
+
+    [Fact]
+    public async Task CreateFile_OverwriteOrphan_SaveFails_RestoreFails_PreservesBackup()
+    {
+        const string targetPath = @"C:\FakeRoot\cats\orphan.pdf";
+        _storage.FileNameInUse("cats", "orphan.pdf").Returns(true);
+        _storage.BuildManagedPath("cats", "orphan.pdf").Returns(targetPath);
+        _storage.ManagedFileExists(targetPath).Returns(true);
+
+        // A real temp file stands in for the backup so the cleanup branch (File.Exists/Delete)
+        // actually runs instead of short-circuiting on a non-existent fake path.
+        string backupPath = MakeRealBackupFile();
+        try
+        {
+            _storage.BackupManagedFile(targetPath).Returns(backupPath);
+            // The restore attempt itself fails (e.g., the target is locked); the backup is then the
+            // only surviving copy of the original bytes and must not be deleted.
+            _storage.When(s => s.ReplaceInPlace(backupPath, targetPath))
+                .Do(_ => throw new IOException("restore failed"));
+
+            var (service, _, _) = await BuildServiceOverFailingSaveAsync();
+            var request = new CmsFileCreateRequest { Folder = "cats", Overwrite = true };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.CreateFileAsync(request, MakeFormFile("orphan.pdf"), TestContext.Current.CancellationToken));
+
+            _storage.Received(1).ReplaceInPlace(backupPath, targetPath);
+            Assert.True(System.IO.File.Exists(backupPath));
+        }
+        finally
+        {
+            if (System.IO.File.Exists(backupPath))
+            {
+                System.IO.File.Delete(backupPath);
+            }
+        }
+    }
+
     #endregion
 
     #region Update
@@ -451,6 +523,81 @@ public sealed class CmsFileServiceTests : IDisposable
         // The file was decrypted on disk but the save failed, so it must be re-encrypted with the
         // original key to stay consistent with the rolled-back (still-encrypted) database row.
         _encryption.Received(1).EncryptFileInPlace(filePath, "old-key");
+    }
+
+    [Fact]
+    public async Task UpdateFile_ReplacementUpload_SaveFails_RestoresOriginalFile()
+    {
+        var (service, fileGuid, filePath) = await BuildServiceOverFailingSaveAsync();
+        _storage.ManagedFileExists(filePath).Returns(true);
+        const string backupPath = @"C:\FakeTemp\backup-original";
+        _storage.BackupManagedFile(filePath).Returns(backupPath);
+        var request = new CmsFileUpdateRequest { Description = "seeded" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UpdateFileAsync(fileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken));
+
+        // ReplaceInPlace swapped in the new upload, but the save failed, so the pre-replacement
+        // backup must be moved back over the managed path to restore the original bytes.
+        _storage.Received(1).BackupManagedFile(filePath);
+        _storage.Received(1).ReplaceInPlace(backupPath, filePath);
+    }
+
+    [Fact]
+    public async Task UpdateFile_ReplacementUpload_SaveFails_RestoreFails_PreservesBackup()
+    {
+        var (service, fileGuid, filePath) = await BuildServiceOverFailingSaveAsync();
+        _storage.ManagedFileExists(filePath).Returns(true);
+
+        string backupPath = MakeRealBackupFile();
+        try
+        {
+            _storage.BackupManagedFile(filePath).Returns(backupPath);
+            // The restore attempt fails, so the backup holds the only copy of the pre-update bytes
+            // (the database rolled back to that older record) and must be preserved, not deleted.
+            _storage.When(s => s.ReplaceInPlace(backupPath, filePath))
+                .Do(_ => throw new IOException("restore failed"));
+            var request = new CmsFileUpdateRequest { Description = "seeded" };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.UpdateFileAsync(fileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken));
+
+            _storage.Received(1).ReplaceInPlace(backupPath, filePath);
+            Assert.True(System.IO.File.Exists(backupPath));
+        }
+        finally
+        {
+            if (System.IO.File.Exists(backupPath))
+            {
+                System.IO.File.Delete(backupPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFile_ReplacementUpload_SaveSucceeds_DeletesBackup()
+    {
+        var file = await SeedFileAsync();
+        _storage.ManagedFileExists(file.FilePath).Returns(true);
+
+        string backupPath = MakeRealBackupFile();
+        try
+        {
+            _storage.BackupManagedFile(file.FilePath).Returns(backupPath);
+            var request = new CmsFileUpdateRequest { Description = "seeded" };
+
+            await _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken);
+
+            // A committed save makes the pre-replacement backup obsolete; it must be cleaned up.
+            Assert.False(System.IO.File.Exists(backupPath));
+        }
+        finally
+        {
+            if (System.IO.File.Exists(backupPath))
+            {
+                System.IO.File.Delete(backupPath);
+            }
+        }
     }
 
     #endregion

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -87,6 +87,10 @@ public sealed class CmsFileServiceTests : IDisposable
         return path;
     }
 
+    // Shared seed timestamp so update requests can present a matching LastModifiedOn
+    // (UpdateFileAsync rejects stale or missing values with 409/400 semantics).
+    private readonly DateTime _seededModifiedOn = DateTime.Now.AddDays(-1);
+
     private async Task<File> SeedFileAsync(Action<File>? customize = null)
     {
         var file = new File
@@ -97,7 +101,7 @@ public sealed class CmsFileServiceTests : IDisposable
             FriendlyName = "cats-seeded.pdf",
             Description = "seeded",
             ModifiedBy = "test",
-            ModifiedOn = DateTime.Now.AddDays(-1)
+            ModifiedOn = _seededModifiedOn
         };
         customize?.Invoke(file);
         _context.Files.Add(file);
@@ -123,7 +127,7 @@ public sealed class CmsFileServiceTests : IDisposable
             FriendlyName = "cats-plain.pdf",
             Description = "seeded",
             ModifiedBy = "test",
-            ModifiedOn = DateTime.Now.AddDays(-1)
+            ModifiedOn = _seededModifiedOn
         };
         customize?.Invoke(file);
         await using (var seedContext = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
@@ -149,6 +153,33 @@ public sealed class CmsFileServiceTests : IDisposable
             InterceptionResult<int> result, CancellationToken cancellationToken = default)
         {
             throw new InvalidOperationException("simulated save failure");
+        }
+    }
+
+    /// <summary>
+    /// Throws only when the save being intercepted deletes the given file, so a purge run's other
+    /// per-file saves succeed normally. Lets PurgeDeletedFilesAsync's per-file isolation be tested
+    /// without a database that can produce a real transient failure.
+    /// </summary>
+    private sealed class SelectiveThrowingSaveInterceptor : SaveChangesInterceptor
+    {
+        private readonly Guid _failingFileGuid;
+
+        public SelectiveThrowingSaveInterceptor(Guid failingFileGuid)
+        {
+            _failingFileGuid = failingFileGuid;
+        }
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
+            InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            bool targetsFailingFile = eventData.Context?.ChangeTracker.Entries<File>()
+                .Any(e => e.State == EntityState.Deleted && e.Entity.FileGuid == _failingFileGuid) ?? false;
+            if (targetsFailingFile)
+            {
+                throw new InvalidOperationException("simulated transient save failure");
+            }
+            return ValueTask.FromResult(result);
         }
     }
 
@@ -379,6 +410,7 @@ public sealed class CmsFileServiceTests : IDisposable
         var request = new CmsFileUpdateRequest
         {
             Description = "seeded",
+            LastModifiedOn = _seededModifiedOn,
             Permissions = new List<string> { "SVMSecure.Keep", "SVMSecure.New" }
         };
 
@@ -398,6 +430,7 @@ public sealed class CmsFileServiceTests : IDisposable
         var request = new CmsFileUpdateRequest
         {
             Description = "seeded",
+            LastModifiedOn = _seededModifiedOn,
             IamIds = new List<string> { "100NEW" }
         };
 
@@ -413,7 +446,7 @@ public sealed class CmsFileServiceTests : IDisposable
     {
         var file = await SeedFileAsync();
         _storage.ManagedFileExists(file.FilePath).Returns(true);
-        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = true };
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = true, LastModifiedOn = _seededModifiedOn };
 
         var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
 
@@ -430,7 +463,7 @@ public sealed class CmsFileServiceTests : IDisposable
             f.Key = "old-key";
         });
         _storage.ManagedFileExists(file.FilePath).Returns(true);
-        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = false };
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = false, LastModifiedOn = _seededModifiedOn };
 
         var dto = await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
 
@@ -444,7 +477,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task UpdateFile_WithReplacementUpload_ReplacesInPlaceAndAudits()
     {
         var file = await SeedFileAsync();
-        var request = new CmsFileUpdateRequest { Description = "seeded" };
+        var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
         await _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken);
 
@@ -458,7 +491,7 @@ public sealed class CmsFileServiceTests : IDisposable
         // The record keeps its name/path on replacement, so a .png swapped for the seeded
         // .pdf would leave the stored .pdf holding .png bytes; the upload must be rejected.
         var file = await SeedFileAsync();
-        var request = new CmsFileUpdateRequest { Description = "seeded" };
+        var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.png"), TestContext.Current.CancellationToken));
@@ -469,7 +502,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task UpdateFile_WithReplacementUpload_RestoresSoftDeletedFile()
     {
         var file = await SeedFileAsync(f => f.DeletedOn = DateTime.Now);
-        var request = new CmsFileUpdateRequest { Description = "seeded" };
+        var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
         await _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken);
 
@@ -483,7 +516,7 @@ public sealed class CmsFileServiceTests : IDisposable
     public async Task UpdateFile_MetadataOnly_DoesNotRestoreSoftDeletedFile()
     {
         var file = await SeedFileAsync(f => f.DeletedOn = DateTime.Now);
-        var request = new CmsFileUpdateRequest { Description = "updated" };
+        var request = new CmsFileUpdateRequest { Description = "updated", LastModifiedOn = _seededModifiedOn };
 
         await _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken);
 
@@ -500,11 +533,55 @@ public sealed class CmsFileServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task UpdateFile_StaleLastModifiedOn_ThrowsConcurrency_BeforeAnyChange()
+    {
+        var file = await SeedFileAsync();
+        var request = new CmsFileUpdateRequest
+        {
+            Description = "changed",
+            LastModifiedOn = _seededModifiedOn.AddMinutes(-5)
+        };
+
+        var ex = await Assert.ThrowsAsync<CmsConcurrencyException>(
+            () => _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken));
+
+        // Names who saved and when, and nothing was mutated or audited.
+        Assert.Contains("modified by test", ex.Message);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("seeded", saved.Description);
+        _audit.DidNotReceive().Audit(Arg.Any<File>(), CmsFileAuditActions.EditFile, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task UpdateFile_MissingLastModifiedOn_ThrowsArgumentException()
+    {
+        var file = await SeedFileAsync();
+        var request = new CmsFileUpdateRequest { Description = "changed" };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.UpdateFileAsync(file.FileGuid, request, null, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CheckName_ExistingRecord_ReturnsItsModifiedOn()
+    {
+        // The overwrite flow echoes this back as LastModifiedOn, so it must be the record's value.
+        var file = await SeedFileAsync();
+        _storage.IsValidFolder("cats").Returns(true);
+        _storage.BuildManagedPath("cats", "seeded.pdf").Returns(file.FilePath);
+
+        var check = await _service.CheckNameAsync("cats", "seeded.pdf", TestContext.Current.CancellationToken);
+
+        Assert.Equal(file.FileGuid, check.ExistingFileGuid);
+        Assert.Equal(_seededModifiedOn, check.ExistingModifiedOn);
+    }
+
+    [Fact]
     public async Task UpdateFile_EncryptToggleOn_SaveFails_DecryptsFileBack()
     {
         var (service, fileGuid, filePath) = await BuildServiceOverFailingSaveAsync();
         _storage.ManagedFileExists(filePath).Returns(true);
-        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = true };
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = true, LastModifiedOn = _seededModifiedOn };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.UpdateFileAsync(fileGuid, request, null, TestContext.Current.CancellationToken));
@@ -523,7 +600,7 @@ public sealed class CmsFileServiceTests : IDisposable
             f.Key = "old-key";
         });
         _storage.ManagedFileExists(filePath).Returns(true);
-        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = false };
+        var request = new CmsFileUpdateRequest { Description = "seeded", Encrypt = false, LastModifiedOn = _seededModifiedOn };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.UpdateFileAsync(fileGuid, request, null, TestContext.Current.CancellationToken));
@@ -540,7 +617,7 @@ public sealed class CmsFileServiceTests : IDisposable
         _storage.ManagedFileExists(filePath).Returns(true);
         const string backupPath = @"C:\FakeTemp\backup-original";
         _storage.BackupManagedFile(filePath).Returns(backupPath);
-        var request = new CmsFileUpdateRequest { Description = "seeded" };
+        var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.UpdateFileAsync(fileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken));
@@ -565,7 +642,7 @@ public sealed class CmsFileServiceTests : IDisposable
             // (the database rolled back to that older record) and must be preserved, not deleted.
             _storage.When(s => s.ReplaceInPlace(backupPath, filePath))
                 .Do(_ => throw new IOException("restore failed"));
-            var request = new CmsFileUpdateRequest { Description = "seeded" };
+            var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => service.UpdateFileAsync(fileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken));
@@ -592,7 +669,7 @@ public sealed class CmsFileServiceTests : IDisposable
         try
         {
             _storage.BackupManagedFile(file.FilePath).Returns(backupPath);
-            var request = new CmsFileUpdateRequest { Description = "seeded" };
+            var request = new CmsFileUpdateRequest { Description = "seeded", LastModifiedOn = _seededModifiedOn };
 
             await _service.UpdateFileAsync(file.FileGuid, request, MakeFormFile("newversion.pdf"), TestContext.Current.CancellationToken);
 
@@ -683,6 +760,57 @@ public sealed class CmsFileServiceTests : IDisposable
         Assert.DoesNotContain(stale.FileGuid, remaining);
         Assert.Contains(recent.FileGuid, remaining);
         Assert.Contains(active.FileGuid, remaining);
+    }
+
+    [Fact]
+    public async Task PurgeDeletedFiles_IsolatesPerFileFailure_AndContinuesPurgingOthers()
+    {
+        // A transient save error (e.g. SqlException) on one file must not abort the whole
+        // nightly purge run; the loop should isolate it and keep purging the rest.
+        var storeName = "VIPER_" + Guid.NewGuid();
+        var failing = new File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = @"C:\FakeRoot\cats\bad.pdf",
+            Folder = "cats",
+            FriendlyName = "cats-bad.pdf",
+            Description = "seeded",
+            ModifiedBy = "test",
+            ModifiedOn = DateTime.Now,
+            DeletedOn = DateTime.Now.AddDays(-40)
+        };
+        var good = new File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = @"C:\FakeRoot\cats\good.pdf",
+            Folder = "cats",
+            FriendlyName = "cats-good.pdf",
+            Description = "seeded",
+            ModifiedBy = "test",
+            ModifiedOn = DateTime.Now,
+            DeletedOn = DateTime.Now.AddDays(-40)
+        };
+        await using (var seedContext = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase(storeName).Options))
+        {
+            seedContext.Files.AddRange(failing, good);
+            await seedContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var partiallyFailingContext = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase(storeName)
+            .AddInterceptors(new SelectiveThrowingSaveInterceptor(failing.FileGuid))
+            .Options);
+        var service = new CmsFileService(partiallyFailingContext, _aaudContext, _storage, _encryption, _audit,
+            _userHelper, Substitute.For<ILogger<CmsFileService>>());
+
+        var purged = await service.PurgeDeletedFilesAsync(30, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, purged);
+        var remaining = await partiallyFailingContext.Files.Select(f => f.FileGuid)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        Assert.Contains(failing.FileGuid, remaining);
+        Assert.DoesNotContain(good.FileGuid, remaining);
     }
 
     [Fact]

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -646,6 +646,55 @@ public sealed class CmsFileServiceTests : IDisposable
         _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.DeleteFile, "File Deleted");
     }
 
+    [Fact]
+    public async Task PermanentDelete_StillSucceeds_WhenDiskDeleteFails()
+    {
+        var file = await SeedFileAsync();
+        _storage.ManagedFileExists(file.FilePath).Returns(true);
+        _storage.When(s => s.DeleteManagedFile(file.FilePath)).Do(_ => throw new IOException("file is locked"));
+
+        var result = await _service.PermanentlyDeleteFileAsync(file.FileGuid, TestContext.Current.CancellationToken);
+
+        // The record is gone by the time the disk delete runs, so a storage failure is logged
+        // (orphaned bytes) rather than surfaced as a failure of the whole delete.
+        Assert.True(result);
+        Assert.Empty(await _context.Files.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PurgeDeletedFiles_RemovesOnlyFilesPastRetention()
+    {
+        var stale = await SeedFileAsync(f => f.DeletedOn = DateTime.Now.AddDays(-40));
+        var recent = await SeedFileAsync(f => f.DeletedOn = DateTime.Now.AddDays(-5));
+        var active = await SeedFileAsync();
+
+        var purged = await _service.PurgeDeletedFilesAsync(30, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, purged);
+        var remaining = await _context.Files.Select(f => f.FileGuid).ToListAsync(TestContext.Current.CancellationToken);
+        Assert.DoesNotContain(stale.FileGuid, remaining);
+        Assert.Contains(recent.FileGuid, remaining);
+        Assert.Contains(active.FileGuid, remaining);
+    }
+
+    [Fact]
+    public async Task PurgeDeletedFiles_DetachesFromContentBlocks()
+    {
+        var file = await SeedFileAsync(f => f.DeletedOn = DateTime.Now.AddDays(-40));
+        _context.ContentBlockToFiles.Add(new Viper.Models.VIPER.ContentBlockToFile
+        {
+            ContentBlockId = 1,
+            FileGuid = file.FileGuid
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var purged = await _service.PurgeDeletedFilesAsync(30, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, purged);
+        Assert.Empty(await _context.Files.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.ContentBlockToFiles.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
     #endregion
 
     #region CheckName
@@ -752,9 +801,9 @@ public sealed class CmsFileServiceTests : IDisposable
             f.DeletedOn = DateTime.Now;
         });
 
-        var (active, activeTotal) = await _service.GetFilesAsync(null, "active", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
-        var (deleted, deletedTotal) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
-        var (all, allTotal) = await _service.GetFilesAsync(null, "all", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+        var (active, activeTotal) = await _service.GetFilesAsync(null, "active", null, null, null, 1, 50, null, false, ct: TestContext.Current.CancellationToken);
+        var (deleted, deletedTotal) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50, null, false, ct: TestContext.Current.CancellationToken);
+        var (all, allTotal) = await _service.GetFilesAsync(null, "all", null, null, null, 1, 50, null, false, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, activeTotal);
         Assert.Single(active);
@@ -762,6 +811,29 @@ public sealed class CmsFileServiceTests : IDisposable
         Assert.Single(deleted);
         Assert.Equal(2, allTotal);
         Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task GetFiles_Deleted_ScopedToOwner_ReturnsOnlyFilesTheyDeleted()
+    {
+        var mine = await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-mine.pdf";
+            f.DeletedOn = DateTime.Now;
+            f.ModifiedBy = "me";
+        });
+        await SeedFileAsync(f =>
+        {
+            f.FriendlyName = "cats-theirs.pdf";
+            f.DeletedOn = DateTime.Now;
+            f.ModifiedBy = "them";
+        });
+
+        var (files, total) = await _service.GetFilesAsync(null, "deleted", null, null, null, 1, 50, null, false,
+            "me", TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, total);
+        Assert.Equal(mine.FileGuid, Assert.Single(files).FileGuid);
     }
 
     [Fact]
@@ -781,7 +853,7 @@ public sealed class CmsFileServiceTests : IDisposable
             f.FilePath = @"C:\FakeRoot\students\doc.pdf";
         });
 
-        var (files, total) = await _service.GetFilesAsync("cats", "active", null, null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+        var (files, total) = await _service.GetFilesAsync("cats", "active", null, null, null, 1, 50, null, false, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, total);
         Assert.All(files, f => Assert.StartsWith("cats", f.Folder));
@@ -798,7 +870,7 @@ public sealed class CmsFileServiceTests : IDisposable
             f.Description = "unrelated";
         });
 
-        var (files, total) = await _service.GetFilesAsync(null, "active", "budget", null, null, 1, 50, null, false, TestContext.Current.CancellationToken);
+        var (files, total) = await _service.GetFilesAsync(null, "active", "budget", null, null, 1, 50, null, false, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, total);
         Assert.Equal("cats-seeded.pdf", files[0].FriendlyName);
@@ -817,7 +889,7 @@ public sealed class CmsFileServiceTests : IDisposable
             });
         }
 
-        var (page2, total) = await _service.GetFilesAsync(null, "active", null, null, null, 2, 2, "friendlyName", false, TestContext.Current.CancellationToken);
+        var (page2, total) = await _service.GetFilesAsync(null, "active", null, null, null, 2, 2, "friendlyName", false, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(5, total);
         Assert.Equal(2, page2.Count);
@@ -849,9 +921,9 @@ public sealed class CmsFileServiceTests : IDisposable
             f.DeletedOn = DateTime.Now;
         });
 
-        var active = await _service.GetFolderCountsAsync("active", null, null, TestContext.Current.CancellationToken);
-        var unencrypted = await _service.GetFolderCountsAsync("active", false, null, TestContext.Current.CancellationToken);
-        var publicOnly = await _service.GetFolderCountsAsync("active", null, true, TestContext.Current.CancellationToken);
+        var active = await _service.GetFolderCountsAsync("active", null, null, ct: TestContext.Current.CancellationToken);
+        var unencrypted = await _service.GetFolderCountsAsync("active", false, null, ct: TestContext.Current.CancellationToken);
+        var publicOnly = await _service.GetFolderCountsAsync("active", null, true, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, active.Count);
         Assert.Equal(2, active.Single(c => c.Folder == "cats").Count);
@@ -875,7 +947,7 @@ public sealed class CmsFileServiceTests : IDisposable
             f.FilePath = @"C:\FakeRoot\accreditation\two.pdf";
         });
 
-        var counts = await _service.GetFolderCountsAsync("active", null, null, TestContext.Current.CancellationToken);
+        var counts = await _service.GetFolderCountsAsync("active", null, null, ct: TestContext.Current.CancellationToken);
 
         var entry = Assert.Single(counts);
         Assert.Equal(2, entry.Count);

--- a/test/CMS/CmsLeftNavServiceTests.cs
+++ b/test/CMS/CmsLeftNavServiceTests.cs
@@ -204,6 +204,36 @@ public sealed class CmsLeftNavServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveItems_EmptyHeaderText_IsAllowed()
+    {
+        // Legacy parity: menus use empty-text headers as spacer rows, and the display side
+        // renders them as blank dividers. A menu containing one must stay saveable.
+        var menu = await SeedMenuAsync();
+
+        var dto = await _service.SaveItemsAsync(menu.LeftNavMenuId, new List<LeftNavItemEdit>
+        {
+            new() { LeftNavItemId = 0, MenuItemText = "", IsHeader = true },
+            new() { LeftNavItemId = 0, MenuItemText = "A Link", IsHeader = false, Url = "/link" },
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, dto!.Items.Count);
+        Assert.Equal("", dto.Items[0].MenuItemText);
+        Assert.True(dto.Items[0].IsHeader);
+    }
+
+    [Fact]
+    public async Task SaveItems_EmptyLinkText_Throws()
+    {
+        var menu = await SeedMenuAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _service.SaveItemsAsync(menu.LeftNavMenuId, new List<LeftNavItemEdit>
+            {
+                new() { LeftNavItemId = 0, MenuItemText = "  ", IsHeader = false, Url = "/link" },
+            }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task SaveItems_UnknownMenu_ReturnsNull()
     {
         var dto = await _service.SaveItemsAsync(9999, new List<LeftNavItemEdit>(), TestContext.Current.CancellationToken);

--- a/test/CMS/CmsLeftNavServiceTests.cs
+++ b/test/CMS/CmsLeftNavServiceTests.cs
@@ -119,6 +119,38 @@ public sealed class CmsLeftNavServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateMenu_DuplicateFriendlyName_ThrowsCaseInsensitive()
+    {
+        await SeedMenuAsync(m => m.FriendlyName = "cats-home");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.CreateMenuAsync(new LeftNavMenuAddEdit
+        {
+            MenuHeaderText = "Dup",
+            System = "Viper",
+            FriendlyName = "CATS-HOME"
+        }, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdateMenu_DuplicateFriendlyName_Rejected_ButKeepingOwnIsAllowed()
+    {
+        var alpha = await SeedMenuAsync(m => m.FriendlyName = "alpha");
+        var beta = await SeedMenuAsync(m => m.FriendlyName = "beta");
+
+        // Renaming beta onto alpha's friendly name (any case) is rejected.
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.UpdateMenuAsync(beta.LeftNavMenuId,
+            new LeftNavMenuAddEdit { MenuHeaderText = "B", System = "Viper", FriendlyName = "ALPHA" },
+            TestContext.Current.CancellationToken));
+
+        // Keeping its own friendly name (self-match excluded) is allowed.
+        var updated = await _service.UpdateMenuAsync(alpha.LeftNavMenuId,
+            new LeftNavMenuAddEdit { MenuHeaderText = "A renamed", System = "Viper", FriendlyName = "ALPHA" },
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(updated);
+    }
+
+    [Fact]
     public async Task DeleteMenu_CascadesToItemsAndPermissions()
     {
         var menu = await SeedMenuAsync(m => m.LeftNavItems.Add(MakeItem("Link", 1, url: "/x", permissions: "SVMSecure.CATS")));
@@ -177,5 +209,35 @@ public sealed class CmsLeftNavServiceTests : IDisposable
         var dto = await _service.SaveItemsAsync(9999, new List<LeftNavItemEdit>(), TestContext.Current.CancellationToken);
 
         Assert.Null(dto);
+    }
+
+    [Fact]
+    public async Task SaveItems_UnknownItemId_Throws_AndDoesNotResurrect()
+    {
+        var menu = await SeedMenuAsync(m => m.LeftNavItems.Add(MakeItem("Keep Me", 1, url: "/keep")));
+
+        // A stale client posts an id that no longer exists in the menu.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.SaveItemsAsync(menu.LeftNavMenuId,
+            new List<LeftNavItemEdit>
+            {
+                new() { LeftNavItemId = 987654, MenuItemText = "Deleted Elsewhere" }
+            }, TestContext.Current.CancellationToken));
+
+        // Nothing was created; the menu still holds only its original item.
+        Assert.Equal(1, await _context.LeftNavItems.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SaveItems_DuplicateItemIds_ThrowsArgumentException()
+    {
+        var menu = await SeedMenuAsync(m => m.LeftNavItems.Add(MakeItem("Keep Me", 1, url: "/keep")));
+        var keepId = menu.LeftNavItems.First().LeftNavItemId;
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.SaveItemsAsync(menu.LeftNavMenuId,
+            new List<LeftNavItemEdit>
+            {
+                new() { LeftNavItemId = keepId, MenuItemText = "A" },
+                new() { LeftNavItemId = keepId, MenuItemText = "B" }
+            }, TestContext.Current.CancellationToken));
     }
 }

--- a/test/CMS/CmsTrashPurgeScheduledJobTests.cs
+++ b/test/CMS/CmsTrashPurgeScheduledJobTests.cs
@@ -36,7 +36,7 @@ public sealed class CmsTrashPurgeScheduledJobTests
 
         await job.RunAsync(Context(), CancellationToken.None);
 
-        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, default);
+        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public sealed class CmsTrashPurgeScheduledJobTests
 
         await job.RunAsync(Context(), CancellationToken.None);
 
-        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, default);
+        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/CMS/CmsTrashPurgeScheduledJobTests.cs
+++ b/test/CMS/CmsTrashPurgeScheduledJobTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Jobs;
+using Viper.Areas.CMS.Services;
+using Viper.Areas.Scheduler.Models;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// The trash-purge job permanently deletes files, so its config gate is safety-critical: it must
+/// stay off unless an environment explicitly opts in via <see cref="CmsTrash.PurgeEnabledConfigKey"/>.
+/// </summary>
+public sealed class CmsTrashPurgeScheduledJobTests
+{
+    private static CmsTrashPurgeScheduledJob MakeJob(ICmsFileService fileService, bool? enabled)
+    {
+        var settings = new Dictionary<string, string?>();
+        if (enabled != null)
+        {
+            settings[CmsTrash.PurgeEnabledConfigKey] = enabled.Value ? "true" : "false";
+        }
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        return new CmsTrashPurgeScheduledJob(
+            fileService, configuration, Substitute.For<ILogger<CmsTrashPurgeScheduledJob>>());
+    }
+
+    private static ScheduledJobContext Context() => new(ScheduledJobContext.SchedulerActor);
+
+    [Fact]
+    public async Task RunAsync_DoesNotPurge_WhenFlagMissing()
+    {
+        var fileService = Substitute.For<ICmsFileService>();
+        var job = MakeJob(fileService, enabled: null);
+
+        await job.RunAsync(Context(), CancellationToken.None);
+
+        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, default);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotPurge_WhenDisabled()
+    {
+        var fileService = Substitute.For<ICmsFileService>();
+        var job = MakeJob(fileService, enabled: false);
+
+        await job.RunAsync(Context(), CancellationToken.None);
+
+        await fileService.DidNotReceiveWithAnyArgs().PurgeDeletedFilesAsync(default, default);
+    }
+
+    [Fact]
+    public async Task RunAsync_Purges_WhenEnabled()
+    {
+        var fileService = Substitute.For<ICmsFileService>();
+        fileService.PurgeDeletedFilesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(3);
+        var job = MakeJob(fileService, enabled: true);
+
+        await job.RunAsync(Context(), CancellationToken.None);
+
+        await fileService.Received(1).PurgeDeletedFilesAsync(CmsTrash.RetentionDays, Arg.Any<CancellationToken>());
+    }
+}

--- a/test/CMS/CmsUserPhotoServiceTests.cs
+++ b/test/CMS/CmsUserPhotoServiceTests.cs
@@ -10,8 +10,9 @@ using Viper.Models.AAUD;
 namespace Viper.test.CMS;
 
 /// <summary>
-/// Tests for CmsUserPhotoService: AAUD id resolution, alternate ProfilePhotos lookup with
-/// traversal protection, and delegation to the Students photo pipeline.
+/// Tests for CmsUserPhotoService: AAUD id resolution (MailId, LoginId, IamId, MothraId),
+/// alternate ProfilePhotos lookup with traversal protection, delegation to the Students photo
+/// pipeline, and the Last-Modified timestamp used for conditional-caching (FIX 4).
 /// </summary>
 public sealed class CmsUserPhotoServiceTests : IDisposable
 {
@@ -51,7 +52,8 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
         }
     }
 
-    private void SeedUser(string loginId = "jdoe", string mailId = "jdoe", string iamId = "1000999")
+    private void SeedUser(string loginId = "jdoe", string mailId = "jdoe", string iamId = "1000999",
+        string mothraId = "m1")
     {
         _aaudContext.AaudUsers.Add(new AaudUser
         {
@@ -66,7 +68,7 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
             DisplayLastName = "Doe",
             DisplayFirstName = "Jane",
             DisplayFullName = "Doe, Jane",
-            MothraId = "m1",
+            MothraId = mothraId,
             SpridenId = null,
             Pidm = null,
             EmployeeId = null,
@@ -80,10 +82,10 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
     [Fact]
     public async Task GetUserPhoto_ByMailId_DelegatesToStudentPipeline()
     {
-        var photo = await _service.GetUserPhotoAsync("jdoe", null, null, preferAltPhoto: false,
+        var photo = await _service.GetUserPhotoAsync("jdoe", null, null, null, preferAltPhoto: false,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(IdCardPhotoBytes, photo);
+        Assert.Equal(IdCardPhotoBytes, photo.Bytes);
         await _photoService.Received(1).GetStudentPhotoAsync("jdoe");
     }
 
@@ -92,19 +94,40 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
     {
         SeedUser(loginId: "jdoe", mailId: "janedoe");
 
-        await _service.GetUserPhotoAsync(null, "jdoe", null, preferAltPhoto: false,
+        await _service.GetUserPhotoAsync(null, "jdoe", null, null, preferAltPhoto: false,
             TestContext.Current.CancellationToken);
 
         await _photoService.Received(1).GetStudentPhotoAsync("janedoe");
     }
 
     [Fact]
-    public async Task GetUserPhoto_UnknownLoginId_FallsBackToDefaultPipeline()
+    public async Task GetUserPhoto_ByMothraId_ResolvesMailIdThroughAaud()
     {
-        var photo = await _service.GetUserPhotoAsync(null, "nosuchuser", null, preferAltPhoto: false,
+        SeedUser(mothraId: "m-9001", mailId: "janedoe");
+
+        await _service.GetUserPhotoAsync(null, null, null, "m-9001", preferAltPhoto: false,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(IdCardPhotoBytes, photo);
+        await _photoService.Received(1).GetStudentPhotoAsync("janedoe");
+    }
+
+    [Fact]
+    public async Task GetUserPhoto_UnknownMothraId_FallsBackToDefaultPipeline()
+    {
+        var photo = await _service.GetUserPhotoAsync(null, null, null, "no-such-mothra", preferAltPhoto: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(IdCardPhotoBytes, photo.Bytes);
+        await _photoService.Received(1).GetStudentPhotoAsync(string.Empty);
+    }
+
+    [Fact]
+    public async Task GetUserPhoto_UnknownLoginId_FallsBackToDefaultPipeline()
+    {
+        var photo = await _service.GetUserPhotoAsync(null, "nosuchuser", null, null, preferAltPhoto: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(IdCardPhotoBytes, photo.Bytes);
         await _photoService.Received(1).GetStudentPhotoAsync(string.Empty);
     }
 
@@ -115,10 +138,10 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
         await File.WriteAllBytesAsync(Path.Join(_profilePhotoRoot, "1000999.jpg"), AltPhotoBytes,
             TestContext.Current.CancellationToken);
 
-        var photo = await _service.GetUserPhotoAsync(null, "jdoe", null, preferAltPhoto: true,
+        var photo = await _service.GetUserPhotoAsync(null, "jdoe", null, null, preferAltPhoto: true,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(AltPhotoBytes, photo);
+        Assert.Equal(AltPhotoBytes, photo.Bytes);
         await _photoService.DidNotReceive().GetStudentPhotoAsync(Arg.Any<string>());
     }
 
@@ -129,10 +152,10 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
         await File.WriteAllBytesAsync(Path.Join(_profilePhotoRoot, "1000999.jpg"), AltPhotoBytes,
             TestContext.Current.CancellationToken);
 
-        var photo = await _service.GetUserPhotoAsync("jdoe", null, null, preferAltPhoto: true,
+        var photo = await _service.GetUserPhotoAsync("jdoe", null, null, null, preferAltPhoto: true,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(AltPhotoBytes, photo);
+        Assert.Equal(AltPhotoBytes, photo.Bytes);
         await _photoService.DidNotReceive().GetStudentPhotoAsync(Arg.Any<string>());
     }
 
@@ -141,10 +164,10 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
     {
         SeedUser(mailId: "janedoe", iamId: "1000999");
 
-        var photo = await _service.GetUserPhotoAsync(null, "jdoe", null, preferAltPhoto: true,
+        var photo = await _service.GetUserPhotoAsync(null, "jdoe", null, null, preferAltPhoto: true,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(IdCardPhotoBytes, photo);
+        Assert.Equal(IdCardPhotoBytes, photo.Bytes);
         await _photoService.Received(1).GetStudentPhotoAsync("janedoe");
     }
 
@@ -154,9 +177,38 @@ public sealed class CmsUserPhotoServiceTests : IDisposable
     [InlineData("a/b")]
     public async Task GetUserPhoto_TraversalShapedIamId_IgnoresAltPhoto(string iamId)
     {
-        var photo = await _service.GetUserPhotoAsync(null, null, iamId, preferAltPhoto: true,
+        var photo = await _service.GetUserPhotoAsync(null, null, iamId, null, preferAltPhoto: true,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(IdCardPhotoBytes, photo);
+        Assert.Equal(IdCardPhotoBytes, photo.Bytes);
+    }
+
+    [Fact]
+    public async Task GetUserPhoto_AltPhoto_LastModifiedReflectsFileWriteTime_TruncatedToWholeSeconds()
+    {
+        SeedUser(iamId: "1000999");
+        var photoPath = Path.Join(_profilePhotoRoot, "1000999.jpg");
+        await File.WriteAllBytesAsync(photoPath, AltPhotoBytes, TestContext.Current.CancellationToken);
+        var fileWriteTime = File.GetLastWriteTimeUtc(photoPath);
+
+        var photo = await _service.GetUserPhotoAsync(null, "jdoe", null, null, preferAltPhoto: true,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, photo.LastModified.Millisecond);
+        Assert.True(Math.Abs((photo.LastModified.UtcDateTime - fileWriteTime).TotalSeconds) < 1.5);
+    }
+
+    [Fact]
+    public async Task GetUserPhoto_IdCardPhoto_LastModifiedIsStableAcrossCalls()
+    {
+        // The delegated Students pipeline exposes no per-file timestamp, so id-card/nopic
+        // responses use a stable per-process proxy; repeated calls must agree.
+        var first = await _service.GetUserPhotoAsync("jdoe", null, null, null, preferAltPhoto: false,
+            TestContext.Current.CancellationToken);
+        var second = await _service.GetUserPhotoAsync("jdoe", null, null, null, preferAltPhoto: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(first.LastModified, second.LastModified);
+        Assert.Equal(0, first.LastModified.Millisecond);
     }
 }

--- a/test/CMS/MaxLengthEachAttributeTests.cs
+++ b/test/CMS/MaxLengthEachAttributeTests.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using Areas.CMS.Validation;
+using Viper.Areas.CMS.Validation;
 
 namespace Viper.test.CMS;
 

--- a/test/CMS/MaxLengthEachAttributeTests.cs
+++ b/test/CMS/MaxLengthEachAttributeTests.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using Areas.CMS.Validation;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for MaxLengthEachAttribute, which bounds each string element of a collection (used for
+/// left-nav item permission strings vs the varchar(500) permission column).
+/// </summary>
+public sealed class MaxLengthEachAttributeTests
+{
+    private static ValidationResult? Validate(object? value, int length)
+    {
+        var attribute = new MaxLengthEachAttribute(length);
+        return attribute.GetValidationResult(value, new ValidationContext(new object()));
+    }
+
+    [Fact]
+    public void AllElementsWithinLimit_Succeeds()
+    {
+        var value = new List<string> { "SVMSecure.CATS", new string('a', 500) };
+
+        Assert.Equal(ValidationResult.Success, Validate(value, 500));
+    }
+
+    [Fact]
+    public void AnyElementOverLimit_Fails()
+    {
+        var value = new List<string> { "ok", new string('a', 501) };
+
+        Assert.NotEqual(ValidationResult.Success, Validate(value, 500));
+    }
+
+    [Fact]
+    public void NullValue_Succeeds()
+    {
+        Assert.Equal(ValidationResult.Success, Validate(null, 500));
+    }
+
+    [Fact]
+    public void EmptyCollection_Succeeds()
+    {
+        Assert.Equal(ValidationResult.Success, Validate(new List<string>(), 500));
+    }
+}

--- a/test/CMS/SafeUrlAttributeTests.cs
+++ b/test/CMS/SafeUrlAttributeTests.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using Areas.CMS.Validation;
+using Viper.Areas.CMS.Validation;
 
 namespace Viper.test.CMS;
 

--- a/test/CMS/SafeUrlAttributeTests.cs
+++ b/test/CMS/SafeUrlAttributeTests.cs
@@ -62,6 +62,20 @@ public sealed class SafeUrlAttributeTests
         Assert.NotEqual(ValidationResult.Success, Validate("foo:bar/baz", allowRelative: true));
     }
 
+    [Theory]
+    [InlineData("//evil.example/path")]
+    [InlineData("//evil.example")]
+    [InlineData("/\\evil.example/path")]
+    [InlineData("\\\\evil.example\\path")]
+    [InlineData("\\/evil.example")]
+    public void BothModes_RejectProtocolRelativeUrls(string url)
+    {
+        // A scheme-less "//host" (or its backslash variants) navigates off-site, so it must be
+        // rejected even in relative mode, where bare relative paths are otherwise allowed.
+        Assert.NotEqual(ValidationResult.Success, Validate(url, allowRelative: true));
+        Assert.NotEqual(ValidationResult.Success, Validate(url, allowRelative: false));
+    }
+
     [Fact]
     public void RelativeMode_AllowsColonAfterFirstSegment()
     {

--- a/test/Classes/Utilities/DateRangeHelperTests.cs
+++ b/test/Classes/Utilities/DateRangeHelperTests.cs
@@ -31,4 +31,14 @@ public class DateRangeHelperTests
 
         Assert.Equal(to, result);
     }
+
+    [Fact]
+    public void ExclusiveUpperBound_MaxValueDate_ClampsToMaxValueWithoutOverflow()
+    {
+        // A user-suppliable "To" at the DateTime ceiling has no next midnight to advance to, so
+        // advancing by a day would overflow. The helper clamps to MaxValue instead.
+        var result = DateRangeHelper.ExclusiveUpperBound(DateTime.MaxValue.Date);
+
+        Assert.Equal(DateTime.MaxValue, result);
+    }
 }

--- a/web/Areas/CMS/Constants/CmsFileTypes.cs
+++ b/web/Areas/CMS/Constants/CmsFileTypes.cs
@@ -36,9 +36,26 @@ namespace Viper.Areas.CMS.Constants
             ["exe"] = "application/vnd.microsoft.portable-executable"
         };
 
+        /// <summary>
+        /// Extensions the browser would render as active markup (script execution / inline SVG)
+        /// rather than download. Legacy .html files must stay downloadable, so instead of removing
+        /// them from the allow-list we serve these as an attachment, never inline, to close the
+        /// stored-XSS path from an uploaded .html/.svg running in the app origin.
+        /// </summary>
+        public static readonly IReadOnlySet<string> InlineUnsafeExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "html", "htm", "xhtml", "svg"
+        };
+
         public static bool IsAllowedFileName(string fileName)
         {
             return MimeTypes.ContainsKey(GetExtension(fileName));
+        }
+
+        /// <summary>True when a file must be served as a download rather than rendered inline.</summary>
+        public static bool ShouldForceAttachment(string fileName)
+        {
+            return InlineUnsafeExtensions.Contains(GetExtension(fileName));
         }
 
         public static string GetMimeType(string fileName)

--- a/web/Areas/CMS/Constants/CmsPermissions.cs
+++ b/web/Areas/CMS/Constants/CmsPermissions.cs
@@ -10,6 +10,11 @@ namespace Viper.Areas.CMS.Constants
         public const string ManageContentBlocks = "SVMSecure.CMS.ManageContentBlocks";
         public const string CreateContentBlock = "SVMSecure.CMS.CreateContentBlock";
         public const string ManageNavigation = "SVMSecure.CMS.ManageNavigation";
+
+        // Legacy parity: the ColdFusion CMS gated permanent ("dev only") content-block delete on
+        // SVMSecure.CATS.Admin (cms/views/contentBlock.cfm, cms/inc_contentBlock.cfm). VIPER 2 reuses
+        // it for permanent delete of blocks and files; legacy file permanent delete was AllFiles-only,
+        // so hard delete of files is deliberately narrowed to admins here.
         public const string Admin = "SVMSecure.CATS.Admin";
     }
 }

--- a/web/Areas/CMS/Constants/CmsTrash.cs
+++ b/web/Areas/CMS/Constants/CmsTrash.cs
@@ -1,0 +1,20 @@
+namespace Viper.Areas.CMS.Constants
+{
+    /// <summary>
+    /// Trash (soft-delete) retention policy. A soft-deleted CMS file stays recoverable for this
+    /// many days, then the CmsTrashPurgeScheduledJob permanently deletes it (record + disk),
+    /// matching the legacy 30-day "will be permanently deleted on ..." behavior.
+    /// </summary>
+    public static class CmsTrash
+    {
+        public const int RetentionDays = 30;
+
+        /// <summary>
+        /// Config key gating the trash-purge job. Absent/false means the job never permanently
+        /// deletes, so it can ship disabled and stay off across app restarts and IIS recycles
+        /// (unlike a dashboard tweak). Kept false until the legacy VIPER 1 30-day purge is retired,
+        /// so the two never purge in parallel; flipped to true (via SSM in deployed envs) at cutover.
+        /// </summary>
+        public const string PurgeEnabledConfigKey = "Cms:TrashPurgeEnabled";
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -6,7 +6,6 @@ using Viper.Areas.CMS.Services;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
 using Viper.Models;
-using Viper.Models.VIPER;
 using Viper.Services;
 using Web.Authorization;
 
@@ -84,7 +83,7 @@ namespace Viper.Areas.CMS.Controllers
         //GET: content/fn/{friendlyName} — public display endpoint; permission filtering happens
         //inside GetContentBlocksAllowed (public flag, block permissions, or CMS admin).
         [HttpGet("fn/{friendlyName}")]
-        public ActionResult<ContentBlock?> GetContentBlockByFn(string friendlyName)
+        public ActionResult<ContentBlockDto> GetContentBlockByFn(string friendlyName)
         {
             // status: 1 = active only. A public display endpoint must never serve soft-deleted
             // blocks (passing null would include DeletedOn != null rows).
@@ -95,7 +94,11 @@ namespace Viper.Areas.CMS.Controllers
                 return NotFound();
             }
 
-            return blocks[0];
+            // Project to a DTO so this anonymous endpoint never serializes the raw entity graph:
+            // returning the entity would leak each attached file's encryption Key and server
+            // FilePath, the full (unsanitized) ContentHistory, and the block's permission rows.
+            // Content is already render-sanitized by GetContentBlocksAllowed.
+            return CmsContentBlockMapper.ToDto(blocks[0]);
         }
 
         //GET: content/5/history
@@ -279,7 +282,8 @@ namespace Viper.Areas.CMS.Controllers
         {
             if (permanent)
             {
-                // Permanent delete removes history and cannot be undone; admin only.
+                // Permanent delete removes history and cannot be undone; admin only, matching the
+                // legacy "dev only" (SVMSecure.CATS.Admin) gate on permanent content-block delete.
                 if (!_userHelper.HasPermission(_rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin))
                 {
                     return ForbidApi();

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -20,15 +20,18 @@ namespace Viper.Areas.CMS.Controllers
         private readonly RAPSContext _rapsContext;
         private readonly IHtmlSanitizerService _sanitizerService;
         private readonly ICmsContentBlockService _blockService;
+        private readonly ICmsFileStorageService _storage;
         private readonly IUserHelper _userHelper;
 
         public CMSContentController(VIPERContext context, RAPSContext rapsContext,
-            IHtmlSanitizerService sanitizerService, ICmsContentBlockService blockService, IUserHelper userHelper)
+            IHtmlSanitizerService sanitizerService, ICmsContentBlockService blockService,
+            ICmsFileStorageService storage, IUserHelper userHelper)
         {
             _context = context;
             _rapsContext = rapsContext;
             _sanitizerService = sanitizerService;
             _blockService = blockService;
+            _storage = storage;
             _userHelper = userHelper;
         }
 
@@ -52,6 +55,17 @@ namespace Viper.Areas.CMS.Controllers
         public async Task<ActionResult<List<string>>> GetViperSectionPaths(CancellationToken ct = default)
         {
             return await _blockService.GetViperSectionPathsAsync(ct);
+        }
+
+        // GET: content/folders
+        // The section path IS a file folder (legacy parity): a block's files live in this folder.
+        // Exposed to content-block editors so the section path can be chosen from the real upload
+        // folders without requiring AllFiles (the /api/cms/files/folders endpoint is AllFiles-gated).
+        [HttpGet("folders")]
+        [Permission(Allow = CmsPermissions.ManageContentBlocks + "," + CmsPermissions.CreateContentBlock)]
+        public ActionResult<List<string>> GetFolders()
+        {
+            return _storage.GetTopLevelFolders();
         }
 
         //GET: content/5

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -37,15 +37,27 @@ namespace Viper.Areas.CMS.Controllers
         //GET: content
         [HttpGet]
         [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [ApiPagination(DefaultPerPage = 50, MaxPerPage = 500)]
         public async Task<ActionResult<List<ContentBlockDto>>> GetContentBlocks(
+            ApiPagination? pagination,
             string status = "active",
             string? system = null,
             string? viperSectionPath = null,
             string? search = null,
             bool? isPublic = null,
+            string? sortBy = "title",
+            bool descending = false,
             CancellationToken ct = default)
         {
-            return await _blockService.GetContentBlocksAsync(status, system, viperSectionPath, search, isPublic, ct);
+            var page = pagination?.Page ?? 1;
+            var perPage = pagination?.PerPage ?? 50;
+            var (blocks, total) = await _blockService.GetContentBlocksAsync(status, system, viperSectionPath, search,
+                isPublic, page, perPage, sortBy, descending, ct);
+            if (pagination != null)
+            {
+                pagination.TotalRecords = total;
+            }
+            return blocks;
         }
 
         //GET: content/section-paths

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -95,7 +95,7 @@ namespace Viper.Areas.CMS.Controllers
         //GET: content/fn/{friendlyName} — public display endpoint; permission filtering happens
         //inside GetContentBlocksAllowed (public flag, block permissions, or CMS admin).
         [HttpGet("fn/{friendlyName}")]
-        public ActionResult<ContentBlockDto> GetContentBlockByFn(string friendlyName)
+        public ActionResult<PublicContentBlockDto> GetContentBlockByFn(string friendlyName)
         {
             // status: 1 = active only. A public display endpoint must never serve soft-deleted
             // blocks (passing null would include DeletedOn != null rows).
@@ -106,11 +106,12 @@ namespace Viper.Areas.CMS.Controllers
                 return NotFound();
             }
 
-            // Project to a DTO so this anonymous endpoint never serializes the raw entity graph:
-            // returning the entity would leak each attached file's encryption Key and server
-            // FilePath, the full (unsanitized) ContentHistory, and the block's permission rows.
-            // Content is already render-sanitized by GetContentBlocksAllowed.
-            return CmsContentBlockMapper.ToDto(blocks[0]);
+            // Project to the public DTO so this anonymous endpoint never serializes the raw entity
+            // graph (attached-file encryption Keys, server FilePaths, unsanitized ContentHistory,
+            // permission rows) nor management metadata (editor login ids, permission names,
+            // System/section placement). Content is already render-sanitized by
+            // GetContentBlocksAllowed; display consumers read only content + title.
+            return CmsContentBlockMapper.ToPublicDto(blocks[0]);
         }
 
         //GET: content/5/history

--- a/web/Areas/CMS/Controllers/CMSFilesController.cs
+++ b/web/Areas/CMS/Controllers/CMSFilesController.cs
@@ -192,6 +192,12 @@ namespace Viper.Areas.CMS.Controllers
             {
                 return BadRequest(ex.Message);
             }
+            // Before InvalidOperationException: CmsConcurrencyException derives from it, and a
+            // stale edit must surface as 409 (someone saved first), not a generic 400.
+            catch (CmsConcurrencyException ex)
+            {
+                return Conflict(ex.Message);
+            }
             catch (InvalidOperationException ex)
             {
                 LogFileConflict(nameof(UpdateFile), null, file?.FileName, ex);

--- a/web/Areas/CMS/Controllers/CMSFilesController.cs
+++ b/web/Areas/CMS/Controllers/CMSFilesController.cs
@@ -59,7 +59,7 @@ namespace Viper.Areas.CMS.Controllers
             var page = pagination?.Page ?? 1;
             var perPage = pagination?.PerPage ?? 50;
             var (files, total) = await _fileService.GetFilesAsync(folder, status, search, encrypted, isPublic,
-                page, perPage, sortBy, descending, ct);
+                page, perPage, sortBy, descending, OwnerRestriction(), ct);
             if (pagination != null)
             {
                 pagination.TotalRecords = total;
@@ -83,7 +83,7 @@ namespace Viper.Areas.CMS.Controllers
         public async Task<ActionResult<List<CmsFolderCountDto>>> GetFolderCounts(
             bool? encrypted, bool? isPublic, string status = "active", CancellationToken ct = default)
         {
-            return await _fileService.GetFolderCountsAsync(status, encrypted, isPublic, ct);
+            return await _fileService.GetFolderCountsAsync(status, encrypted, isPublic, OwnerRestriction(), ct);
         }
 
         // GET /api/cms/files/audit
@@ -206,7 +206,7 @@ namespace Viper.Areas.CMS.Controllers
             if (permanent)
             {
                 // Hard delete is restricted to admins; soft delete is available to all file managers.
-                if (!_userHelper.HasPermission(_rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin))
+                if (!IsCmsAdmin())
                 {
                     return ForbidApi();
                 }
@@ -219,7 +219,35 @@ namespace Viper.Areas.CMS.Controllers
         [HttpPost("{fileGuid:guid}/restore")]
         public async Task<IActionResult> RestoreFile(Guid fileGuid, CancellationToken ct = default)
         {
+            if (!IsCmsAdmin())
+            {
+                // Non-admins may only restore files they trashed themselves.
+                var file = await _fileService.GetFileAsync(fileGuid, ct);
+                var login = _userHelper.GetCurrentUser()?.LoginId;
+                if (file?.DeletedOn == null || login == null
+                    || !string.Equals(file.ModifiedBy, login, StringComparison.OrdinalIgnoreCase))
+                {
+                    return ForbidApi();
+                }
+            }
             return await _fileService.RestoreFileAsync(fileGuid, ct) ? NoContent() : NotFound();
+        }
+
+        private bool IsCmsAdmin() =>
+            _userHelper.HasPermission(_rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin);
+
+        // Scopes trash queries: admins see the whole trash (null); everyone else only the files they
+        // deleted (matched by ModifiedBy), so nothing leaks across users but people can recover their own.
+        // A missing user context fails closed (empty string matches no ModifiedBy) rather than falling
+        // through to the admin-level unrestricted view.
+        private string? OwnerRestriction()
+        {
+            var user = _userHelper.GetCurrentUser();
+            if (user == null)
+            {
+                return string.Empty;
+            }
+            return IsCmsAdmin() ? null : user.LoginId;
         }
 
         // POST /api/cms/files/import — move files from the legacy VIPER webroot into the store

--- a/web/Areas/CMS/Controllers/CMSLeftNavController.cs
+++ b/web/Areas/CMS/Controllers/CMSLeftNavController.cs
@@ -46,8 +46,15 @@ namespace Viper.Areas.CMS.Controllers
         [HttpPost]
         public async Task<ActionResult<LeftNavMenuDto>> CreateMenu(LeftNavMenuAddEdit menu, CancellationToken ct = default)
         {
-            var created = await _leftNavService.CreateMenuAsync(menu, ct);
-            return CreatedAtAction(nameof(GetMenu), new { leftNavMenuId = created.LeftNavMenuId }, created);
+            try
+            {
+                var created = await _leftNavService.CreateMenuAsync(menu, ct);
+                return CreatedAtAction(nameof(GetMenu), new { leftNavMenuId = created.LeftNavMenuId }, created);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
         }
 
         // PUT /api/cms/left-navs/5
@@ -55,12 +62,19 @@ namespace Viper.Areas.CMS.Controllers
         public async Task<ActionResult<LeftNavMenuDto>> UpdateMenu(int leftNavMenuId, LeftNavMenuAddEdit menu,
             CancellationToken ct = default)
         {
-            var updated = await _leftNavService.UpdateMenuAsync(leftNavMenuId, menu, ct);
-            if (updated == null)
+            try
             {
-                return NotFound();
+                var updated = await _leftNavService.UpdateMenuAsync(leftNavMenuId, menu, ct);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+                return updated;
             }
-            return updated;
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
         }
 
         // PUT /api/cms/left-navs/5/items — full item list; order follows the array
@@ -68,17 +82,25 @@ namespace Viper.Areas.CMS.Controllers
         public async Task<ActionResult<LeftNavMenuDto>> SaveItems(int leftNavMenuId, List<LeftNavItemEdit> items,
             CancellationToken ct = default)
         {
-            if (items.Where(i => i.LeftNavItemId > 0).GroupBy(i => i.LeftNavItemId).Any(g => g.Count() > 1))
+            try
             {
-                return BadRequest("Duplicate item ids are not allowed.");
+                var updated = await _leftNavService.SaveItemsAsync(leftNavMenuId, items, ct);
+                if (updated == null)
+                {
+                    return NotFound();
+                }
+                return updated;
             }
-
-            var updated = await _leftNavService.SaveItemsAsync(leftNavMenuId, items, ct);
-            if (updated == null)
+            catch (ArgumentException ex)
             {
-                return NotFound();
+                // Malformed request (e.g. duplicate item ids).
+                return BadRequest(ex.Message);
             }
-            return updated;
+            catch (InvalidOperationException ex)
+            {
+                // Stale client: a supplied item id no longer exists in the menu.
+                return Conflict(ex.Message);
+            }
         }
 
         // DELETE /api/cms/left-navs/5 — deletes the menu and all items (no soft delete, matching legacy)

--- a/web/Areas/CMS/Controllers/CMSUserPhotoController.cs
+++ b/web/Areas/CMS/Controllers/CMSUserPhotoController.cs
@@ -15,6 +15,7 @@ namespace Viper.Areas.CMS.Controllers
     public class CMSUserPhotoController : ApiController
     {
         private const int CacheSeconds = 3600;
+        private const int StaleWhileRevalidateSeconds = 86400;
 
         private readonly ICmsUserPhotoService _photoService;
 
@@ -27,31 +28,49 @@ namespace Viper.Areas.CMS.Controllers
         [HttpGet("by-mail/{mailId}")]
         public async Task<IActionResult> GetByMailId(string mailId, bool altPhoto = false, CancellationToken ct = default)
         {
-            return await ServePhoto(mailId: mailId, loginId: null, iamId: null, altPhoto, ct);
+            return await ServePhoto(mailId: mailId, loginId: null, iamId: null, mothraId: null, altPhoto, ct);
         }
 
         // GET /api/cms/photos/by-login/{loginId}?altPhoto=true|false
         [HttpGet("by-login/{loginId}")]
         public async Task<IActionResult> GetByLoginId(string loginId, bool altPhoto = false, CancellationToken ct = default)
         {
-            return await ServePhoto(mailId: null, loginId: loginId, iamId: null, altPhoto, ct);
+            return await ServePhoto(mailId: null, loginId: loginId, iamId: null, mothraId: null, altPhoto, ct);
         }
 
         // GET /api/cms/photos/by-iam/{iamId}?altPhoto=true|false
         [HttpGet("by-iam/{iamId}")]
         public async Task<IActionResult> GetByIamId(string iamId, bool altPhoto = false, CancellationToken ct = default)
         {
-            return await ServePhoto(mailId: null, loginId: null, iamId: iamId, altPhoto, ct);
+            return await ServePhoto(mailId: null, loginId: null, iamId: iamId, mothraId: null, altPhoto, ct);
+        }
+
+        // GET /api/cms/photos/by-mothra/{mothraId}?altPhoto=true|false
+        [HttpGet("by-mothra/{mothraId}")]
+        public async Task<IActionResult> GetByMothraId(string mothraId, bool altPhoto = false, CancellationToken ct = default)
+        {
+            return await ServePhoto(mailId: null, loginId: null, iamId: null, mothraId: mothraId, altPhoto, ct);
         }
 
         private async Task<IActionResult> ServePhoto(string? mailId, string? loginId, string? iamId,
-            bool altPhoto, CancellationToken ct)
+            string? mothraId, bool altPhoto, CancellationToken ct)
         {
-            var photo = await _photoService.GetUserPhotoAsync(mailId, loginId, iamId, altPhoto, ct);
-            // Photos change rarely; let browsers cache for an hour (legacy used short-lived
-            // cache headers with long stale-while-revalidate).
-            Response.Headers.CacheControl = $"private, max-age={CacheSeconds}";
-            return File(photo, "image/jpeg");
+            var photo = await _photoService.GetUserPhotoAsync(mailId, loginId, iamId, mothraId, altPhoto, ct);
+
+            // Photos change rarely; let browsers cache for an hour and keep serving a stale copy
+            // for up to a day while revalidating (legacy used short-lived cache headers with long
+            // stale-while-revalidate). Last-Modified/If-Modified-Since lets a 304 skip the body
+            // entirely, which matters because pages render hundreds of these.
+            Response.Headers.CacheControl = $"private, max-age={CacheSeconds}, stale-while-revalidate={StaleWhileRevalidateSeconds}";
+            Response.GetTypedHeaders().LastModified = photo.LastModified;
+
+            var ifModifiedSince = Request.GetTypedHeaders().IfModifiedSince;
+            if (ifModifiedSince != null && photo.LastModified <= ifModifiedSince.Value)
+            {
+                return StatusCode(StatusCodes.Status304NotModified);
+            }
+
+            return File(photo.Bytes, "image/jpeg");
         }
     }
 }

--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -472,6 +472,9 @@ namespace Viper.Areas.CMS.Data
                 }
 
                 byte[] bytes = System.IO.File.ReadAllBytes(tempFileName);
+                // The zip itself is inert, but keep the whole /CMS/Files surface consistent:
+                // no MIME sniffing on any download response.
+                CmsFileResponse.SetNoSniff(controller.Response);
                 return controller.File(bytes, MimeTypes["zip"], safeDownloadName);
             }
             finally
@@ -553,11 +556,15 @@ namespace Viper.Areas.CMS.Data
                 contentType = "application/octet-stream";
             }
 
+            // Stop the browser from MIME-sniffing a benign type into an active one.
+            CmsFileResponse.SetNoSniff(controller.Response);
+
             // Build Content-Disposition from the stored record's name, not the user-supplied
             // friendlyName param, and let the framework encode it so a hostile fn cannot shape
-            // the header. Mirrors the DownloadZip download-name hardening.
+            // the header. Mirrors the DownloadZip download-name hardening. Inline-unsafe types
+            // (html/svg) are forced to download so an uploaded page cannot run in the app origin.
             var downloadName = CmsFilePathSafety.SanitizeZipEntryName(file.FriendlyName, file.FilePath);
-            var contentDisposition = new ContentDispositionHeaderValue("inline");
+            var contentDisposition = new ContentDispositionHeaderValue(CmsFileResponse.DispositionType(file.FilePath));
             contentDisposition.SetHttpFileName(downloadName);
             controller.Response.Headers.ContentDisposition = contentDisposition.ToString();
 

--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -57,6 +57,20 @@ namespace Viper.Areas.CMS.Data
 
             if (blocks != null && _rapsContext != null)
             {
+                // Resolve the user's access once, not per (block x permission) - mirrors
+                // CheckFilePermission's single-resolve HashSet approach.
+                var isCmsAdmin = false;
+                var hasSvmSecure = false;
+                HashSet<string> userPermissions = new(StringComparer.OrdinalIgnoreCase);
+                if (currentUser != null)
+                {
+                    isCmsAdmin = UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure.CMS.ManageContentBlocks");
+                    hasSvmSecure = UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure");
+                    userPermissions = UserHelper.GetAllPermissions(_rapsContext, currentUser)
+                        .Select(p => p.Permission)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                }
+
                 foreach (var b in blocks)
                 {
                     var hasAccess = b.AllowPublicAccess; //block is available without authentication
@@ -64,13 +78,12 @@ namespace Viper.Areas.CMS.Data
                     {
                         hasAccess =
                             //CMS admin
-                            UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure.CMS.ManageContentBlocks") ||
+                            isCmsAdmin ||
                             //available to all logged in users
-                            b.ContentBlockToPermissions.Count == 0 && UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure") ||
+                            b.ContentBlockToPermissions.Count == 0 && hasSvmSecure ||
                             //available due to having specific permission(s)
                             b.ContentBlockToPermissions.Count > 0 && b.ContentBlockToPermissions
-                                .Any(cp => UserHelper.GetAllPermissions(_rapsContext, currentUser)
-                                    .Any(p => string.Compare(cp.Permission, p.Permission, true) == 0));
+                                .Any(cp => userPermissions.Contains(cp.Permission));
                     }
                     // only include blocks that the user has permission to see
                     if (hasAccess)
@@ -175,6 +188,7 @@ namespace Viper.Areas.CMS.Data
         public CMSFile? GetFileByGuid(Guid fileGuid)
         {
             var file = _viperContext?.Files
+                .AsNoTracking()
                 .Include(p => p.FileToPermissions)
                 .Include(p => p.FileToPeople)
                 .AsSplitQuery()
@@ -187,6 +201,7 @@ namespace Viper.Areas.CMS.Data
         public CMSFile? GetFileByOldUrl(string oldUrl)
         {
             var file = _viperContext?.Files
+                .AsNoTracking()
                 .Include(p => p.FileToPermissions)
                 .Include(p => p.FileToPeople)
                 .AsSplitQuery()
@@ -199,6 +214,7 @@ namespace Viper.Areas.CMS.Data
         public CMSFile? GetFileByFriendlyName(string friendlyName)
         {
             var file = _viperContext?.Files
+                .AsNoTracking()
                 .Include(p => p.FileToPermissions)
                 .Include(p => p.FileToPeople)
                 .AsSplitQuery()
@@ -212,6 +228,7 @@ namespace Viper.Areas.CMS.Data
         {
             var filePath = folder + @"\" + name;
             var file = _viperContext?.Files
+                .AsNoTracking()
                 .Include(p => p.FileToPermissions)
                 .Include(p => p.FileToPeople)
                 .AsSplitQuery()
@@ -231,47 +248,6 @@ namespace Viper.Areas.CMS.Data
             var cmsf = new CMSFile(file);
             ReplaceRootFolder(cmsf);
             return cmsf;
-        }
-        #endregion
-
-        #region public IEnumerable<CMSFile> GetAllFiles(string? folder, bool? isPublic, string? search, string? status, bool? encrypted)
-        /// <summary>
-        /// Search for matching files
-        /// </summary>
-        public IEnumerable<CMSFile> GetAllFiles(string? folder, bool? isPublic, string? search, string? status, bool? encrypted)
-        {
-
-            // get files based on paramenters
-            var files = _viperContext?.Files
-                    .Include(p => p.FileToPermissions)
-                    .Include(p => p.FileToPeople)
-                    .Where(f => (string.IsNullOrEmpty(folder) && f.FilePath.Contains(folder + @"\")) || string.IsNullOrEmpty(folder))
-                    .Where(f => f.AllowPublicAccess.Equals(isPublic) || isPublic == null)
-                    .Where(c => (string.IsNullOrEmpty(status) || (c.DeletedOn == null && status.ToLower() != "active") || (c.DeletedOn != null && status.ToLower() == "active")))
-                    .Where(f => f.Encrypted.Equals(encrypted) || encrypted == null)
-                    .Where(f => (string.IsNullOrEmpty(search) || f.FriendlyName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        f.Description.Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        string.IsNullOrEmpty(f.OldUrl) ? string.IsNullOrEmpty(search) : f.OldUrl.Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        f.FilePath.Contains(search, StringComparison.OrdinalIgnoreCase)))
-                .OrderBy(c => c.FriendlyName)
-                .AsSplitQuery()
-                .ToList();
-
-            if (files != null)
-            {
-                List<CMSFile> cmslist = new();
-                foreach (var f in files)
-                {
-                    CMSFile cmsf = new(f);
-                    cmslist.Add(cmsf);
-                    ReplaceRootFolder(cmsf);
-                }
-
-                return cmslist;
-            }
-
-            return new List<CMSFile>();
-
         }
         #endregion
 
@@ -424,15 +400,27 @@ namespace Viper.Areas.CMS.Data
                 CMSFile? file = GetFile(guid, null, null, null, null);
 
                 // only add files that exist and where the user has permission
-                if (file != null && System.IO.File.Exists(file.FilePath) && CheckFilePermission(file))
+                if (file == null || !System.IO.File.Exists(file.FilePath))
                 {
-                    if (currentUser != null && _viperContext != null)
-                    {
-                        AuditFileAccess(_viperContext, file, currentUser, "AccessFile", string.Empty);
-                    }
-
-                    files.Add(file);
+                    continue;
                 }
+
+                if (!CheckFilePermission(file))
+                {
+                    // Legacy parity: a denied file in a ZIP request is audited like a single-file deny.
+                    if (_viperContext != null)
+                    {
+                        AuditFileAccess(_viperContext, file, currentUser, "AccessFileDenied", string.Empty);
+                    }
+                    continue;
+                }
+
+                if (_viperContext != null)
+                {
+                    AuditFileAccess(_viperContext, file, currentUser, "AccessFile", string.Empty);
+                }
+
+                files.Add(file);
             }
 
             if (files.Count == 0)
@@ -527,7 +515,7 @@ namespace Viper.Areas.CMS.Data
 
             if (!CheckFilePermission(file))
             {
-                if (currentUser != null && _viperContext != null)
+                if (_viperContext != null)
                 {
                     AuditFileAccess(_viperContext, file, currentUser, "AccessFileDenied", detail);
                 }
@@ -536,7 +524,7 @@ namespace Viper.Areas.CMS.Data
                 return controller.View("~/Views/Home/403.cshtml", (HttpStatusCode)403);
             }
 
-            if (currentUser != null && _viperContext != null)
+            if (_viperContext != null)
             {
                 AuditFileAccess(_viperContext, file, currentUser, "AccessFile", detail);
             }
@@ -620,20 +608,27 @@ namespace Viper.Areas.CMS.Data
                 LogSanitizer.SanitizeString(request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty));
         }
 
-        #region public static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser user, string action, string detail)
-        public static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser user, string action, string detail)
+        #region public static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser? user, string action, string detail)
+        public static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser? user, string action, string detail)
         {
+            // Legacy parity: anonymous/public access is audited too (null user -> null login/iam),
+            // while requests from the internal kiosk range (192.168.*) are not audited at all.
+            if (HttpHelper.HttpContext?.Connection.RemoteIpAddress?.ToString().StartsWith("192.168.") == true)
+            {
+                return;
+            }
+
             UserHelper userHelper = new();
 
             FileAudit fileAudit = new()
             {
                 Timestamp = DateTime.Now,
-                Loginid = user.LoginId,
+                Loginid = user?.LoginId,
                 Action = action,
                 Detail = detail,
                 FileGuid = file.FileGuid,
                 FilePath = file.FilePath,
-                IamId = user.IamId,
+                IamId = user?.IamId,
                 FileMetaData = JsonSerializer.Serialize<CMSFileMetaData>(file.MetaData),
                 ClientData = JsonSerializer.Serialize(userHelper.GetClientData())
             };
@@ -681,8 +676,6 @@ namespace Viper.Areas.CMS.Data
 
         CMSFile? GetFileByFolderAndName(string folder, string name);
 
-        IEnumerable<CMSFile> GetAllFiles(string? folder, bool? isPublic, string? search, string? status, bool? encrypted);
-
         static string GetFriendlyURL(string friendlyName, bool allowPublicAccess = false) => throw new NotImplementedException();
 
         static string GetURL(string fileGUID, bool allowPublicAccess = false) => throw new NotImplementedException();
@@ -699,7 +692,7 @@ namespace Viper.Areas.CMS.Data
 
         IActionResult ProvideFile(Controller controller, string id, string friendlyName, string oldURL);
 
-        static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser user, string action, string detail) => throw new NotImplementedException();
+        static void AuditFileAccess(VIPERContext viperContext, CMSFile file, AaudUser? user, string action, string detail) => throw new NotImplementedException();
 
         byte[] DecryptFile(byte[] encryptedData, string keystring);
 

--- a/web/Areas/CMS/Jobs/CmsTrashPurgeScheduledJob.cs
+++ b/web/Areas/CMS/Jobs/CmsTrashPurgeScheduledJob.cs
@@ -1,0 +1,51 @@
+using Viper.Areas.CMS.Constants;
+using Viper.Areas.CMS.Services;
+using Viper.Areas.Scheduler.Models;
+using Viper.Areas.Scheduler.Services;
+
+namespace Viper.Areas.CMS.Jobs
+{
+    /// <summary>
+    /// Daily purge of the CMS file trash: permanently deletes files that were soft-deleted more than
+    /// <see cref="CmsTrash.RetentionDays"/> days ago (record + disk), restoring the legacy 30-day
+    /// retention routine that VIPER 1 ran but the migration hadn't yet reimplemented.
+    ///
+    /// Gated by <see cref="CmsTrash.PurgeEnabledConfigKey"/> (default false): the job stays
+    /// registered and fires on cron, but no-ops until an environment opts in via config. That lets
+    /// it ship disabled and be enabled only once the legacy VIPER 1 purge is retired, without a
+    /// dashboard change that the next app restart would silently undo.
+    /// </summary>
+    [ScheduledJob(id: "cms:trash-purge", cron: "0 3 * * *")]
+    public sealed class CmsTrashPurgeScheduledJob : IScheduledJob
+    {
+        private readonly ICmsFileService _fileService;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<CmsTrashPurgeScheduledJob> _logger;
+
+        public CmsTrashPurgeScheduledJob(ICmsFileService fileService, IConfiguration configuration,
+            ILogger<CmsTrashPurgeScheduledJob> logger)
+        {
+            _fileService = fileService;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public async Task RunAsync(ScheduledJobContext context, CancellationToken ct)
+        {
+            if (!_configuration.GetValue<bool>(CmsTrash.PurgeEnabledConfigKey))
+            {
+                context.WriteLine(
+                    $"CMS trash purge is disabled ({CmsTrash.PurgeEnabledConfigKey} is not true); skipping.");
+                _logger.LogInformation(
+                    "CMS trash purge skipped: {ConfigKey} is not enabled", CmsTrash.PurgeEnabledConfigKey);
+                return;
+            }
+
+            context.WriteLine($"CMS trash purge starting (retention={CmsTrash.RetentionDays}d, modBy={context.ModBy})");
+            var purged = await _fileService.PurgeDeletedFilesAsync(CmsTrash.RetentionDays, ct);
+            context.WriteLine($"Purged {purged} trashed file(s) older than {CmsTrash.RetentionDays} days.");
+            _logger.LogInformation(
+                "CMS trash purge removed {Count} file(s) older than {Days} days", purged, CmsTrash.RetentionDays);
+        }
+    }
+}

--- a/web/Areas/CMS/Models/CmsContentBlockMapper.cs
+++ b/web/Areas/CMS/Models/CmsContentBlockMapper.cs
@@ -26,5 +26,7 @@ namespace Viper.Areas.CMS.Models
         [MapperIgnoreTarget(nameof(ContentBlockDto.Permissions))]
         [MapperIgnoreTarget(nameof(ContentBlockDto.Files))]
         private static partial ContentBlockDto ToDtoBase(ContentBlock block);
+
+        public static partial PublicContentBlockDto ToPublicDto(ContentBlock block);
     }
 }

--- a/web/Areas/CMS/Models/CmsContentBlockMapper.cs
+++ b/web/Areas/CMS/Models/CmsContentBlockMapper.cs
@@ -12,7 +12,6 @@ namespace Viper.Areas.CMS.Models
             var dto = ToDtoBase(block);
             dto.Permissions = block.ContentBlockToPermissions.Select(p => p.Permission).OrderBy(p => p).ToList();
             dto.Files = block.ContentBlockToFiles
-                .Where(f => f.File != null)
                 .Select(f => new ContentBlockFileDto
                 {
                     FileGuid = f.FileGuid,

--- a/web/Areas/CMS/Models/CmsFileMapper.cs
+++ b/web/Areas/CMS/Models/CmsFileMapper.cs
@@ -1,4 +1,5 @@
 using Riok.Mapperly.Abstractions;
+using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models.DTOs;
 using File = Viper.Models.VIPER.File;
 
@@ -26,6 +27,8 @@ namespace Viper.Areas.CMS.Models
                 .ToList();
             dto.Url = Data.CMS.GetURL(file.FileGuid.ToString(), file.AllowPublicAccess);
             dto.FriendlyUrl = Data.CMS.GetFriendlyURL(file.FriendlyName, file.AllowPublicAccess);
+            // When a file is in the trash, surface the date the purge job will permanently delete it.
+            dto.PurgeOn = file.DeletedOn?.AddDays(CmsTrash.RetentionDays);
             return dto;
         }
 
@@ -34,6 +37,7 @@ namespace Viper.Areas.CMS.Models
         [MapperIgnoreTarget(nameof(CmsFileDto.People))]
         [MapperIgnoreTarget(nameof(CmsFileDto.Url))]
         [MapperIgnoreTarget(nameof(CmsFileDto.FriendlyUrl))]
+        [MapperIgnoreTarget(nameof(CmsFileDto.PurgeOn))]
         private static partial CmsFileDto ToCmsFileDtoBase(File file);
     }
 }

--- a/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
+++ b/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
@@ -13,6 +13,10 @@ namespace Viper.Areas.CMS.Models.DTOs
         public DateTime ModifiedOn { get; set; }
         public string ModifiedBy { get; set; } = string.Empty;
         public DateTime? DeletedOn { get; set; }
+
+        /// <summary>When a trashed file will be permanently purged (DeletedOn + retention); null if not deleted.</summary>
+        public DateTime? PurgeOn { get; set; }
+
         public List<string> Permissions { get; set; } = new();
         public List<CmsFilePersonDto> People { get; set; } = new();
         public string Url { get; set; } = string.Empty;

--- a/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
+++ b/web/Areas/CMS/Models/DTOs/CmsFileDto.cs
@@ -49,5 +49,12 @@ namespace Viper.Areas.CMS.Models.DTOs
         public string? ExistingFriendlyName { get; set; }
 
         public bool ExistingDeleted { get; set; }
+
+        /// <summary>
+        /// ModifiedOn of the conflicting record, echoed back as LastModifiedOn when the user
+        /// chooses to overwrite it, so the overwrite hits the same 409 stale-edit guard as a
+        /// metadata edit if the record changed after this check.
+        /// </summary>
+        public DateTime? ExistingModifiedOn { get; set; }
     }
 }

--- a/web/Areas/CMS/Models/DTOs/CmsFileRequests.cs
+++ b/web/Areas/CMS/Models/DTOs/CmsFileRequests.cs
@@ -40,6 +40,12 @@ namespace Viper.Areas.CMS.Models.DTOs
     /// </summary>
     public class CmsFileUpdateRequest
     {
+        /// <summary>
+        /// ModifiedOn value the client loaded; updates with a stale value get 409 Conflict
+        /// and a missing value gets 400 (mirrors CMSBlockAddEdit.LastModifiedOn).
+        /// </summary>
+        public DateTime? LastModifiedOn { get; set; }
+
         [MaxLength(1000)]
         public string? Description { get; set; }
 

--- a/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
+++ b/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
@@ -19,6 +19,19 @@ namespace Viper.Areas.CMS.Models.DTOs
         public List<ContentBlockFileDto> Files { get; set; } = new();
     }
 
+    /// <summary>
+    /// Shape served by the anonymous display endpoint (content/fn/{friendlyName}). Carries only
+    /// what public rendering needs; the full ContentBlockDto would disclose editor login ids,
+    /// permission names, and placement metadata to unauthenticated callers.
+    /// </summary>
+    public class PublicContentBlockDto
+    {
+        public int ContentBlockId { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public string? Title { get; set; }
+        public string? FriendlyName { get; set; }
+    }
+
     public class ContentBlockFileDto
     {
         public Guid FileGuid { get; set; }

--- a/web/Areas/CMS/Models/DTOs/CreateLinkDto.cs
+++ b/web/Areas/CMS/Models/DTOs/CreateLinkDto.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using Areas.CMS.Validation;
+using Viper.Areas.CMS.Validation;
 
 namespace Areas.CMS.Models.DTOs;
 

--- a/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
+++ b/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using Areas.CMS.Validation;
 
 namespace Viper.Areas.CMS.Models.DTOs
@@ -52,12 +53,16 @@ namespace Viper.Areas.CMS.Models.DTOs
     /// </summary>
     public class LeftNavItemEdit
     {
+        // JsonRequired (not defaulting on omission): an under-posted id would silently turn an
+        // update into a new item, and an omitted isHeader would silently clear a header.
+        [JsonRequired]
         public int LeftNavItemId { get; set; }
 
         [Required]
         [MaxLength(500)]
         public string MenuItemText { get; set; } = string.Empty;
 
+        [JsonRequired]
         public bool IsHeader { get; set; }
 
         [MaxLength(1000)]

--- a/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
+++ b/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
@@ -60,7 +60,8 @@ namespace Viper.Areas.CMS.Models.DTOs
         [JsonRequired]
         public int LeftNavItemId { get; set; }
 
-        [Required]
+        // Not [Required]: a header item may have empty text (legacy renders it as a blank
+        // spacer row). Links still need text - enforced in CmsLeftNavService.SaveItemsAsync.
         [MaxLength(250)]
         public string MenuItemText { get; set; } = string.Empty;
 

--- a/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
+++ b/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
-using Areas.CMS.Validation;
+using Viper.Areas.CMS.Validation;
 
 namespace Viper.Areas.CMS.Models.DTOs
 {

--- a/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
+++ b/web/Areas/CMS/Models/DTOs/LeftNavDtos.cs
@@ -27,23 +27,25 @@ namespace Viper.Areas.CMS.Models.DTOs
         public List<string> Permissions { get; set; } = new();
     }
 
+    // MaxLength values mirror the LeftNavMenu column sizes in VIPERContext so an over-long value
+    // is rejected as a 400 rather than surfacing as a 500 when SQL Server truncates/rejects it.
     public class LeftNavMenuAddEdit
     {
         [Required]
-        [MaxLength(500)]
+        [MaxLength(100)]
         public string MenuHeaderText { get; set; } = string.Empty;
 
         [Required]
         [MaxLength(50)]
         public string System { get; set; } = "Viper";
 
-        [MaxLength(250)]
+        [MaxLength(100)]
         public string? ViperSectionPath { get; set; }
 
-        [MaxLength(250)]
+        [MaxLength(200)]
         public string? Page { get; set; }
 
-        [MaxLength(250)]
+        [MaxLength(100)]
         public string? FriendlyName { get; set; }
     }
 
@@ -59,16 +61,18 @@ namespace Viper.Areas.CMS.Models.DTOs
         public int LeftNavItemId { get; set; }
 
         [Required]
-        [MaxLength(500)]
+        [MaxLength(250)]
         public string MenuItemText { get; set; } = string.Empty;
 
         [JsonRequired]
         public bool IsHeader { get; set; }
 
-        [MaxLength(1000)]
+        [MaxLength(250)]
         [SafeUrl(AllowRelative = true)]
         public string? Url { get; set; }
 
+        // Each permission is stored in the varchar(500) LeftNavItemToPermission.permission column.
+        [MaxLengthEach(500)]
         public List<string> Permissions { get; set; } = new();
     }
 }

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -20,8 +20,9 @@ namespace Viper.Areas.CMS.Services
 
     public interface ICmsContentBlockService
     {
-        Task<List<ContentBlockDto>> GetContentBlocksAsync(string status, string? system, string? viperSectionPath,
-            string? search, bool? isPublic = null, CancellationToken ct = default);
+        Task<(List<ContentBlockDto> Blocks, int Total)> GetContentBlocksAsync(string status, string? system,
+            string? viperSectionPath, string? search, bool? isPublic, int page, int perPage, string? sortBy,
+            bool descending, CancellationToken ct = default);
 
         Task<ContentBlockDto?> GetContentBlockAsync(int contentBlockId, CancellationToken ct = default);
 
@@ -84,8 +85,9 @@ namespace Viper.Areas.CMS.Services
             _userHelper = userHelper;
         }
 
-        public async Task<List<ContentBlockDto>> GetContentBlocksAsync(string status, string? system,
-            string? viperSectionPath, string? search, bool? isPublic = null, CancellationToken ct = default)
+        public async Task<(List<ContentBlockDto> Blocks, int Total)> GetContentBlocksAsync(string status, string? system,
+            string? viperSectionPath, string? search, bool? isPublic, int page, int perPage, string? sortBy,
+            bool descending, CancellationToken ct = default)
         {
             var query = _context.ContentBlocks
                 .AsNoTracking()
@@ -122,10 +124,25 @@ namespace Viper.Areas.CMS.Services
                     || b.Content.Contains(search));
             }
 
+            int total = await query.CountAsync(ct);
+
+            query = (sortBy?.ToLowerInvariant(), descending) switch
+            {
+                ("vipersectionpath", false) => query.OrderBy(b => b.ViperSectionPath).ThenBy(b => b.Title),
+                ("vipersectionpath", true) => query.OrderByDescending(b => b.ViperSectionPath).ThenBy(b => b.Title),
+                ("page", false) => query.OrderBy(b => b.Page).ThenBy(b => b.Title),
+                ("page", true) => query.OrderByDescending(b => b.Page).ThenBy(b => b.Title),
+                ("modifiedon", false) => query.OrderBy(b => b.ModifiedOn),
+                ("modifiedon", true) => query.OrderByDescending(b => b.ModifiedOn),
+                (_, true) => query.OrderByDescending(b => b.Title),
+                _ => query.OrderBy(b => b.Title)
+            };
+
             // List view: project without Content (it can be large) — the editor loads the full
             // block. Two stages because GetFriendlyURL reads HttpContext and can't translate to SQL.
             var blocks = await query
-                .OrderBy(b => b.Title)
+                .Skip((page - 1) * perPage)
+                .Take(perPage)
                 .Select(b => new
                 {
                     b.ContentBlockId,
@@ -156,7 +173,7 @@ namespace Viper.Areas.CMS.Services
                 })
                 .ToListAsync(ct);
 
-            return blocks.Select(b => new ContentBlockDto
+            var dtos = blocks.Select(b => new ContentBlockDto
             {
                 ContentBlockId = b.ContentBlockId,
                 Title = b.Title,
@@ -178,6 +195,8 @@ namespace Viper.Areas.CMS.Services
                     Url = Data.CMS.GetFriendlyURL(f.FriendlyName, f.AllowPublicAccess)
                 }).ToList()
             }).ToList();
+
+            return (dtos, total);
         }
 
         public async Task<ContentBlockDto?> GetContentBlockAsync(int contentBlockId, CancellationToken ct = default)

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -114,9 +114,11 @@ namespace Viper.Areas.CMS.Services
             }
             if (!string.IsNullOrEmpty(search))
             {
-                query = query.Where(b => (b.Title != null && b.Title.Contains(search))
-                    || (b.FriendlyName != null && b.FriendlyName.Contains(search))
-                    || (b.Page != null && b.Page.Contains(search))
+                // Coalescing null columns to "" (never a match: search is non-empty here) keeps
+                // this a flat OR chain the SQL and in-memory providers both translate.
+                query = query.Where(b => (b.Title ?? "").Contains(search)
+                    || (b.FriendlyName ?? "").Contains(search)
+                    || (b.Page ?? "").Contains(search)
                     || b.Content.Contains(search));
             }
 
@@ -143,7 +145,6 @@ namespace Viper.Areas.CMS.Services
                         .OrderBy(p => p)
                         .ToList(),
                     Files = b.ContentBlockToFiles
-                        .Where(f => f.File != null)
                         .Select(f => new
                         {
                             f.FileGuid,
@@ -423,8 +424,8 @@ namespace Viper.Areas.CMS.Services
         // <ins>/<del> change markers on top of our normal allowlist.
         private string BuildDiffHtml(string oldContent, string newContent)
         {
-            var oldSafe = _sanitizer.Sanitize(oldContent ?? string.Empty);
-            var newSafe = _sanitizer.Sanitize(newContent ?? string.Empty);
+            var oldSafe = _sanitizer.Sanitize(oldContent);
+            var newSafe = _sanitizer.Sanitize(newContent);
             var diff = HtmlDiffer.Execute(oldSafe, newSafe);
             return _sanitizer.SanitizeDiff(diff);
         }
@@ -492,9 +493,9 @@ namespace Viper.Areas.CMS.Services
             }
             if (!string.IsNullOrEmpty(filter.Search))
             {
-                query = query.Where(x => (x.Block.Title != null && x.Block.Title.Contains(filter.Search))
-                    || (x.Block.FriendlyName != null && x.Block.FriendlyName.Contains(filter.Search))
-                    || (x.Block.Page != null && x.Block.Page.Contains(filter.Search)));
+                query = query.Where(x => (x.Block.Title ?? "").Contains(filter.Search)
+                    || (x.Block.FriendlyName ?? "").Contains(filter.Search)
+                    || (x.Block.Page ?? "").Contains(filter.Search));
             }
             return query;
         }

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -546,7 +546,7 @@ namespace Viper.Areas.CMS.Services
             {
                 return;
             }
-            int existing = await _context.Files.CountAsync(f => fileGuids.Contains(f.FileGuid), ct);
+            int existing = await _context.Files.CountAsync(f => EF.Parameter(fileGuids).Contains(f.FileGuid), ct);
             if (existing != fileGuids.Count)
             {
                 throw new ArgumentException("One or more attached files do not exist.");

--- a/web/Areas/CMS/Services/CmsFileAuditService.cs
+++ b/web/Areas/CMS/Services/CmsFileAuditService.cs
@@ -123,7 +123,7 @@ namespace Viper.Areas.CMS.Services
             }
             if (!string.IsNullOrEmpty(filter.Search))
             {
-                query = query.Where(a => (a.FilePath != null && a.FilePath.Contains(filter.Search))
+                query = query.Where(a => a.FilePath.Contains(filter.Search)
                     || (a.Detail != null && a.Detail.Contains(filter.Search)));
             }
             return query;

--- a/web/Areas/CMS/Services/CmsFileCrypto.cs
+++ b/web/Areas/CMS/Services/CmsFileCrypto.cs
@@ -34,7 +34,7 @@ namespace Viper.Areas.CMS.Services
         /// </summary>
         public static string ReadMasterKey(string keyFilePath)
         {
-            string? masterKey = System.IO.File.ReadLines(keyFilePath).Skip(1).FirstOrDefault();
+            string? masterKey = File.ReadLines(keyFilePath).Skip(1).FirstOrDefault();
             if (string.IsNullOrWhiteSpace(masterKey))
             {
                 throw new InvalidOperationException("CMS master key file is missing the key line.");

--- a/web/Areas/CMS/Services/CmsFileEncryptionService.cs
+++ b/web/Areas/CMS/Services/CmsFileEncryptionService.cs
@@ -61,12 +61,12 @@ namespace Viper.Areas.CMS.Services
         /// </summary>
         private static void ReplaceFileContents(string filePath, Func<byte[], byte[]> transform)
         {
-            byte[] contents = System.IO.File.ReadAllBytes(filePath);
+            byte[] contents = File.ReadAllBytes(filePath);
             string tempPath = filePath + ".tmp";
             try
             {
-                System.IO.File.WriteAllBytes(tempPath, transform(contents));
-                System.IO.File.Move(tempPath, filePath, overwrite: true);
+                File.WriteAllBytes(tempPath, transform(contents));
+                File.Move(tempPath, filePath, overwrite: true);
             }
             catch (IOException)
             {
@@ -84,7 +84,7 @@ namespace Viper.Areas.CMS.Services
         {
             try
             {
-                System.IO.File.Delete(tempPath);
+                File.Delete(tempPath);
             }
             catch (IOException)
             {

--- a/web/Areas/CMS/Services/CmsFileImportService.cs
+++ b/web/Areas/CMS/Services/CmsFileImportService.cs
@@ -109,13 +109,22 @@ namespace Viper.Areas.CMS.Services
                     continue;
                 }
 
-                string finalName = _storage.GetAvailableFileName(request.Folder, source.FileName);
+                // GetAvailableFileName only sees disk + DB, so two source files sharing a basename
+                // would both preview the same name. Reserving each planned name (as the sequential
+                // import writes would) makes a later line resolve to the same unique name the import
+                // actually assigns it, instead of advertising one it will lose.
+                string availableOnStore = _storage.GetAvailableFileName(request.Folder, source.FileName);
+                bool sharesNameWithEarlierLine = plannedNames.Contains(availableOnStore);
+                string finalName = sharesNameWithEarlierLine
+                    ? _storage.GetAvailableFileName(request.Folder, source.FileName, plannedNames)
+                    : availableOnStore;
                 string friendlyName = CmsFileNaming.BuildFriendlyName(request.Folder, finalName);
                 if (await _context.Files.AnyAsync(f => f.FriendlyName == friendlyName, ct))
                 {
                     result.Message = $"A file with the name {friendlyName} already exists.";
                     continue;
                 }
+                plannedNames.Add(finalName);
 
                 result.CanImport = true;
                 result.FileName = finalName;
@@ -125,9 +134,9 @@ namespace Viper.Areas.CMS.Services
                 }
                 result.FriendlyName = friendlyName;
                 result.OldUrl = "/" + source.Relative.Replace('\\', '/');
-                if (!plannedNames.Add(finalName))
+                if (sharesNameWithEarlierLine)
                 {
-                    result.Message = "Another line uses the same file name; this one will be renamed during import.";
+                    result.Message = "Shares a name with an earlier line in this import; renamed to keep both.";
                 }
             }
             return results;

--- a/web/Areas/CMS/Services/CmsFileImportService.cs
+++ b/web/Areas/CMS/Services/CmsFileImportService.cs
@@ -150,12 +150,17 @@ namespace Viper.Areas.CMS.Services
         /// </summary>
         private SourceResolution ResolveSource(string rawPath)
         {
-            string relative = rawPath.TrimStart('/', '\\').Replace('/', '\\');
+            // Import lines are legacy Windows webroot paths; treat both separator styles as separators
+            // and rejoin with the host separator so parsing and traversal detection are identical on
+            // every OS. Path APIs only honor the host separator, so on Linux a "..\" segment would
+            // otherwise be read as part of a filename and slip past the outside-webroot check.
+            var segments = rawPath.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+            string relative = string.Join('/', segments);
             string sourcePath;
             string fileName;
             try
             {
-                sourcePath = Path.GetFullPath(Path.Join(_legacyWebroot, relative));
+                sourcePath = Path.GetFullPath(Path.Join(_legacyWebroot, Path.Join(segments)));
                 fileName = Path.GetFileName(sourcePath);
             }
             catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
@@ -344,10 +349,9 @@ namespace Viper.Areas.CMS.Services
                 return result;
             }
 
-            string? dbKey = null;
             try
             {
-                dbKey = _encryption.GenerateKeyForDb();
+                string dbKey = _encryption.GenerateKeyForDb();
                 _encryption.EncryptFileInPlace(file.FilePath, dbKey);
                 file.Key = dbKey;
                 file.Encrypted = true;
@@ -361,10 +365,11 @@ namespace Viper.Areas.CMS.Services
                     await _context.SaveChangesAsync(CancellationToken.None);
                     result.Success = true;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
                 {
-                    // Any save failure, whatever the exception type, means the key was not
-                    // persisted; the file must be decrypted back or it is unrecoverable.
+                    // A save failure (DB, SQL, or invalid entity state) means the key was never
+                    // persisted; the file must be decrypted back or it is unrecoverable. Anything
+                    // else is truly unexpected and is left to propagate.
                     RollBackUnsavedEncryption(file, dbKey, ex, result);
                 }
             }

--- a/web/Areas/CMS/Services/CmsFileResponse.cs
+++ b/web/Areas/CMS/Services/CmsFileResponse.cs
@@ -1,0 +1,28 @@
+using Microsoft.Net.Http.Headers;
+using Viper.Areas.CMS.Constants;
+
+namespace Viper.Areas.CMS.Services
+{
+    /// <summary>
+    /// Response hardening shared by the CMS file download paths (/CMS/Files). Every file response
+    /// gets X-Content-Type-Options: nosniff so a benign-typed upload cannot be MIME-sniffed into an
+    /// active type, and inline-unsafe types (html/svg/...) are forced to download instead of
+    /// rendering in the app origin.
+    /// </summary>
+    public static class CmsFileResponse
+    {
+        public static void SetNoSniff(HttpResponse response)
+        {
+            response.Headers[HeaderNames.XContentTypeOptions] = "nosniff";
+        }
+
+        /// <summary>
+        /// Content-Disposition type for a served file: "attachment" for types a browser would
+        /// execute/render inline, "inline" for everything else.
+        /// </summary>
+        public static string DispositionType(string fileName)
+        {
+            return CmsFileTypes.ShouldForceAttachment(fileName) ? "attachment" : "inline";
+        }
+    }
+}

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
@@ -218,7 +219,8 @@ namespace Viper.Areas.CMS.Services
                 SuggestedName = inUse ? _storage.GetAvailableFileName(folder, name) : name,
                 ExistingFileGuid = existing?.FileGuid,
                 ExistingFriendlyName = existing?.FriendlyName,
-                ExistingDeleted = existing?.DeletedOn != null
+                ExistingDeleted = existing?.DeletedOn != null,
+                ExistingModifiedOn = existing?.ModifiedOn
             };
         }
 
@@ -319,10 +321,10 @@ namespace Viper.Areas.CMS.Services
                 await _context.SaveChangesAsync(ct);
                 saved = true;
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException or OperationCanceledException)
             {
-                // A failed save never persisted the record. Drop the pending changes, then reconcile
-                // the managed store: restore an overwritten file's original bytes, or remove the
+                // A failed or cancelled save never persisted the record. Drop the pending changes, then
+                // reconcile the managed store: restore an overwritten file's original bytes, or remove the
                 // freshly stored copy, so nothing is left orphaned or destroyed.
                 _context.ChangeTracker.Clear();
                 ReconcileStoreAfterFailedCreate(finalPath, overwriteBackup);
@@ -350,6 +352,10 @@ namespace Viper.Areas.CMS.Services
             {
                 return null;
             }
+
+            // Stale-edit guard first, before anything touches the file on disk (mirrors
+            // CmsContentBlockService: missing value -> 400, stale value -> 409).
+            AssertNotStale(entity, request.LastModifiedOn);
 
             // Validate a replacement upload before anything touches the file on disk, so a bad type
             // can't leave the file half-transformed or strand a backup copy.
@@ -391,6 +397,21 @@ namespace Viper.Areas.CMS.Services
 
             var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
             return CmsFileMapper.ToCmsFileDto(entity, names);
+        }
+
+        private static void AssertNotStale(File entity, DateTime? lastModifiedOn)
+        {
+            if (lastModifiedOn == null)
+            {
+                throw new ArgumentException("LastModifiedOn is required so concurrent edits can be detected.");
+            }
+            // Compare to the second: serialized timestamps lose sub-second precision round-tripping
+            // through the client.
+            if (Math.Abs((entity.ModifiedOn - lastModifiedOn.Value).TotalSeconds) >= 1)
+            {
+                throw new CmsConcurrencyException(
+                    $"This file was modified by {entity.ModifiedBy} on {entity.ModifiedOn:g}. Reload to get the latest version.");
+            }
         }
 
         /// <summary>
@@ -517,10 +538,10 @@ namespace Viper.Areas.CMS.Services
                 await _context.SaveChangesAsync(CancellationToken.None);
                 saved = true;
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                // Any failure type means the new state was not persisted; drop the pending changes
-                // and reconcile the on-disk file back to its original state before rethrowing.
+                // A database save failure means the new state was not persisted; drop the pending
+                // changes and reconcile the on-disk file back to its original state before rethrowing.
                 _context.ChangeTracker.Clear();
                 if (originalFileBackup != null)
                 {
@@ -710,7 +731,7 @@ namespace Viper.Areas.CMS.Services
                         purged++;
                     }
                 }
-                catch (Exception ex) when (ex is DbUpdateException or IOException or InvalidOperationException)
+                catch (Exception ex) when (ex is DbUpdateException or SqlException or IOException or InvalidOperationException)
                 {
                     // Isolate per-file failures so one bad file doesn't abort the whole purge run.
                     _context.ChangeTracker.Clear();

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -3,6 +3,7 @@ using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
 using Viper.Areas.CMS.Models.DTOs;
 using Viper.Classes.SQLContext;
+using Viper.Classes.Utilities;
 using File = Viper.Models.VIPER.File;
 
 namespace Viper.Areas.CMS.Services
@@ -617,7 +618,7 @@ namespace Viper.Areas.CMS.Services
             {
                 _logger.LogCritical(ex, "CMS overwrite at {FilePath} could not be restored after a failed "
                     + "create; the original bytes are preserved at {BackupPath} for manual recovery.",
-                    Viper.Classes.Utilities.LogSanitizer.SanitizeString(finalPath), overwriteBackup);
+                    LogSanitizer.SanitizeString(finalPath), overwriteBackup);
             }
         }
 
@@ -683,7 +684,7 @@ namespace Viper.Areas.CMS.Services
             {
                 _logger.LogError(ex, "CMS file record {FileGuid} was deleted but its bytes at {FilePath} "
                     + "could not be removed from disk.",
-                    fileGuid, Viper.Classes.Utilities.LogSanitizer.SanitizeString(entity.FilePath));
+                    fileGuid, LogSanitizer.SanitizeString(entity.FilePath));
             }
             return true;
         }

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -220,6 +220,9 @@ namespace Viper.Areas.CMS.Services
 
             string tempPath = await _storage.SaveToTempAsync(file, ct);
             string finalPath;
+            // Overwriting an orphaned on-disk file (no DB row) destroys its bytes; snapshot them first
+            // so a later failure can roll the original back instead of leaving nothing in its place.
+            string? overwriteBackup = null;
             try
             {
                 if (dbKey != null)
@@ -233,6 +236,10 @@ namespace Viper.Areas.CMS.Services
                     {
                         throw new InvalidOperationException(
                             $"{uploadName} belongs to an existing file record; replace its content by editing that file.");
+                    }
+                    if (_storage.ManagedFileExists(targetPath))
+                    {
+                        overwriteBackup = _storage.BackupManagedFile(targetPath);
                     }
                     _storage.ReplaceInPlace(tempPath, targetPath);
                     finalPath = targetPath;
@@ -253,7 +260,9 @@ namespace Viper.Areas.CMS.Services
             string friendlyName = CmsFileNaming.BuildFriendlyName(request.Folder, Path.GetFileName(finalPath));
             if (await _context.Files.AnyAsync(f => f.FriendlyName == friendlyName, ct))
             {
-                _storage.DeleteManagedFile(finalPath);
+                // The new bytes are already on disk; reconcile the store (restore an overwritten
+                // original, or delete a fresh copy) before failing so nothing is left behind.
+                ReconcileStoreAfterFailedCreate(finalPath, overwriteBackup);
                 throw new InvalidOperationException($"A file with the name {friendlyName} already exists.");
             }
 
@@ -284,17 +293,30 @@ namespace Viper.Areas.CMS.Services
             _context.Files.Add(entity);
             _audit.Audit(entity, CmsFileAuditActions.AddFile, BuildCreateDetail(entity));
             _audit.Audit(entity, CmsFileAuditActions.UploadFile, "NewFile");
+            bool saved = false;
             try
             {
                 await _context.SaveChangesAsync(ct);
+                saved = true;
             }
             catch (Exception)
             {
-                // The upload is already in the managed store; any failed save would orphan it on
-                // disk, so drop the pending changes and remove the stored copy before rethrowing.
+                // A failed save never persisted the record. Drop the pending changes, then reconcile
+                // the managed store: restore an overwritten file's original bytes, or remove the
+                // freshly stored copy, so nothing is left orphaned or destroyed.
                 _context.ChangeTracker.Clear();
-                _storage.DeleteManagedFile(finalPath);
+                ReconcileStoreAfterFailedCreate(finalPath, overwriteBackup);
                 throw;
+            }
+            finally
+            {
+                // Only clean up on a committed save (the backup is then obsolete). On a failed save the
+                // reconcile above owns the backup: a successful restore already consumed it via Move, and
+                // a FAILED restore must keep it as the last copy of the original bytes.
+                if (saved && overwriteBackup != null && System.IO.File.Exists(overwriteBackup))
+                {
+                    System.IO.File.Delete(overwriteBackup);
+                }
             }
 
             var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
@@ -309,9 +331,12 @@ namespace Viper.Areas.CMS.Services
                 return null;
             }
 
-            var changes = new List<string>();
-            bool encrypt = request.Encrypt ?? false;
-            bool allowPublicAccess = request.AllowPublicAccess ?? false;
+            // Validate a replacement upload before anything touches the file on disk, so a bad type
+            // can't leave the file half-transformed or strand a backup copy.
+            if (file != null)
+            {
+                ValidateReplacementUpload(entity, file);
+            }
 
             // The crypto toggle and any replacement upload below transform the file on disk before
             // the metadata save. Capture the pre-change state so a failed save can reconcile the
@@ -319,8 +344,59 @@ namespace Viper.Areas.CMS.Services
             bool originalEncrypted = entity.Encrypted;
             string? originalKey = entity.Key;
 
-            // Encryption toggle happens before any file replacement so the replacement upload
-            // is written with the file's final encryption state.
+            // A replacement overwrites the bytes on disk before the save commits. Snapshot the
+            // original file first (it carries the original encryption state too) so a failed save
+            // can roll it back; restoring it supersedes the crypto-only reconcile below.
+            string? originalFileBackup = file != null && _storage.ManagedFileExists(entity.FilePath)
+                ? _storage.BackupManagedFile(entity.FilePath)
+                : null;
+
+            var changes = new List<string>();
+            ApplyEncryptionToggle(entity, request.Encrypt ?? false, changes);
+            ApplyScalarFieldChanges(entity, request, changes);
+
+            ApplyPermissionDeltas(entity, CleanList(request.Permissions), changes);
+            ApplyPersonDeltas(entity, CleanList(request.IamIds), changes);
+
+            if (file != null)
+            {
+                await WriteReplacementUploadAsync(entity, file, changes, ct);
+            }
+
+            entity.ModifiedOn = DateTime.Now;
+            entity.ModifiedBy = CurrentLoginId();
+
+            _audit.Audit(entity, CmsFileAuditActions.EditFile, string.Join("; ", changes));
+            await SaveUpdateAndReconcileAsync(entity, originalFileBackup, originalEncrypted, originalKey);
+
+            var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
+            return CmsFileMapper.ToCmsFileDto(entity, names);
+        }
+
+        /// <summary>
+        /// A replacement upload keeps the record's name and path, so its bytes must be an allowed
+        /// type and match the original extension; otherwise the stored file would hold mismatched
+        /// content and serve a corrupt download. Runs before anything touches disk.
+        /// </summary>
+        private static void ValidateReplacementUpload(File entity, IFormFile file)
+        {
+            if (!CmsFileTypes.IsAllowedFileName(file.FileName))
+            {
+                throw new ArgumentException("File type is not allowed.");
+            }
+            string replacementExt = Path.GetExtension(entity.FilePath);
+            if (!string.Equals(replacementExt, Path.GetExtension(file.FileName), StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException($"The replacement file must be the same type as the original ({replacementExt}).");
+            }
+        }
+
+        /// <summary>
+        /// Applies the encryption toggle in place before any replacement upload, so the replacement
+        /// is written with the file's final encryption state. Records the change for the audit trail.
+        /// </summary>
+        private void ApplyEncryptionToggle(File entity, bool encrypt, List<string> changes)
+        {
             if (encrypt && !entity.Encrypted)
             {
                 string dbKey = _encryption.GenerateKeyForDb();
@@ -342,13 +418,21 @@ namespace Viper.Areas.CMS.Services
                 entity.Encrypted = false;
                 changes.Add("Decrypted file");
             }
+        }
 
+        /// <summary>
+        /// Applies the description, public-access, and Old URL edits, recording each that actually
+        /// changes for the audit trail.
+        /// </summary>
+        private static void ApplyScalarFieldChanges(File entity, CmsFileUpdateRequest request, List<string> changes)
+        {
             string newDescription = request.Description ?? string.Empty;
             if (entity.Description != newDescription)
             {
                 entity.Description = newDescription;
                 changes.Add("Description updated");
             }
+            bool allowPublicAccess = request.AllowPublicAccess ?? false;
             if (entity.AllowPublicAccess != allowPublicAccess)
             {
                 entity.AllowPublicAccess = allowPublicAccess;
@@ -360,72 +444,86 @@ namespace Viper.Areas.CMS.Services
                 entity.OldUrl = newOldUrl;
                 changes.Add("Old URL updated");
             }
+        }
 
-            ApplyPermissionDeltas(entity, CleanList(request.Permissions), changes);
-            ApplyPersonDeltas(entity, CleanList(request.IamIds), changes);
-
-            if (file != null)
+        /// <summary>
+        /// Writes a replacement upload over the record's file: encrypts the temp copy to the file's
+        /// current state if needed, swaps it in, audits the replacement, and revives a soft-deleted
+        /// record (the overwrite-conflict flow). The temp copy is always cleaned up.
+        /// </summary>
+        private async Task WriteReplacementUploadAsync(File entity, IFormFile file, List<string> changes, CancellationToken ct)
+        {
+            string tempPath = await _storage.SaveToTempAsync(file, ct);
+            try
             {
-                if (!CmsFileTypes.IsAllowedFileName(file.FileName))
+                if (entity.Encrypted && !string.IsNullOrEmpty(entity.Key))
                 {
-                    throw new ArgumentException("File type is not allowed.");
+                    _encryption.EncryptFileInPlace(tempPath, entity.Key);
                 }
-                // The replacement keeps the existing record's name and path, so its bytes must
-                // stay the same type; a mismatched extension would leave the stored .pdf holding
-                // .png bytes and serve a corrupt download.
-                string currentExt = Path.GetExtension(entity.FilePath);
-                if (!string.Equals(currentExt, Path.GetExtension(file.FileName), StringComparison.OrdinalIgnoreCase))
+                _storage.ReplaceInPlace(tempPath, entity.FilePath);
+            }
+            finally
+            {
+                if (System.IO.File.Exists(tempPath))
                 {
-                    throw new ArgumentException($"The replacement file must be the same type as the original ({currentExt}).");
-                }
-                string tempPath = await _storage.SaveToTempAsync(file, ct);
-                try
-                {
-                    if (entity.Encrypted && !string.IsNullOrEmpty(entity.Key))
-                    {
-                        _encryption.EncryptFileInPlace(tempPath, entity.Key);
-                    }
-                    _storage.ReplaceInPlace(tempPath, entity.FilePath);
-                }
-                finally
-                {
-                    if (System.IO.File.Exists(tempPath))
-                    {
-                        System.IO.File.Delete(tempPath);
-                    }
-                }
-                _audit.Audit(entity, CmsFileAuditActions.UploadFile, "ReplacingFile");
-
-                // Uploading new content into a soft-deleted record (the overwrite-conflict
-                // flow) makes it live again; metadata-only edits leave deletion state alone.
-                if (entity.DeletedOn != null)
-                {
-                    entity.DeletedOn = null;
-                    changes.Add("Restored file");
+                    System.IO.File.Delete(tempPath);
                 }
             }
+            _audit.Audit(entity, CmsFileAuditActions.UploadFile, "ReplacingFile");
 
-            entity.ModifiedOn = DateTime.Now;
-            entity.ModifiedBy = CurrentLoginId();
+            // Uploading new content into a soft-deleted record (the overwrite-conflict flow) makes
+            // it live again; metadata-only edits leave deletion state alone.
+            if (entity.DeletedOn != null)
+            {
+                entity.DeletedOn = null;
+                changes.Add("Restored file");
+            }
+        }
 
-            _audit.Audit(entity, CmsFileAuditActions.EditFile, string.Join("; ", changes));
+        /// <summary>
+        /// Persists the metadata edit, reconciling the on-disk file when the save fails: restore the
+        /// pre-replacement backup (which also restores the original encryption state) or, with no
+        /// replacement, revert just the crypto transform. The backup is deleted once the save commits;
+        /// if a restore fails it is left in place as the last copy of the original bytes.
+        /// </summary>
+        private async Task SaveUpdateAndReconcileAsync(File entity, string? originalFileBackup,
+            bool originalEncrypted, string? originalKey)
+        {
+            bool saved = false;
             try
             {
                 // The file on disk may already be in its new encryption state; cancelling the save
                 // would strand it without a matching key, so it runs to completion even if aborted.
                 await _context.SaveChangesAsync(CancellationToken.None);
+                saved = true;
             }
             catch (Exception)
             {
                 // Any failure type means the new state was not persisted; drop the pending changes
-                // and reconcile the on-disk file back to its original encryption state before rethrowing.
+                // and reconcile the on-disk file back to its original state before rethrowing.
                 _context.ChangeTracker.Clear();
-                RevertCryptoOnSaveFailure(entity, originalEncrypted, originalKey);
+                if (originalFileBackup != null)
+                {
+                    // A replacement overwrote the file; restoring the original bytes also restores
+                    // the original encryption state, so the crypto-only reconcile is skipped.
+                    RestoreOriginalFileOnSaveFailure(entity, originalFileBackup);
+                }
+                else
+                {
+                    RevertCryptoOnSaveFailure(entity, originalEncrypted, originalKey);
+                }
                 throw;
             }
-
-            var names = await GetNamesByIamIdAsync(entity.FileToPeople.Select(p => p.IamId), ct);
-            return CmsFileMapper.ToCmsFileDto(entity, names);
+            finally
+            {
+                // Only clean up on a committed save (the backup is then obsolete). On a failed save the
+                // reconcile above owns the backup: a successful restore already consumed it via Move, and
+                // a FAILED restore must keep it as the last copy of the original bytes.
+                if (saved && originalFileBackup != null && System.IO.File.Exists(originalFileBackup))
+                {
+                    System.IO.File.Delete(originalFileBackup);
+                }
+            }
         }
 
         /// <summary>
@@ -457,6 +555,53 @@ namespace Viper.Areas.CMS.Services
             {
                 _logger.LogCritical(ex, "CMS file {FileGuid} could not be reverted after a failed save; "
                     + "its on-disk encryption no longer matches the database.", entity.FileGuid);
+            }
+        }
+
+        /// <summary>
+        /// A failed save after a replacement upload leaves the new bytes on disk while the database
+        /// rolled back to the original record. Move the pre-replacement backup back into place so a
+        /// download serves the original content (and its original encryption state). A failure to
+        /// restore is logged as critical (with the preserved backup path) rather than swallowed; the
+        /// caller leaves the backup in place so it remains the last copy of the original bytes.
+        /// </summary>
+        private void RestoreOriginalFileOnSaveFailure(File entity, string backupPath)
+        {
+            try
+            {
+                _storage.ReplaceInPlace(backupPath, entity.FilePath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                _logger.LogCritical(ex, "CMS file {FileGuid} could not be restored after a failed save; "
+                    + "the on-disk content may not match the database. The original bytes are preserved "
+                    + "at {BackupPath} for manual recovery.", entity.FileGuid, backupPath);
+            }
+        }
+
+        /// <summary>
+        /// A create that has already written its bytes but then fails (friendly-name clash or save
+        /// error) must not leave the store changed. When the write overwrote an orphaned file, move
+        /// its pre-overwrite backup back so the original content survives; otherwise just delete the
+        /// freshly stored copy. A failed restore is logged as critical (with the preserved backup
+        /// path) rather than swallowed; the caller leaves the backup in place for recovery.
+        /// </summary>
+        private void ReconcileStoreAfterFailedCreate(string finalPath, string? overwriteBackup)
+        {
+            if (overwriteBackup == null)
+            {
+                _storage.DeleteManagedFile(finalPath);
+                return;
+            }
+            try
+            {
+                _storage.ReplaceInPlace(overwriteBackup, finalPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                _logger.LogCritical(ex, "CMS overwrite at {FilePath} could not be restored after a failed "
+                    + "create; the original bytes are preserved at {BackupPath} for manual recovery.",
+                    Viper.Classes.Utilities.LogSanitizer.SanitizeString(finalPath), overwriteBackup);
             }
         }
 

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -116,6 +116,9 @@ namespace Viper.Areas.CMS.Services
                 ("modifiedon", true) => query.OrderByDescending(f => f.ModifiedOn),
                 ("oldurl", false) => query.OrderBy(f => f.OldUrl),
                 ("oldurl", true) => query.OrderByDescending(f => f.OldUrl),
+                // Trash views: ascending = closest to the purge cutoff first.
+                ("deletedon", false) => query.OrderBy(f => f.DeletedOn).ThenBy(f => f.FriendlyName),
+                ("deletedon", true) => query.OrderByDescending(f => f.DeletedOn).ThenBy(f => f.FriendlyName),
                 (_, true) => query.OrderByDescending(f => f.FriendlyName),
                 _ => query.OrderBy(f => f.FriendlyName)
             };

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -10,9 +10,11 @@ namespace Viper.Areas.CMS.Services
     public interface ICmsFileService
     {
         Task<(List<CmsFileDto> Files, int Total)> GetFilesAsync(string? folder, string status, string? search,
-            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending, CancellationToken ct = default);
+            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending,
+            string? restrictDeletedToOwner = null, CancellationToken ct = default);
 
-        Task<List<CmsFolderCountDto>> GetFolderCountsAsync(string status, bool? encrypted, bool? isPublic, CancellationToken ct = default);
+        Task<List<CmsFolderCountDto>> GetFolderCountsAsync(string status, bool? encrypted, bool? isPublic,
+            string? restrictDeletedToOwner = null, CancellationToken ct = default);
 
         Task<CmsFileNameCheckDto> CheckNameAsync(string folder, string fileName, CancellationToken ct = default);
 
@@ -27,6 +29,12 @@ namespace Viper.Areas.CMS.Services
         Task<bool> RestoreFileAsync(Guid fileGuid, CancellationToken ct = default);
 
         Task<bool> PermanentlyDeleteFileAsync(Guid fileGuid, CancellationToken ct = default);
+
+        /// <summary>
+        /// Permanently deletes trashed files whose DeletedOn is older than <paramref name="retentionDays"/>.
+        /// Used by the trash-purge scheduled job. Returns the number of files purged.
+        /// </summary>
+        Task<int> PurgeDeletedFilesAsync(int retentionDays, CancellationToken ct = default);
     }
 
     /// <summary>
@@ -59,7 +67,8 @@ namespace Viper.Areas.CMS.Services
         }
 
         public async Task<(List<CmsFileDto> Files, int Total)> GetFilesAsync(string? folder, string status, string? search,
-            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending, CancellationToken ct = default)
+            bool? encrypted, bool? isPublic, int page, int perPage, string? sortBy, bool descending,
+            string? restrictDeletedToOwner = null, CancellationToken ct = default)
         {
             var query = _context.Files
                 .AsNoTracking()
@@ -76,7 +85,7 @@ namespace Viper.Areas.CMS.Services
                 query = query.Where(f => f.Folder == folder || (f.Folder != null && f.Folder.StartsWith(folderPrefix)));
             }
 
-            query = ApplyStatusFilter(query, status);
+            query = ApplyStatusFilter(query, status, restrictDeletedToOwner);
 
             if (encrypted != null)
             {
@@ -120,14 +129,14 @@ namespace Viper.Areas.CMS.Services
         }
 
         public async Task<List<CmsFolderCountDto>> GetFolderCountsAsync(string status, bool? encrypted, bool? isPublic,
-            CancellationToken ct = default)
+            string? restrictDeletedToOwner = null, CancellationToken ct = default)
         {
             var query = _context.Files
                 .AsNoTracking()
                 .TagWith("CmsFileService.GetFolderCounts")
                 .AsQueryable();
 
-            query = ApplyStatusFilter(query, status);
+            query = ApplyStatusFilter(query, status, restrictDeletedToOwner);
 
             if (encrypted != null)
             {
@@ -154,13 +163,20 @@ namespace Viper.Areas.CMS.Services
                 .ToList();
         }
 
-        private static IQueryable<File> ApplyStatusFilter(IQueryable<File> query, string? status)
+        // restrictDeletedToOwner scopes deleted files to the login that deleted them (ModifiedBy),
+        // so non-admins only see files they trashed. Admins pass null and see the whole trash.
+        private static IQueryable<File> ApplyStatusFilter(IQueryable<File> query, string? status,
+            string? restrictDeletedToOwner = null)
         {
             return status?.ToLowerInvariant() switch
             {
                 "active" => query.Where(f => f.DeletedOn == null),
-                "deleted" => query.Where(f => f.DeletedOn != null),
-                _ => query
+                "deleted" => restrictDeletedToOwner == null
+                    ? query.Where(f => f.DeletedOn != null)
+                    : query.Where(f => f.DeletedOn != null && f.ModifiedBy == restrictDeletedToOwner),
+                _ => restrictDeletedToOwner == null
+                    ? query
+                    : query.Where(f => f.DeletedOn == null || f.ModifiedBy == restrictDeletedToOwner)
             };
         }
 
@@ -644,16 +660,60 @@ namespace Viper.Areas.CMS.Services
             }
 
             _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Deleted");
+            // Remove every dependent row before the File delete: content-block attachments use
+            // ClientSetNull (no DB cascade), so a still-attached file would otherwise trip the FK.
+            // Purging a still-attached file detaches it from those blocks.
+            var blockLinks = await _context.ContentBlockToFiles.Where(l => l.FileGuid == fileGuid).ToListAsync(ct);
+            _context.RemoveRange(blockLinks);
             _context.RemoveRange(entity.FileToPermissions);
             _context.RemoveRange(entity.FileToPeople);
             _context.Remove(entity);
             await _context.SaveChangesAsync(ct);
 
-            if (_storage.ManagedFileExists(entity.FilePath))
+            // The DB row is already gone at this point, so a failed disk delete only strands bytes;
+            // log it for manual cleanup rather than failing an operation that did delete the record.
+            try
             {
-                _storage.DeleteManagedFile(entity.FilePath);
+                if (_storage.ManagedFileExists(entity.FilePath))
+                {
+                    _storage.DeleteManagedFile(entity.FilePath);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogError(ex, "CMS file record {FileGuid} was deleted but its bytes at {FilePath} "
+                    + "could not be removed from disk.",
+                    fileGuid, Viper.Classes.Utilities.LogSanitizer.SanitizeString(entity.FilePath));
             }
             return true;
+        }
+
+        public async Task<int> PurgeDeletedFilesAsync(int retentionDays, CancellationToken ct = default)
+        {
+            var cutoff = DateTime.Now.AddDays(-retentionDays);
+            var guids = await _context.Files
+                .Where(f => f.DeletedOn != null && f.DeletedOn < cutoff)
+                .Select(f => f.FileGuid)
+                .ToListAsync(ct);
+
+            int purged = 0;
+            foreach (var guid in guids)
+            {
+                try
+                {
+                    if (await PermanentlyDeleteFileAsync(guid, ct))
+                    {
+                        purged++;
+                    }
+                }
+                catch (Exception ex) when (ex is DbUpdateException or IOException or InvalidOperationException)
+                {
+                    // Isolate per-file failures so one bad file doesn't abort the whole purge run.
+                    _context.ChangeTracker.Clear();
+                    _logger.LogError(ex, "CMS trash purge failed to delete file {FileGuid}", guid);
+                }
+            }
+            return purged;
         }
 
         private async Task<File?> LoadFileAsync(Guid fileGuid, bool tracking, CancellationToken ct)

--- a/web/Areas/CMS/Services/CmsFileStorageService.cs
+++ b/web/Areas/CMS/Services/CmsFileStorageService.cs
@@ -30,9 +30,11 @@ namespace Viper.Areas.CMS.Services
 
         /// <summary>
         /// The name MoveIntoPlace would store folder\fileName under: the name itself when free,
-        /// otherwise the first free name_0..name_999 candidate.
+        /// otherwise the first free name_0..name_999 candidate. <paramref name="reservedNames"/>
+        /// (optional) are treated as already taken, so callers planning several writes in one
+        /// batch get the same unique names the sequential moves would actually assign.
         /// </summary>
-        string GetAvailableFileName(string folder, string fileName);
+        string GetAvailableFileName(string folder, string fileName, IReadOnlySet<string>? reservedNames = null);
 
         /// <summary>Resolved managed path for folder\fileName (validated to stay under the root).</summary>
         string BuildManagedPath(string folder, string fileName);
@@ -49,6 +51,13 @@ namespace Viper.Areas.CMS.Services
 
         /// <summary>Overwrite the managed file at <paramref name="existingFilePath"/> with a temp file.</summary>
         void ReplaceInPlace(string tempPath, string existingFilePath);
+
+        /// <summary>
+        /// Copy a managed file to a temp backup outside the storage root and return its path. Pair
+        /// with ReplaceInPlace(backupPath, originalPath) to roll the original bytes back into place
+        /// after a failed save.
+        /// </summary>
+        string BackupManagedFile(string filePath);
 
         /// <summary>Delete a file, verifying it lives under the storage root first.</summary>
         void DeleteManagedFile(string filePath);
@@ -134,10 +143,12 @@ namespace Viper.Areas.CMS.Services
             return _context.Files.Any(f => f.FilePath == targetPath);
         }
 
-        public string GetAvailableFileName(string folder, string fileName)
+        public string GetAvailableFileName(string folder, string fileName, IReadOnlySet<string>? reservedNames = null)
         {
             string finalName = Path.GetFileName(fileName);
-            return FileNameInUse(folder, finalName) ? GetUniqueFileName(folder, finalName) : finalName;
+            bool taken = FileNameInUse(folder, finalName)
+                || (reservedNames != null && reservedNames.Contains(finalName));
+            return taken ? GetUniqueFileName(folder, finalName, reservedNames) : finalName;
         }
 
         public string BuildManagedPath(string folder, string fileName)
@@ -189,6 +200,16 @@ namespace Viper.Areas.CMS.Services
             System.IO.File.Move(tempPath, existingFilePath, overwrite: true);
         }
 
+        public string BackupManagedFile(string filePath)
+        {
+            AssertUnderRoot(filePath);
+            string tempFolder = Path.Join(Path.GetTempPath(), "Viper-CMS-Uploads");
+            System.IO.Directory.CreateDirectory(tempFolder);
+            string backupPath = Path.Join(tempFolder, Guid.NewGuid().ToString("N"));
+            System.IO.File.Copy(filePath, backupPath, overwrite: true);
+            return backupPath;
+        }
+
         public void DeleteManagedFile(string filePath)
         {
             AssertUnderRoot(filePath);
@@ -203,7 +224,7 @@ namespace Viper.Areas.CMS.Services
             return IsUnderRoot(filePath) && System.IO.File.Exists(filePath);
         }
 
-        private string GetUniqueFileName(string folder, string fileName)
+        private string GetUniqueFileName(string folder, string fileName, IReadOnlySet<string>? reservedNames = null)
         {
             string baseName = Path.GetFileNameWithoutExtension(fileName);
             string extension = Path.GetExtension(fileName);
@@ -211,7 +232,8 @@ namespace Viper.Areas.CMS.Services
             for (int i = 0; i < 1000; i++)
             {
                 string candidate = $"{baseName}_{i}{extension}";
-                if (!FileNameInUse(folder, candidate))
+                if (!FileNameInUse(folder, candidate)
+                    && (reservedNames == null || !reservedNames.Contains(candidate)))
                 {
                     return candidate;
                 }

--- a/web/Areas/CMS/Services/CmsFileStorageService.cs
+++ b/web/Areas/CMS/Services/CmsFileStorageService.cs
@@ -88,8 +88,10 @@ namespace Viper.Areas.CMS.Services
             {
                 return new List<string>();
             }
-            return System.IO.Directory.GetDirectories(RootFolder)
-                .Select(d => Path.GetFileName(d) ?? string.Empty)
+            // DirectoryInfo.Name gives the (non-null) leaf folder name directly, avoiding the
+            // Path.GetFileName nullable return that would otherwise need coalescing.
+            return new DirectoryInfo(RootFolder).GetDirectories()
+                .Select(d => d.Name)
                 .Where(d => !string.IsNullOrEmpty(d))
                 .OrderBy(d => d)
                 .ToList();
@@ -116,7 +118,7 @@ namespace Viper.Areas.CMS.Services
 
             var segments = folder.Split(['\\', '/'], StringSplitOptions.None);
             if (segments.Any(s => string.IsNullOrWhiteSpace(s) || s == "." || s == ".."
-                    || s.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0))
+                    || HasInvalidNameChar(s)))
             {
                 return false;
             }
@@ -134,7 +136,7 @@ namespace Viper.Areas.CMS.Services
         public bool FileNameInUse(string folder, string fileName)
         {
             string targetPath = BuildTargetPath(folder, fileName);
-            if (System.IO.File.Exists(targetPath))
+            if (File.Exists(targetPath))
             {
                 return true;
             }
@@ -145,7 +147,7 @@ namespace Viper.Areas.CMS.Services
 
         public string GetAvailableFileName(string folder, string fileName, IReadOnlySet<string>? reservedNames = null)
         {
-            string finalName = Path.GetFileName(fileName);
+            string finalName = GetLeafName(fileName);
             bool taken = FileNameInUse(folder, finalName)
                 || (reservedNames != null && reservedNames.Contains(finalName));
             return taken ? GetUniqueFileName(folder, finalName, reservedNames) : finalName;
@@ -173,7 +175,7 @@ namespace Viper.Areas.CMS.Services
                 throw new ArgumentException($"Invalid folder", nameof(folder));
             }
 
-            string finalName = Path.GetFileName(fileName);
+            string finalName = GetLeafName(fileName);
             if (string.IsNullOrWhiteSpace(finalName) || !CmsFileTypes.IsAllowedFileName(finalName))
             {
                 throw new ArgumentException("Invalid file name", nameof(fileName));
@@ -190,14 +192,14 @@ namespace Viper.Areas.CMS.Services
 
             string targetPath = BuildTargetPath(folder, finalName);
             System.IO.Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-            System.IO.File.Move(tempPath, targetPath);
+            File.Move(tempPath, targetPath);
             return targetPath;
         }
 
         public void ReplaceInPlace(string tempPath, string existingFilePath)
         {
             AssertUnderRoot(existingFilePath);
-            System.IO.File.Move(tempPath, existingFilePath, overwrite: true);
+            File.Move(tempPath, existingFilePath, overwrite: true);
         }
 
         public string BackupManagedFile(string filePath)
@@ -206,22 +208,22 @@ namespace Viper.Areas.CMS.Services
             string tempFolder = Path.Join(Path.GetTempPath(), "Viper-CMS-Uploads");
             System.IO.Directory.CreateDirectory(tempFolder);
             string backupPath = Path.Join(tempFolder, Guid.NewGuid().ToString("N"));
-            System.IO.File.Copy(filePath, backupPath, overwrite: true);
+            File.Copy(filePath, backupPath, overwrite: true);
             return backupPath;
         }
 
         public void DeleteManagedFile(string filePath)
         {
             AssertUnderRoot(filePath);
-            if (System.IO.File.Exists(filePath))
+            if (File.Exists(filePath))
             {
-                System.IO.File.Delete(filePath);
+                File.Delete(filePath);
             }
         }
 
         public bool ManagedFileExists(string filePath)
         {
-            return IsUnderRoot(filePath) && System.IO.File.Exists(filePath);
+            return IsUnderRoot(filePath) && File.Exists(filePath);
         }
 
         private string GetUniqueFileName(string folder, string fileName, IReadOnlySet<string>? reservedNames = null)
@@ -243,7 +245,11 @@ namespace Viper.Areas.CMS.Services
 
         private string BuildTargetPath(string folder, string fileName)
         {
-            string path = Path.GetFullPath(Path.Join(RootFolder, folder, Path.GetFileName(fileName)));
+            // Split the folder on both separator styles and rejoin with the host separator so a
+            // user-supplied "sub\dir" resolves to real nested folders on Linux too (Path.Join would
+            // otherwise treat "sub\dir" as one literal directory name there).
+            string[] folderSegments = folder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+            string path = Path.GetFullPath(Path.Join(RootFolder, Path.Join(folderSegments), GetLeafName(fileName)));
             AssertUnderRoot(path);
             return path;
         }
@@ -261,6 +267,27 @@ namespace Viper.Areas.CMS.Services
             string fullPath = Path.GetFullPath(filePath);
             string root = Path.GetFullPath(RootFolder + Path.DirectorySeparatorChar);
             return fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Final path segment of a name, treating both '\' and '/' as separators so path components
+        /// are stripped identically on every OS (Path.GetFileName only honors the host separator, so
+        /// on Linux it would keep a "sub\file" prefix from a legacy Windows-style name).
+        /// </summary>
+        private static string GetLeafName(string name)
+        {
+            int lastSeparator = name.LastIndexOfAny(['\\', '/']);
+            return lastSeparator >= 0 ? name[(lastSeparator + 1)..] : name;
+        }
+
+        // Reject on an explicit, OS-independent set rather than Path.GetInvalidFileNameChars, which
+        // on Linux returns only { '\0', '/' } and would let '<', '>', ':' etc. through. Stricter than
+        // the host filesystem on purpose (defense in depth).
+        private static readonly char[] InvalidNameChars = ['<', '>', ':', '"', '|', '?', '*'];
+
+        private static bool HasInvalidNameChar(string segment)
+        {
+            return segment.Any(c => c < ' ' || Array.IndexOf(InvalidNameChars, c) >= 0);
         }
     }
 }

--- a/web/Areas/CMS/Services/CmsLeftNavService.cs
+++ b/web/Areas/CMS/Services/CmsLeftNavService.cs
@@ -80,6 +80,8 @@ namespace Viper.Areas.CMS.Services
 
         public async Task<LeftNavMenuDto> CreateMenuAsync(LeftNavMenuAddEdit request, CancellationToken ct = default)
         {
+            await AssertFriendlyNameUniqueAsync(request.FriendlyName, null, ct);
+
             var menu = new LeftNavMenu();
             ApplyMenuFields(menu, request);
             menu.ModifiedOn = DateTime.Now;
@@ -97,6 +99,8 @@ namespace Viper.Areas.CMS.Services
             {
                 return null;
             }
+
+            await AssertFriendlyNameUniqueAsync(request.FriendlyName, leftNavMenuId, ct);
 
             ApplyMenuFields(menu, request);
             menu.ModifiedOn = DateTime.Now;
@@ -126,10 +130,27 @@ namespace Viper.Areas.CMS.Services
 
         public async Task<LeftNavMenuDto?> SaveItemsAsync(int leftNavMenuId, List<LeftNavItemEdit> items, CancellationToken ct = default)
         {
+            // Reject duplicate ids up front so every caller gets the guard (was in the controller).
+            if (items.Where(i => i.LeftNavItemId > 0).GroupBy(i => i.LeftNavItemId).Any(g => g.Count() > 1))
+            {
+                throw new ArgumentException("Duplicate item ids are not allowed.");
+            }
+
             var menu = await LoadMenuAsync(leftNavMenuId, tracking: true, ct);
             if (menu == null)
             {
                 return null;
+            }
+
+            var existingById = menu.LeftNavItems.ToDictionary(i => i.LeftNavItemId);
+
+            // A supplied id that isn't in this menu means the client's copy is stale (the item was
+            // deleted, or belongs to another menu). Reject rather than silently resurrecting it as a
+            // new row.
+            if (items.Any(i => i.LeftNavItemId > 0 && !existingById.ContainsKey(i.LeftNavItemId)))
+            {
+                throw new InvalidOperationException(
+                    "One or more items no longer exist in this menu. Reload and try again.");
             }
 
             var requestedIds = items.Where(i => i.LeftNavItemId > 0).Select(i => i.LeftNavItemId).ToHashSet();
@@ -142,7 +163,6 @@ namespace Viper.Areas.CMS.Services
                 menu.LeftNavItems.Remove(item);
             }
 
-            var existingById = menu.LeftNavItems.ToDictionary(i => i.LeftNavItemId);
             int order = 1;
             foreach (var requested in items)
             {
@@ -178,6 +198,26 @@ namespace Viper.Areas.CMS.Services
 
             await _context.SaveChangesAsync(ct);
             return await GetMenuAsync(leftNavMenuId, ct);
+        }
+
+        // FriendlyName resolves menus in LayoutController via FirstOrDefault, so duplicates make
+        // resolution nondeterministic. Reject them case-insensitively at write time. SQL Server's
+        // default collation is case-insensitive; ToLower keeps the check correct on other providers.
+        private async Task AssertFriendlyNameUniqueAsync(string? friendlyName, int? exceptMenuId, CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(friendlyName))
+            {
+                return;
+            }
+
+            var normalized = friendlyName.ToLower();
+            bool taken = await _context.LeftNavMenus
+                .AnyAsync(m => m.FriendlyName != null && m.FriendlyName.ToLower() == normalized
+                    && (exceptMenuId == null || m.LeftNavMenuId != exceptMenuId), ct);
+            if (taken)
+            {
+                throw new ArgumentException("Friendly name must be unique.");
+            }
         }
 
         private async Task<LeftNavMenu?> LoadMenuAsync(int leftNavMenuId, bool tracking, CancellationToken ct)

--- a/web/Areas/CMS/Services/CmsLeftNavService.cs
+++ b/web/Areas/CMS/Services/CmsLeftNavService.cs
@@ -136,6 +136,13 @@ namespace Viper.Areas.CMS.Services
                 throw new ArgumentException("Duplicate item ids are not allowed.");
             }
 
+            // Links need text; a header may be blank - legacy menus use empty headers as spacer
+            // rows and the display side still renders them that way.
+            if (items.Any(i => !i.IsHeader && string.IsNullOrWhiteSpace(i.MenuItemText)))
+            {
+                throw new ArgumentException("Every link needs text - fill in the empty link before saving.");
+            }
+
             var menu = await LoadMenuAsync(leftNavMenuId, tracking: true, ct);
             if (menu == null)
             {

--- a/web/Areas/CMS/Services/CmsNavMenu.cs
+++ b/web/Areas/CMS/Services/CmsNavMenu.cs
@@ -7,19 +7,21 @@ namespace Viper.Areas.CMS.Services
     public class CmsNavMenu
     {
         private readonly RAPSContext _rapsContext;
-        public CmsNavMenu(RAPSContext context)
+        private readonly IUserHelper _userHelper;
+
+        public CmsNavMenu(RAPSContext context, IUserHelper? userHelper = null)
         {
             _rapsContext = context;
+            _userHelper = userHelper ?? new UserHelper();
         }
 
         public NavMenu Nav()
         {
-            UserHelper userHelper = new();
-            var user = userHelper.GetCurrentUser();
-            bool canManageBlocks = userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks);
-            bool canCreateBlocks = userHelper.HasPermission(_rapsContext, user, CmsPermissions.CreateContentBlock);
-            bool canManageFiles = userHelper.HasPermission(_rapsContext, user, CmsPermissions.AllFiles);
-            bool canManageNav = userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageNavigation);
+            var user = _userHelper.GetCurrentUser();
+            bool canManageBlocks = _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks);
+            bool canCreateBlocks = _userHelper.HasPermission(_rapsContext, user, CmsPermissions.CreateContentBlock);
+            bool canManageFiles = _userHelper.HasPermission(_rapsContext, user, CmsPermissions.AllFiles);
+            bool canManageNav = _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageNavigation);
 
             var nav = new List<NavMenuItem>();
 

--- a/web/Areas/CMS/Services/CmsUserPhotoService.cs
+++ b/web/Areas/CMS/Services/CmsUserPhotoService.cs
@@ -105,14 +105,14 @@ namespace Viper.Areas.CMS.Services
 
             var photoPath = Path.GetFullPath(Path.Join(_profilePhotoPath, Path.GetFileName(iamId) + ".jpg"));
             var root = Path.GetFullPath(_profilePhotoPath + Path.DirectorySeparatorChar);
-            if (!photoPath.StartsWith(root, StringComparison.OrdinalIgnoreCase) || !System.IO.File.Exists(photoPath))
+            if (!photoPath.StartsWith(root, StringComparison.OrdinalIgnoreCase) || !File.Exists(photoPath))
             {
                 return null;
             }
 
             try
             {
-                return await System.IO.File.ReadAllBytesAsync(photoPath, ct);
+                return await File.ReadAllBytesAsync(photoPath, ct);
             }
             catch (IOException ex)
             {

--- a/web/Areas/CMS/Services/CmsUserPhotoService.cs
+++ b/web/Areas/CMS/Services/CmsUserPhotoService.cs
@@ -9,12 +9,21 @@ namespace Viper.Areas.CMS.Services
     public interface ICmsUserPhotoService
     {
         /// <summary>
-        /// Get a user photo by any supported id. Resolution order matches legacy userPhoto.cfc:
-        /// alternate profile photo (by IamId, only when requested via preferAltPhoto),
-        /// then id-card photo (by MailId), then the default "no picture" image.
+        /// Get a user photo by any supported id (MailId, LoginId, IamId, or MothraId). Resolution
+        /// order matches legacy userPhoto.cfc: alternate profile photo (by IamId, only when
+        /// requested via preferAltPhoto), then id-card photo (by MailId), then the default
+        /// "no picture" image. The result carries a Last-Modified value for conditional caching.
         /// </summary>
-        Task<byte[]> GetUserPhotoAsync(string? mailId, string? loginId, string? iamId, bool preferAltPhoto, CancellationToken ct = default);
+        Task<CmsUserPhotoResult> GetUserPhotoAsync(string? mailId, string? loginId, string? iamId, string? mothraId,
+            bool preferAltPhoto, CancellationToken ct = default);
     }
+
+    /// <summary>
+    /// A served photo's bytes plus the timestamp to publish as Last-Modified/use for
+    /// If-Modified-Since comparisons. Always truncated to whole seconds, since HTTP dates
+    /// have second precision.
+    /// </summary>
+    public sealed record CmsUserPhotoResult(byte[] Bytes, DateTimeOffset LastModified);
 
     /// <summary>
     /// User photos for the CMS area (legacy userPhoto.cfc). Id-card photo lookup, caching, and
@@ -28,6 +37,12 @@ namespace Viper.Areas.CMS.Services
         private readonly IPhotoService _photoService;
         private readonly ILogger<CmsUserPhotoService> _logger;
         private readonly string _profilePhotoPath;
+
+        // The delegated Students photo pipeline (id-card photo and its nopic fallback) doesn't
+        // expose a per-file timestamp, so those two outcomes share this stable per-process
+        // proxy for Last-Modified: it only changes on deploy/restart, which is exactly when a
+        // browser-cached copy should be treated as stale.
+        private static readonly DateTimeOffset DelegatedPhotoLastModified = TruncateToSeconds(DateTimeOffset.UtcNow);
 
         [GeneratedRegex("^[a-zA-Z0-9.-]+$")]
         private static partial Regex SafeIdRegex();
@@ -43,11 +58,11 @@ namespace Viper.Areas.CMS.Services
                 ?? Path.Join(Data.CMS.GetRootFileFolder(), "ProfilePhotos");
         }
 
-        public async Task<byte[]> GetUserPhotoAsync(string? mailId, string? loginId, string? iamId,
-            bool preferAltPhoto, CancellationToken ct = default)
+        public async Task<CmsUserPhotoResult> GetUserPhotoAsync(string? mailId, string? loginId, string? iamId,
+            string? mothraId, bool preferAltPhoto, CancellationToken ct = default)
         {
             // Resolve whichever id was provided to the person's mailId (+ iamId when needed).
-            (mailId, iamId) = await ResolveIdsAsync(mailId, loginId, iamId, needIamId: preferAltPhoto, ct);
+            (mailId, iamId) = await ResolveIdsAsync(mailId, loginId, iamId, mothraId, needIamId: preferAltPhoto, ct);
 
             if (preferAltPhoto && iamId != null)
             {
@@ -58,11 +73,12 @@ namespace Viper.Areas.CMS.Services
                 }
             }
 
-            return await _photoService.GetStudentPhotoAsync(mailId ?? string.Empty);
+            var bytes = await _photoService.GetStudentPhotoAsync(mailId ?? string.Empty);
+            return new CmsUserPhotoResult(bytes, DelegatedPhotoLastModified);
         }
 
         private async Task<(string? MailId, string? IamId)> ResolveIdsAsync(string? mailId, string? loginId,
-            string? iamId, bool needIamId, CancellationToken ct)
+            string? iamId, string? mothraId, bool needIamId, CancellationToken ct)
         {
             // Skip the lookup when every id the caller needs is already known. A mailId alone
             // serves the id-card photo with no DB query (the legacy hot path for <img> tags).
@@ -84,6 +100,10 @@ namespace Viper.Areas.CMS.Services
             {
                 query = query.Where(u => u.IamId == iamId);
             }
+            else if (!string.IsNullOrEmpty(mothraId))
+            {
+                query = query.Where(u => u.MothraId == mothraId);
+            }
             else
             {
                 return (null, null);
@@ -95,7 +115,7 @@ namespace Viper.Areas.CMS.Services
             return user == null ? (mailId, iamId) : (user.MailId ?? mailId, user.IamId ?? iamId);
         }
 
-        private async Task<byte[]?> ReadAltPhotoAsync(string iamId, CancellationToken ct)
+        private async Task<CmsUserPhotoResult?> ReadAltPhotoAsync(string iamId, CancellationToken ct)
         {
             if (!SafeIdRegex().IsMatch(iamId))
             {
@@ -112,7 +132,9 @@ namespace Viper.Areas.CMS.Services
 
             try
             {
-                return await File.ReadAllBytesAsync(photoPath, ct);
+                var bytes = await File.ReadAllBytesAsync(photoPath, ct);
+                var lastModified = TruncateToSeconds(new DateTimeOffset(File.GetLastWriteTimeUtc(photoPath), TimeSpan.Zero));
+                return new CmsUserPhotoResult(bytes, lastModified);
             }
             catch (IOException ex)
             {
@@ -124,6 +146,13 @@ namespace Viper.Areas.CMS.Services
                 _logger.LogError(ex, "Access denied reading alt photo for {IamId}", LogSanitizer.SanitizeId(iamId));
                 return null;
             }
+        }
+
+        // HTTP dates (and If-Modified-Since comparisons) only have second precision; truncating
+        // here keeps a stable value fed back on the next request's comparison.
+        private static DateTimeOffset TruncateToSeconds(DateTimeOffset value)
+        {
+            return value.AddTicks(-(value.UtcTicks % TimeSpan.TicksPerSecond));
         }
     }
 }

--- a/web/Areas/CMS/Validation/MaxLengthEachAttribute.cs
+++ b/web/Areas/CMS/Validation/MaxLengthEachAttribute.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+
+namespace Areas.CMS.Validation;
+
+/// <summary>
+/// Validates that every string element in a collection is at most <see cref="Length"/> characters.
+/// [MaxLength] on a collection property bounds only the element count, not each element, so this
+/// guards individual entries against their backing column size (e.g. permission strings vs the
+/// varchar(500) LeftNavItemToPermission.permission column).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class MaxLengthEachAttribute : ValidationAttribute
+{
+    public MaxLengthEachAttribute(int length)
+    {
+        Length = length;
+    }
+
+    public int Length { get; }
+
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is not IEnumerable items)
+        {
+            return ValidationResult.Success;
+        }
+
+        foreach (var item in items)
+        {
+            if (item is string s && s.Length > Length)
+            {
+                return new ValidationResult($"Each value must be {Length} characters or fewer.");
+            }
+        }
+
+        return ValidationResult.Success;
+    }
+}

--- a/web/Areas/CMS/Validation/MaxLengthEachAttribute.cs
+++ b/web/Areas/CMS/Validation/MaxLengthEachAttribute.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.ComponentModel.DataAnnotations;
 
-namespace Areas.CMS.Validation;
+namespace Viper.Areas.CMS.Validation;
 
 /// <summary>
 /// Validates that every string element in a collection is at most <see cref="Length"/> characters.

--- a/web/Areas/CMS/Validation/SafeUrlAttribute.cs
+++ b/web/Areas/CMS/Validation/SafeUrlAttribute.cs
@@ -33,9 +33,21 @@ public sealed class SafeUrlAttribute : ValidationAttribute
         // rooted paths like "/CMS/files" (parsed as file:// on Unix)
         if (!url.Split('/', '?', '#')[0].Contains(':'))
         {
-            return AllowRelative
-                ? ValidationResult.Success
-                : new ValidationResult("URL must be a full address starting with http, https, mailto, or tel.");
+            if (!AllowRelative)
+            {
+                return new ValidationResult("URL must be a full address starting with http, https, mailto, or tel.");
+            }
+
+            // Reject protocol-relative ("network-path") references like "//evil.example/x":
+            // a browser navigates those off-site even though they carry no scheme. Backslashes
+            // are normalized to forward slashes when parsing URLs, so "/\", "\\", and "\/" are
+            // equivalent bypasses and must be rejected too.
+            if (url.Length >= 2 && (url[0] == '/' || url[0] == '\\') && (url[1] == '/' || url[1] == '\\'))
+            {
+                return new ValidationResult("URL must not start with // (that would point to another site).");
+            }
+
+            return ValidationResult.Success;
         }
 
         return Uri.TryCreate(url, UriKind.Absolute, out var uri)

--- a/web/Areas/CMS/Validation/SafeUrlAttribute.cs
+++ b/web/Areas/CMS/Validation/SafeUrlAttribute.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace Areas.CMS.Validation;
+namespace Viper.Areas.CMS.Validation;
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class SafeUrlAttribute : ValidationAttribute

--- a/web/Classes/Utilities/DateRangeHelper.cs
+++ b/web/Classes/Utilities/DateRangeHelper.cs
@@ -12,5 +12,15 @@ public static class DateRangeHelper
     /// &lt; against the result.
     /// </summary>
     public static DateTime ExclusiveUpperBound(DateTime to)
-        => to.Date == to ? to.AddDays(1) : to;
+    {
+        // There is no day after DateTime.MaxValue.Date to advance to, so AddDays(1) would throw
+        // for a user-suppliable filter value at the ceiling. Clamp to MaxValue, which is still a
+        // safe exclusive upper bound (nothing sorts after it).
+        if (to >= DateTime.MaxValue.Date)
+        {
+            return DateTime.MaxValue;
+        }
+
+        return to.Date == to ? to.AddDays(1) : to;
+    }
 }

--- a/web/Services/HtmlSanitizerService.cs
+++ b/web/Services/HtmlSanitizerService.cs
@@ -95,7 +95,7 @@ namespace Viper.Services
             // Also lock <img src> to relative URLs only — matches the legacy antisamy-cms.xml
             // onsiteURL regex and prevents editor-authored content from embedding third-party
             // tracking beacons or any absolute-URL image (same-origin absolutes included).
-            sanitizer.FilterUrl += (sender, args) =>
+            sanitizer.FilterUrl += (_, args) =>
             {
                 if (args.OriginalUrl.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
                 {

--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -39,5 +39,11 @@
     "Hangfire": {
         // Hangfire's tables live in ConnectionStrings:VIPER.
         "Enabled": true
+    },
+    "Cms": {
+        // Gates the cms:trash-purge scheduled job. Keep false until the legacy VIPER 1 30-day
+        // trash purge is retired, so the two never purge in parallel. Flip to true (via SSM in
+        // deployed envs) at cutover to let the daily job permanently delete files trashed > 30 days ago.
+        "TrashPurgeEnabled": false
     }
 }


### PR DESCRIPTION
Final slice, part 6 of 6 (stacks on #249 — the diff below shows only this slice). Replaces #242, whose branch predates a rebase onto main and holds the stale pre-rebase history. After this merges, the entire CMS migration is in.

**Scope**
- Security hardening: anonymous content endpoint no longer serializes file encryption keys; stored-XSS hardening on file downloads (no-sniff + forced attachment for inline-unsafe types); protocol-relative URL rejection in link validation; left-nav validation and save integrity; OS-independent path handling.
- Inline block file uploads (staged client-side, committed on Save with rollback) and legacy-parity 30-day trash auto-purge job (`Cms:TrashPurgeEnabled`, default off until the VIPER 1 purge is retired).
- Server-side paging for the content-block list; hub opened to granular-permission users; activity-rail correctness; Vue page complexity reduction; ReSharper/CodeQL cleanups.
- Full-branch review fixes: the anonymous `content/fn` endpoint now returns a minimal public DTO (was disclosing editor login ids, permission names, and placement metadata); legacy-parity download auditing (anonymous hits audited, ZIP permission denies audited, `192.168.*` excluded); single-resolve permission set per content-block render; stale-response guard in the shared server table; query-only navigations no longer steal focus; link-collections fetch guards; activity rows are a single stretched title link (no controls nested in an anchor).
- File-edit 409 concurrency guard mirroring content blocks (Reload / Keep editing dialog), including the overwrite-by-upload path via `ExistingModifiedOn` on the name check.
- User-photo parity: `by-mothra` lookup and `Last-Modified`/`If-Modified-Since` 304 conditional caching with `stale-while-revalidate`.

**Deploy notes (whole stack)**
- TEST/PROD config: `CMS:LegacyWebrootPath` (import tool), `viperfiles.txt` key file must exist (`S:\Settings\`), optional `CMS:FileStorageRoot`/`CMS:ProfilePhotoPath`/`CMS:EncryptionKeyFile` overrides, `CMS:DownloadRateLimit` limits, `Cms:TrashPurgeEnabled` stays false until the legacy VIPER 1 purge is retired.
- Deployment still flows through `Development` → TEST first, per repo convention.
