### PR TITLE
chore(config): add Benjamin's IP to internal allowlist

### DIFF
--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -16,6 +16,7 @@
         "InternalAllowlist": [
             "::1", // IPv6 localhost
             "127.0.0.1", // IPv4 localhost
+            "192.168.33.2", // Benjamin
             "192.168.32.172", // Brandon
             "192.168.33.1", // Jason
             "192.168.32.195", // Keith


### PR DESCRIPTION
## Summary
- Adds Benjamin's IP (192.168.33.2) to the InternalAllowlist in web/appsettings.json for new developer onboarding.