### PR TITLE
fix: address open code scanning alerts (log forging, missed Where)

### DIFF
--- a/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
+++ b/web/Areas/ClinicalScheduler/Services/ScheduleEditService.cs
@@ -126,7 +126,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
                     .ToListAsync(cancellationToken);
 
                 _logger.LogDebug("Found {Count} total existing schedules for MothraId='{MothraId}' in weeks [{WeekIds}]: {Details}",
-                    allExistingForWeeks.Count, LogSanitizer.SanitizeId(mothraId), string.Join(",", weekIds),
+                    allExistingForWeeks.Count, LogSanitizer.SanitizeId(mothraId), LogSanitizer.SanitizeString(string.Join(",", weekIds)),
                     string.Join(", ", allExistingForWeeks.Select(s => $"Week {s.WeekId} in Rotation {s.RotationId} (ID: {s.InstructorScheduleId})")));
 
 
@@ -245,7 +245,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
             catch (Exception saveEx) when (saveEx is DbUpdateException or SqlException)
             {
                 _logger.LogError(saveEx, "Database save failed for MothraId='{MothraId}', RotationId={RotationId}, WeekIds=[{WeekIds}]",
-                    LogSanitizer.SanitizeId(mothraId), rotationId, string.Join(",", weekIds));
+                    LogSanitizer.SanitizeId(mothraId), rotationId, LogSanitizer.SanitizeString(string.Join(",", weekIds)));
 
                 // Only a unique/duplicate-key violation means the instructor is already scheduled.
                 // Other DB errors (foreign-key, check constraints, etc.) fall through to the generic message.
@@ -554,7 +554,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
             catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
                 _logger.LogError(ex, "Error checking other rotation schedules for {MothraId} on weeks {WeekIds} for grad year {GradYear}",
-                    LogSanitizer.SanitizeId(mothraId), string.Join(",", weekIds), LogSanitizer.SanitizeYear(gradYear));
+                    LogSanitizer.SanitizeId(mothraId), LogSanitizer.SanitizeString(string.Join(",", weekIds)), LogSanitizer.SanitizeYear(gradYear));
                 throw new InvalidOperationException("Failed to retrieve other rotation schedules. Please try again or contact support if the problem persists.", ex);
             }
         }
@@ -581,7 +581,7 @@ namespace Viper.Areas.ClinicalScheduler.Services
             }
             catch (Exception ex) when (ex is DbUpdateException or SqlException or InvalidOperationException)
             {
-                _logger.LogError(ex, "Error getting scheduled instructors for rotation {RotationId} on weeks {WeekIds}", rotationId, string.Join(",", weekIds));
+                _logger.LogError(ex, "Error getting scheduled instructors for rotation {RotationId} on weeks {WeekIds}", rotationId, LogSanitizer.SanitizeString(string.Join(",", weekIds)));
                 throw new InvalidOperationException("Failed to retrieve scheduled instructors. Please try again or contact support if the problem persists.", ex);
             }
         }

--- a/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/NonCrestHarvestPhase.cs
@@ -429,13 +429,12 @@ public sealed class NonCrestHarvestPhase : HarvestPhaseBase
         }
 
         foreach (var course in courses
-            .Where(c => c.Source == EffortConstants.SourceNonCrest && !academicDepts.Contains(c.CustDept)))
+            .Where(c => c.Source == EffortConstants.SourceNonCrest
+                && !academicDepts.Contains(c.CustDept)
+                && !string.IsNullOrWhiteSpace(c.Crn)
+                && directorDeptByCrn.ContainsKey(c.Crn)))
         {
-            if (!string.IsNullOrWhiteSpace(course.Crn) &&
-                directorDeptByCrn.TryGetValue(course.Crn, out var iorDept))
-            {
-                course.CustDept = iorDept;
-            }
+            course.CustDept = directorDeptByCrn[course.Crn];
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes both open CodeQL code scanning alerts:

- **Alert #714 (cs/log-forging, error)**: [ScheduleEditService.cs:248](https://github.com/ucdavis/VIPER/security/code-scanning/714) flagged `string.Join(",", weekIds)` flowing into a log entry. While `int[]` values cannot actually carry control characters, this line was previously dismissed as a false positive (alert #117) and CodeQL re-flagged it as a new alert when the surrounding catch block changed in #229. Wrapping with `LogSanitizer.SanitizeString()` closes the taint path permanently. Applied to all four occurrences of the pattern in the file (lines 129, 248, 557, 584) so the parallel sites with dismissed alerts (#120, #146) do not re-flag either.
- **Alert #703 (cs/linq/missed-where, note)**: [NonCrestHarvestPhase.cs:431](https://github.com/ucdavis/VIPER/security/code-scanning/703) flagged the `ApplyDirectorCustodialDeptFallback` foreach whose body was a single guarding `if`. Moved the CRN presence and dictionary membership checks into the existing `.Where()` clause; the loop body now only performs the assignment. Behavior is unchanged.

## Testing

- `npm run lint` on both files: passes (remaining CA1502 complexity warnings are pre-existing on an untouched method)
- `npm run test:backend`: all 2134 tests pass, including `ApplyDirectorCustodialDeptFallback_InheritsDirectorDept_OnlyForNonAcademicCourses`