### PR TITLE
VPR-59 [4/4] CMS: delegated block editing via per-block edit permissions

### DIFF
--- a/VueApp/src/CMS/__tests__/cms-home.test.ts
+++ b/VueApp/src/CMS/__tests__/cms-home.test.ts
@@ -3,9 +3,11 @@ import { useUserStore } from "@/store/UserStore"
 import { mountCms, flushPromises } from "./test-utils"
 
 // The hub checks the trash for files nearing the purge cutoff (file managers only).
-const getMock = vi.fn<(...args: unknown[]) => Promise<{ success: boolean; result: unknown[] }>>(() =>
-    Promise.resolve({ success: true, result: [] }),
-)
+// Default GET: empty success. routeEditable() overrides this per test; the beforeEach below restores
+// it so the override never leaks into a later test (which previously required this suite to run last).
+const defaultGetImpl = (): Promise<{ success: boolean; result: unknown[] }> =>
+    Promise.resolve({ success: true, result: [] })
+const getMock = vi.fn<(...args: unknown[]) => Promise<{ success: boolean; result: unknown[] }>>(defaultGetImpl)
 vi.mock("@/composables/ViperFetch", () => ({
     useFetch: () => ({
         get: getMock,
@@ -20,6 +22,10 @@ vi.mock("@/composables/ViperFetch", () => ({
         },
     }),
 }))
+
+beforeEach(() => {
+    getMock.mockImplementation(defaultGetImpl)
+})
 
 function trashedFile(friendlyName: string, purgeOn: string) {
     return { fileGuid: `g-${friendlyName}`, friendlyName, purgeOn, deletedOn: "2024-01-01T00:00:00" }
@@ -136,5 +142,82 @@ describe("cmsHome.vue - permission-gated sections", () => {
 
         expect(wrapper.text()).toContain("Your account does not have access to any CMS tools.")
         expect(wrapper.findAllComponents({ name: "QBtn" })).toHaveLength(0)
+    })
+})
+
+/**
+ * Delegated editors (no ManageContentBlocks) get a "Blocks you can edit" card listing GET /editable
+ * results, linking each to its editor. It shows only for non-managers with a non-empty list, and it
+ * suppresses the no-access banner. Managers use the normal Content Blocks card, so they never fetch
+ * or render this card. routeEditable() overrides the shared get() mock within these specs; the
+ * beforeEach above restores it, so their ordering relative to the other specs no longer matters.
+ */
+describe("cmsHome.vue - delegated editable blocks card", () => {
+    const EDITABLE = [
+        {
+            contentBlockId: 11,
+            title: "Alpha",
+            friendlyName: "alpha",
+            viperSectionPath: "/a",
+            page: null,
+            modifiedOn: "2024-01-01T00:00:00",
+            modifiedBy: "u",
+        },
+        {
+            contentBlockId: 12,
+            title: null,
+            friendlyName: "beta",
+            viperSectionPath: "/b",
+            page: null,
+            modifiedOn: "2024-01-02T00:00:00",
+            modifiedBy: "u",
+        },
+    ]
+
+    function routeEditable(items: unknown[]) {
+        getMock.mockImplementation((...args: unknown[]) => {
+            const url = args[0] as unknown as string
+            if (url.includes("editable")) {
+                return Promise.resolve({ success: true, result: items })
+            }
+            return Promise.resolve({ success: true, result: [] })
+        })
+    }
+
+    function editLinks(wrapper: Awaited<ReturnType<typeof mountHome>>) {
+        return wrapper
+            .findAllComponents({ name: "QBtn" })
+            .filter((b) => (b.props("to") as { name?: string } | undefined)?.name === "CmsContentBlockEdit")
+    }
+
+    it("lists editable blocks with edit links and suppresses the no-access banner for a non-manager", async () => {
+        routeEditable(EDITABLE)
+        const wrapper = await mountHome(["SVMSecure.CMS"])
+        await flushPromises()
+        await flushPromises()
+
+        expect(wrapper.text()).toContain("Blocks you can edit")
+        expect(wrapper.text()).not.toContain("does not have access to any CMS tools")
+
+        // Falls back to the friendly name when a block has no title (block 12 -> "beta").
+        expect(editLinks(wrapper).map((b) => b.props("label"))).toStrictEqual(["Alpha", "beta"])
+        expect(editLinks(wrapper)[0]!.props("to")).toStrictEqual({
+            name: "CmsContentBlockEdit",
+            params: { id: 11 },
+        })
+    })
+
+    it("does not fetch or show the editable card for a manager", async () => {
+        // The shared get() mock accumulates calls across tests; clear it so this assertion only
+        // sees this manager mount's requests.
+        getMock.mockClear()
+        routeEditable(EDITABLE)
+        const wrapper = await mountHome() // Full admin
+        await flushPromises()
+
+        expect(wrapper.text()).not.toContain("Blocks you can edit")
+        // Managers still get the normal tool card, and never hit the editable endpoint.
+        expect(wrapper.text()).toContain("Content Blocks")
+        expect(getMock.mock.calls.map((c) => c[0] as unknown as string).some((u) => u.includes("editable"))).toBeFalsy()
     })
 })

--- a/VueApp/src/CMS/__tests__/content-block-edit-delegated.test.ts
+++ b/VueApp/src/CMS/__tests__/content-block-edit-delegated.test.ts
@@ -1,0 +1,217 @@
+import ContentBlockEdit from "@/CMS/pages/ContentBlockEdit.vue"
+import { useUserStore } from "@/store/UserStore"
+import { mountCms, flushPromises, flushRouter, createTestRouter } from "./test-utils"
+
+/**
+ * Delegated editing: a user WITHOUT ManageContentBlocks/CreateContentBlock who reaches an existing
+ * block edits only its content and files. The settings sidebar collapses to a read-only summary
+ * (no inputs, no permission selectors, no public-access toggle), the content editor and attached
+ * files stay functional, and Save issues the content-only PATCH (with the same lastModifiedOn
+ * concurrency stamp + 409 conflict dialog as the full save). Mock ViperFetch; the inline uploader
+ * is stubbed with a controllable commit().
+ */
+
+const mockGet = vi.fn<(...args: unknown[]) => unknown>()
+const mockPost = vi.fn<(...args: unknown[]) => unknown>()
+const mockPut = vi.fn<(...args: unknown[]) => unknown>()
+const mockPatch = vi.fn<(...args: unknown[]) => unknown>()
+const mockDel = vi.fn<(...args: unknown[]) => unknown>()
+vi.mock("@/composables/ViperFetch", () => ({
+    useFetch: () => ({
+        get: (...args: unknown[]) => mockGet(...args),
+        post: (...args: unknown[]) => mockPost(...args),
+        put: (...args: unknown[]) => mockPut(...args),
+        patch: (...args: unknown[]) => mockPatch(...args),
+        del: (...args: unknown[]) => mockDel(...args),
+        createUrlSearchParams: (obj: Record<string, string | number | null | undefined>) => {
+            const params = new URLSearchParams()
+            for (const [k, v] of Object.entries(obj)) {
+                if (v !== null && v !== undefined) {
+                    params.append(k, v.toString())
+                }
+            }
+            return params
+        },
+    }),
+}))
+
+const BLOCK = {
+    contentBlockId: 7,
+    content: "<p>hello</p>",
+    title: "Welcome",
+    system: "Viper",
+    application: null,
+    page: "home",
+    viperSectionPath: "/apps",
+    blockOrder: 2,
+    friendlyName: "welcome",
+    allowPublicAccess: false,
+    modifiedOn: "2024-03-01T12:00:00",
+    modifiedBy: "editor",
+    deletedOn: null,
+    permissions: ["SVMSecure.CMS"],
+    editPermissions: ["SVMSecure.CMS.Delegate"],
+    files: [{ fileGuid: "f1", friendlyName: "a.pdf", url: "/files/a.pdf" }],
+}
+
+function routeGet() {
+    mockGet.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string
+        if (url.includes("/history")) {
+            return Promise.resolve({ success: true, result: [] })
+        }
+        return Promise.resolve({ success: true, result: structuredClone(BLOCK) })
+    })
+}
+
+// QEditor relies on document.execCommand and rich-text DOM that happy-dom lacks; stub it with a
+// minimal v-model textarea so block.content still binds without exercising the real editor.
+const qEditorStub = {
+    name: "QEditor",
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+    methods: {
+        getContentEl() {
+            return null
+        },
+    },
+    template: `<textarea :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+}
+
+const mockCommit = vi.fn<() => Promise<{ attached: unknown[]; createdGuids: string[] }>>()
+const inlineUploadStub = {
+    name: "InlineFileUpload",
+    props: ["folder", "permissions", "allowPublicAccess", "contentBlockId"],
+    emits: ["staged-count"],
+    template: "<div class='inline-upload-stub' />",
+    methods: {
+        commit() {
+            return mockCommit()
+        },
+    },
+}
+
+// mountCms seeds a full CMS admin; drop to a delegated editor (holds a block edit permission but
+// none of the CMS management permissions) so the page switches into content-only mode. canManage is
+// a reactive computed, so the template re-renders after the permission change.
+async function mountDelegated(permissions = ["SVMSecure", "SVMSecure.CMS", "SVMSecure.CMS.Delegate"]) {
+    const router = createTestRouter()
+    await router.push({ name: "CmsContentBlockEdit", params: { id: "7" } })
+    await router.isReady()
+    const wrapper = mountCms(
+        ContentBlockEdit,
+        { global: { stubs: { QEditor: qEditorStub, InlineFileUpload: inlineUploadStub } } },
+        router,
+    )
+    useUserStore().setPermissions(permissions)
+    await flushPromises()
+    await flushPromises()
+    return { wrapper, router }
+}
+
+async function submitForm(wrapper: Awaited<ReturnType<typeof mountDelegated>>["wrapper"]): Promise<void> {
+    await wrapper.findComponent({ name: "QForm" }).find("form").trigger("submit")
+    await flushPromises()
+    await flushPromises()
+}
+
+beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockPatch.mockReset()
+    mockDel.mockReset()
+    mockCommit.mockReset()
+    mockCommit.mockResolvedValue({ attached: [], createdGuids: [] })
+    routeGet()
+})
+
+describe("ContentBlockEdit.vue - delegated (content-only) mode", () => {
+    it("renders a read-only settings summary and hides the manager-only controls", async () => {
+        const { wrapper } = await mountDelegated()
+
+        // No editable Title/Page inputs, no System select, no permission selectors, no public toggle.
+        const inputLabels = wrapper.findAllComponents({ name: "QInput" }).map((i) => i.props("label"))
+        expect(inputLabels).not.toContain("Title")
+        expect(inputLabels).not.toContain("Page")
+        const selectLabels = wrapper.findAllComponents({ name: "QSelect" }).map((s) => s.props("label"))
+        expect(selectLabels).not.toContain("System")
+        expect(selectLabels).not.toContain("Permissions")
+        expect(selectLabels).not.toContain("Edit access")
+        expect(wrapper.findComponent({ name: "QToggle" }).exists()).toBeFalsy()
+
+        // The identifying fields appear as plain text, and the content editor is still available.
+        const summary = wrapper.find(".settings-summary")
+        expect(summary.exists()).toBeTruthy()
+        expect(summary.text()).toContain("/apps")
+        expect(summary.text()).toContain("home")
+        expect(wrapper.text()).toContain("Welcome")
+        expect(wrapper.find("textarea").exists()).toBeTruthy()
+    })
+
+    it("treats a CreateContentBlock holder as delegated on an EXISTING block", async () => {
+        // CreateContentBlock owns only the create flow; the update endpoint is manager-only,
+        // so showing this user the manager editor would end in a 403 on save.
+        const { wrapper } = await mountDelegated([
+            "SVMSecure",
+            "SVMSecure.CMS",
+            "SVMSecure.CMS.CreateContentBlock",
+            "SVMSecure.CMS.Delegate",
+        ])
+        expect(wrapper.find(".settings-summary").exists()).toBeTruthy()
+        const selectLabels = wrapper.findAllComponents({ name: "QSelect" }).map((s) => s.props("label"))
+        expect(selectLabels).not.toContain("Permissions")
+        expect(selectLabels).not.toContain("Edit access")
+    })
+
+    it("keeps the attached-files controls functional for a delegated editor", async () => {
+        const { wrapper } = await mountDelegated()
+
+        // The existing attachment, the attach-by-search select, and the inline uploader all render.
+        expect(wrapper.text()).toContain("a.pdf")
+        const attach = wrapper.findAllComponents({ name: "QSelect" }).find((s) => s.props("label") === "Attach a file")
+        expect(attach).toBeTruthy()
+        expect(wrapper.findComponent({ name: "InlineFileUpload" }).exists()).toBeTruthy()
+    })
+
+    it("saves via the content PATCH endpoint with content, lastModifiedOn, and the attachment set", async () => {
+        mockPatch.mockResolvedValue({ success: true, result: { ...BLOCK } })
+        const { wrapper } = await mountDelegated()
+
+        await submitForm(wrapper)
+
+        expect(mockPatch).toHaveBeenCalledOnce()
+        const [url, payload] = mockPatch.mock.calls[0]!
+        expect(url).toContain("CMS/content/7/content")
+        expect(payload).toEqual({
+            content: "<p>hello</p>",
+            lastModifiedOn: "2024-03-01T12:00:00",
+            fileGuids: ["f1"],
+        })
+        // The full-save verbs are never used in delegated mode.
+        expect(mockPut).not.toHaveBeenCalled()
+        expect(mockPost).not.toHaveBeenCalled()
+        // Same titled confirmation a manager gets; delegated mode differs in the endpoint, not the UX.
+        expect(document.body.textContent).toContain('Saved "Welcome"')
+    })
+
+    it("sends a delegated editor home after saving, since they can't reach the manage listing", async () => {
+        mockPatch.mockResolvedValue({ success: true, result: { ...BLOCK } })
+        const { wrapper, router } = await mountDelegated()
+
+        await submitForm(wrapper)
+        await flushRouter()
+
+        expect(router.currentRoute.value.name).toBe("CmsHome")
+    })
+
+    it("opens the edit-conflict dialog when the content PATCH returns a 409", async () => {
+        mockPatch.mockResolvedValue({ success: false, status: 409, errors: ["Someone else saved this block."] })
+        const { wrapper } = await mountDelegated()
+
+        await submitForm(wrapper)
+
+        expect(document.body.textContent).toContain("Edit Conflict")
+        expect(document.body.textContent).toContain("Someone else saved this block.")
+    })
+})

--- a/VueApp/src/CMS/__tests__/content-block-edit-save.test.ts
+++ b/VueApp/src/CMS/__tests__/content-block-edit-save.test.ts
@@ -46,11 +46,12 @@ const BLOCK = {
     modifiedBy: "editor",
     deletedOn: null,
     permissions: ["SVMSecure.CMS"],
+    editPermissions: ["SVMSecure.CMS.Delegate"],
     files: [{ fileGuid: "f1", friendlyName: "a.pdf", url: "/files/a.pdf" }],
 }
 
 // The payload buildSavePayload derives from BLOCK (files flattened to fileGuids, modifiedOn
-// becoming the lastModifiedOn concurrency stamp).
+// becoming the lastModifiedOn concurrency stamp, editPermissions carried through).
 const EXPECTED_PUT_PAYLOAD = {
     contentBlockId: 7,
     content: "<p>hello</p>",
@@ -63,6 +64,7 @@ const EXPECTED_PUT_PAYLOAD = {
     friendlyName: "welcome",
     allowPublicAccess: false,
     permissions: ["SVMSecure.CMS"],
+    editPermissions: ["SVMSecure.CMS.Delegate"],
     fileGuids: ["f1"],
     lastModifiedOn: "2024-03-01T12:00:00",
 }
@@ -177,6 +179,14 @@ describe("ContentBlockEdit.vue - save payload", () => {
         expect(router.currentRoute.value.name).toBe("CmsContentBlocks")
     })
 
+    it("renders the Edit access permission selector for a manager", async () => {
+        const { wrapper } = await mountEdit()
+        const editAccess = wrapper
+            .findAllComponents({ name: "QSelect" })
+            .find((s) => s.props("label") === "Edit access")
+        expect(editAccess).toBeTruthy()
+    })
+
     it("create-mode save POSTs with a null lastModifiedOn and empty friendlyName collapsed to null", async () => {
         mockPost.mockResolvedValue({ success: true, result: { ...BLOCK, contentBlockId: 42, files: [] } })
         const { wrapper, router } = await mountEdit({ params: {} })
@@ -249,7 +259,7 @@ describe("ContentBlockEdit.vue - staged upload commit", () => {
 
         // The new upload is soft-deleted and detached again; the pre-existing file stays.
         expect(mockDel).toHaveBeenCalledOnce()
-        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/f2")
+        expect(mockDel.mock.calls[0]![0]).toContain("CMS/content/7/files/f2")
         expect(wrapper.text()).toContain("Friendly name already in use")
         expect(wrapper.text()).toContain("a.pdf")
         expect(wrapper.text()).not.toContain("b.pdf")
@@ -266,7 +276,7 @@ describe("ContentBlockEdit.vue - 409 conflict handling", () => {
 
         await submitForm(wrapper)
 
-        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/f2")
+        expect(mockDel.mock.calls[0]![0]).toContain("CMS/content/7/files/f2")
         expect(document.body.textContent).toContain("Edit Conflict")
         expect(document.body.textContent).toContain("Someone else saved this block.")
 
@@ -289,17 +299,17 @@ describe("ContentBlockEdit.vue - 409 conflict handling", () => {
     })
 })
 
-// Like routeGet, but the file-search endpoint returns a catalog including one already-attached
-// file (f1) and one new candidate (f9).
+// Like routeGet, but the attachable-files endpoint returns candidates including one already-attached
+// file (f1) and one new candidate (f9). The endpoint's slim shape omits the URL.
 function routeGetWithFileSearch() {
     mockGet.mockImplementation((...args: unknown[]) => {
         const url = args[0] as string
-        if (url.includes("cms/files/")) {
+        if (url.includes("attachable-files")) {
             return Promise.resolve({
                 success: true,
                 result: [
-                    { fileGuid: "f1", friendlyName: "a.pdf", friendlyUrl: "/files/a.pdf" },
-                    { fileGuid: "f9", friendlyName: "new.pdf", friendlyUrl: "/files/new.pdf" },
+                    { fileGuid: "f1", friendlyName: "a.pdf" },
+                    { fileGuid: "f9", friendlyName: "new.pdf" },
                 ],
             })
         }
@@ -311,7 +321,7 @@ function routeGetWithFileSearch() {
 }
 
 describe("ContentBlockEdit.vue - attached files", () => {
-    it("searches active files (excluding already-attached ones) and attaches the selection", async () => {
+    it("searches attachable files (excluding already-attached ones) and attaches the selection", async () => {
         routeGetWithFileSearch()
         const { wrapper } = await mountEdit()
 
@@ -322,9 +332,10 @@ describe("ContentBlockEdit.vue - attached files", () => {
         await flushPromises()
         await flushPromises()
 
-        const fileSearch = mockGet.mock.calls.map((c) => c[0] as string).find((u) => u.includes("cms/files/?"))
+        // The block-scoped attachable-files endpoint (not the global file catalog) backs the search.
+        const fileSearch = mockGet.mock.calls.map((c) => c[0] as string).find((u) => u.includes("attachable-files"))
         expect(fileSearch).toContain("search=pdf")
-        expect(fileSearch).toContain("status=active")
+        expect(fileSearch).toContain("contentBlockId=7")
         // The already-attached f1 is excluded from the options.
         const options = attachSelect.props("options") as { fileGuid: string }[]
         expect(options.map((o) => o.fileGuid)).toEqual(["f9"])

--- a/VueApp/src/CMS/__tests__/inline-file-upload.test.ts
+++ b/VueApp/src/CMS/__tests__/inline-file-upload.test.ts
@@ -111,7 +111,9 @@ function routeCheckName(check: NameCheck) {
     })
 }
 
-function mountUpload(props: Partial<{ folder: string | null; allowPublicAccess: boolean }> = {}) {
+function mountUpload(
+    props: Partial<{ folder: string | null; allowPublicAccess: boolean; contentBlockId: number | null }> = {},
+) {
     return mountCms(InlineFileUpload, {
         props: {
             folder: "Apps",
@@ -391,5 +393,73 @@ describe("inlineFileUpload.vue - commit", () => {
         const deleted = mockDel.mock.calls.map((c) => c[0] as string)
         expect(deleted.some((u) => u.includes("cms/files/n1"))).toBe(true)
         expect(deleted.some((u) => u.includes("cms/files/n2"))).toBe(true)
+    })
+})
+
+// With a contentBlockId, the uploader targets the block-scoped files API a delegated editor can
+// reach: check-name/upload/rollback all live under CMS/content/{id}/files, the folder + permissions
+// come from the block (not the client), and the per-file overwrite-in-place / use-existing paths
+// (which that API lacks) are unavailable.
+describe("inlineFileUpload.vue - block-scoped (delegated) mode", () => {
+    it("checks names and uploads through the block-scoped files API, sending only the file", async () => {
+        mockPostForm.mockResolvedValue({ success: true, result: cmsFile("c1", "report.pdf") })
+        const wrapper = mountUpload({ contentBlockId: 7 })
+        await stage("report.pdf")
+
+        const checkUrl = mockGet.mock.calls[0]![0] as string
+        expect(checkUrl).toContain("CMS/content/7/files/check-name")
+        // The block implies the folder, so it is not sent.
+        expect(checkUrl).not.toContain("folder=")
+
+        const result = await commitOf(wrapper)()
+
+        const [url, data] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(url).toContain("CMS/content/7/files/")
+        expect(data.has("folder")).toBeFalsy()
+        expect(data.has("permissions")).toBeFalsy()
+        expect(data.has("allowPublicAccess")).toBeFalsy()
+        expect(result.createdGuids).toStrictEqual(["c1"])
+    })
+
+    it("rolls back through the block-scoped delete when a later upload fails", async () => {
+        mockPostForm
+            .mockResolvedValueOnce({ success: true, result: cmsFile("c1", "a.pdf") })
+            .mockResolvedValueOnce({ success: false, errors: ["disk full"] })
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const wrapper = mountUpload({ contentBlockId: 7 })
+        await stage("a.pdf")
+        await stage("b.pdf")
+
+        await expect(commitOf(wrapper)()).rejects.toThrow("disk full")
+
+        expect(mockDel.mock.calls[0]![0]).toContain("CMS/content/7/files/c1")
+    })
+
+    it("offers only rename and overwrite on a conflict (no use-existing) in block-scoped mode", async () => {
+        routeCheckName(CONFLICT)
+        const wrapper = mountUpload({ contentBlockId: 7 })
+        await stage("report.pdf")
+
+        const options = wrapper.findComponent({ name: "QOptionGroup" }).props("options") as { label: string }[]
+        expect(options.map((o) => o.label)).toStrictEqual([
+            "Upload under a new name (report_1.pdf)",
+            "Overwrite the existing file",
+        ])
+    })
+
+    it("uploads with the overwrite flag (POST, not PUT) when overwrite is chosen in block-scoped mode", async () => {
+        routeCheckName(CONFLICT)
+        mockPostForm.mockResolvedValue({ success: true, result: cmsFile("c2", "report.pdf") })
+        const wrapper = mountUpload({ contentBlockId: 7 })
+        await stage("report.pdf")
+
+        wrapper.findComponent({ name: "QOptionGroup" }).vm.$emit("update:modelValue", "overwrite")
+        const result = await commitOf(wrapper)()
+
+        expect(mockPutForm).not.toHaveBeenCalled()
+        const [url, data] = mockPostForm.mock.calls[0]! as [string, FormData]
+        expect(url).toContain("CMS/content/7/files/")
+        expect(data.get("overwrite")).toBe("true")
+        expect(result.createdGuids).toStrictEqual(["c2"])
     })
 })

--- a/VueApp/src/CMS/components/InlineFileUpload.vue
+++ b/VueApp/src/CMS/components/InlineFileUpload.vue
@@ -85,7 +85,7 @@
 // fallow-ignore-file complexity
 import { computed, inject, ref, watch } from "vue"
 import { useDropZone, useFileDialog } from "@vueuse/core"
-import { useFetch } from "@/composables/ViperFetch"
+import { useCmsFiles } from "@/CMS/composables/use-cms-files"
 import StatusBanner from "@/components/StatusBanner.vue"
 import { CMS_ACCEPTED_EXTENSIONS } from "@/CMS/file-types"
 import type { CmsFile, CmsFileNameCheck } from "@/CMS/types/"
@@ -99,13 +99,20 @@ const props = defineProps<{
     // Uploaded files inherit the block's public-access flag: a file on a public block must itself be
     // publicly downloadable, or anonymous viewers get a broken/denied link.
     allowPublicAccess?: boolean
+    // When set (edit mode), uploads go through the block-scoped files API, which a delegated editor
+    // can reach and which derives the folder + view permissions from the block itself. When null
+    // (create mode, no id yet), the global files API is used - unchanged legacy behavior.
+    contentBlockId?: number | null
 }>()
 
 const emit = defineEmits<{ "staged-count": [count: number] }>()
 
-const apiURL = inject("apiURL") + "cms/files/"
-const { get, postForm, putForm, del, createUrlSearchParams } = useFetch()
-
+const apiRoot = inject("apiURL")
+// All file API calls go through the CMS file service (built on useFetch); the component only chooses
+// which operation to invoke. isContentScoped mirrors the service's mode: the block-scoped API exposes
+// only check-name / upload / delete, so overwrite-in-place and attach-existing (below) stay global.
+const files = useCmsFiles(apiRoot as string, () => props.contentBlockId)
+const isContentScoped = files.isScoped
 type StagedFile = {
     key: string
     file: File
@@ -150,8 +157,9 @@ function conflictOptions(item: StagedFile) {
         { label: `Upload under a new name (${item.conflict!.suggestedName})`, value: "rename" },
         { label: "Overwrite the existing file", value: "overwrite" },
     ]
-    // "Use existing" only works when the conflict is a real file record we can attach.
-    if (item.conflict!.existingFileGuid) {
+    // "Use existing" only works when the conflict is a real file record we can attach, and only on
+    // the global files API (the block-scoped API has no per-file GET to fetch it).
+    if (item.conflict!.existingFileGuid && !isContentScoped.value) {
         opts.push({ label: "Use the existing file instead (don't upload)", value: "existing" })
     }
     return opts
@@ -170,8 +178,7 @@ async function stageFile(file: File | null | undefined) {
 
     busy.value = true
     try {
-        const params = createUrlSearchParams({ folder: props.folder!, fileName: file.name })
-        const check = await get(apiURL + "check-name?" + params)
+        const check = await files.checkName(file.name, props.folder!)
         const conflict: CmsFileNameCheck | null = check.success && check.result.inUse ? check.result : null
         staged.value.push({ key: String(++keyCounter), file, conflict, action: "rename" })
     } finally {
@@ -206,7 +213,7 @@ async function commit(): Promise<{ attached: CmsFile[]; createdGuids: string[] }
         // rollbacks nor masks the original upload error, which is always what we rethrow.
         for (const guid of createdGuids) {
             try {
-                await del(apiURL + guid)
+                await files.remove(guid)
             } catch {
                 // Swallow rollback failures; the leftover file falls to the trash-purge job.
             }
@@ -220,19 +227,23 @@ async function commit(): Promise<{ attached: CmsFile[]; createdGuids: string[] }
 type CommitResult = { file: CmsFile; created: boolean }
 
 // Attach the existing file without uploading anything - never rolled back, it pre-existed.
+// Global files API only (per-file GET); see commitOne.
 async function attachExisting(item: StagedFile): Promise<CommitResult> {
-    const res = await get(apiURL + item.conflict!.existingFileGuid)
+    const res = await files.getFile(item.conflict!.existingFileGuid!)
     if (!res.success) throw new Error(res.errors?.[0] ?? `Could not load ${item.conflict!.existingFriendlyName}`)
     return { file: res.result as CmsFile, created: false }
 }
 
-// Shared multipart body: the file plus the block's public-access flag and permissions.
+// Shared multipart body. On the global files API the client supplies public-access + permissions;
+// the block-scoped API derives both from the block, so only the file itself is sent there.
 function buildUploadData(item: StagedFile): FormData {
     const data = new FormData()
     data.append("file", item.file)
-    data.append("allowPublicAccess", String(props.allowPublicAccess ?? false))
-    for (const permission of props.permissions) {
-        data.append("permissions", permission)
+    if (!isContentScoped.value) {
+        data.append("allowPublicAccess", String(props.allowPublicAccess ?? false))
+        for (const permission of props.permissions) {
+            data.append("permissions", permission)
+        }
     }
     return data
 }
@@ -242,9 +253,10 @@ function buildUploadData(item: StagedFile): FormData {
 // The edit endpoint is a whole-record save, so the record is re-read first: its ModifiedOn is the
 // required stale-edit guard, and its description, old URL, people, and encryption state are echoed
 // back. Omitting any of them would silently clear (or decrypt) the file we are only re-uploading.
+// Global files API only (per-file GET + PUT); see commitOne.
 async function overwriteInPlace(item: StagedFile, data: FormData): Promise<CommitResult> {
     const guid = item.conflict!.existingFileGuid!
-    const existing = await get(apiURL + guid)
+    const existing = await files.getFile(guid)
     if (!existing.success) throw new Error(existing.errors?.[0] ?? `Could not load ${item.file.name}`)
     const current = existing.result as CmsFile
     data.append("lastModifiedOn", current.modifiedOn)
@@ -254,32 +266,36 @@ async function overwriteInPlace(item: StagedFile, data: FormData): Promise<Commi
     for (const person of current.people) {
         data.append("iamIds", person.iamId)
     }
-    const res = await putForm(apiURL + guid, data)
+    const res = await files.overwriteInPlace(guid, data)
     if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to overwrite ${item.file.name}`)
     return { file: res.result as CmsFile, created: false }
 }
 
-// New record created (new upload, rename, or overwriting an orphaned on-disk file with no
-// record); folder is required. This is safe to roll back on a failed save.
+// New record created (new upload, rename, or overwriting an orphaned on-disk file with no record).
+// The global files API needs the folder in the body; the block-scoped API knows it. Safe to roll back.
 async function uploadNew(item: StagedFile, data: FormData): Promise<CommitResult> {
-    data.append("folder", props.folder!)
+    if (!isContentScoped.value) {
+        data.append("folder", props.folder!)
+    }
     if (item.conflict && item.action === "overwrite") {
         data.append("overwrite", "true")
     } else if (item.conflict && item.action === "rename") {
         data.append("fileName", item.conflict.suggestedName)
     }
-    const res = await postForm(apiURL, data)
+    const res = await files.upload(data)
     if (!res.success) throw new Error(res.errors?.[0] ?? `Failed to upload ${item.file.name}`)
     return { file: res.result as CmsFile, created: true }
 }
 
 // Returns the resulting file and whether a NEW record was created (true = safe to roll back).
+// The block-scoped API exposes only POST, so its overwrites go through uploadNew (overwrite flag)
+// and attach-existing is never offered there (conflictOptions omits it).
 async function commitOne(item: StagedFile): Promise<CommitResult> {
-    if (item.conflict && item.action === "existing" && item.conflict.existingFileGuid) {
+    if (!isContentScoped.value && item.conflict && item.action === "existing" && item.conflict.existingFileGuid) {
         return attachExisting(item)
     }
     const data = buildUploadData(item)
-    if (item.conflict && item.action === "overwrite" && item.conflict.existingFileGuid) {
+    if (!isContentScoped.value && item.conflict && item.action === "overwrite" && item.conflict.existingFileGuid) {
         return overwriteInPlace(item, data)
     }
     return uploadNew(item, data)

--- a/VueApp/src/CMS/components/PermissionSelector.vue
+++ b/VueApp/src/CMS/components/PermissionSelector.vue
@@ -11,7 +11,7 @@
         :label="label"
         :options="filteredOptions"
         :loading="loading"
-        hint="Users need any one of the selected permissions"
+        :hint="hint"
         @update:model-value="emit('update:modelValue', $event ?? [])"
         @filter="filterOptions"
     />
@@ -25,8 +25,9 @@ withDefaults(
     defineProps<{
         modelValue: string[]
         label?: string
+        hint?: string
     }>(),
-    { label: "Permissions" },
+    { label: "Permissions", hint: "Users need any one of the selected permissions" },
 )
 
 const emit = defineEmits<{ "update:modelValue": [value: string[]] }>()

--- a/VueApp/src/CMS/components/PermissionSelector.vue
+++ b/VueApp/src/CMS/components/PermissionSelector.vue
@@ -11,7 +11,7 @@
         :label="label"
         :options="filteredOptions"
         :loading="loading"
-        :hint="hint"
+        :hint="hint ?? undefined"
         @update:model-value="emit('update:modelValue', $event ?? [])"
         @filter="filterOptions"
     />
@@ -21,11 +21,13 @@
 import { ref } from "vue"
 import { getPermissionOptions } from "@/CMS/services/cms-options-service"
 
+// hint accepts null to opt out entirely (no reserved bottom space), since passing
+// undefined would fall back to the default hint.
 withDefaults(
     defineProps<{
         modelValue: string[]
         label?: string
-        hint?: string
+        hint?: string | null
     }>(),
     { label: "Permissions", hint: "Users need any one of the selected permissions" },
 )

--- a/VueApp/src/CMS/composables/use-cms-files.ts
+++ b/VueApp/src/CMS/composables/use-cms-files.ts
@@ -1,0 +1,44 @@
+import { computed, toValue } from "vue"
+import type { MaybeRefOrGetter } from "vue"
+import { useFetch } from "@/composables/ViperFetch"
+
+// Service layer for the CMS file operations the inline uploader needs. Every endpoint is built from
+// the app API base (VITE_API_URL, injected as `apiURL`) and every call goes through `useFetch()`, so
+// the component never constructs URLs or touches `fetch` itself.
+//
+// Scoped mode (a content-block id given) targets the block-scoped files API a delegated editor can
+// reach: `CMS/content/{id}/files/...`, where the folder + view permissions are derived from the block
+// server-side. Global mode (no id) targets the folder-wide `cms/files/...` API. The block-scoped API
+// exposes only check-name / upload / delete, so per-file overwrite-in-place and use-existing (GET/PUT
+// on a specific file) are global-only; callers gate those on `isScoped`.
+export function useCmsFiles(apiRoot: string, contentBlockId: MaybeRefOrGetter<number | null | undefined>) {
+    const { get, postForm, putForm, del, createUrlSearchParams } = useFetch()
+
+    const isScoped = computed(() => typeof toValue(contentBlockId) === "number")
+    const base = computed(() =>
+        isScoped.value ? `${apiRoot}CMS/content/${toValue(contentBlockId)}/files/` : `${apiRoot}cms/files/`,
+    )
+
+    return {
+        isScoped,
+        // Block-scoped check-name derives the folder from the block; the global one takes it as a param.
+        checkName(fileName: string, folder: string) {
+            const params = isScoped.value
+                ? createUrlSearchParams({ fileName })
+                : createUrlSearchParams({ folder, fileName })
+            return get(`${base.value}check-name?${params}`)
+        },
+        getFile(fileGuid: string) {
+            return get(base.value + fileGuid)
+        },
+        upload(data: FormData) {
+            return postForm(base.value, data)
+        },
+        overwriteInPlace(existingFileGuid: string, data: FormData) {
+            return putForm(base.value + existingFileGuid, data)
+        },
+        remove(fileGuid: string) {
+            return del(base.value + fileGuid)
+        },
+    }
+}

--- a/VueApp/src/CMS/pages/CmsHome.vue
+++ b/VueApp/src/CMS/pages/CmsHome.vue
@@ -3,7 +3,7 @@
         <h1 class="q-my-none q-mb-md">Content Management System</h1>
 
         <StatusBanner
-            v-if="visibleSections.length === 0"
+            v-if="showNoAccess"
             type="info"
         >
             Your account does not have access to any CMS tools. Contact the VIPER team if you need access.
@@ -52,6 +52,38 @@
                             />
                         </q-card-actions>
                     </q-card>
+
+                    <q-card
+                        v-if="showEditableCard"
+                        flat
+                        bordered
+                    >
+                        <q-card-section>
+                            <h2 class="text-h6 text-primary q-my-none">
+                                <q-icon
+                                    name="edit_note"
+                                    size="sm"
+                                    class="q-mr-sm"
+                                />
+                                Blocks you can edit
+                            </h2>
+                            <div class="text-body2 text-grey-8 q-mt-xs">
+                                Content blocks you've been granted access to edit.
+                            </div>
+                        </q-card-section>
+                        <q-card-actions class="column items-start">
+                            <q-btn
+                                v-for="editable in editableBlocks"
+                                :key="editable.contentBlockId"
+                                flat
+                                dense
+                                no-caps
+                                color="primary"
+                                :label="editable.title || editable.friendlyName || `Block ${editable.contentBlockId}`"
+                                :to="{ name: 'CmsContentBlockEdit', params: { id: editable.contentBlockId } }"
+                            />
+                        </q-card-actions>
+                    </q-card>
                 </div>
             </div>
             <div
@@ -75,7 +107,7 @@ import { useUserStore } from "@/store/UserStore"
 import { useFetch } from "@/composables/ViperFetch"
 import StatusBanner from "@/components/StatusBanner.vue"
 import RecentActivity from "@/CMS/components/RecentActivity.vue"
-import type { CmsFile } from "@/CMS/types/"
+import type { CmsFile, EditableBlock } from "@/CMS/types/"
 
 const userStore = useUserStore()
 const apiURL = inject("apiURL")
@@ -165,6 +197,43 @@ const canManageBlocks = computed(() => userStore.userInfo.permissions.includes("
 const canManageFiles = computed(() => userStore.userInfo.permissions.includes("SVMSecure.CMS.AllFiles"))
 const canManageNav = computed(() => userStore.userInfo.permissions.includes("SVMSecure.CMS.ManageNavigation"))
 const showRecentActivity = computed(() => canManageBlocks.value || canManageFiles.value || canManageNav.value)
+
+// Delegated editors (users without ManageContentBlocks who hold a block's edit permission) get a
+// card listing the blocks they may edit. Managers use the normal Content Blocks card, so the list
+// is fetched only for non-managers (the endpoint returns empty for them anyway).
+const editableBlocks = ref<EditableBlock[]>([])
+// False until the delegated lookup has actually resolved (or is skipped for managers), so the
+// "no access" banner below never flashes while the request is pending or when it failed.
+const editableLoaded = ref(false)
+const showEditableCard = computed(() => editableBlocks.value.length > 0 && !canManageBlocks.value)
+
+watch(
+    canManageBlocks,
+    async (canManage) => {
+        if (canManage) {
+            editableBlocks.value = []
+            editableLoaded.value = true
+            return
+        }
+        editableLoaded.value = false
+        const res = await get(`${apiURL}CMS/content/editable`)
+        // Only treat the result as loaded on success: a failed lookup must not read as an empty
+        // (no-access) result.
+        if (res.success) {
+            editableBlocks.value = res.result ?? []
+            editableLoaded.value = true
+        } else {
+            editableBlocks.value = []
+        }
+    },
+    { immediate: true },
+)
+
+// The no-access banner is only for users with neither a tool card nor any block to edit; the
+// editable card must suppress it.
+const showNoAccess = computed(
+    () => editableLoaded.value && visibleSections.value.length === 0 && editableBlocks.value.length === 0,
+)
 
 // Warn file managers when trashed files approach the purge cutoff. PurgeOn comes from the API
 // (deletedOn + retention), so the warning stays correct if the retention window ever changes.

--- a/VueApp/src/CMS/pages/ContentBlockEdit.vue
+++ b/VueApp/src/CMS/pages/ContentBlockEdit.vue
@@ -2,12 +2,12 @@
     <div class="q-pa-md">
         <BreadcrumbHeading
             :label="isNew ? 'Add Content Block' : 'Edit Content Block'"
-            parent-label="Manage Content Blocks"
-            :parent-to="{ name: 'CmsContentBlocks' }"
+            :parent-label="canManage ? 'Manage Content Blocks' : 'Content Management System'"
+            :parent-to="canManage ? { name: 'CmsContentBlocks' } : { name: 'CmsHome' }"
         />
 
         <StatusBanner
-            v-if="block.deletedOn"
+            v-if="block.deletedOn && canManage"
             type="warning"
             class="q-mb-md"
         >
@@ -33,6 +33,7 @@
             <div class="row q-col-gutter-lg">
                 <div class="col-12">
                     <q-input
+                        v-if="canManage"
                         v-model="block.title"
                         dense
                         outlined
@@ -42,6 +43,12 @@
                         aria-required="true"
                         hide-bottom-space
                     />
+                    <h2
+                        v-else
+                        class="text-h6 q-mt-none q-mb-md"
+                    >
+                        {{ block.title }}
+                    </h2>
 
                     <div
                         id="content-editor-label"
@@ -125,97 +132,113 @@
                         <q-card-section class="q-gutter-y-sm">
                             <h2 class="text-h6 q-my-none">Settings</h2>
 
-                            <q-select
-                                v-model="block.system"
-                                dense
-                                options-dense
-                                outlined
-                                label="System"
-                                class="required-field"
-                                :options="['Viper', 'Public']"
-                                :rules="[(v: string | null) => !!v || 'System is required']"
-                                aria-required="true"
-                                hint="Which site shows this block: the VIPER intranet or the public site."
-                                @update:model-value="onSystemChange"
-                            />
+                            <template v-if="canManage">
+                                <q-select
+                                    v-model="block.system"
+                                    dense
+                                    options-dense
+                                    outlined
+                                    label="System"
+                                    class="required-field"
+                                    :options="['Viper', 'Public']"
+                                    :rules="[(v: string | null) => !!v || 'System is required']"
+                                    aria-required="true"
+                                    hint="Which site shows this block: the VIPER intranet or the public site."
+                                    @update:model-value="onSystemChange"
+                                />
 
-                            <q-select
-                                v-if="isNew"
-                                v-model="block.viperSectionPath"
-                                dense
-                                options-dense
-                                outlined
-                                label="VIPER section path"
-                                class="required-field"
-                                :options="folders"
-                                :rules="[(v: string | null) => !!v || 'A VIPER section path is required']"
-                                aria-required="true"
-                                hint="The VIPER app folder this block's files are stored in; it can't be changed later."
-                            />
-                            <q-input
+                                <q-select
+                                    v-if="isNew"
+                                    v-model="block.viperSectionPath"
+                                    dense
+                                    options-dense
+                                    outlined
+                                    label="VIPER section path"
+                                    class="required-field"
+                                    :options="folders"
+                                    :rules="[(v: string | null) => !!v || 'A VIPER section path is required']"
+                                    aria-required="true"
+                                    hint="The VIPER app folder this block's files are stored in; it can't be changed later."
+                                />
+                                <q-input
+                                    v-else
+                                    :model-value="block.viperSectionPath"
+                                    dense
+                                    outlined
+                                    readonly
+                                    label="VIPER section path"
+                                >
+                                    <template #append>
+                                        <q-icon
+                                            name="help"
+                                            size="xs"
+                                            tabindex="0"
+                                            role="img"
+                                            aria-label="The section path can't be edited after the block is created"
+                                        >
+                                            <q-tooltip>
+                                                The section path can't be edited after the block is created.
+                                            </q-tooltip>
+                                        </q-icon>
+                                    </template>
+                                </q-input>
+
+                                <q-input
+                                    v-model="block.page"
+                                    dense
+                                    outlined
+                                    label="Page"
+                                />
+
+                                <q-input
+                                    v-model.number="block.blockOrder"
+                                    dense
+                                    outlined
+                                    type="number"
+                                    label="Block order"
+                                />
+
+                                <q-input
+                                    v-model="block.friendlyName"
+                                    dense
+                                    outlined
+                                    label="Friendly name"
+                                    hint="Used for URL-friendly access; must be unique"
+                                />
+
+                                <q-toggle
+                                    v-model="block.allowPublicAccess"
+                                    label="Public access"
+                                    @update:model-value="autoEnabledPublicAccess = false"
+                                />
+
+                                <StatusBanner
+                                    v-if="autoEnabledPublicAccess"
+                                    type="info"
+                                    live="assertive"
+                                >
+                                    Public system content is visible to everyone, so we turned on Public access. Switch
+                                    it off if this block should stay restricted.
+                                </StatusBanner>
+                            </template>
+
+                            <!-- Delegated editors can't change settings; show the identifying fields as text. -->
+                            <dl
                                 v-else
-                                :model-value="block.viperSectionPath"
-                                dense
-                                outlined
-                                readonly
-                                label="VIPER section path"
+                                class="settings-summary q-my-none"
                             >
-                                <template #append>
-                                    <q-icon
-                                        name="help"
-                                        size="xs"
-                                        tabindex="0"
-                                        role="img"
-                                        aria-label="The section path can't be edited after the block is created"
-                                    >
-                                        <q-tooltip>
-                                            The section path can't be edited after the block is created.
-                                        </q-tooltip>
-                                    </q-icon>
-                                </template>
-                            </q-input>
-
-                            <q-input
-                                v-model="block.page"
-                                dense
-                                outlined
-                                label="Page"
-                            />
-
-                            <q-input
-                                v-model.number="block.blockOrder"
-                                dense
-                                outlined
-                                type="number"
-                                label="Block order"
-                            />
-
-                            <q-input
-                                v-model="block.friendlyName"
-                                dense
-                                outlined
-                                label="Friendly name"
-                                hint="Used for URL-friendly access; must be unique"
-                            />
-
-                            <q-toggle
-                                v-model="block.allowPublicAccess"
-                                label="Public access"
-                                @update:model-value="autoEnabledPublicAccess = false"
-                            />
-
-                            <StatusBanner
-                                v-if="autoEnabledPublicAccess"
-                                type="info"
-                                live="assertive"
-                            >
-                                Public system content is visible to everyone, so we turned on Public access. Switch it
-                                off if this block should stay restricted.
-                            </StatusBanner>
+                                <dt>Title</dt>
+                                <dd>{{ block.title || "—" }}</dd>
+                                <dt>VIPER section path</dt>
+                                <dd>{{ block.viperSectionPath || "—" }}</dd>
+                                <dt>Page</dt>
+                                <dd>{{ block.page || "—" }}</dd>
+                            </dl>
                         </q-card-section>
                     </q-card>
 
                     <q-card
+                        v-if="canManage"
                         flat
                         bordered
                         class="q-mb-md"
@@ -227,7 +250,23 @@
                     </q-card>
 
                     <q-card
-                        v-if="canAccessFiles || block.files.length > 0"
+                        v-if="canManage"
+                        flat
+                        bordered
+                        class="q-mb-md"
+                    >
+                        <q-card-section>
+                            <h2 class="text-h6 q-my-none q-mb-sm">Edit access</h2>
+                            <PermissionSelector
+                                v-model="block.editPermissions"
+                                label="Edit access"
+                                hint="Holders of any of these permissions may edit this block's content and files (not its settings)"
+                            />
+                        </q-card-section>
+                    </q-card>
+
+                    <q-card
+                        v-if="canEditFiles || block.files.length > 0"
                         flat
                         bordered
                     >
@@ -239,6 +278,7 @@
                                 class="row items-center q-mb-xs"
                             >
                                 <a
+                                    v-if="file.url"
                                     :href="file.url"
                                     target="_blank"
                                     rel="noopener"
@@ -247,8 +287,14 @@
                                     {{ file.friendlyName }}
                                     <span class="sr-only">(opens in new window)</span>
                                 </a>
+                                <span
+                                    v-else
+                                    class="col ellipsis"
+                                >
+                                    {{ file.friendlyName }}
+                                </span>
                                 <q-btn
-                                    v-if="canAccessFiles"
+                                    v-if="canEditFiles"
                                     dense
                                     flat
                                     size="sm"
@@ -261,7 +307,7 @@
                                 </q-btn>
                             </div>
                             <q-select
-                                v-if="canAccessFiles"
+                                v-if="canEditFiles"
                                 v-model="fileToAttach"
                                 dense
                                 options-dense
@@ -277,12 +323,13 @@
                                 @update:model-value="attachFile"
                             />
                             <InlineFileUpload
-                                v-if="canAccessFiles"
+                                v-if="canEditFiles"
                                 ref="inlineUploadRef"
                                 class="q-mt-sm"
                                 :folder="block.viperSectionPath"
                                 :permissions="block.permissions"
                                 :allow-public-access="block.allowPublicAccess"
+                                :content-block-id="isNew ? null : block.contentBlockId"
                                 @staged-count="stagedCount = $event"
                             />
                         </q-card-section>
@@ -346,6 +393,7 @@ import { computed, inject, onMounted, ref } from "vue"
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import { useQuasar } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
+import { useUserStore } from "@/store/UserStore"
 import { useUnsavedChanges } from "@/composables/use-unsaved-changes"
 import { useContentDiffViewer } from "@/CMS/composables/use-content-diff-viewer"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
@@ -356,6 +404,7 @@ import RichTextEditor from "@/components/RichTextEditor.vue"
 import StatusBanner from "@/components/StatusBanner.vue"
 import ContentDiffDialog from "@/CMS/components/ContentDiffDialog.vue"
 import type {
+    AttachableFile,
     CmsContentBlock,
     CmsContentBlockFile,
     CmsContentHistoryDiff,
@@ -368,15 +417,27 @@ const filesApiURL = inject("apiURL") + "cms/files/"
 const route = useRoute()
 const router = useRouter()
 const $q = useQuasar()
-const { get, post, put, del, createUrlSearchParams } = useFetch()
-
-// This route also admits CreateContentBlock-only users. The folder list (for the section path)
-// is served by a content-scoped endpoint they can reach; the file catalog (attach/upload) still
-// requires AllFiles, so gate only those.
-const canAccessFiles = checkHasOnePermission(["SVMSecure.CMS.AllFiles"])
+const userStore = useUserStore()
+const { get, post, put, patch, del, createUrlSearchParams } = useFetch()
 
 const blockId = computed(() => (route.params.id ? Number(route.params.id) : null))
 const isNew = computed(() => blockId.value === null)
+
+// Managers get the full editor everywhere. CreateContentBlock holders own only the create flow:
+// on an EXISTING block they are delegated editors like anyone else (the update endpoint is
+// manager-only), so the settings sidebar collapses to a read-only summary and the save switches
+// to the PATCH endpoint.
+const canManage = computed(
+    () =>
+        userStore.userInfo.permissions.includes("SVMSecure.CMS.ManageContentBlocks") ||
+        (isNew.value && userStore.userInfo.permissions.includes("SVMSecure.CMS.CreateContentBlock")),
+)
+
+// The global file catalog (search + create-mode upload) still requires AllFiles. In edit mode the
+// attach/upload controls run through the block-scoped API instead, which any editor of the block
+// (manager or delegated) may use - so gate those on being in edit mode rather than on AllFiles.
+const canAccessFiles = checkHasOnePermission(["SVMSecure.CMS.AllFiles"])
+const canEditFiles = computed(() => (isNew.value ? canAccessFiles : true))
 
 const formRef = ref()
 const saving = ref(false)
@@ -397,10 +458,15 @@ const emptyBlock = (): CmsContentBlock => ({
     modifiedBy: "",
     deletedOn: null,
     permissions: [],
+    editPermissions: [],
     files: [],
 })
 
 const block = ref<CmsContentBlock>(emptyBlock())
+
+// New files created during a save are rolled back through the same API they were uploaded to:
+// the block-scoped files route in edit mode, the global one in create mode (see InlineFileUpload).
+const fileRollbackBase = computed(() => (isNew.value ? filesApiURL : `${apiURL}/${block.value.contentBlockId}/files/`))
 
 // Files chosen in the inline uploader are staged client-side and only uploaded on Save. Fold their
 // count into the dirty state so staging alone trips the unsaved-changes guard.
@@ -421,8 +487,8 @@ const selectedHistory = ref<CmsContentHistoryItem | null>(null)
 const viewingVersion = ref(false)
 const autoEnabledPublicAccess = ref(false)
 
-const fileToAttach = ref<CmsFile | null>(null)
-const fileOptions = ref<CmsFile[]>([])
+const fileToAttach = ref<AttachableFile | null>(null)
+const fileOptions = ref<AttachableFile[]>([])
 const searchingFiles = ref(false)
 
 const editorToolbar = [
@@ -439,11 +505,16 @@ async function loadBlock() {
     if (blockId.value === null) return
     const res = await get(apiURL + "/" + blockId.value)
     if (!res.success) {
-        $q.notify({ type: "negative", message: "Content block not found" })
-        void router.push({ name: "CmsContentBlocks" })
+        // Surface the API's message when it has one: with delegated editing this route relies on
+        // server-side 403s, and "not found" would mislead a user whose edit access was revoked.
+        $q.notify({ type: "negative", message: res.errors?.[0] ?? "Content block not found" })
+        // Managers fall back to the block list; delegated editors can't reach it, so send them home.
+        void router.push({ name: canManage.value ? "CmsContentBlocks" : "CmsHome" })
         return
     }
-    block.value = res.result
+    // editPermissions is manager-only in the UI but always defaulted so the Edit access selector and
+    // the save payload never bind to undefined.
+    block.value = { ...res.result, editPermissions: res.result.editPermissions ?? [] }
     autoEnabledPublicAccess.value = false
     setInitialState()
     await loadHistory()
@@ -516,12 +587,17 @@ async function searchFiles(val: string, update: (fn: () => void) => void) {
         return
     }
     searchingFiles.value = true
-    const params = createUrlSearchParams({ search: val.trim(), status: "active", perPage: 15 })
-    const res = await get(filesApiURL + "?" + params)
+    // attachable-files returns the files the current user may attach to this block, scoped by the
+    // block id in edit mode (omitted while creating). A delegated editor can reach this endpoint.
+    const params = createUrlSearchParams({
+        search: val.trim(),
+        contentBlockId: isNew.value ? undefined : block.value.contentBlockId,
+    })
+    const res = await get(apiURL + "/attachable-files?" + params)
     searchingFiles.value = false
     update(() => {
         const attachedGuids = new Set(block.value.files.map((f) => f.fileGuid))
-        fileOptions.value = res.success ? res.result.filter((f: CmsFile) => !attachedGuids.has(f.fileGuid)) : []
+        fileOptions.value = res.success ? res.result.filter((f: AttachableFile) => !attachedGuids.has(f.fileGuid)) : []
     })
 }
 
@@ -530,7 +606,8 @@ function attachFile() {
     block.value.files.push({
         fileGuid: fileToAttach.value.fileGuid,
         friendlyName: fileToAttach.value.friendlyName,
-        url: fileToAttach.value.friendlyUrl,
+        // attachable-files omits the URL; the block's own GET repopulates it on the next reload after save.
+        url: "",
     })
     fileToAttach.value = null
 }
@@ -579,7 +656,7 @@ async function rollbackFiles(createdGuids: string[]) {
     if (createdGuids.length === 0) return
     for (const guid of createdGuids) {
         try {
-            await del(filesApiURL + guid)
+            await del(fileRollbackBase.value + guid)
         } catch {
             // Best-effort cleanup: a failed delete must not abort the remaining rollbacks or throw
             // past the caller, which would mask the real save/conflict outcome (matches InlineFileUpload.commit).
@@ -612,8 +689,19 @@ function buildSavePayload() {
         friendlyName: block.value.friendlyName || null,
         allowPublicAccess: block.value.allowPublicAccess,
         permissions: block.value.permissions,
+        editPermissions: block.value.editPermissions,
         fileGuids: block.value.files.map((f) => f.fileGuid),
         lastModifiedOn: isNew.value ? null : block.value.modifiedOn,
+    }
+}
+
+// Content-only save used by delegated editors: just the content and the current attachment set,
+// with the same concurrency stamp and 409 semantics as the full save.
+function buildContentPayload() {
+    return {
+        content: block.value.content,
+        lastModifiedOn: block.value.modifiedOn,
+        fileGuids: block.value.files.map((f) => f.fileGuid),
     }
 }
 
@@ -635,14 +723,32 @@ async function handleSaveConflict(res: { errors: string[] | null }, rollbackGuid
     })
 }
 
-function applySaveSuccess(res: { result: CmsContentBlock }) {
-    const title = res.result.title
+function applySaveSuccess(res: { result: CmsContentBlock | null }) {
+    // The manager save echoes the saved block back; the delegated content PATCH may return no body,
+    // so name the block from what is already on screen.
+    const title = res.result?.title ?? block.value.title
     $q.notify({ type: "positive", message: isNew.value ? `Created "${title}"` : `Saved "${title}"` })
-    // Adopt the saved server state and clear the dirty baseline so the unsaved-changes guard stays
-    // quiet, then return to the listing (the conventional post-save destination for this form).
-    block.value = res.result
+    viewingVersion.value = false
+    selectedHistory.value = null
+    autoEnabledPublicAccess.value = false
+    if (res.result) {
+        block.value = { ...res.result, editPermissions: res.result.editPermissions ?? [] }
+    }
+    // Clear the dirty baseline (the editor now holds exactly what was saved) so the unsaved-changes
+    // guard stays quiet on the way out, then leave for wherever this editor came from: managers get
+    // the listing, delegated editors can't reach it and go home (same split as loadBlock's fallback).
     resetDirtyState()
-    void router.push({ name: "CmsContentBlocks" })
+    void router.push({ name: canManage.value ? "CmsContentBlocks" : "CmsHome" })
+}
+
+// Managers (and creators) save the whole block; delegated editors PATCH content + files only.
+function submitBlock() {
+    if (!canManage.value) {
+        return patch(apiURL + "/" + block.value.contentBlockId + "/content", buildContentPayload())
+    }
+    return isNew.value
+        ? post(apiURL, buildSavePayload())
+        : put(apiURL + "/" + block.value.contentBlockId, buildSavePayload())
 }
 
 async function saveBlock() {
@@ -658,10 +764,7 @@ async function saveBlock() {
         return
     }
 
-    const payload = buildSavePayload()
-    const res = isNew.value
-        ? await post(apiURL, payload)
-        : await put(apiURL + "/" + block.value.contentBlockId, payload)
+    const res = await submitBlock()
     saving.value = false
 
     if (res.status === 409) {
@@ -702,5 +805,21 @@ onMounted(() => {
 .required-field :deep(.q-field__label)::after {
     content: " *";
     color: var(--q-negative);
+}
+
+/* Read-only settings summary for delegated editors: small muted labels over plain values. */
+.settings-summary dt {
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    color: var(--ucdavis-black-60);
+}
+
+.settings-summary dd {
+    margin: 0 0 0.5rem;
+}
+
+.settings-summary dd:last-child {
+    margin-bottom: 0;
 }
 </style>

--- a/VueApp/src/CMS/pages/LeftNavEdit.vue
+++ b/VueApp/src/CMS/pages/LeftNavEdit.vue
@@ -96,6 +96,10 @@
                             />
                         </div>
 
+                        <p class="text-body2 text-grey-8 q-mt-none q-mb-sm">
+                            Users need any one of an item's "Visible to" permissions to see it.
+                        </p>
+
                         <SortableList
                             v-model="items"
                             item-key="key"
@@ -139,6 +143,7 @@
                                         <PermissionSelector
                                             v-model="item.permissions"
                                             label="Visible to"
+                                            :hint="null"
                                         />
                                     </div>
                                 </div>

--- a/VueApp/src/CMS/router/routes.ts
+++ b/VueApp/src/CMS/router/routes.ts
@@ -1,6 +1,6 @@
 import ViperLayout from "@/layouts/ViperLayout.vue"
-import type { RouteLocationNormalized } from "vue-router"
 import { checkHasOnePermission } from "@/composables/CheckPagePermission"
+import type { RouteLocationNormalized } from "vue-router"
 
 // Granular CMS permissions that grant the Home hub. The hub adapts to whichever of these the user
 // holds, and CmsNavMenu links it for any of them, so the Home route guard and the area-root
@@ -76,15 +76,28 @@ const routes = [
     {
         path: "/CMS/ManageContentBlocks/Edit/:id?",
         name: "CmsContentBlockEdit",
-        // CreateContentBlock-only users may create via this route (no id);
-        // editing an existing block requires ManageContentBlocks, matching
-        // the API, which gates GET/PUT of existing blocks the same way.
+        // Deliberately no meta.permissions: managers, CreateContentBlock holders, and delegated
+        // editors (who hold one of a block's edit permissions but NO CMS-prefixed permission) all
+        // use this route, and the store only loads SVMSecure.CMS-prefixed permissions - so any
+        // permission gate here would lock out delegates (a plain "SVMSecure" entry never loads).
+        // requireLogin still forces an authenticated session, the server 403s the block's
+        // GET/PUT/PATCH for anyone who may neither manage nor edit it, and the page adapts to the
+        // user's capability (full editor vs. content-only).
         meta: {
             layout: ViperLayout,
-            permissions: ["SVMSecure.CMS.ManageContentBlocks", "SVMSecure.CMS.CreateContentBlock"],
         },
-        beforeEnter: (to: RouteLocationNormalized) =>
-            !to.params.id || checkHasOnePermission(["SVMSecure.CMS.ManageContentBlocks"]) ? true : { name: "CmsAuth" },
+        // Edit mode (an id in the path) stays open to delegated editors — the server enforces
+        // per-block access. Create mode (no id) has no per-block delegation to fall back on, so gate it
+        // to users who can actually create a block; otherwise the Add form is a guaranteed-forbidden
+        // save (PATCH /content/0/content → 403) for a non-creator who lands on it.
+        beforeEnter: (to: RouteLocationNormalized) => {
+            if (to.params.id) {
+                return true
+            }
+            return checkHasOnePermission(["SVMSecure.CMS.CreateContentBlock", "SVMSecure.CMS.ManageContentBlocks"])
+                ? true
+                : { name: "CmsHome" }
+        },
         component: () => import("@/CMS/pages/ContentBlockEdit.vue"),
     },
     {

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -61,6 +61,10 @@ type CmsContentBlock = {
     modifiedBy: string
     deletedOn: string | null
     permissions: string[]
+    // Holders of any of these permissions may edit this block's content and files (but not its
+    // settings) even without ManageContentBlocks. Managers manage this list; delegated editors
+    // receive it but never see it in the UI.
+    editPermissions: string[]
     files: CmsContentBlockFile[]
 }
 
@@ -68,6 +72,25 @@ type CmsContentBlockFile = {
     fileGuid: string
     friendlyName: string
     url: string
+}
+
+// A block the current user may edit via delegation (GET /api/CMS/content/editable). It carries just
+// enough to render the hub's "Blocks you can edit" list and link to the editor.
+type EditableBlock = {
+    contentBlockId: number
+    title: string | null
+    friendlyName: string | null
+    viperSectionPath: string | null
+    page: string | null
+    modifiedOn: string
+    modifiedBy: string
+}
+
+// A managed file the user may attach to a block, from GET /api/CMS/content/attachable-files. Deliberately
+// slimmer than CmsFile: the search only needs the GUID to attach and a name to display.
+type AttachableFile = {
+    fileGuid: string
+    friendlyName: string
 }
 
 type CmsContentHistoryItem = {
@@ -202,6 +225,8 @@ export type {
     ContentBlock,
     CmsContentBlock,
     CmsContentBlockFile,
+    EditableBlock,
+    AttachableFile,
     CmsContentHistoryItem,
     CmsLeftNavMenu,
     CmsLeftNavItem,

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using NSubstitute.ExceptionExtensions;
@@ -29,6 +30,7 @@ namespace Viper.test.CMS;
 public sealed class CMSContentControllerTests : IDisposable
 {
     private readonly ICmsContentBlockService _blockService;
+    private readonly ICmsFileService _fileService;
     private readonly ICmsFileStorageService _storage;
     private readonly IUserHelper _userHelper;
     private readonly VIPERContext _context;
@@ -38,15 +40,23 @@ public sealed class CMSContentControllerTests : IDisposable
     public CMSContentControllerTests()
     {
         _blockService = Substitute.For<ICmsContentBlockService>();
+        _fileService = Substitute.For<ICmsFileService>();
         _storage = Substitute.For<ICmsFileStorageService>();
         _userHelper = Substitute.For<IUserHelper>();
         var sanitizer = Substitute.For<IHtmlSanitizerService>();
+        var logger = Substitute.For<ILogger<CMSContentController>>();
         _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
             .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
         _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
             .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
 
-        _controller = new CMSContentController(_context, _rapsContext, sanitizer, _blockService, _storage, _userHelper);
+        // The content/history/PATCH endpoints now gate on CanEditAsync; default it open so the
+        // existing passthrough tests exercise the mapping. Tests that assert the 403 path override
+        // it for their block id.
+        _blockService.CanEditAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        _controller = new CMSContentController(_context, _rapsContext, sanitizer, _blockService, _fileService,
+            _storage, _userHelper, logger);
         SetupControllerContext();
     }
 
@@ -139,11 +149,27 @@ public sealed class CMSContentControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task GetContentBlock_ReturnsNotFound_WhenMissing()
+    public async Task GetContentBlock_ReturnsNotFound_WhenBlockDoesNotExist()
     {
-        _blockService.GetContentBlockAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
+        // A genuinely missing block: not editable AND no section-path row, so 404 (not 403), and the
+        // full block is never loaded on this path.
+        _blockService.CanEditAsync(999, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(999, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
 
         var result = await _controller.GetContentBlock(999, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _blockService.DidNotReceive().GetContentBlockAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetContentBlock_ReturnsNotFound_WhenBlockNullAfterAuthPasses()
+    {
+        // Defensive race guard: CanEditAsync passed but the block is gone by the time we load it,
+        // so 404 rather than a null 200.
+        _blockService.GetContentBlockAsync(5, Arg.Any<CancellationToken>()).ReturnsNull();
+
+        var result = await _controller.GetContentBlock(5, TestContext.Current.CancellationToken);
 
         Assert.IsType<NotFoundResult>(result.Result);
     }
@@ -209,6 +235,9 @@ public sealed class CMSContentControllerTests : IDisposable
         // permission names, or placement fields (PublicContentBlockDto, not ContentBlockDto).
         Assert.DoesNotContain("modifiedBy", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("permissions", json, StringComparison.OrdinalIgnoreCase);
+        // "permissions" DoesNotContain already covers "editPermissions", but assert it explicitly:
+        // the public DTO must never disclose a block's delegated-editor permission list.
+        Assert.DoesNotContain("editPermissions", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("\"system\"", json, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("viperSectionPath", json, StringComparison.OrdinalIgnoreCase);
     }
@@ -308,23 +337,25 @@ public sealed class CMSContentControllerTests : IDisposable
     [Fact]
     public async Task UpdateContentOnly_ReturnsBlock_OnSuccess()
     {
-        var update = new ContentOnlyUpdate { Content = "<p>quick</p>", LastModifiedOn = DateTime.Now };
-        _blockService.UpdateContentOnlyAsync(4, update.Content, update.LastModifiedOn, Arg.Any<CancellationToken>())
-            .Returns(Block(4));
+        var fileGuids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var update = new ContentOnlyUpdate { Content = "<p>quick</p>", LastModifiedOn = DateTime.Now, FileGuids = fileGuids };
+        // Match the exact GUID collection so the test fails if the controller drops or replaces it.
+        _blockService.UpdateContentOnlyAsync(4, update.Content, update.LastModifiedOn,
+            Arg.Is<List<Guid>?>(g => g != null && g.SequenceEqual(fileGuids)), Arg.Any<CancellationToken>()).Returns(Block(4));
 
         var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
         await _blockService.Received(1).UpdateContentOnlyAsync(4, update.Content, update.LastModifiedOn,
-            Arg.Any<CancellationToken>());
+            Arg.Is<List<Guid>?>(g => g != null && g.SequenceEqual(fileGuids)), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task UpdateContentOnly_ReturnsConflict_OnConcurrencyException()
     {
         var update = new ContentOnlyUpdate { Content = "<p>quick</p>", LastModifiedOn = DateTime.Now };
-        _blockService.UpdateContentOnlyAsync(4, update.Content, update.LastModifiedOn, Arg.Any<CancellationToken>())
-            .Throws(new CmsConcurrencyException("stale"));
+        _blockService.UpdateContentOnlyAsync(4, update.Content, update.LastModifiedOn, Arg.Any<List<Guid>?>(),
+            Arg.Any<CancellationToken>()).Throws(new CmsConcurrencyException("stale"));
 
         var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
 
@@ -428,6 +459,106 @@ public sealed class CMSContentControllerTests : IDisposable
             Arg.Any<CancellationToken>());
     }
 
+    // Denial coverage for the history endpoints: CanEditAsync defaults to true in setup, so without
+    // these a removed gate would go unnoticed. Each asserts 403 (block exists) / 404 (block missing)
+    // and that the underlying history service method is never reached.
+    [Fact]
+    public async Task GetHistory_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.GetHistory(5, TestContext.Current.CancellationToken);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        await _blockService.DidNotReceive().GetHistoryAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHistory_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.GetHistory(5, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _blockService.DidNotReceive().GetHistoryAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHistoryVersion_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.GetHistoryVersion(5, 12, TestContext.Current.CancellationToken);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        await _blockService.DidNotReceive().GetHistoryVersionAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHistoryVersion_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.GetHistoryVersion(5, 12, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _blockService.DidNotReceive().GetHistoryVersionAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHistoryVersionDiff_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.GetHistoryVersionDiff(5, 12, TestContext.Current.CancellationToken);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        await _blockService.DidNotReceive().GetHistoryVersionDiffAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHistoryVersionDiff_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.GetHistoryVersionDiff(5, 12, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _blockService.DidNotReceive().GetHistoryVersionDiffAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiffAgainstHistoryVersion_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        var request = new DiffAgainstHistoryRequest { Content = "<p>draft</p>" };
+
+        var result = await _controller.DiffAgainstHistoryVersion(5, 12, request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        await _blockService.DidNotReceive().DiffContentAgainstHistoryAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiffAgainstHistoryVersion_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        var request = new DiffAgainstHistoryRequest { Content = "<p>draft</p>" };
+
+        var result = await _controller.DiffAgainstHistoryVersion(5, 12, request, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
     [Fact]
     public async Task DiffAgainstHistoryVersion_ReturnsNotFound_WhenNull()
     {
@@ -499,6 +630,312 @@ public sealed class CMSContentControllerTests : IDisposable
 
         Assert.IsType<NoContentResult>(result);
         await _blockService.Received(1).PermanentlyDeleteAsync(5, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Delegated editing gates + content-scoped file ops
+
+    private static IFormFile FakeFormFile(string name, byte[]? bytes = null)
+    {
+        bytes ??= new byte[] { 1, 2, 3 };
+        return new FormFile(new MemoryStream(bytes), 0, bytes.Length, "file", name);
+    }
+
+    [Fact]
+    public async Task GetContentBlock_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        // Block exists (section-path row present) but the user may not edit it -> 403, not 404.
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.GetContentBlock(5, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _blockService.DidNotReceive().GetContentBlockAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_Returns403_WhenCannotEdit()
+    {
+        _blockService.CanEditAsync(4, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        var update = new ContentOnlyUpdate { Content = "<p>x</p>", LastModifiedOn = DateTime.Now };
+
+        var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _blockService.DidNotReceive().UpdateContentOnlyAsync(Arg.Any<int>(), Arg.Any<string>(),
+            Arg.Any<DateTime?>(), Arg.Any<List<Guid>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(4, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        var update = new ContentOnlyUpdate { Content = "<p>x</p>", LastModifiedOn = DateTime.Now };
+
+        var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetEditableBlocks_PassesThrough()
+    {
+        var blocks = new List<ContentBlockDto> { Block() };
+        _blockService.GetEditableBlocksAsync(Arg.Any<CancellationToken>()).Returns(blocks);
+
+        var result = await _controller.GetEditableBlocks(TestContext.Current.CancellationToken);
+
+        Assert.Same(blocks, result.Value);
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_EditMode_Returns403_WhenCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.SearchAttachableFiles("report", 5, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _blockService.DidNotReceive().SearchAttachableFilesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_EditMode_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.SearchAttachableFiles("report", 5, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _blockService.DidNotReceive().SearchAttachableFilesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_CreateMode_Returns403_WithoutCreateOrManage()
+    {
+        var user = new AaudUser { AaudUserId = 1, LoginId = "u" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks).Returns(false);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.CreateContentBlock).Returns(false);
+
+        var result = await _controller.SearchAttachableFiles("report", null, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_CreateMode_AllowsCreator()
+    {
+        var user = new AaudUser { AaudUserId = 1, LoginId = "u" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks).Returns(false);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.CreateContentBlock).Returns(true);
+        var files = new List<CmsAttachableFileDto> { new() { FriendlyName = "x" } };
+        _blockService.SearchAttachableFilesAsync("report", Arg.Any<CancellationToken>()).Returns(files);
+
+        var result = await _controller.SearchAttachableFiles("report", null, TestContext.Current.CancellationToken);
+
+        Assert.Same(files, result.Value);
+    }
+
+    [Fact]
+    public async Task CheckBlockFileName_ReturnsBadRequest_WhenBlockHasNoSectionPath()
+    {
+        // Matches UploadBlockFile: the block exists but is not configured for uploads.
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CheckBlockFileName_ReturnsNotFound_WhenBlockMissing()
+    {
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CheckBlockFileName_Returns403_WhenExistsButCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        await _fileService.DidNotReceive().CheckNameAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadBlockFile_BuildsRequestFromBlock()
+    {
+        _blockService.GetContentBlockAsync(5, Arg.Any<CancellationToken>()).Returns(new ContentBlockDto
+        {
+            ContentBlockId = 5,
+            ViperSectionPath = "students",
+            AllowPublicAccess = true,
+            Permissions = new List<string> { "SVMSecure.View" }
+        });
+        _fileService.CreateFileAsync(Arg.Any<CmsFileCreateRequest>(), Arg.Any<IFormFile>(), Arg.Any<CancellationToken>())
+            .Returns(new CmsFileDto());
+        var file = FakeFormFile("doc.pdf");
+        var form = new ContentBlockFileUpload { FileName = "renamed.pdf", Overwrite = true };
+
+        var result = await _controller.UploadBlockFile(5, form, file, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Value);
+        // The folder, public flag, and permissions are taken from the block; only name/overwrite
+        // come from the client.
+        await _fileService.Received(1).CreateFileAsync(
+            Arg.Is<CmsFileCreateRequest>(r => r.Folder == "students" && r.AllowPublicAccess == true
+                && r.Permissions.Contains("SVMSecure.View") && r.FileName == "renamed.pdf" && r.Overwrite == true),
+            file, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadBlockFile_RefusesUpload_WhenBlockHasNoSectionPath()
+    {
+        // Mirrors CheckBlockFileName: without a section path there is no upload folder, and the
+        // request must not fall back to the storage root.
+        _blockService.GetContentBlockAsync(5, Arg.Any<CancellationToken>()).Returns(new ContentBlockDto
+        {
+            ContentBlockId = 5,
+            ViperSectionPath = null
+        });
+
+        var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+        await _fileService.DidNotReceive().CreateFileAsync(Arg.Any<CmsFileCreateRequest>(), Arg.Any<IFormFile>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadBlockFile_Returns403_WhenCannotEdit()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
+            TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _fileService.DidNotReceive().CreateFileAsync(Arg.Any<CmsFileCreateRequest>(), Arg.Any<IFormFile>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadBlockFile_Returns404_WhenBlockMissing()
+    {
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
+            TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+        await _fileService.DidNotReceive().CreateFileAsync(Arg.Any<CmsFileCreateRequest>(), Arg.Any<IFormFile>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_SoftDeletes_WhenServiceReportsEligible()
+    {
+        var fileGuid = Guid.NewGuid();
+        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns(true);
+        _fileService.RollbackDeleteFileAsync(fileGuid, 5, Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NoContentResult>(result);
+        // The recheck-and-delete go through the single rollback method, not a bare SoftDeleteFileAsync.
+        await _fileService.Received(1).RollbackDeleteFileAsync(fileGuid, 5, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_Returns409_WhenFileBecameSharedInWindow()
+    {
+        // Eligible at the check, but RollbackDeleteFileAsync's recheck finds it attached elsewhere now.
+        var fileGuid = Guid.NewGuid();
+        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns(true);
+        _fileService.RollbackDeleteFileAsync(fileGuid, 5, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, obj.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_Returns403_WhenServiceReportsIneligible()
+    {
+        // The service returns false for someone-else's file / another folder / attached-elsewhere.
+        var fileGuid = Guid.NewGuid();
+        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _fileService.DidNotReceive().RollbackDeleteFileAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_Returns404_WhenFileMissing()
+    {
+        var fileGuid = Guid.NewGuid();
+        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns((bool?)null);
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result);
+        await _fileService.DidNotReceive().RollbackDeleteFileAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_Returns403_WhenCannotEdit()
+    {
+        var fileGuid = Guid.NewGuid();
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _blockService.DidNotReceive().IsFileRollbackDeletableAsync(Arg.Any<int>(), Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteBlockFile_Returns404_WhenBlockMissing()
+    {
+        var fileGuid = Guid.NewGuid();
+        _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+
+        var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result);
+        await _blockService.DidNotReceive().IsFileRollbackDeletableAsync(Arg.Any<int>(), Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -784,13 +784,8 @@ public sealed class CMSContentControllerTests : IDisposable
     [Fact]
     public async Task UploadBlockFile_BuildsRequestFromBlock()
     {
-        _blockService.GetContentBlockAsync(5, Arg.Any<CancellationToken>()).Returns(new ContentBlockDto
-        {
-            ContentBlockId = 5,
-            ViperSectionPath = "students",
-            AllowPublicAccess = true,
-            Permissions = new List<string> { "SVMSecure.View" }
-        });
+        _blockService.GetUploadSettingsAsync(5, Arg.Any<CancellationToken>())
+            .Returns((true, "students", true, new List<string> { "SVMSecure.View" }));
         _fileService.CreateFileAsync(Arg.Any<CmsFileCreateRequest>(), Arg.Any<IFormFile>(), Arg.Any<CancellationToken>())
             .Returns(new CmsFileDto());
         var file = FakeFormFile("doc.pdf");
@@ -812,11 +807,8 @@ public sealed class CMSContentControllerTests : IDisposable
     {
         // Mirrors CheckBlockFileName: without a section path there is no upload folder, and the
         // request must not fall back to the storage root.
-        _blockService.GetContentBlockAsync(5, Arg.Any<CancellationToken>()).Returns(new ContentBlockDto
-        {
-            ContentBlockId = 5,
-            ViperSectionPath = null
-        });
+        _blockService.GetUploadSettingsAsync(5, Arg.Any<CancellationToken>())
+            .Returns((true, (string?)null, false, new List<string>()));
 
         var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
             TestContext.Current.CancellationToken);

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -573,8 +573,16 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks).Returns(isManager);
         _userHelper.HasPermission(_rapsContext, user, "SVMSecure")
             .Returns(permissions.Contains("SVMSecure"));
+        // Mirrors the real UserHelper: HasPermission is derived from GetAllPermissions, so a
+        // manager's set must actually contain the permission for CanEditAsync's single-resolve
+        // HashSet check to see it.
+        var allPermissions = permissions.ToList();
+        if (isManager)
+        {
+            allPermissions.Add(CmsPermissions.ManageContentBlocks);
+        }
         _userHelper.GetAllPermissions(_rapsContext, user)
-            .Returns(permissions.Select(p => new TblPermission { Permission = p }).ToList());
+            .Returns(allPermissions.Select(p => new TblPermission { Permission = p }).ToList());
     }
 
     private async Task<Models.VIPER.File> SeedFileAsync(string friendlyName, string folder = "cats",
@@ -1079,6 +1087,20 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         var file = await SeedFileAsync("cats-x.pdf", folder: "cats", modifiedBy: "delegate");
         _context.ContentBlockToFiles.Add(new ContentBlockToFile { ContentBlockId = other.ContentBlockId, FileGuid = file.FileGuid });
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_False_WhenAlreadyDeleted()
+    {
+        var block = await SeedBlockAsync(); // cats
+        var file = await SeedFileAsync("cats-x.pdf", folder: "cats", modifiedBy: "delegate",
+            customize: f => f.DeletedOn = DateTime.Now);
         _userHelper.GetCurrentUser().Returns(DelegateUser());
 
         var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -1,8 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
 using Viper.Areas.CMS.Services;
 using Viper.Classes.SQLContext;
+using Viper.Models.AAUD;
+using Viper.Models.RAPS;
 using Viper.Models.VIPER;
 using Viper.Services;
 
@@ -16,24 +19,30 @@ namespace Viper.test.CMS;
 public sealed class CmsContentBlockServiceTests : IDisposable
 {
     private readonly VIPERContext _context;
+    private readonly RAPSContext _rapsContext;
     private readonly IHtmlSanitizerService _sanitizer;
+    private readonly IUserHelper _userHelper;
     private readonly CmsContentBlockService _service;
 
     public CmsContentBlockServiceTests()
     {
         _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
             .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
+        _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
+            .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
         _sanitizer = Substitute.For<IHtmlSanitizerService>();
         _sanitizer.Sanitize(Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
         // Pass-through so diff tests assert on the real htmldiff.net markers, not a sanitized copy.
         _sanitizer.SanitizeDiff(Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+        _userHelper = Substitute.For<IUserHelper>();
 
-        _service = new CmsContentBlockService(_context, _sanitizer, Substitute.For<IUserHelper>());
+        _service = new CmsContentBlockService(_context, _rapsContext, _sanitizer, _userHelper);
     }
 
     public void Dispose()
     {
         _context.Dispose();
+        _rapsContext.Dispose();
     }
 
     private async Task<ContentBlock> SeedBlockAsync(Action<ContentBlock>? customize = null)
@@ -298,7 +307,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         var block = await SeedBlockAsync();
 
         var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>quick edit</p>", block.ModifiedOn,
-            TestContext.Current.CancellationToken);
+            ct: TestContext.Current.CancellationToken);
 
         Assert.Equal("<p>quick edit</p>", dto!.Content);
         Assert.Equal("Seeded Block", dto.Title);
@@ -348,8 +357,8 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task History_ListAndVersionRetrieval()
     {
         var block = await SeedBlockAsync();
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v3</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v3</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
 
         var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
         Assert.Equal(2, history.Count);
@@ -462,8 +471,8 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task GetHistoryVersionDiff_AgainstPreviousVersion_MarksChangesAndReSanitizes()
     {
         var block = await SeedBlockAsync();
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v3</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v3</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
 
         // History newest-first is [v2, original]; v2 has a predecessor (original) to diff against.
         var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
@@ -487,7 +496,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task GetHistoryVersionDiff_OriginalVersion_HasNoComparison()
     {
         var block = await SeedBlockAsync();
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
 
         var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
         var original = history[^1];
@@ -516,7 +525,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task DiffContentAgainstHistory_ComparesDraftToSelectedVersion()
     {
         var block = await SeedBlockAsync();
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
 
         var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
         var original = history[^1];
@@ -536,7 +545,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task DiffContentAgainstHistory_IdenticalContent_ReportsNoChanges()
     {
         var block = await SeedBlockAsync();
-        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, TestContext.Current.CancellationToken);
+        await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>v2</p>", block.ModifiedOn, ct: TestContext.Current.CancellationToken);
 
         var history = await _service.GetHistoryAsync(block.ContentBlockId, TestContext.Current.CancellationToken);
         var original = history[^1]; // holds "<p>original</p>"
@@ -550,6 +559,544 @@ public sealed class CmsContentBlockServiceTests : IDisposable
         Assert.False(diff.HasChanges);
         Assert.DoesNotContain("<ins", diff.Content);
         Assert.DoesNotContain("<del", diff.Content);
+    }
+
+    #endregion
+
+    #region Delegated edit authorization (CanEditAsync)
+
+    private static AaudUser DelegateUser() => new() { AaudUserId = 10, LoginId = "delegate", MothraId = "m10" };
+
+    private void SignInAs(AaudUser user, bool isManager, params string[] permissions)
+    {
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks).Returns(isManager);
+        _userHelper.HasPermission(_rapsContext, user, "SVMSecure")
+            .Returns(permissions.Contains("SVMSecure"));
+        _userHelper.GetAllPermissions(_rapsContext, user)
+            .Returns(permissions.Select(p => new TblPermission { Permission = p }).ToList());
+    }
+
+    private async Task<Models.VIPER.File> SeedFileAsync(string friendlyName, string folder = "cats",
+        string modifiedBy = "test", Action<Models.VIPER.File>? customize = null)
+    {
+        var file = new Models.VIPER.File
+        {
+            FileGuid = Guid.NewGuid(),
+            FilePath = $@"C:\FakeRoot\{folder}\{friendlyName}",
+            Folder = folder,
+            FriendlyName = friendlyName,
+            Description = "",
+            ModifiedBy = modifiedBy,
+            ModifiedOn = DateTime.Now
+        };
+        customize?.Invoke(file);
+        _context.Files.Add(file);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return file;
+    }
+
+    [Fact]
+    public async Task CanEdit_Manager_CanEditAnyBlock()
+    {
+        // Manager holds no edit permission and the block delegates none, yet manage overrides.
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: true);
+
+        Assert.True(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_HolderOfEditPermission_CanEdit()
+    {
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Editors");
+
+        Assert.True(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_HolderOfViewPermissionOnly_CannotEdit()
+    {
+        var block = await SeedBlockAsync(b =>
+        {
+            b.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = "SVMSecure.Viewers" });
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" });
+        });
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Viewers");
+
+        Assert.False(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_Anonymous_CannotEdit()
+    {
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
+        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+
+        Assert.False(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_EmptyEditList_IsManagerOnly()
+    {
+        // Empty edit list means manager-only, NOT the view-list's empty-means-all-SVMSecure rule.
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Editors");
+
+        Assert.False(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_SoftDeletedBlock_NotEditableByDelegate()
+    {
+        var block = await SeedBlockAsync(b =>
+        {
+            b.DeletedOn = DateTime.Now;
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" });
+        });
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Editors");
+
+        Assert.False(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_MatchIsCaseInsensitive()
+    {
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
+        SignInAs(DelegateUser(), isManager: false, "svmsecure.editors");
+
+        Assert.True(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CanEdit_MissingBlock_ReturnsFalseEvenForManager()
+    {
+        SignInAs(DelegateUser(), isManager: true);
+
+        Assert.False(await _service.CanEditAsync(999999, TestContext.Current.CancellationToken));
+    }
+
+    #endregion
+
+    #region Content-only update: file deltas + edit permissions
+
+    [Fact]
+    public async Task UpdateContentOnly_WithFileGuids_ReplacesAttachments()
+    {
+        var keep = await SeedFileAsync("keep.pdf");
+        var add = await SeedFileAsync("add.pdf");
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = keep.FileGuid }));
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            new List<Guid> { add.FileGuid }, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        var file = Assert.Single(dto.Files);
+        Assert.Equal("add.pdf", file.FriendlyName);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_WithUnknownFileGuid_Throws()
+    {
+        var block = await SeedBlockAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.UpdateContentOnlyAsync(
+            block.ContentBlockId, "<p>edit</p>", block.ModifiedOn, new List<Guid> { Guid.NewGuid() },
+            TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_WithFileGuids_LeavesSettingsUntouched()
+    {
+        var file = await SeedFileAsync("cats-attach.pdf");
+        var block = await SeedBlockAsync(b =>
+        {
+            b.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = "SVMSecure.Viewers" });
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" });
+        });
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            new List<Guid> { file.FileGuid }, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        // The content-only path never touches title/system/permission fields.
+        Assert.Equal("Seeded Block", dto.Title);
+        Assert.Equal("Viper", dto.System);
+        Assert.Equal(new List<string> { "SVMSecure.Viewers" }, dto.Permissions);
+        Assert.Equal(new List<string> { "SVMSecure.Editors" }, dto.EditPermissions);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_WithoutFileGuids_LeavesAttachmentsAlone()
+    {
+        var file = await SeedFileAsync("cats-attach.pdf");
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = file.FileGuid }));
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            ct: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        var attached = Assert.Single(dto.Files);
+        Assert.Equal("cats-attach.pdf", attached.FriendlyName);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_RejectsAttachingFileTheUserCannotDownload()
+    {
+        // A delegate who guesses a restricted file's GUID must not be able to attach it (the
+        // attachment list would leak its name); same rules as the attachable-files search.
+        var restricted = await SeedFileAsync("restricted.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" }));
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.UpdateContentOnlyAsync(
+            block.ContentBlockId, "<p>edit</p>", block.ModifiedOn, new List<Guid> { restricted.FileGuid },
+            TestContext.Current.CancellationToken));
+        Assert.Empty(_context.ContentBlockToFiles.Where(f => f.ContentBlockId == block.ContentBlockId));
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_AllowsAttachingFileTheDelegateUploaded()
+    {
+        // An inline upload inherits the block's VIEW permission, which a delegate need not hold; they
+        // must still be able to attach the file they just uploaded (ModifiedBy = the delegate) INTO
+        // this block's folder ("cats" for both the seeded block and file), even though its permission
+        // would otherwise fail the download-access check.
+        var uploaded = await SeedFileAsync("uploaded.pdf", folder: "cats", modifiedBy: "delegate", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" }));
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            new List<Guid> { uploaded.FileGuid }, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        var attached = Assert.Single(dto.Files);
+        Assert.Equal("uploaded.pdf", attached.FriendlyName);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_RejectsAttachingUploadedFileFromAnotherFolder()
+    {
+        // The uploader exception is scoped to the block's own folder: a delegate cannot take a
+        // restricted file they uploaded for a different section ("faculty") and attach it to a block
+        // in another section ("cats"), which would leak the file's name/URL through the target block's
+        // attachment list. Mirrors the folder scope on the rollback-delete rule.
+        var uploaded = await SeedFileAsync("faculty-secret.pdf", folder: "faculty", modifiedBy: "delegate",
+            customize: f => f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" }));
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.UpdateContentOnlyAsync(
+            block.ContentBlockId, "<p>edit</p>", block.ModifiedOn, new List<Guid> { uploaded.FileGuid },
+            TestContext.Current.CancellationToken));
+        Assert.Empty(_context.ContentBlockToFiles.Where(f => f.ContentBlockId == block.ContentBlockId));
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_RejectsAttachingDeletedFile()
+    {
+        // The search filters deleted files out; attaching one by a known GUID would resurrect
+        // it into an active block, so the attach guard treats deleted as not attachable.
+        var deleted = await SeedFileAsync("deleted.pdf", customize: f => f.DeletedOn = DateTime.Now);
+        var block = await SeedBlockAsync();
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _service.UpdateContentOnlyAsync(
+            block.ContentBlockId, "<p>edit</p>", block.ModifiedOn, new List<Guid> { deleted.FileGuid },
+            TestContext.Current.CancellationToken));
+        Assert.Empty(_context.ContentBlockToFiles.Where(f => f.ContentBlockId == block.ContentBlockId));
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_KeepsExistingRestrictedAttachment()
+    {
+        // A restricted file a manager already attached must not fail the delegate's save when
+        // the client resends the unchanged attachment set.
+        var restricted = await SeedFileAsync("restricted.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" }));
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = restricted.FileGuid }));
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var dto = await _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            new List<Guid> { restricted.FileGuid }, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(dto);
+        var kept = Assert.Single(dto.Files);
+        Assert.Equal("restricted.pdf", kept.FriendlyName);
+    }
+
+    [Fact]
+    public async Task UpdateContentOnly_StaleLastModifiedOn_ThrowsConcurrency()
+    {
+        var block = await SeedBlockAsync();
+
+        await Assert.ThrowsAsync<CmsConcurrencyException>(() => _service.UpdateContentOnlyAsync(
+            block.ContentBlockId, "<p>edit</p>", block.ModifiedOn.AddMinutes(-5),
+            ct: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Update_AppliesEditPermissionDeltas()
+    {
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.OldEditors" }));
+        var request = MakeRequest(block, r => r.EditPermissions = new List<string> { "SVMSecure.NewEditors" });
+
+        var dto = await _service.UpdateContentBlockAsync(block.ContentBlockId, request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new List<string> { "SVMSecure.NewEditors" }, dto!.EditPermissions);
+    }
+
+    [Fact]
+    public async Task CreateThenGet_RoundTripsEditPermissions()
+    {
+        var request = new CMSBlockAddEdit
+        {
+            ContentBlockId = 0,
+            Content = "<p>new</p>",
+            Title = "Delegated Block",
+            System = "Viper",
+            AllowPublicAccess = false,
+            EditPermissions = new List<string> { "SVMSecure.Editors" }
+        };
+
+        var created = await _service.CreateContentBlockAsync(request, TestContext.Current.CancellationToken);
+        // Drop the tracked graph so the fetch verifies GetContentBlockAsync actually loads the
+        // edit-permission navigation from the store, not a still-tracked instance from the create.
+        _context.ChangeTracker.Clear();
+        var fetched = await _service.GetContentBlockAsync(created.ContentBlockId, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new List<string> { "SVMSecure.Editors" }, created.EditPermissions);
+        Assert.Equal(new List<string> { "SVMSecure.Editors" }, fetched!.EditPermissions);
+    }
+
+    #endregion
+
+    #region Editable listing + attachable search
+
+    [Fact]
+    public async Task GetEditableBlocks_FiltersByIntersection_AndExcludesDeleted()
+    {
+        await SeedBlockAsync(b =>
+        {
+            b.Title = "Mine";
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" });
+        });
+        await SeedBlockAsync(b =>
+        {
+            b.Title = "NotMine";
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Others" });
+        });
+        await SeedBlockAsync(b =>
+        {
+            b.Title = "DeletedMine";
+            b.DeletedOn = DateTime.Now;
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" });
+        });
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Editors");
+
+        var blocks = await _service.GetEditableBlocksAsync(TestContext.Current.CancellationToken);
+
+        var only = Assert.Single(blocks);
+        Assert.Equal("Mine", only.Title);
+        Assert.Equal(string.Empty, only.Content);
+    }
+
+    [Fact]
+    public async Task GetEditableBlocks_Anonymous_ReturnsEmpty()
+    {
+        await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
+        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+
+        var blocks = await _service.GetEditableBlocksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(blocks);
+    }
+
+    [Fact]
+    public async Task GetEditableBlocks_Manager_ReturnsEmpty()
+    {
+        // Documented contract: delegated matches only. Managers work from the full list page,
+        // even when their own permissions happen to intersect a block's edit list.
+        await SeedBlockAsync(b =>
+            b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
+        SignInAs(DelegateUser(), isManager: true, "SVMSecure.Editors");
+
+        var blocks = await _service.GetEditableBlocksAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(blocks);
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_ShortTerm_ReturnsEmpty()
+    {
+        await SeedFileAsync("report.pdf");
+
+        var results = await _service.SearchAttachableFilesAsync("r", TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_MatchesFriendlyName_MinimalDto()
+    {
+        var file = await SeedFileAsync("annual-report.pdf");
+        await SeedFileAsync("unrelated.pdf");
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var results = await _service.SearchAttachableFilesAsync("report", TestContext.Current.CancellationToken);
+
+        var match = Assert.Single(results);
+        Assert.Equal(file.FileGuid, match.FileGuid);
+        Assert.Equal("annual-report.pdf", match.FriendlyName);
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_CapsAt25_AndExcludesDeleted()
+    {
+        // A deleted file that would sort first must still be excluded from the picker.
+        var deleted = await SeedFileAsync("aaa-match.pdf");
+        deleted.DeletedOn = DateTime.Now;
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        for (int i = 0; i < 30; i++)
+        {
+            await SeedFileAsync($"doc-{i:00}-match.pdf");
+        }
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var results = await _service.SearchAttachableFilesAsync("match", TestContext.Current.CancellationToken);
+
+        Assert.Equal(25, results.Count);
+        Assert.DoesNotContain(results, r => r.FriendlyName == "aaa-match.pdf");
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_Anonymous_ReturnsEmpty()
+    {
+        await SeedFileAsync("report-match.pdf");
+        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+
+        Assert.Empty(await _service.SearchAttachableFilesAsync("match", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SearchAttachableFiles_HidesFilesTheUserCannotDownload()
+    {
+        // The picker is reachable by delegated editors, so it must not leak names/guids of
+        // files the user could not download. Same rules as downloads: public, unrestricted
+        // (any SVMSecure user), permission match (case-insensitive), or explicit person grant.
+        await SeedFileAsync("open-match.pdf");
+        await SeedFileAsync("public-match.pdf", customize: f =>
+        {
+            f.AllowPublicAccess = true;
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" });
+        });
+        await SeedFileAsync("granted-match.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "svmsecure.editors" }));
+        await SeedFileAsync("person-match.pdf", customize: f =>
+        {
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" });
+            f.FileToPeople.Add(new FileToPerson { IamId = "iam-10" });
+        });
+        await SeedFileAsync("restricted-match.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.SchoolAdmin" }));
+        var user = DelegateUser();
+        user.IamId = "iam-10";
+        SignInAs(user, isManager: false, "SVMSecure", "SVMSecure.Editors");
+
+        var results = await _service.SearchAttachableFilesAsync("match", TestContext.Current.CancellationToken);
+
+        var names = results.Select(r => r.FriendlyName).ToList();
+        Assert.Contains("open-match.pdf", names);
+        Assert.Contains("public-match.pdf", names);
+        Assert.Contains("granted-match.pdf", names);
+        Assert.Contains("person-match.pdf", names);
+        Assert.DoesNotContain("restricted-match.pdf", names);
+    }
+
+    #endregion
+
+    #region Inline-upload rollback eligibility (IsFileRollbackDeletableAsync)
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_True_WhenUploaderSameFolderNotSharedElsewhere()
+    {
+        var block = await SeedBlockAsync(); // ViperSectionPath = "cats"
+        var file = await SeedFileAsync("cats-x.pdf", folder: "cats", modifiedBy: "delegate");
+        _context.ContentBlockToFiles.Add(new ContentBlockToFile { ContentBlockId = block.ContentBlockId, FileGuid = file.FileGuid });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_False_WhenUploadedBySomeoneElse()
+    {
+        var block = await SeedBlockAsync();
+        var file = await SeedFileAsync("cats-x.pdf", folder: "cats", modifiedBy: "someoneElse");
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_False_WhenFileInAnotherFolder()
+    {
+        var block = await SeedBlockAsync(); // cats
+        var file = await SeedFileAsync("faculty-x.pdf", folder: "faculty", modifiedBy: "delegate");
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_False_WhenAttachedToAnotherBlock()
+    {
+        var block = await SeedBlockAsync();
+        var other = await SeedBlockAsync();
+        var file = await SeedFileAsync("cats-x.pdf", folder: "cats", modifiedBy: "delegate");
+        _context.ContentBlockToFiles.Add(new ContentBlockToFile { ContentBlockId = other.ContentBlockId, FileGuid = file.FileGuid });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, file.FileGuid,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsFileRollbackDeletable_Null_WhenFileMissing()
+    {
+        var block = await SeedBlockAsync();
+        _userHelper.GetCurrentUser().Returns(DelegateUser());
+
+        var result = await _service.IsFileRollbackDeletableAsync(block.ContentBlockId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
     }
 
     #endregion

--- a/test/CMS/CmsFileServiceTests.cs
+++ b/test/CMS/CmsFileServiceTests.cs
@@ -24,7 +24,7 @@ public sealed class CmsFileServiceTests : IDisposable
     private readonly ICmsFileEncryptionService _encryption;
     private readonly ICmsFileAuditService _audit;
     private readonly IUserHelper _userHelper;
-    private readonly CmsFileService _service;
+    private readonly TestableCmsFileService _service;
     private readonly List<VIPERContext> _extraContexts = new();
     private readonly List<MemoryStream> _formFileStreams = new();
 
@@ -49,7 +49,7 @@ public sealed class CmsFileServiceTests : IDisposable
         _audit = Substitute.For<ICmsFileAuditService>();
         _userHelper = Substitute.For<IUserHelper>();
 
-        _service = new CmsFileService(_context, _aaudContext, _storage, _encryption, _audit, _userHelper,
+        _service = new TestableCmsFileService(_context, _aaudContext, _storage, _encryption, _audit, _userHelper,
             Substitute.For<ILogger<CmsFileService>>());
     }
 
@@ -755,6 +755,48 @@ public sealed class CmsFileServiceTests : IDisposable
         var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(saved.DeletedOn);
         _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+    }
+
+    [Fact]
+    public async Task RollbackDeleteFile_NotAttachedElsewhere_SoftDeletesAndAudits()
+    {
+        var file = await SeedFileAsync();
+
+        var result = await _service.RollbackDeleteFileAsync(file.FileGuid, contentBlockId: 5, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(saved.DeletedOn);
+        _audit.Received(1).Audit(Arg.Any<File>(), CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+    }
+
+    [Fact]
+    public async Task RollbackDeleteFile_AlreadyDeleted_ReturnsFalse_DoesNotReAudit()
+    {
+        var deletedOn = DateTime.Now.AddMinutes(-5);
+        var file = await SeedFileAsync(f => f.DeletedOn = deletedOn);
+
+        var result = await _service.RollbackDeleteFileAsync(file.FileGuid, contentBlockId: 5, TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(deletedOn, saved.DeletedOn);
+        _audit.DidNotReceive().Audit(Arg.Any<File>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RollbackDeleteFile_AttachedToAnotherBlock_ReturnsFalse_LeavesFileInPlace()
+    {
+        var file = await SeedFileAsync();
+        _context.ContentBlockToFiles.Add(new ContentBlockToFile { ContentBlockId = 99, FileGuid = file.FileGuid });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _service.RollbackDeleteFileAsync(file.FileGuid, contentBlockId: 5, TestContext.Current.CancellationToken);
+
+        Assert.False(result);
+        var saved = await _context.Files.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Null(saved.DeletedOn);
+        _audit.DidNotReceive().Audit(Arg.Any<File>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Fact]

--- a/test/CMS/TestableCmsFileService.cs
+++ b/test/CMS/TestableCmsFileService.cs
@@ -1,0 +1,35 @@
+using System.Data;
+using Microsoft.Extensions.Logging;
+using Viper.Areas.CMS.Services;
+using Viper.Classes.SQLContext;
+
+namespace Viper.test.CMS
+{
+    /// <summary>
+    /// Testable version of CmsFileService that bypasses transaction handling for unit tests
+    /// (the EF in-memory provider used in these tests doesn't support transactions).
+    /// </summary>
+    internal class TestableCmsFileService : CmsFileService
+    {
+        public TestableCmsFileService(
+            VIPERContext context,
+            AAUDContext aaudContext,
+            ICmsFileStorageService storage,
+            ICmsFileEncryptionService encryption,
+            ICmsFileAuditService audit,
+            IUserHelper userHelper,
+            ILogger<CmsFileService> logger)
+            : base(context, aaudContext, storage, encryption, audit, userHelper, logger)
+        {
+        }
+
+        protected override async Task<T> ExecuteInTransactionAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            IsolationLevel isolationLevel,
+            CancellationToken cancellationToken)
+        {
+            // Execute the operation directly without transaction for testing
+            return await operation(cancellationToken);
+        }
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -436,23 +436,23 @@ namespace Viper.Areas.CMS.Controllers
             {
                 return BadRequest("A file is required.");
             }
-            var block = await _blockService.GetContentBlockAsync(contentBlockId, ct);
-            if (block == null)
+            var (found, sectionPath, allowPublicAccess, permissions) = await _blockService.GetUploadSettingsAsync(contentBlockId, ct);
+            if (!found)
             {
                 return NotFound();
             }
             // The section path IS the upload folder; refuse the upload when the block has none
             // (mirrors CheckBlockFileName) rather than falling back to the storage root.
-            if (string.IsNullOrEmpty(block.ViperSectionPath))
+            if (string.IsNullOrEmpty(sectionPath))
             {
                 return BadRequest("The content block has no VIPER section path to upload into.");
             }
 
             var request = new CmsFileCreateRequest
             {
-                Folder = block.ViperSectionPath,
-                AllowPublicAccess = block.AllowPublicAccess,
-                Permissions = block.Permissions,
+                Folder = sectionPath,
+                AllowPublicAccess = allowPublicAccess,
+                Permissions = permissions,
                 FileName = form.FileName,
                 Overwrite = form.Overwrite
             };
@@ -502,7 +502,7 @@ namespace Viper.Areas.CMS.Controllers
             // deleted out from under it. A false result means it became shared/gone in that window.
             return await _fileService.RollbackDeleteFileAsync(fileGuid, contentBlockId, ct)
                 ? NoContent()
-                : Conflict("The file could not be rolled back; it may now be attached to another block.");
+                : Conflict("The file could not be rolled back; it may have been deleted already or attached to another block.");
         }
 
         private void LogFileConflict(string operation, string? folder, string? fileName, Exception ex)

--- a/web/Areas/CMS/Controllers/CMSContentController.cs
+++ b/web/Areas/CMS/Controllers/CMSContentController.cs
@@ -6,6 +6,7 @@ using Viper.Areas.CMS.Models.DTOs;
 using Viper.Areas.CMS.Services;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
+using Viper.Classes.Utilities;
 using Viper.Models;
 using Viper.Services;
 using Web.Authorization;
@@ -16,23 +17,31 @@ namespace Viper.Areas.CMS.Controllers
     [Route("/api/CMS/content")]
     public class CMSContentController : ApiController
     {
+        // Uploads through the content-scoped file endpoint match CMSFilesController's ceiling.
+        private const long MaxUploadBytes = 100_000_000;
+
         private readonly VIPERContext _context;
         private readonly RAPSContext _rapsContext;
         private readonly IHtmlSanitizerService _sanitizerService;
         private readonly ICmsContentBlockService _blockService;
+        private readonly ICmsFileService _fileService;
         private readonly ICmsFileStorageService _storage;
         private readonly IUserHelper _userHelper;
+        private readonly ILogger<CMSContentController> _logger;
 
         public CMSContentController(VIPERContext context, RAPSContext rapsContext,
             IHtmlSanitizerService sanitizerService, ICmsContentBlockService blockService,
-            ICmsFileStorageService storage, IUserHelper userHelper)
+            ICmsFileService fileService, ICmsFileStorageService storage, IUserHelper userHelper,
+            ILogger<CMSContentController> logger)
         {
             _context = context;
             _rapsContext = rapsContext;
             _sanitizerService = sanitizerService;
             _blockService = blockService;
+            _fileService = fileService;
             _storage = storage;
             _userHelper = userHelper;
+            _logger = logger;
         }
 
         //GET: content
@@ -80,14 +89,21 @@ namespace Viper.Areas.CMS.Controllers
             return _storage.GetTopLevelFolders();
         }
 
-        //GET: content/5
+        //GET: content/5 — the editor loads a single block. Widened to any SVMSecure user so
+        //delegated editors can open blocks they hold an edit permission for; CanEditAsync is the
+        //real boundary (managers always pass, delegates only for their live blocks).
         [HttpGet("{contentBlockId:int}")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<ContentBlockDto>> GetContentBlock(int contentBlockId, CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             var block = await _blockService.GetContentBlockAsync(contentBlockId, ct);
             if (block == null)
             {
+                // Guards the narrow race where the block is removed between the checks above and here.
                 return NotFound();
             }
             return block;
@@ -115,20 +131,29 @@ namespace Viper.Areas.CMS.Controllers
             return CmsContentBlockMapper.ToPublicDto(block);
         }
 
-        //GET: content/5/history
+        //GET: content/5/history — widened to editors (delegates may view/load history for their
+        //blocks); CanEditAsync gates access. The cross-block history viewer below stays manager-only.
         [HttpGet("{contentBlockId:int}/history")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<List<ContentHistoryListItemDto>>> GetHistory(int contentBlockId, CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             return await _blockService.GetHistoryAsync(contentBlockId, ct);
         }
 
         //GET: content/5/history/12
         [HttpGet("{contentBlockId:int}/history/{contentHistoryId:int}")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<ContentHistoryDto>> GetHistoryVersion(int contentBlockId, int contentHistoryId,
             CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             var version = await _blockService.GetHistoryVersionAsync(contentBlockId, contentHistoryId, ct);
             if (version == null)
             {
@@ -139,10 +164,14 @@ namespace Viper.Areas.CMS.Controllers
 
         //GET: content/5/history/12/diff — rendered diff of this version against the previous version
         [HttpGet("{contentBlockId:int}/history/{contentHistoryId:int}/diff")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<ContentHistoryDiffDto>> GetHistoryVersionDiff(int contentBlockId, int contentHistoryId,
             CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             var diff = await _blockService.GetHistoryVersionDiffAsync(contentBlockId, contentHistoryId, ct);
             if (diff == null)
             {
@@ -154,10 +183,14 @@ namespace Viper.Areas.CMS.Controllers
         //POST: content/5/history/12/diff — rendered diff of a posted draft against this version.
         //POST (not GET) because the editor's current content rides in the body.
         [HttpPost("{contentBlockId:int}/history/{contentHistoryId:int}/diff")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<ContentHistoryDiffDto>> DiffAgainstHistoryVersion(int contentBlockId, int contentHistoryId,
             DiffAgainstHistoryRequest request, CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             var diff = await _blockService.DiffContentAgainstHistoryAsync(contentBlockId, contentHistoryId, request.Content, ct);
             if (diff == null)
             {
@@ -255,15 +288,22 @@ namespace Viper.Areas.CMS.Controllers
             }
         }
 
-        //PATCH: content/5/content — quick save for content-only edits
+        //PATCH: content/5/content — quick save for content-only edits (content + optional attached
+        //files). Widened to editors; CanEditAsync is the field-whitelisting boundary — this path never
+        //maps title, placement, or permission fields, so a delegate cannot alter them here.
         [HttpPatch("{contentBlockId:int}/content")]
-        [Permission(Allow = CmsPermissions.ManageContentBlocks)]
+        [Permission(Allow = "SVMSecure")]
         public async Task<ActionResult<ContentBlockDto>> UpdateContentOnly(int contentBlockId,
             ContentOnlyUpdate update, CancellationToken ct = default)
         {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
             try
             {
-                var updated = await _blockService.UpdateContentOnlyAsync(contentBlockId, update.Content, update.LastModifiedOn, ct);
+                var updated = await _blockService.UpdateContentOnlyAsync(contentBlockId, update.Content,
+                    update.LastModifiedOn, update.FileGuids, ct);
                 if (updated == null)
                 {
                     return NotFound();
@@ -278,6 +318,41 @@ namespace Viper.Areas.CMS.Controllers
             {
                 return ValidationProblem(ex.Message);
             }
+        }
+
+        //GET: content/editable — blocks the current user may edit by delegation (their permissions
+        //intersect the block's edit list). Managers use the full list page; this returns delegated
+        //matches only. Literal segment does not collide with the int-constrained {contentBlockId} route.
+        [HttpGet("editable")]
+        [Permission(Allow = "SVMSecure")]
+        public async Task<ActionResult<List<ContentBlockDto>>> GetEditableBlocks(CancellationToken ct = default)
+        {
+            return await _blockService.GetEditableBlocksAsync(ct);
+        }
+
+        //GET: content/attachable-files?search=&contentBlockId= — attach-by-search picker for the editor.
+        //In edit mode the caller passes the block id and must be able to edit it. In create mode there
+        //is no block yet, so only block creators/managers may search the store.
+        [HttpGet("attachable-files")]
+        [Permission(Allow = "SVMSecure")]
+        public async Task<ActionResult<List<CmsAttachableFileDto>>> SearchAttachableFiles(
+            string? search, int? contentBlockId, CancellationToken ct = default)
+        {
+            if (contentBlockId == null)
+            {
+                var user = _userHelper.GetCurrentUser();
+                bool canCreate = _userHelper.HasPermission(_rapsContext, user, CmsPermissions.ManageContentBlocks)
+                    || _userHelper.HasPermission(_rapsContext, user, CmsPermissions.CreateContentBlock);
+                if (!canCreate)
+                {
+                    return ForbidApi();
+                }
+            }
+            else if (!await _blockService.CanEditAsync(contentBlockId.Value, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId.Value, ct);
+            }
+            return await _blockService.SearchAttachableFilesAsync(search, ct);
         }
 
         //POST: content/5/restore
@@ -307,6 +382,147 @@ namespace Viper.Areas.CMS.Controllers
             return await _blockService.SoftDeleteAsync(contentBlockId, ct) ? NoContent() : NotFound();
         }
 
+        // GET: content/5/files/check-name?fileName= — pre-upload conflict check scoped to the block's
+        // folder (its section path). Lets delegated editors, who lack AllFiles, use the same
+        // conflict-check flow as managers without exposing the folder-wide file endpoint.
+        [HttpGet("{contentBlockId:int}/files/check-name")]
+        [Permission(Allow = "SVMSecure")]
+        public async Task<ActionResult<CmsFileNameCheckDto>> CheckBlockFileName(int contentBlockId, string fileName,
+            CancellationToken ct = default)
+        {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
+            // Lightweight lookup: this runs once per staged file, so don't load (and sanitize)
+            // the whole block when only the section path is needed.
+            var (found, sectionPath) = await _blockService.GetSectionPathAsync(contentBlockId, ct);
+            if (!found)
+            {
+                return NotFound();
+            }
+            // The section path IS the upload folder; without one there is nowhere to check names.
+            // 400 (not 404) to match UploadBlockFile: the block exists but isn't set up for uploads.
+            if (string.IsNullOrEmpty(sectionPath))
+            {
+                return BadRequest("The content block has no VIPER section path to upload into.");
+            }
+            try
+            {
+                return await _fileService.CheckNameAsync(sectionPath, fileName, ct);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // POST: content/5/files — inline upload from the editor. The destination folder, public flag,
+        // and permissions are taken from the block (a delegate cannot choose them); only the file,
+        // its name, and the overwrite flag come from the client. One code path for managers and
+        // delegates alike.
+        [HttpPost("{contentBlockId:int}/files")]
+        [RequestSizeLimit(MaxUploadBytes)]
+        [RequestFormLimits(MultipartBodyLengthLimit = MaxUploadBytes)]
+        [Permission(Allow = "SVMSecure")]
+        public async Task<ActionResult<CmsFileDto>> UploadBlockFile(int contentBlockId,
+            [FromForm] ContentBlockFileUpload form, IFormFile? file, CancellationToken ct = default)
+        {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest("A file is required.");
+            }
+            var block = await _blockService.GetContentBlockAsync(contentBlockId, ct);
+            if (block == null)
+            {
+                return NotFound();
+            }
+            // The section path IS the upload folder; refuse the upload when the block has none
+            // (mirrors CheckBlockFileName) rather than falling back to the storage root.
+            if (string.IsNullOrEmpty(block.ViperSectionPath))
+            {
+                return BadRequest("The content block has no VIPER section path to upload into.");
+            }
+
+            var request = new CmsFileCreateRequest
+            {
+                Folder = block.ViperSectionPath,
+                AllowPublicAccess = block.AllowPublicAccess,
+                Permissions = block.Permissions,
+                FileName = form.FileName,
+                Overwrite = form.Overwrite
+            };
+            try
+            {
+                return await _fileService.CreateFileAsync(request, file, ct);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogFileConflict(nameof(UploadBlockFile), request.Folder, file.FileName, ex);
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // DELETE: content/5/files/{fileGuid} — rollback of an inline upload only. A file may be
+        // soft-deleted through the editor solely when the current user uploaded it (ModifiedBy), it
+        // lives in this block's folder, and no OTHER block attaches it. Anything else is a managed
+        // file that must be removed from the file-management UI, so it is refused here.
+        [HttpDelete("{contentBlockId:int}/files/{fileGuid:guid}")]
+        [Permission(Allow = "SVMSecure")]
+        public async Task<IActionResult> DeleteBlockFile(int contentBlockId, Guid fileGuid, CancellationToken ct = default)
+        {
+            if (!await _blockService.CanEditAsync(contentBlockId, ct))
+            {
+                return await ForbiddenOrNotFoundAsync(contentBlockId, ct);
+            }
+
+            // The block-folder / uploader / not-shared-elsewhere rules live in the service (it owns
+            // the DB access); null means the file does not exist, false means it is not an eligible
+            // rollback.
+            var eligible = await _blockService.IsFileRollbackDeletableAsync(contentBlockId, fileGuid, ct);
+            if (eligible == null)
+            {
+                return NotFound();
+            }
+            if (!eligible.Value)
+            {
+                return ForbidApi();
+            }
+
+            // Recheck not-shared-elsewhere and soft-delete together (see RollbackDeleteFileAsync) so a
+            // block that attaches the file after the eligibility check above can't have its attachment
+            // deleted out from under it. A false result means it became shared/gone in that window.
+            return await _fileService.RollbackDeleteFileAsync(fileGuid, contentBlockId, ct)
+                ? NoContent()
+                : Conflict("The file could not be rolled back; it may now be attached to another block.");
+        }
+
+        private void LogFileConflict(string operation, string? folder, string? fileName, Exception ex)
+        {
+            _logger.LogWarning(ex, "CMS content-scoped file {Operation} conflict folder={Folder} fileName={FileName}",
+                LogSanitizer.SanitizeString(operation),
+                LogSanitizer.SanitizeString(folder),
+                LogSanitizer.SanitizeString(fileName));
+        }
+
+        // A block-scoped request the current user cannot edit: 404 when the block does not exist at
+        // all, 403 when it exists but is not theirs to edit. Keeping "exists but forbidden" a 403
+        // preserves the delegated "edit access was revoked" signal the editor relies on; a genuinely
+        // bad id gets a true 404. GetSectionPathAsync is a light existence probe (no content load).
+        private async Task<ActionResult> ForbiddenOrNotFoundAsync(int contentBlockId, CancellationToken ct)
+        {
+            var (found, _) = await _blockService.GetSectionPathAsync(contentBlockId, ct);
+            return found ? ForbidApi() : NotFound();
+        }
+
         private static string CheckBlockForRequiredFields(CMSBlockAddEdit userInput)
         {
             string errors = "";
@@ -329,11 +545,28 @@ namespace Viper.Areas.CMS.Controllers
         [Required(AllowEmptyStrings = true)]
         public string Content { get; set; } = string.Empty;
         public DateTime? LastModifiedOn { get; set; }
+
+        /// <summary>
+        /// When non-null, the block's attached files are replaced with this set (delta add/remove).
+        /// Null leaves attachments untouched, so a content-only save need not resend them.
+        /// </summary>
+        public List<Guid>? FileGuids { get; set; }
     }
 
     public class DiffAgainstHistoryRequest
     {
         [Required(AllowEmptyStrings = true)]
         public string Content { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Client-supplied fields for a content-scoped inline upload. Deliberately minimal: the folder,
+    /// public flag, and permissions are taken from the block server-side, so a delegated editor can
+    /// only influence the stored name and whether to overwrite an orphaned same-named disk file.
+    /// </summary>
+    public class ContentBlockFileUpload
+    {
+        public string? FileName { get; set; }
+        public bool? Overwrite { get; set; }
     }
 }

--- a/web/Areas/CMS/Models/CMSBlockAddEdit.cs
+++ b/web/Areas/CMS/Models/CMSBlockAddEdit.cs
@@ -24,6 +24,12 @@ namespace Viper.Areas.CMS.Models
 
         public ICollection<string> Permissions { get; set; } = new List<string>();
 
+        /// <summary>
+        /// RAPS permissions that authorize delegated editing of this block's content and files.
+        /// Manager-only to change (the full-update path); empty means manager-only editing.
+        /// </summary>
+        public ICollection<string> EditPermissions { get; set; } = new List<string>();
+
         public List<Guid> FileGuids { get; set; } = new();
 
         /// <summary>

--- a/web/Areas/CMS/Models/CmsContentBlockMapper.cs
+++ b/web/Areas/CMS/Models/CmsContentBlockMapper.cs
@@ -11,6 +11,7 @@ namespace Viper.Areas.CMS.Models
         {
             var dto = ToDtoBase(block);
             dto.Permissions = block.ContentBlockToPermissions.Select(p => p.Permission).OrderBy(p => p).ToList();
+            dto.EditPermissions = block.ContentBlockToEditPermissions.Select(p => p.Permission).OrderBy(p => p).ToList();
             dto.Files = block.ContentBlockToFiles
                 .Select(f => ToFileDto(f.FileGuid, f.File.FriendlyName))
                 .OrderBy(f => f.FriendlyName)
@@ -28,6 +29,7 @@ namespace Viper.Areas.CMS.Models
         };
 
         [MapperIgnoreTarget(nameof(ContentBlockDto.Permissions))]
+        [MapperIgnoreTarget(nameof(ContentBlockDto.EditPermissions))]
         [MapperIgnoreTarget(nameof(ContentBlockDto.Files))]
         private static partial ContentBlockDto ToDtoBase(ContentBlock block);
 

--- a/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
+++ b/web/Areas/CMS/Models/DTOs/ContentBlockDto.cs
@@ -16,6 +16,7 @@ namespace Viper.Areas.CMS.Models.DTOs
         public string ModifiedBy { get; set; } = string.Empty;
         public DateTime? DeletedOn { get; set; }
         public List<string> Permissions { get; set; } = new();
+        public List<string> EditPermissions { get; set; } = new();
         public List<ContentBlockFileDto> Files { get; set; } = new();
     }
 
@@ -37,6 +38,18 @@ namespace Viper.Areas.CMS.Models.DTOs
         public Guid FileGuid { get; set; }
         public string FriendlyName { get; set; } = string.Empty;
         public string Url { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Minimal shape for the editor's attach-by-search picker. Carries only the file's guid and
+    /// friendly name so delegated editors (who lack AllFiles) never see server paths, permission
+    /// lists, or people from the managed file store; the file's own download-time permission checks
+    /// still govern who can open it.
+    /// </summary>
+    public class CmsAttachableFileDto
+    {
+        public Guid FileGuid { get; set; }
+        public string FriendlyName { get; set; } = string.Empty;
     }
 
     public class ContentHistoryListItemDto

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using HtmlDiffer = HtmlDiff.HtmlDiff;
+using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
 using Viper.Areas.CMS.Models.DTOs;
 using Viper.Classes.SQLContext;
@@ -21,7 +22,45 @@ namespace Viper.Areas.CMS.Services
 
         Task<ContentBlockDto?> UpdateContentBlockAsync(int contentBlockId, CMSBlockAddEdit request, CancellationToken ct = default);
 
-        Task<ContentBlockDto?> UpdateContentOnlyAsync(int contentBlockId, string content, DateTime? lastModifiedOn, CancellationToken ct = default);
+        Task<ContentBlockDto?> UpdateContentOnlyAsync(int contentBlockId, string content, DateTime? lastModifiedOn,
+            List<Guid>? fileGuids = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Whether the current user may edit this block's content and attached files. True for
+        /// ManageContentBlocks holders (any block, unchanged), otherwise true only for a live block
+        /// whose edit-permission list intersects the user's permissions. Anonymous or missing block
+        /// fails closed.
+        /// </summary>
+        Task<bool> CanEditAsync(int contentBlockId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Active blocks the current user may edit by delegation (their permissions intersect the
+        /// block's edit-permission list). Projected without Content. Empty for anonymous users.
+        /// </summary>
+        Task<List<ContentBlockDto>> GetEditableBlocksAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Active files whose friendly name contains the search term AND the current user could
+        /// download (public, unrestricted, permission match, or person grant - mirrors
+        /// Data.CMS.CheckFilePermission), for the editor's attach-by-search picker. Minimal DTO
+        /// (guid + friendly name only). Empty when the term is shorter than 2 chars or anonymous.
+        /// </summary>
+        Task<List<CmsAttachableFileDto>> SearchAttachableFilesAsync(string? search, CancellationToken ct = default);
+
+        /// <summary>
+        /// The block's section path (its upload folder) without loading the full block - no
+        /// content sanitization, files, or permissions. Found=false when the block does not exist.
+        /// For callers like the pre-upload name check that run repeatedly while staging files.
+        /// </summary>
+        Task<(bool Found, string? SectionPath)> GetSectionPathAsync(int contentBlockId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Whether the editor may roll back (soft-delete) a file it just uploaded to this block:
+        /// null when the file does not exist, false when it is not an eligible rollback (uploaded by
+        /// someone else, in a folder other than the block's, or still attached to another block), and
+        /// true when the current user uploaded it into this block's folder and no other block uses it.
+        /// </summary>
+        Task<bool?> IsFileRollbackDeletableAsync(int contentBlockId, Guid fileGuid, CancellationToken ct = default);
 
         Task<bool> SoftDeleteAsync(int contentBlockId, CancellationToken ct = default);
 
@@ -66,12 +105,15 @@ namespace Viper.Areas.CMS.Services
     public class CmsContentBlockService : ICmsContentBlockService
     {
         private readonly VIPERContext _context;
+        private readonly RAPSContext _rapsContext;
         private readonly IHtmlSanitizerService _sanitizer;
         private readonly IUserHelper _userHelper;
 
-        public CmsContentBlockService(VIPERContext context, IHtmlSanitizerService sanitizer, IUserHelper userHelper)
+        public CmsContentBlockService(VIPERContext context, RAPSContext rapsContext,
+            IHtmlSanitizerService sanitizer, IUserHelper userHelper)
         {
             _context = context;
+            _rapsContext = rapsContext;
             _sanitizer = sanitizer;
             _userHelper = userHelper;
         }
@@ -218,6 +260,10 @@ namespace Viper.Areas.CMS.Services
             {
                 block.ContentBlockToPermissions.Add(new ContentBlockToPermission { Permission = permission });
             }
+            foreach (var permission in CleanList(request.EditPermissions))
+            {
+                block.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = permission });
+            }
             foreach (var fileGuid in fileGuids)
             {
                 block.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = fileGuid });
@@ -248,6 +294,7 @@ namespace Viper.Areas.CMS.Services
             block.ModifiedBy = CurrentLoginId();
 
             ApplyPermissionDeltas(block, CleanList(request.Permissions));
+            ApplyEditPermissionDeltas(block, CleanList(request.EditPermissions));
             ApplyFileDeltas(block, fileGuids);
 
             await _context.SaveChangesAsync(ct);
@@ -255,7 +302,7 @@ namespace Viper.Areas.CMS.Services
         }
 
         public async Task<ContentBlockDto?> UpdateContentOnlyAsync(int contentBlockId, string content,
-            DateTime? lastModifiedOn, CancellationToken ct = default)
+            DateTime? lastModifiedOn, List<Guid>? fileGuids = null, CancellationToken ct = default)
         {
             var block = await LoadBlockAsync(contentBlockId, tracking: true, ct);
             if (block == null)
@@ -264,13 +311,237 @@ namespace Viper.Areas.CMS.Services
             }
 
             AssertNotStale(block, lastModifiedOn);
+
+            // Validate + replace attachments only when the caller sent a set; null leaves the block's
+            // files untouched, so a plain content save need not resend them.
+            List<Guid>? distinctGuids = null;
+            if (fileGuids != null)
+            {
+                distinctGuids = fileGuids.Distinct().ToList();
+                await AssertFilesExistAsync(distinctGuids, ct);
+                // Newly-added files only: keeping a manager-attached restricted file must not
+                // fail a delegate's content save.
+                var alreadyAttached = block.ContentBlockToFiles.Select(f => f.FileGuid).ToHashSet();
+                await AssertFilesAttachableAsync(distinctGuids.Where(g => !alreadyAttached.Contains(g)).ToList(),
+                    block.ViperSectionPath, ct);
+            }
+
             SavePreviousVersionToHistory(block);
             block.Content = content;
             block.ModifiedOn = DateTime.Now;
             block.ModifiedBy = CurrentLoginId();
 
+            if (distinctGuids != null)
+            {
+                ApplyFileDeltas(block, distinctGuids);
+            }
+
             await _context.SaveChangesAsync(ct);
             return await GetContentBlockAsync(contentBlockId, ct);
+        }
+
+        public async Task<bool> CanEditAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var currentUser = _userHelper.GetCurrentUser();
+            if (currentUser == null)
+            {
+                return false;
+            }
+
+            // Load only what the decision needs: the block's deleted flag and its edit-permission
+            // strings. A missing block fails closed even for managers.
+            var block = await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.ContentBlockId == contentBlockId)
+                .Select(b => new
+                {
+                    b.DeletedOn,
+                    EditPermissions = b.ContentBlockToEditPermissions.Select(p => p.Permission).ToList()
+                })
+                .FirstOrDefaultAsync(ct);
+            if (block == null)
+            {
+                return false;
+            }
+
+            // Full manage overrides everything (managers edit any block via the list page).
+            if (_userHelper.HasPermission(_rapsContext, currentUser, CmsPermissions.ManageContentBlocks))
+            {
+                return true;
+            }
+
+            // Delegated editing is explicit: an empty edit list is manager-only (NOT the view-list's
+            // empty-means-all rule), and a soft-deleted block is never editable by a delegate.
+            if (block.DeletedOn != null || block.EditPermissions.Count == 0)
+            {
+                return false;
+            }
+
+            // Resolve the user's permissions once into a case-insensitive set, mirroring
+            // Data.CMS.CheckFilePermission, then intersect with the block's edit permissions.
+            var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
+                .Select(p => p.Permission)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return block.EditPermissions.Any(p => userPermissions.Contains(p));
+        }
+
+        public async Task<List<ContentBlockDto>> GetEditableBlocksAsync(CancellationToken ct = default)
+        {
+            var currentUser = _userHelper.GetCurrentUser();
+            if (currentUser == null)
+            {
+                return new List<ContentBlockDto>();
+            }
+
+            // Delegated matches only, as documented: managers work from the full list page, and
+            // the hub's "Blocks you can edit" card is manager-hidden and expects empty here.
+            if (_userHelper.HasPermission(_rapsContext, currentUser, CmsPermissions.ManageContentBlocks))
+            {
+                return new List<ContentBlockDto>();
+            }
+
+            // Single-resolve: the user's permissions are read once and reused for every block.
+            var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
+                .Select(p => p.Permission)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (userPermissions.Count == 0)
+            {
+                return new List<ContentBlockDto>();
+            }
+
+            // Narrow to active blocks that delegate editing at all, projecting without Content, then
+            // intersect in memory so the match is OrdinalIgnoreCase across SQL and test providers.
+            var candidates = await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.DeletedOn == null && b.ContentBlockToEditPermissions.Any())
+                .OrderBy(b => b.Title)
+                .Select(b => new
+                {
+                    b.ContentBlockId,
+                    b.Title,
+                    b.FriendlyName,
+                    b.ViperSectionPath,
+                    b.Page,
+                    b.ModifiedOn,
+                    b.ModifiedBy,
+                    EditPermissions = b.ContentBlockToEditPermissions.Select(p => p.Permission).ToList()
+                })
+                .ToListAsync(ct);
+
+            return candidates
+                .Where(b => b.EditPermissions.Any(p => userPermissions.Contains(p)))
+                .Select(b => new ContentBlockDto
+                {
+                    ContentBlockId = b.ContentBlockId,
+                    Title = b.Title,
+                    FriendlyName = b.FriendlyName,
+                    ViperSectionPath = b.ViperSectionPath,
+                    Page = b.Page,
+                    ModifiedOn = b.ModifiedOn,
+                    ModifiedBy = b.ModifiedBy
+                })
+                .ToList();
+        }
+
+        public async Task<List<CmsAttachableFileDto>> SearchAttachableFilesAsync(string? search, CancellationToken ct = default)
+        {
+            // Require a meaningful term so the picker doesn't return the whole store on an empty query.
+            if (string.IsNullOrWhiteSpace(search) || search.Trim().Length < 2)
+            {
+                return new List<CmsAttachableFileDto>();
+            }
+            var currentUser = _userHelper.GetCurrentUser();
+            if (currentUser == null)
+            {
+                return new List<CmsAttachableFileDto>();
+            }
+            var term = search.Trim();
+
+            // Name-matched candidates with just the fields the access rules need; the rules are
+            // applied in memory (mirroring GetEditableBlocksAsync) so the permission match stays
+            // OrdinalIgnoreCase across SQL Server and test providers. The candidate pool is capped
+            // so a broad two-character term cannot pull the whole store into memory; accessible
+            // files sorting after the cap are missed, which a longer search term resolves.
+            var candidates = await _context.Files
+                .AsNoTracking()
+                .Where(f => f.DeletedOn == null && f.FriendlyName.Contains(term))
+                .OrderBy(f => f.FriendlyName)
+                .Take(200)
+                .Select(f => new
+                {
+                    f.FileGuid,
+                    f.FriendlyName,
+                    f.AllowPublicAccess,
+                    Permissions = f.FileToPermissions.Select(p => p.Permission).ToList(),
+                    People = f.FileToPeople.Select(p => p.IamId).ToList()
+                })
+                .ToListAsync(ct);
+
+            var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
+                .Select(p => p.Permission)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            // "any SVMSecure user" reuses the already-resolved set rather than re-running the
+            // (4-query) permission resolve HasPermission would trigger on every keystroke here.
+            bool hasSvmSecure = userPermissions.Contains("SVMSecure");
+
+            // This endpoint is reachable by delegated editors, so it must not leak names/guids of
+            // files the user could not download. Same rules as Data.CMS.CheckFilePermission:
+            // public, unrestricted (any SVMSecure user), permission match, or explicit person grant.
+            return candidates
+                .Where(f => f.AllowPublicAccess
+                    || (f.Permissions.Count == 0 && hasSvmSecure)
+                    || f.Permissions.Any(p => userPermissions.Contains(p))
+                    || (currentUser.IamId != null && f.People.Contains(currentUser.IamId)))
+                .Take(25)
+                .Select(f => new CmsAttachableFileDto
+                {
+                    FileGuid = f.FileGuid,
+                    FriendlyName = f.FriendlyName
+                })
+                .ToList();
+        }
+
+        public async Task<(bool Found, string? SectionPath)> GetSectionPathAsync(int contentBlockId, CancellationToken ct = default)
+        {
+            var row = await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.ContentBlockId == contentBlockId)
+                .Select(b => new { b.ViperSectionPath })
+                .FirstOrDefaultAsync(ct);
+            return row == null ? (false, null) : (true, row.ViperSectionPath);
+        }
+
+        public async Task<bool?> IsFileRollbackDeletableAsync(int contentBlockId, Guid fileGuid, CancellationToken ct = default)
+        {
+            var file = await _context.Files
+                .AsNoTracking()
+                .Where(f => f.FileGuid == fileGuid)
+                .Select(f => new { f.ModifiedBy, f.Folder })
+                .FirstOrDefaultAsync(ct);
+            if (file == null)
+            {
+                return null;
+            }
+
+            var sectionPath = await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.ContentBlockId == contentBlockId)
+                .Select(b => b.ViperSectionPath)
+                .FirstOrDefaultAsync(ct);
+
+            // Rollback is only for a file the current user just uploaded into this block's folder.
+            var login = _userHelper.GetCurrentUser()?.LoginId;
+            if (login == null
+                || !string.Equals(file.ModifiedBy, login, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(file.Folder, sectionPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Never trash a file another block still attaches — that would break the other block.
+            bool attachedElsewhere = await _context.ContentBlockToFiles
+                .AnyAsync(cbf => cbf.FileGuid == fileGuid && cbf.ContentBlockId != contentBlockId, ct);
+            return !attachedElsewhere;
         }
 
         public async Task<bool> SoftDeleteAsync(int contentBlockId, CancellationToken ct = default)
@@ -305,6 +576,7 @@ namespace Viper.Areas.CMS.Services
         {
             var block = await _context.ContentBlocks
                 .Include(b => b.ContentBlockToPermissions)
+                .Include(b => b.ContentBlockToEditPermissions)
                 .Include(b => b.ContentBlockToFiles)
                 .Include(b => b.ContentHistories)
                 .AsSplitQuery()
@@ -317,6 +589,7 @@ namespace Viper.Areas.CMS.Services
             _context.RemoveRange(block.ContentHistories);
             _context.RemoveRange(block.ContentBlockToFiles);
             _context.RemoveRange(block.ContentBlockToPermissions);
+            _context.RemoveRange(block.ContentBlockToEditPermissions);
             _context.Remove(block);
             await _context.SaveChangesAsync(ct);
             return true;
@@ -529,6 +802,7 @@ namespace Viper.Areas.CMS.Services
         {
             var query = _context.ContentBlocks
                 .Include(b => b.ContentBlockToPermissions)
+                .Include(b => b.ContentBlockToEditPermissions)
                 .Include(b => b.ContentBlockToFiles)
                     .ThenInclude(f => f.File)
                 .AsSplitQuery();
@@ -552,6 +826,67 @@ namespace Viper.Areas.CMS.Services
             if (existing != fileGuids.Count)
             {
                 throw new ArgumentException("One or more attached files do not exist.");
+            }
+        }
+
+        // The content-only PATCH is reachable by delegated editors, so newly-attached files must
+        // pass the same rules as downloads (public, unrestricted, permission match, person grant -
+        // mirrors SearchAttachableFilesAsync), the one exception being a file the caller uploaded
+        // for this block's folder (below); otherwise a guessed GUID would leak a restricted file's
+        // name through the block's attachment list.
+        private async Task AssertFilesAttachableAsync(List<Guid> fileGuids, string? blockFolder, CancellationToken ct)
+        {
+            if (fileGuids.Count == 0)
+            {
+                return;
+            }
+            // Active files only, matching the search: attaching a soft-deleted file by GUID would
+            // resurrect it into an active block. A deleted file simply comes back missing here.
+            var files = await _context.Files
+                .AsNoTracking()
+                .Where(f => f.DeletedOn == null && EF.Parameter(fileGuids).Contains(f.FileGuid))
+                .Select(f => new
+                {
+                    f.AllowPublicAccess,
+                    f.ModifiedBy,
+                    f.Folder,
+                    Permissions = f.FileToPermissions.Select(p => p.Permission).ToList(),
+                    People = f.FileToPeople.Select(p => p.IamId).ToList()
+                })
+                .ToListAsync(ct);
+            if (files.Count != fileGuids.Count)
+            {
+                throw new ArgumentException("One or more files cannot be attached because they are deleted.");
+            }
+
+            var currentUser = _userHelper.GetCurrentUser();
+            var userPermissions = currentUser == null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : _userHelper.GetAllPermissions(_rapsContext, currentUser)
+                    .Select(p => p.Permission)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            // Derive from the set already resolved above instead of a second permission resolve;
+            // the set is empty for an anonymous user, so this stays false there.
+            bool hasSvmSecure = userPermissions.Contains("SVMSecure");
+            var login = currentUser?.LoginId;
+
+            // A file the current user uploaded into THIS block's folder is always attachable by them. An
+            // inline upload inherits the block's VIEW permissions, which a delegated editor need not hold
+            // (edit and view lists are independent), so the download-access rules above would otherwise
+            // reject the file they just created. ModifiedBy is server-set to the uploader and can't be
+            // forged; the folder match scopes the exception to a file uploaded FOR this block, so a
+            // delegate cannot move a restricted file they uploaded elsewhere onto a block with broader
+            // visibility. This mirrors the uploader+folder check in IsFileRollbackDeletableAsync.
+            bool allAttachable = files.All(f => f.AllowPublicAccess
+                || (f.Permissions.Count == 0 && hasSvmSecure)
+                || f.Permissions.Any(p => userPermissions.Contains(p))
+                || (currentUser?.IamId != null && f.People.Contains(currentUser.IamId))
+                || (login != null
+                    && string.Equals(f.ModifiedBy, login, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(f.Folder, blockFolder, StringComparison.OrdinalIgnoreCase)));
+            if (!allAttachable)
+            {
+                throw new ArgumentException("One or more files cannot be attached because you do not have access to them.");
             }
         }
 
@@ -598,43 +933,40 @@ namespace Viper.Areas.CMS.Services
             block.BlockOrder = request.BlockOrder;
         }
 
-        private void ApplyPermissionDeltas(ContentBlock block, List<string> requested)
+        // Reconciles a block's child collection (permissions / edit-permissions / files) to the
+        // requested key set: remove children whose key is no longer requested, add requested keys not
+        // already present. One implementation instead of three hand-kept copies of the same delta.
+        private void ApplyChildDeltas<TChild, TKey>(ICollection<TChild> children, List<TKey> requested,
+            Func<TChild, TKey> keyOf, Func<TKey, TChild> create, IEqualityComparer<TKey> comparer)
+            where TChild : class
         {
-            var existing = block.ContentBlockToPermissions.ToList();
-            foreach (var cbp in existing.Where(cbp => !requested.Contains(cbp.Permission, StringComparer.OrdinalIgnoreCase)))
+            var requestedKeys = new HashSet<TKey>(requested, comparer);
+            foreach (var child in children.Where(c => !requestedKeys.Contains(keyOf(c))).ToList())
             {
-                block.ContentBlockToPermissions.Remove(cbp);
-                _context.Remove(cbp);
+                children.Remove(child);
+                _context.Remove(child);
             }
-            var existingNames = existing.Select(p => p.Permission).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            foreach (var permission in requested.Where(p => !existingNames.Contains(p)))
+            var existingKeys = new HashSet<TKey>(children.Select(keyOf), comparer);
+            foreach (var key in requestedKeys.Where(k => !existingKeys.Contains(k)))
             {
-                block.ContentBlockToPermissions.Add(new ContentBlockToPermission
-                {
-                    ContentBlockId = block.ContentBlockId,
-                    Permission = permission
-                });
+                children.Add(create(key));
             }
         }
 
-        private void ApplyFileDeltas(ContentBlock block, List<Guid> requested)
-        {
-            var existing = block.ContentBlockToFiles.ToList();
-            foreach (var cbf in existing.Where(cbf => !requested.Contains(cbf.FileGuid)))
-            {
-                block.ContentBlockToFiles.Remove(cbf);
-                _context.Remove(cbf);
-            }
-            var existingGuids = existing.Select(f => f.FileGuid).ToHashSet();
-            foreach (var fileGuid in requested.Where(g => !existingGuids.Contains(g)))
-            {
-                block.ContentBlockToFiles.Add(new ContentBlockToFile
-                {
-                    ContentBlockId = block.ContentBlockId,
-                    FileGuid = fileGuid
-                });
-            }
-        }
+        private void ApplyPermissionDeltas(ContentBlock block, List<string> requested) =>
+            ApplyChildDeltas(block.ContentBlockToPermissions, requested, p => p.Permission,
+                permission => new ContentBlockToPermission { ContentBlockId = block.ContentBlockId, Permission = permission },
+                StringComparer.OrdinalIgnoreCase);
+
+        private void ApplyEditPermissionDeltas(ContentBlock block, List<string> requested) =>
+            ApplyChildDeltas(block.ContentBlockToEditPermissions, requested, p => p.Permission,
+                permission => new ContentBlockToEditPermission { ContentBlockId = block.ContentBlockId, Permission = permission },
+                StringComparer.OrdinalIgnoreCase);
+
+        private void ApplyFileDeltas(ContentBlock block, List<Guid> requested) =>
+            ApplyChildDeltas(block.ContentBlockToFiles, requested, f => f.FileGuid,
+                fileGuid => new ContentBlockToFile { ContentBlockId = block.ContentBlockId, FileGuid = fileGuid },
+                EqualityComparer<Guid>.Default);
 
         private string CurrentLoginId()
         {

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -55,6 +55,15 @@ namespace Viper.Areas.CMS.Services
         Task<(bool Found, string? SectionPath)> GetSectionPathAsync(int contentBlockId, CancellationToken ct = default);
 
         /// <summary>
+        /// The block's upload destination settings (section path, public flag, view permissions)
+        /// without loading the full block - no content sanitization or attached files. For the
+        /// inline-upload endpoint, which may be called repeatedly during a multi-file upload.
+        /// Found=false when the block does not exist.
+        /// </summary>
+        Task<(bool Found, string? SectionPath, bool AllowPublicAccess, List<string> Permissions)> GetUploadSettingsAsync(
+            int contentBlockId, CancellationToken ct = default);
+
+        /// <summary>
         /// Whether the editor may roll back (soft-delete) a file it just uploaded to this block:
         /// null when the file does not exist, false when it is not an eligible rollback (uploaded by
         /// someone else, in a folder other than the block's, or still attached to another block), and
@@ -364,8 +373,15 @@ namespace Viper.Areas.CMS.Services
                 return false;
             }
 
+            // Resolve the user's permissions once into a case-insensitive set, mirroring
+            // Data.CMS.CheckFilePermission, then reuse it for both the manager check and the
+            // delegated-edit-list intersection instead of re-resolving via HasPermission.
+            var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
+                .Select(p => p.Permission)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
             // Full manage overrides everything (managers edit any block via the list page).
-            if (_userHelper.HasPermission(_rapsContext, currentUser, CmsPermissions.ManageContentBlocks))
+            if (userPermissions.Contains(CmsPermissions.ManageContentBlocks))
             {
                 return true;
             }
@@ -377,11 +393,6 @@ namespace Viper.Areas.CMS.Services
                 return false;
             }
 
-            // Resolve the user's permissions once into a case-insensitive set, mirroring
-            // Data.CMS.CheckFilePermission, then intersect with the block's edit permissions.
-            var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
-                .Select(p => p.Permission)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             return block.EditPermissions.Any(p => userPermissions.Contains(p));
         }
 
@@ -393,18 +404,15 @@ namespace Viper.Areas.CMS.Services
                 return new List<ContentBlockDto>();
             }
 
-            // Delegated matches only, as documented: managers work from the full list page, and
-            // the hub's "Blocks you can edit" card is manager-hidden and expects empty here.
-            if (_userHelper.HasPermission(_rapsContext, currentUser, CmsPermissions.ManageContentBlocks))
-            {
-                return new List<ContentBlockDto>();
-            }
-
-            // Single-resolve: the user's permissions are read once and reused for every block.
+            // Single-resolve: the user's permissions are read once and reused for the manager
+            // check below and for every block, instead of HasPermission re-resolving them.
             var userPermissions = _userHelper.GetAllPermissions(_rapsContext, currentUser)
                 .Select(p => p.Permission)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            if (userPermissions.Count == 0)
+
+            // Delegated matches only, as documented: managers work from the full list page, and
+            // the hub's "Blocks you can edit" card is manager-hidden and expects empty here.
+            if (userPermissions.Contains(CmsPermissions.ManageContentBlocks) || userPermissions.Count == 0)
             {
                 return new List<ContentBlockDto>();
             }
@@ -511,12 +519,30 @@ namespace Viper.Areas.CMS.Services
             return row == null ? (false, null) : (true, row.ViperSectionPath);
         }
 
+        public async Task<(bool Found, string? SectionPath, bool AllowPublicAccess, List<string> Permissions)> GetUploadSettingsAsync(
+            int contentBlockId, CancellationToken ct = default)
+        {
+            var row = await _context.ContentBlocks
+                .AsNoTracking()
+                .Where(b => b.ContentBlockId == contentBlockId)
+                .Select(b => new
+                {
+                    b.ViperSectionPath,
+                    b.AllowPublicAccess,
+                    Permissions = b.ContentBlockToPermissions.Select(p => p.Permission).ToList()
+                })
+                .FirstOrDefaultAsync(ct);
+            return row == null
+                ? (false, null, false, new List<string>())
+                : (true, row.ViperSectionPath, row.AllowPublicAccess, row.Permissions);
+        }
+
         public async Task<bool?> IsFileRollbackDeletableAsync(int contentBlockId, Guid fileGuid, CancellationToken ct = default)
         {
             var file = await _context.Files
                 .AsNoTracking()
                 .Where(f => f.FileGuid == fileGuid)
-                .Select(f => new { f.ModifiedBy, f.Folder })
+                .Select(f => new { f.ModifiedBy, f.Folder, f.DeletedOn })
                 .FirstOrDefaultAsync(ct);
             if (file == null)
             {
@@ -529,9 +555,11 @@ namespace Viper.Areas.CMS.Services
                 .Select(b => b.ViperSectionPath)
                 .FirstOrDefaultAsync(ct);
 
-            // Rollback is only for a file the current user just uploaded into this block's folder.
+            // Rollback is only for a file the current user just uploaded into this block's folder,
+            // and only while it's still live - an already soft-deleted file has nothing to roll back.
             var login = _userHelper.GetCurrentUser()?.LoginId;
-            if (login == null
+            if (file.DeletedOn != null
+                || login == null
                 || !string.Equals(file.ModifiedBy, login, StringComparison.OrdinalIgnoreCase)
                 || !string.Equals(file.Folder, sectionPath, StringComparison.OrdinalIgnoreCase))
             {
@@ -856,7 +884,7 @@ namespace Viper.Areas.CMS.Services
                 .ToListAsync(ct);
             if (files.Count != fileGuids.Count)
             {
-                throw new ArgumentException("One or more files cannot be attached because they are deleted.");
+                throw new ArgumentException("One or more files cannot be attached because they are deleted or missing.");
             }
 
             var currentUser = _userHelper.GetCurrentUser();

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Viper.Areas.CMS.Constants;
@@ -697,26 +698,45 @@ namespace Viper.Areas.CMS.Services
 
         public async Task<bool> RollbackDeleteFileAsync(Guid fileGuid, int contentBlockId, CancellationToken ct = default)
         {
-            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
-            if (entity == null || entity.DeletedOn != null)
+            // The load, the deleted check, and the "not attached elsewhere" recheck all happen
+            // inside the same Serializable transaction, so the whole decision is made atomically:
+            // SQL Server range-locks what this transaction read, so a concurrent delete or attach
+            // to a different block either commits first (and this recheck then sees it) or blocks
+            // until this transaction finishes — it can no longer land in the gap between a
+            // snapshot taken before the transaction and the save at the end of it.
+            return await ExecuteInTransactionAsync(async token =>
             {
-                return false;
-            }
-            // Recheck immediately before deleting, in the same operation, so a block that attaches this
-            // file after the caller's eligibility check does not have its attachment deleted from under
-            // it (the check and delete are no longer split across two separate service calls).
-            bool attachedElsewhere = await _context.ContentBlockToFiles
-                .AnyAsync(cbf => cbf.FileGuid == fileGuid && cbf.ContentBlockId != contentBlockId, ct);
-            if (attachedElsewhere)
-            {
-                return false;
-            }
-            entity.DeletedOn = DateTime.Now;
-            entity.ModifiedOn = DateTime.Now;
-            entity.ModifiedBy = CurrentLoginId();
-            _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
-            await _context.SaveChangesAsync(ct);
-            return true;
+                var entity = await LoadFileAsync(fileGuid, tracking: true, token);
+                if (entity == null || entity.DeletedOn != null)
+                {
+                    return false;
+                }
+                bool attachedElsewhere = await _context.ContentBlockToFiles
+                    .AnyAsync(cbf => cbf.FileGuid == fileGuid && cbf.ContentBlockId != contentBlockId, token);
+                if (attachedElsewhere)
+                {
+                    return false;
+                }
+                entity.DeletedOn = DateTime.Now;
+                entity.ModifiedOn = DateTime.Now;
+                entity.ModifiedBy = CurrentLoginId();
+                _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+                await _context.SaveChangesAsync(token);
+                return true;
+            }, IsolationLevel.Serializable, ct);
+        }
+
+        /// <summary>
+        /// Runs <paramref name="operation"/> inside a database transaction at the given isolation
+        /// level. Overridden in tests to bypass transactions (the EF in-memory provider doesn't
+        /// support them).
+        /// </summary>
+        protected virtual Task<T> ExecuteInTransactionAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            IsolationLevel isolationLevel,
+            CancellationToken cancellationToken)
+        {
+            return TransactionHelper.ExecuteInTransactionAsync(_context.Database, operation, isolationLevel, cancellationToken);
         }
 
         public async Task<bool> RestoreFileAsync(Guid fileGuid, CancellationToken ct = default)

--- a/web/Areas/CMS/Services/CmsFileService.cs
+++ b/web/Areas/CMS/Services/CmsFileService.cs
@@ -28,6 +28,14 @@ namespace Viper.Areas.CMS.Services
 
         Task<bool> SoftDeleteFileAsync(Guid fileGuid, CancellationToken ct = default);
 
+        /// <summary>
+        /// Rechecks the not-shared-elsewhere condition and soft-deletes in one step, so a block that
+        /// attaches the file in the gap between an eligibility check and the delete does not get its
+        /// attachment stranded. Returns false (file left in place) when the file is missing, already
+        /// deleted, or now attached to a block other than <paramref name="contentBlockId"/>.
+        /// </summary>
+        Task<bool> RollbackDeleteFileAsync(Guid fileGuid, int contentBlockId, CancellationToken ct = default);
+
         Task<bool> RestoreFileAsync(Guid fileGuid, CancellationToken ct = default);
 
         Task<bool> PermanentlyDeleteFileAsync(Guid fileGuid, CancellationToken ct = default);
@@ -676,6 +684,30 @@ namespace Viper.Areas.CMS.Services
         {
             var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
             if (entity == null)
+            {
+                return false;
+            }
+            entity.DeletedOn = DateTime.Now;
+            entity.ModifiedOn = DateTime.Now;
+            entity.ModifiedBy = CurrentLoginId();
+            _audit.Audit(entity, CmsFileAuditActions.DeleteFile, "File Marked for Deletion");
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+
+        public async Task<bool> RollbackDeleteFileAsync(Guid fileGuid, int contentBlockId, CancellationToken ct = default)
+        {
+            var entity = await LoadFileAsync(fileGuid, tracking: true, ct);
+            if (entity == null || entity.DeletedOn != null)
+            {
+                return false;
+            }
+            // Recheck immediately before deleting, in the same operation, so a block that attaches this
+            // file after the caller's eligibility check does not have its attachment deleted from under
+            // it (the check and delete are no longer split across two separate service calls).
+            bool attachedElsewhere = await _context.ContentBlockToFiles
+                .AnyAsync(cbf => cbf.FileGuid == fileGuid && cbf.ContentBlockId != contentBlockId, ct);
+            if (attachedElsewhere)
             {
                 return false;
             }

--- a/web/Classes/SQLContext/VIPERContext.cs
+++ b/web/Classes/SQLContext/VIPERContext.cs
@@ -33,6 +33,8 @@ public partial class VIPERContext : DbContext
 
     public virtual DbSet<ContentBlockToPermission> ContentBlockToPermissions { get; set; }
 
+    public virtual DbSet<ContentBlockToEditPermission> ContentBlockToEditPermissions { get; set; }
+
     public virtual DbSet<ContentHistory> ContentHistories { get; set; }
 
     public virtual DbSet<FieldType> FieldTypes { get; set; }
@@ -292,6 +294,25 @@ public partial class VIPERContext : DbContext
                 .HasForeignKey(d => d.ContentBlockId)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("FK_ContentBlockToPermissions_ContentBlock");
+        });
+
+        modelBuilder.Entity<ContentBlockToEditPermission>(entity =>
+        {
+            entity.HasKey(e => e.ContentBlockEditPermissionId).HasName("PK_ContentBlockToEditPermission");
+
+            entity.ToTable("ContentBlockToEditPermission");
+
+            entity.Property(e => e.ContentBlockEditPermissionId).HasColumnName("ContentBlockEditPermissionID");
+            entity.Property(e => e.ContentBlockId).HasColumnName("ContentBlockID");
+            entity.Property(e => e.Permission)
+                .HasMaxLength(500)
+                .IsUnicode(false)
+                .HasColumnName("permission");
+
+            entity.HasOne(d => d.ContentBlock).WithMany(p => p.ContentBlockToEditPermissions)
+                .HasForeignKey(d => d.ContentBlockId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_ContentBlockToEditPermission_ContentBlock");
         });
 
         modelBuilder.Entity<ContentHistory>(entity =>

--- a/web/Classes/Utilities/TransactionHelper.cs
+++ b/web/Classes/Utilities/TransactionHelper.cs
@@ -1,0 +1,33 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Viper.Classes.Utilities
+{
+    public static class TransactionHelper
+    {
+        /// <summary>
+        /// Runs <paramref name="operation"/> inside a database transaction at the given isolation
+        /// level, committing on success and rolling back on any exception.
+        /// </summary>
+        public static async Task<T> ExecuteInTransactionAsync<T>(
+            DatabaseFacade database,
+            Func<CancellationToken, Task<T>> operation,
+            IsolationLevel isolationLevel,
+            CancellationToken cancellationToken)
+        {
+            await using var transaction = await database.BeginTransactionAsync(isolationLevel, cancellationToken);
+            try
+            {
+                var result = await operation(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                return result;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+    }
+}

--- a/web/Models/VIPER/ContentBlock.cs
+++ b/web/Models/VIPER/ContentBlock.cs
@@ -32,5 +32,7 @@ public class ContentBlock
 
     public virtual ICollection<ContentBlockToPermission> ContentBlockToPermissions { get; set; } = new List<ContentBlockToPermission>();
 
+    public virtual ICollection<ContentBlockToEditPermission> ContentBlockToEditPermissions { get; set; } = new List<ContentBlockToEditPermission>();
+
     public virtual ICollection<ContentHistory> ContentHistories { get; set; } = new List<ContentHistory>();
 }

--- a/web/Models/VIPER/ContentBlockToEditPermission.cs
+++ b/web/Models/VIPER/ContentBlockToEditPermission.cs
@@ -1,0 +1,12 @@
+namespace Viper.Models.VIPER;
+
+public class ContentBlockToEditPermission
+{
+    public int ContentBlockEditPermissionId { get; set; }
+
+    public int ContentBlockId { get; set; }
+
+    public string Permission { get; set; } = null!;
+
+    public virtual ContentBlock ContentBlock { get; set; } = null!;
+}


### PR DESCRIPTION
Slice 4 of the CMS migration stack (stacks on #253; the diff shows only this feature). Adds **delegated block editing**: admins attach RAPS permissions to a block as its *edit* permissions, and holders of any of them can edit that block's content and attached files — without `SVMSecure.CMS.ManageContentBlocks` and without access to anything else.

## ⚠️ Manual schema change required (before deploying to each environment)

```sql
CREATE TABLE dbo.ContentBlockToEditPermission (
    ContentBlockEditPermissionID int IDENTITY(1,1) NOT NULL
        CONSTRAINT PK_ContentBlockToEditPermission PRIMARY KEY,
    ContentBlockID int NOT NULL
        CONSTRAINT FK_ContentBlockToEditPermission_ContentBlock REFERENCES dbo.ContentBlock (contentBlockID),
    permission varchar(500) NOT NULL
);

CREATE INDEX IX_ContentBlockToEditPermission_ContentBlockID
    ON dbo.ContentBlockToEditPermission (ContentBlockID) INCLUDE (permission);
```

Apply to dev → TEST → PROD ahead of the corresponding deploy (same manual-DDL process as VPR-143). Additive only; invisible to legacy ColdFusion (which reads only the view-permission table), so coexistence is unaffected.

## Semantics

- Edit access to block B = `ManageContentBlocks` **or** any of B's edit permissions (ANY-OF).
- An **empty edit list means manager-only** — delegation is explicit (deliberately not the view list's "empty ⇒ all SVMSecure" rule).
- Delegated editors CAN: edit content, attach existing managed files (capped, minimal-DTO search), upload new files into the block's folder (they inherit the block's view permissions, and the editor can attach them even without holding those permissions), detach files, view/load version history, save (history attribution + 409 stale-edit guard unchanged).
- Delegated editors CANNOT: rename (title or friendly name), change system/section/page/order/public access, change either permission list, delete/restore, reach the manage list/history pages, or touch the file store beyond the block-scoped operations above.
- Soft-deleted blocks are not editable by delegates.

## Implementation

- New `ContentBlockToEditPermission` entity/table + `CanEditAsync` authorization (single-resolve permission HashSet, fail-closed).
- Content-only PATCH gains attachment deltas; server-side field whitelisting is the enforcement boundary (the delegated DTO simply has no settings fields).
- New content-scoped endpoints so the editor has ONE code path for all users: `GET /editable`, `GET /attachable-files`, per-block `files/check-name`, `POST {id}/files`, rollback-only `DELETE {id}/files/{guid}` (owner + folder + not-attached-elsewhere constrained).
- Attach guard: newly-attached files must pass the same download-access check as the search, with one exception — a file the current user uploaded into **this block's own folder** (uploader + folder match, mirroring the rollback-delete rule). This lets a delegate attach an inline upload whose inherited view permission they don't hold, while blocking a restricted file they uploaded for a *different* folder from being attached onto a broader-visibility block.
- Editor renders a capability mode: read-only settings summary for delegates; managers additionally get the "Edit access" selector. Hub gains a "Blocks you can edit" card for delegates.
- Public `fn` endpoint DTO unchanged (no edit-permission disclosure).
- Tests: authorization matrix, field-scoping, attachment deltas, rollback-delete constraints, attach uploader/folder exception (in-folder allowed, cross-folder rejected), editable/attachable filtering, capability-mode rendering, hub card, PATCH conflict flow.
