### PR TITLE
VPR-74 chore(deps): upgrade AWS SDK from v3 to v4

### DIFF
--- a/web/Areas/Effort/Scripts/EffortMigration.csproj
+++ b/web/Areas/Effort/Scripts/EffortMigration.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="5.1.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.201.7" />
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="7.1.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.100" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
   </ItemGroup>
 

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -40,13 +40,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="5.1.0" />
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="7.1.0" />
 
     <PackageReference Include="DotNetDiag.HealthChecks.UI" Version="10.0.7" />
     <PackageReference Include="DotNetDiag.HealthChecks.UI.Client" Version="10.0.7" />
     <PackageReference Include="DotNetDiag.HealthChecks.UI.InMemory.Storage" Version="10.0.7" />
 
-    <PackageReference Include="AWSSDK.Core" Version="3.7.201.7" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.100" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="DotNetEnv" Version="3.2.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />


### PR DESCRIPTION
## Summary

Upgrades the AWS SDK for .NET from v3 to v4 in both projects that reference it (Viper and EffortMigration):

- `AWSSDK.Core` 3.7.201.7 -> **4.0.100**
- `Amazon.Extensions.Configuration.SystemsManager` 5.1.0 -> **7.1.0** (the SDK-v4 line)

Core is pinned to 4.0.100 rather than the latest 4.0.100.2, which was published under the 7-day supply-chain bake window at review time; the delta is routine service-model updates and can be picked up in a later bump.

No code changes were needed: our AWS surface (SSM Parameter Store config load, `AwsSsmHealthCheck`, credential profile registration) uses no APIs removed in v4.

## Breaking changes reviewed

- [SDK v4 migration guide](https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/net-dg-v4.html): nullable value types, collections defaulting to null, STS/S3/DynamoDB changes - none apply to our usage.
- SystemsManager extension crosses two majors: **6.0.0** splits StringList parameters into indexed keys; **6.2.0** throws at startup on case-insensitive duplicate parameter keys under a loaded path. Neither affects the current `/Development` + `/Shared` parameter sets.

## Verification

- `npm run verify:build`: 0 errors; `npm run test:backend`: 2140/2140 passed
- Booted the app locally: clean startup with config loaded from SSM, `/health/detail` fully Healthy including `aws-ssm` (live v4 `GetParametersByPath` call) and all nine `db-*` checks (DB passwords delivered via SSM)
- Confirmed the running process loaded `AWSSDK.Core 4.0.100.0`, `SystemsManager 7.1.0.0`, and transitive `AWSSDK.SimpleSystemsManagement 4.0.6.11`

JIRA: https://ucdsvm.atlassian.net/browse/VPR-74