### PR TITLE
chore(deps): remove unused ASP.NET scaffolding package

### DIFF
--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -70,7 +70,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="NLog.MailKit" Version="6.1.4" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageReference Include="QuestPDF" Version="2026.6.0" />


### PR DESCRIPTION
## What

Removes `Microsoft.VisualStudio.Web.CodeGeneration.Design` 10.0.2 (the `dotnet aspnet-codegenerator` scaffolding package) from `web/Viper.csproj`. One line removed, no code changes.

## Why

**Security advisory noise.** This package is the source of the repo's only NuGet security warnings: it transitively pins `NuGet.Packaging` 6.12.1 and `NuGet.Protocol` 6.12.1, flagged by [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) (low severity, "Defense in Depth update for NuGet Client", fixed in 6.12.5). There is no fixed stable release of the scaffolding package to upgrade to: 10.0.2 is the latest stable, and only 11.0 previews exist.

**Warning noise on every build and dev startup.** The four NU1901 warnings replay on every restore, including the no-op "all projects are up-to-date" restore that runs when `npm run dev` starts `dotnet watch`. Removing the package silences them at the source instead of suppressing them.

**It has been used exactly once, in RAPS, in 2023.** Repo archaeology shows the scaffolder generated the six RAPS CRUD controllers (`Roles`, `RoleTemplates`, `AdGroups`, `Permissions`, `MemberPermissions`, `Audit`) between May and July 2023. They still carry the template fingerprints: `// PUT: Roles/5` route comments, `if (_context.TblRoles == null) return NotFound();` guards, `CreatedAtAction("GetTblRole", ...)`, and the `<Model>Exists()` helpers. No other area (ClinicalScheduler, Effort, CTS, Students, CMS) has any scaffold trace, and nothing in scripts or docs invokes `aspnet-codegenerator`. Scaffolding is a one-time code emitter: the generated controllers are ordinary checked-in source and are unaffected by the removal.

## Does it save on bundle size or startup?

**Bundle: yes, substantially.** The package is the only design-time tool in the project without `PrivateAssets="all"` (compare the EF Core `Design`/`Tools` references), so its entire ~105-package dependency closure ships in the publish output: the Roslyn workspaces stack, MSBuild libraries, the NuGet client stack, Mono.TextTemplating, and Humanizer with 48 satellite language folders.

Measured with clean `dotnet publish` runs (`npm run dev:backend-build-only`) before and after:

| | Files | Size |
|---|---|---|
| Before | 1186 | 205.7 MB |
| After | 1072 | 186.1 MB |
| Saved | 114 | 18.7 MB (~9.5%) |

Largest items dropped: `Microsoft.CodeAnalysis.Features.dll` (5.6 MB), `Microsoft.CodeAnalysis.CSharp.Features.dll` (2.2 MB), `Microsoft.Build.dll` (2.1 MB), `Microsoft.AspNetCore.Razor.Language.dll` (1.0 MB), the `NuGet.*` client stack (~1.7 MB), `Microsoft.VisualStudio.Web.CodeGenerators.Mvc.dll`, and 48 Humanizer satellite language assemblies plus Roslyn localization folders.

**Startup: no measurable change.** The .NET runtime loads assemblies lazily, and nothing ever referenced these at runtime, so they were dead weight on disk rather than a startup cost. The practical startup win is the smaller deploy artifact and the NU1901 noise disappearing from `npm run dev`.

If anyone needs to scaffold a controller again, re-add the package for the one-off task (ideally at a patched version if one exists by then), scaffold, and remove it.

## Verification

- Clean `dotnet publish` succeeds after removal; output diff shows only the scaffolding dependency closure dropped (no app assemblies affected).
- `npm run verify:build` passes with zero NU1901 warnings.
- No source references: repo-wide search for `Microsoft.VisualStudio.Web.CodeGeneration` and `aspnet-codegenerator` matches nothing outside the csproj.
