### PR TITLE
chore(warnings): resolve 26 analyzer quick wins and fix RAPS bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -163,6 +163,13 @@ dotnet_style_qualification_for_property = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_event = false:silent
 
-# EF Core scaffold-generated DbContext files — partial methods are intentional extension points
+# EF Core scaffold-generated DbContext files — partial methods are intentional extension points,
+# and the maintainability index is dominated by the generated OnModelCreating (not hand-maintained code)
 [**/SQLContext/*Context.cs]
 dotnet_diagnostic.S3251.severity = none
+dotnet_diagnostic.CA1505.severity = none
+
+# S6964: flags value-type props as under-postable, but ApiPagination is never bound from a request:
+# ApiPaginationAttribute.OnActionExecuting always constructs the object and overwrites the action argument
+[web/Models/ApiPagination.cs]
+dotnet_diagnostic.S6964.severity = none

--- a/scripts/lib/build-cache.js
+++ b/scripts/lib/build-cache.js
@@ -282,7 +282,10 @@ function getCachedBuildOutput(projectName) {
         return null
     }
 
-    return cacheEntry.output || ""
+    // Entries are written by whichever build script ran first, and some cache MSBuild's raw
+    // output with its diagnostic-repeating summary intact. Strip on read so every consumer
+    // sees each diagnostic once regardless of who populated the entry.
+    return stripSummaryDetail(cacheEntry.output || "")
 }
 
 /**
@@ -508,6 +511,56 @@ const ZERO_ERRORS_PATTERN = /\b0\s+Error\(s\)/i
 // Matches "Build succeeded" message from MSBuild
 const BUILD_SUCCEEDED_PATTERN = /Build succeeded\./i
 
+// Matches the line that opens MSBuild's end-of-build summary
+const BUILD_RESULT_PATTERN = /^\s*Build (succeeded|FAILED)\.\s*$/i
+
+// Matches a diagnostic detail line, e.g. "Foo.cs(9,5): warning CA1502: ..." or ": error CS1234"
+const DIAGNOSTIC_DETAIL_PATTERN = /:\s*(warning|error)\s+[A-Za-z]+\d+/i
+
+/**
+ * MSBuild prints every diagnostic inline as it compiles, then repeats the entire list in its
+ * end-of-build summary, so all warnings appear twice. `-clp:NoSummary` does not suppress it on
+ * the .NET 10 SDK (verified: the switch parses, ErrorsOnly takes effect, NoSummary does not),
+ * so filter the repeat out ourselves. The summary's header, counts, and elapsed time are kept.
+ * @returns {(line: string) => boolean} - Stateful predicate: true if the line should be shown
+ */
+function createSummaryDetailFilter() {
+    let inSummary = false
+    return (line) => {
+        if (BUILD_RESULT_PATTERN.test(line)) {
+            inSummary = true
+            return true
+        }
+        return !(inSummary && DIAGNOSTIC_DETAIL_PATTERN.test(line))
+    }
+}
+
+/**
+ * Count warning diagnostics in build output. Assumes summary repeats are already stripped,
+ * which getCachedBuildOutput guarantees, so each warning counts once.
+ * @param {string} output - Build output
+ * @returns {number} - Number of warning diagnostics
+ */
+function countBuildWarnings(output) {
+    if (!output) {
+        return 0
+    }
+    return (output.match(/:\s*warning\s+[A-Za-z]+\d+/gi) || []).length
+}
+
+/**
+ * Non-streaming form of createSummaryDetailFilter, for output captured up front.
+ * @param {string} output - Full build output
+ * @returns {string} - Output with the summary's repeated diagnostic lines removed
+ */
+function stripSummaryDetail(output) {
+    if (!output || !output.trim()) {
+        return output || ""
+    }
+    const shouldEmit = createSummaryDetailFilter()
+    return output.split("\n").filter(shouldEmit).join("\n")
+}
+
 /**
  * Filter build output to show only error lines (not warnings)
  * @param {string} output - Full build output
@@ -517,7 +570,10 @@ function filterBuildErrors(output) {
     if (!output || !output.trim()) {
         return ""
     }
-    const errorLines = output
+    // Cached output still holds MSBuild's summary, so drop its repeats before filtering;
+    // otherwise every error is reported twice.
+    const deduped = stripSummaryDetail(output)
+    const errorLines = deduped
         .split("\n")
         .filter(
             (line) =>
@@ -538,7 +594,7 @@ function filterBuildErrors(output) {
         .join("\n")
         .trim()
     // Fall back to original output when no error lines matched to avoid silent failures
-    return errorLines || output
+    return errorLines || deduped
 }
 
 /**
@@ -585,6 +641,9 @@ module.exports = {
     getCachedBuildOutput,
     filterBuildErrors,
     isConfirmedWarningsOnly,
+    createSummaryDetailFilter,
+    stripSummaryDetail,
+    countBuildWarnings,
     clearBuildCache,
     buildIfNeeded,
     computeProjectHash,

--- a/scripts/lint-staged-dotnet.js
+++ b/scripts/lint-staged-dotnet.js
@@ -19,6 +19,7 @@ const {
     needsFormatCheck,
     markFormatChecked,
     getCachedFormatOutput,
+    stripSummaryDetail,
     clearCacheIfRequested,
 } = require("./lib/build-cache")
 
@@ -188,12 +189,14 @@ const runBuild = (projectPath) => {
 
     try {
         logger.info(`Building ${buildPath} project for code analysis...`)
-        const result = execFileSync("dotnet", buildArgs, {
+        const rawResult = execFileSync("dotnet", buildArgs, {
             encoding: "utf8",
             timeout: 60_000, // Reduce timeout to 1 minute
             stdio: ["inherit", "pipe", "pipe"], // Suppress stdout, capture for parsing
             env: { ...env, DOTNET_USE_COMPILER_SERVER: "1" },
         })
+        // MSBuild's summary repeats every diagnostic, which made each finding report twice
+        const result = stripSummaryDetail(rawResult)
 
         // Store successful build in cache
         try {
@@ -210,7 +213,7 @@ const runBuild = (projectPath) => {
     } catch (error) {
         // Handle build failures - still capture analyzer output
         if (error.stdout || error.stderr) {
-            const output = (error.stdout || "") + (error.stderr || "")
+            const output = stripSummaryDetail((error.stdout || "") + (error.stderr || ""))
 
             // Store build output even for failed builds so analyzers can process it
             try {

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -13,6 +13,8 @@ const {
     getCachedBuildOutput,
     filterBuildErrors,
     isConfirmedWarningsOnly,
+    createSummaryDetailFilter,
+    countBuildWarnings,
     clearCacheIfRequested,
 } = require("./lib/build-cache")
 
@@ -54,8 +56,33 @@ function createErrorWithOutput(message, output) {
     return error
 }
 
-// Helper function to run commands and capture output for caching
+// Buffers the trailing partial line so a filtering decision is never split across two chunks.
+function createFilteredWriter(stream, shouldEmit) {
+    let pending = ""
+    return {
+        write(text) {
+            pending += text
+            const lines = pending.split("\n")
+            pending = lines.pop() ?? ""
+            for (const line of lines) {
+                if (shouldEmit(line)) {
+                    stream.write(`${line}\n`)
+                }
+            }
+        },
+        flush() {
+            if (pending && shouldEmit(pending)) {
+                stream.write(pending)
+            }
+            pending = ""
+        },
+    }
+}
+
+// options.lineFilter builds a per-stream predicate applied to displayed output only; the captured
+// output stays complete so caching and error filtering still see everything.
 function runCommandWithOutput(command, args, options = {}) {
+    const { lineFilter, ...spawnOptions } = options
     return new Promise((resolve, reject) => {
         let stdout = ""
         let stderr = ""
@@ -63,20 +90,26 @@ function runCommandWithOutput(command, args, options = {}) {
         const fullCommand = args.length > 0 ? `${command} ${args.join(" ")}` : command
         const child = spawn(fullCommand, {
             shell: true,
-            ...options,
+            ...spawnOptions,
         })
+
+        const passThrough = () => true
+        const outWriter = createFilteredWriter(process.stdout, lineFilter ? lineFilter() : passThrough)
+        const errWriter = createFilteredWriter(process.stderr, lineFilter ? lineFilter() : passThrough)
 
         child.stdout.on("data", (data) => {
             stdout += data.toString()
-            process.stdout.write(data)
+            outWriter.write(data.toString())
         })
 
         child.stderr.on("data", (data) => {
             stderr += data.toString()
-            process.stderr.write(data)
+            errWriter.write(data.toString())
         })
 
         child.on("exit", (code) => {
+            outWriter.flush()
+            errWriter.flush()
             const output = stdout + stderr
             if (code === 0) {
                 resolve(output)
@@ -86,6 +119,8 @@ function runCommandWithOutput(command, args, options = {}) {
         })
 
         child.on("error", (err) => {
+            outWriter.flush()
+            errWriter.flush()
             reject(createErrorWithOutput(err.message, stdout + stderr))
         })
     })
@@ -175,7 +210,15 @@ async function verifyDotNetBuild() {
             showCachedDotNetErrors(webFailed, testFailed)
             return false
         }
-        logger.success(".NET compilation passed ✓ (cached)")
+        // A cached run prints no build output, so surface the warning count the cache already holds
+        const warningCount = countBuildWarnings(
+            getCachedBuildOutput("Viper.test.csproj") ?? getCachedBuildOutput("Viper.csproj"),
+        )
+        logger.success(
+            warningCount > 0
+                ? `.NET compilation passed ✓ (cached, ${warningCount} warning(s))`
+                : ".NET compilation passed ✓ (cached)",
+        )
         return true
     }
 
@@ -195,6 +238,7 @@ async function verifyDotNetBuild() {
             ],
             {
                 env: { ...env, DOTNET_USE_COMPILER_SERVER: "1", DOTNET_CLI_FORCE_UTF8_ENCODING: "true" },
+                lineFilter: createSummaryDetailFilter,
             },
         )
 

--- a/test/ClinicalScheduler/ClinicalSchedulerTestBase.cs
+++ b/test/ClinicalScheduler/ClinicalSchedulerTestBase.cs
@@ -38,7 +38,7 @@ namespace Viper.test.ClinicalScheduler
         public const string CardiologyEditPermission = "SVMSecure.ClnSched.Edit.Cardio";
         public const string InternalMedicineEditPermission = "SVMSecure.ClnSched.Edit.IM";
 
-        public static readonly int TestYear = DateTime.UtcNow.Year;
+        public static readonly int TestYear = DateTime.Now.Year;
         public static readonly int TestTermCode = TestYear * 100 + 1;
 
         // Shared test infrastructure

--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -120,8 +120,8 @@ namespace Viper.test.ClinicalScheduler
                 await _context.Weeks.AddAsync(new Week
                 {
                     WeekId = weekId,
-                    DateStart = DateTime.UtcNow.AddDays(-7.0 * (10 - weekId)),
-                    DateEnd = DateTime.UtcNow.AddDays(-7.0 * (10 - weekId) + 6),
+                    DateStart = DateTime.Now.AddDays(-7.0 * (10 - weekId)),
+                    DateEnd = DateTime.Now.AddDays(-7.0 * (10 - weekId) + 6),
                     TermCode = 202501
                 });
             }

--- a/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
@@ -88,7 +88,7 @@ namespace Viper.test.ClinicalScheduler.Integration
 
             // Add test data for student schedule params using TestDataBuilder
             var (week, weekGradYear) = TestDataBuilder.CreateWeekScenario(1, gradYear,
-                new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+                new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local));
             Context.Weeks.Add(week);
             Context.WeekGradYears.Add(weekGradYear);
             await Context.SaveChangesAsync();

--- a/test/ClinicalScheduler/Integration/ServiceLayerIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/ServiceLayerIntegrationTest.cs
@@ -1,9 +1,11 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Viper.Areas.ClinicalScheduler.Extensions;
 using Viper.Areas.ClinicalScheduler.Models.DTOs.Responses;
 using Viper.Areas.ClinicalScheduler.Services;
 using Viper.Areas.CTS.Models;
+using Viper.Classes.SQLContext;
 using Viper.Models.ClinicalScheduler;
 using CtsModels = Viper.Models.CTS;
 
@@ -16,6 +18,10 @@ namespace Viper.test.ClinicalScheduler.Integration
     /// </summary>
     public class ServiceLayerIntegrationTest : IntegrationTestBase
     {
+        private static readonly DateTime ScheduleStart = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Local);
+        private static readonly DateTime ScheduleEnd = new(2024, 1, 7, 0, 0, 0, DateTimeKind.Local);
+
+        private readonly VIPERContext _viperContext;
         private readonly IStudentScheduleService _studentScheduleService;
         private readonly IInstructorScheduleService _instructorScheduleService;
         private readonly ClinicalScheduleService _clinicalScheduleService;
@@ -24,142 +30,18 @@ namespace Viper.test.ClinicalScheduler.Integration
 
         public ServiceLayerIntegrationTest()
         {
+            // The schedule services read VIPERContext, which IntegrationTestBase does not supply.
+            // Give them a real in-memory one so these tests exercise the services themselves.
+            // A stub here would let the suite stay green with the services broken.
+            _viperContext = new VIPERContext(
+                new DbContextOptionsBuilder<VIPERContext>()
+                    .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                    .Options);
 
-            // Create mock services since actual services require VIPERContext
-            // Note: studentLogger not used since we're mocking the service
-            var mockStudentService = Substitute.For<IStudentScheduleService>();
-            mockStudentService.GetStudentScheduleAsync(
-                Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(),
-                Arg.Any<int?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>())
-                .Returns(callInfo =>
-                {
-                    var mothraId = callInfo.ArgAt<string>(1);
-                    var rotationId = callInfo.ArgAt<int?>(2);
-                    var weekId = callInfo.ArgAt<int?>(4);
-
-                    // Return mock data that matches the test scenarios
-                    var mockData = new List<ClinicalScheduledStudent>();
-
-                    // Add mock student data that matches the test expectations
-                    if ((rotationId == null || rotationId == CardiologyRotationId) &&
-                        (mothraId == null || mothraId == "12345") &&
-                        (weekId == null || weekId == 1))
-                    {
-                        mockData.Add(new ClinicalScheduledStudent
-                        {
-                            MothraId = "12345",
-                            FirstName = "Student",
-                            LastName = "One",
-                            FullName = "Student One",
-                            ServiceId = CardiologyServiceId,
-                            RotationId = CardiologyRotationId,
-                            WeekId = 1,
-                            ServiceName = "Cardiology Service",
-                            RotationName = "Cardiology",
-                            DateStart = DateTime.Now.AddDays(-1),
-                            DateEnd = DateTime.Now.AddDays(5)
-                        });
-                    }
-
-                    // Add mock data for rotation ID 300 tests
-                    if ((rotationId == null || rotationId == 300) &&
-                        (mothraId == null || mothraId == "12345") &&
-                        (weekId == null || weekId == 10))
-                    {
-                        mockData.Add(new ClinicalScheduledStudent
-                        {
-                            MothraId = "12345",
-                            FirstName = "Student",
-                            LastName = "One",
-                            FullName = "Student One",
-                            ServiceId = CardiologyServiceId,
-                            RotationId = 300,
-                            WeekId = 10,
-                            ServiceName = "Test Service",
-                            RotationName = "Test Rotation",
-                            DateStart = DateTime.Now.AddDays(-1),
-                            DateEnd = DateTime.Now.AddDays(5)
-                        });
-                    }
-
-                    return Task.FromResult(mockData);
-                });
-            _studentScheduleService = mockStudentService;
-
-            // Note: instructorLogger not used since we're mocking the service
-            var mockInstructorService = Substitute.For<IInstructorScheduleService>();
-            mockInstructorService.GetInstructorScheduleAsync(
-                Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(),
-                Arg.Any<int?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<bool?>())
-                .Returns(callInfo =>
-                {
-                    var mothraId = callInfo.ArgAt<string>(1);
-                    var rotationId = callInfo.ArgAt<int?>(2);
-                    var weekId = callInfo.ArgAt<int?>(4);
-
-                    // Return mock data that matches the test scenarios
-                    var mockData = new List<CtsModels.InstructorSchedule>();
-
-                    // Add mock instructor data that matches the test expectations
-                    if ((rotationId == null || rotationId == CardiologyRotationId) &&
-                        (mothraId == null || mothraId == "instructor1") &&
-                        (weekId == null || weekId == 1))
-                    {
-                        mockData.Add(new CtsModels.InstructorSchedule
-                        {
-                            InstructorScheduleId = 101,
-                            MothraId = "instructor1",
-                            RotationId = CardiologyRotationId,
-                            WeekId = 1,
-                            Evaluator = true
-                        });
-                    }
-
-                    // Add mock data for SurgeryRotationId tests
-                    if ((rotationId == null || rotationId == SurgeryRotationId) &&
-                        (mothraId == null || mothraId == "instructor1") &&
-                        (weekId == null || weekId == 1))
-                    {
-                        mockData.Add(new CtsModels.InstructorSchedule
-                        {
-                            InstructorScheduleId = 102,
-                            MothraId = "instructor1",
-                            RotationId = SurgeryRotationId,
-                            WeekId = 1,
-                            Evaluator = true
-                        });
-                    }
-
-                    // Add mock data for rotation ID 300 tests - return both instructors when querying rotation 300
-                    if ((rotationId == null || rotationId == 300))
-                    {
-                        if (weekId == null || weekId == 10)
-                        {
-                            mockData.Add(new CtsModels.InstructorSchedule
-                            {
-                                InstructorScheduleId = 301,
-                                MothraId = "instructor1",
-                                RotationId = 300,
-                                WeekId = 10,
-                                Evaluator = true
-                            });
-                        }
-                        if (weekId == null || weekId == 11)
-                        {
-                            mockData.Add(new CtsModels.InstructorSchedule
-                            {
-                                InstructorScheduleId = 302,
-                                MothraId = "instructor2",
-                                RotationId = 300,
-                                WeekId = 11,
-                                Evaluator = false
-                            });
-                        }
-                    }
-
-                    return Task.FromResult(mockData);
-                });
-            _instructorScheduleService = mockInstructorService;
+            _studentScheduleService = new StudentScheduleService(
+                _viperContext, Substitute.For<ILogger<StudentScheduleService>>());
+            _instructorScheduleService = new InstructorScheduleService(
+                _viperContext, Substitute.For<ILogger<InstructorScheduleService>>());
 
             _clinicalScheduleService = new ClinicalScheduleService(
                 _studentScheduleService,
@@ -173,23 +55,107 @@ namespace Viper.test.ClinicalScheduler.Integration
             _evaluationPolicyService = new EvaluationPolicyService();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _viperContext.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Both services Include Week, Service and Rotation, so those rows must exist for a
+        /// schedule row to come back at all. Adds each only once per context.
+        /// </summary>
+        private void EnsureScheduleReferenceRows(int weekId, int rotationId)
+        {
+            if (_viperContext.Services.Local.All(s => s.ServiceId != CardiologyServiceId))
+            {
+                _viperContext.Services.Add(new CtsModels.Service
+                {
+                    ServiceId = CardiologyServiceId,
+                    ServiceName = "Cardiology Service",
+                    ShortName = "CARD"
+                });
+            }
+            if (_viperContext.Weeks.Local.All(w => w.WeekId != weekId))
+            {
+                _viperContext.Weeks.Add(new CtsModels.Week
+                {
+                    WeekId = weekId,
+                    DateStart = ScheduleStart,
+                    DateEnd = ScheduleEnd
+                });
+            }
+            if (_viperContext.Rotations.Local.All(r => r.RotId != rotationId))
+            {
+                _viperContext.Rotations.Add(new CtsModels.Rotation
+                {
+                    RotId = rotationId,
+                    ServiceId = CardiologyServiceId,
+                    Name = $"Rotation {rotationId}",
+                    Abbreviation = $"R{rotationId}"
+                });
+            }
+        }
+
+        private void AddInstructorSchedule(int id, string mothraId, int rotationId, int weekId, bool evaluator,
+            string lastName = "Instructor", string firstName = "Test")
+        {
+            EnsureScheduleReferenceRows(weekId, rotationId);
+            _viperContext.InstructorSchedules.Add(new CtsModels.InstructorSchedule
+            {
+                InstructorScheduleId = id,
+                MothraId = mothraId,
+                RotationId = rotationId,
+                ServiceId = CardiologyServiceId,
+                WeekId = weekId,
+                Evaluator = evaluator,
+                LastName = lastName,
+                FirstName = firstName,
+                FullName = $"{firstName} {lastName}",
+                RotationName = $"Rotation {rotationId}",
+                Abbreviation = $"R{rotationId}",
+                ServiceName = "Cardiology Service",
+                DateStart = ScheduleStart,
+                DateEnd = ScheduleEnd
+            });
+        }
+
+        private void AddStudentSchedule(int id, string mothraId, int rotationId, int weekId,
+            string lastName = "Student", string firstName = "Test")
+        {
+            EnsureScheduleReferenceRows(weekId, rotationId);
+            _viperContext.StudentSchedules.Add(new CtsModels.StudentSchedule
+            {
+                StudentScheduleId = id,
+                PersonId = id,
+                MothraId = mothraId,
+                RotationId = rotationId,
+                ServiceId = CardiologyServiceId,
+                WeekId = weekId,
+                LastName = lastName,
+                FirstName = firstName,
+                FullName = $"{firstName} {lastName}",
+                RotationName = $"Rotation {rotationId}",
+                Abbreviation = $"R{rotationId}",
+                ServiceName = "Cardiology Service",
+                DateStart = ScheduleStart,
+                DateEnd = ScheduleEnd
+            });
+        }
+
         [Fact]
         public async Task ServiceDecomposition_StudentScheduleService_WorksIndependently()
         {
-            // Arrange - Setup mock to return test data
-            var testStudent = new ClinicalScheduledStudent
-            {
-                MothraId = "student1"
-            };
-
-            var mockService = Substitute.For<IStudentScheduleService>();
-            mockService.GetStudentScheduleAsync(
-                Arg.Any<int?>(), Arg.Any<string>(), CardiologyRotationId, Arg.Any<int?>(),
-                Arg.Any<int?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>())
-                .Returns(new List<ClinicalScheduledStudent> { testStudent });
+            // Arrange - two rotations, so the assertion proves the filter rather than the seed
+            AddStudentSchedule(1, "student1", CardiologyRotationId, weekId: 1);
+            AddStudentSchedule(2, "student2", SurgeryRotationId, weekId: 1);
+            await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act
-            var schedules = await mockService.GetStudentScheduleAsync(
+            var schedules = await _studentScheduleService.GetStudentScheduleAsync(
                 classYear: null,
                 mothraId: null,
                 rotationId: CardiologyRotationId,
@@ -200,25 +166,18 @@ namespace Viper.test.ClinicalScheduler.Integration
             );
 
             // Assert
-            Assert.NotEmpty(schedules);
             Assert.Single(schedules);
             Assert.Equal("student1", schedules[0].MothraId);
+            Assert.Equal(CardiologyRotationId, schedules[0].RotationId);
         }
 
         [Fact]
         public async Task ServiceDecomposition_InstructorScheduleService_WorksIndependently()
         {
-            // Arrange
-            var instructorSchedule = new InstructorSchedule
-            {
-                InstructorScheduleId = 10,
-                MothraId = "instructor1",
-                RotationId = SurgeryRotationId,
-                WeekId = 1,
-                Evaluator = true
-            };
-            Context.InstructorSchedules.Add(instructorSchedule);
-            await Context.SaveChangesAsync();
+            // Arrange - a second instructor on the same rotation keeps the mothraId filter honest
+            AddInstructorSchedule(10, "instructor1", SurgeryRotationId, weekId: 1, evaluator: true);
+            AddInstructorSchedule(11, "instructor2", SurgeryRotationId, weekId: 1, evaluator: false);
+            await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Use InstructorScheduleService directly (methods signatures are different)
             var schedules = await _instructorScheduleService.GetInstructorScheduleAsync(
@@ -244,12 +203,25 @@ namespace Viper.test.ClinicalScheduler.Integration
         [Fact]
         public async Task ClinicalScheduleService_DelegatesToNewServices_ForBackwardCompatibility()
         {
-            // Arrange - Test data is provided by mocked services
-            // The test focuses on service delegation, not actual data
-            await Context.SaveChangesAsync();
+            // Arrange - collaborators are mocked on purpose here. This test is about whether
+            // ClinicalScheduleService forwards to them, not about their queries, so it builds its
+            // own doubles rather than using the real services the other tests exercise.
+            var studentService = Substitute.For<IStudentScheduleService>();
+            studentService.GetStudentScheduleAsync(
+                Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(),
+                Arg.Any<int?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>())
+                .Returns(new List<ClinicalScheduledStudent> { new() { MothraId = "12345" } });
+
+            var instructorService = Substitute.For<IInstructorScheduleService>();
+            instructorService.GetInstructorScheduleAsync(
+                Arg.Any<int?>(), Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<int?>(),
+                Arg.Any<int?>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<bool?>())
+                .Returns(new List<CtsModels.InstructorSchedule> { new() { MothraId = "instructor1" } });
+
+            var delegatingService = new ClinicalScheduleService(studentService, instructorService);
 
             // Act - Use ClinicalScheduleService which should delegate
-            var studentSchedules = await _clinicalScheduleService.GetStudentSchedule(
+            var studentSchedules = await delegatingService.GetStudentSchedule(
                 classYear: null,
                 mothraId: null,
                 rotationId: CardiologyRotationId,
@@ -258,7 +230,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 startDate: null,
                 endDate: null
             );
-            var instructorSchedules = await _clinicalScheduleService.GetInstructorSchedule(
+            var instructorSchedules = await delegatingService.GetInstructorSchedule(
                 classYear: null,
                 mothraId: null,
                 rotationId: CardiologyRotationId,
@@ -269,9 +241,10 @@ namespace Viper.test.ClinicalScheduler.Integration
                 active: null
             );
 
-            // Assert - Verify delegation works correctly
-            Assert.NotEmpty(studentSchedules);
-            Assert.NotEmpty(instructorSchedules);
+            // Assert - the collaborators were called with the filter forwarded (every other
+            // argument matches its default), and their results came back untouched
+            await studentService.Received(1).GetStudentScheduleAsync(rotationId: CardiologyRotationId);
+            await instructorService.Received(1).GetInstructorScheduleAsync(rotationId: CardiologyRotationId);
             Assert.Equal("12345", studentSchedules[0].MothraId);
             Assert.Equal("instructor1", instructorSchedules[0].MothraId);
         }
@@ -359,52 +332,22 @@ namespace Viper.test.ClinicalScheduler.Integration
         [Fact]
         public async Task ServiceIntegration_CompleteScheduleManagement_Flow()
         {
-            // Arrange - Setup complete schedule scenario
-            var week1 = new Week { WeekId = 10, DateStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), DateEnd = new DateTime(2024, 1, 7, 0, 0, 0, DateTimeKind.Utc) };
-            var week2 = new Week { WeekId = 11, DateStart = new DateTime(2024, 1, 8, 0, 0, 0, DateTimeKind.Utc), DateEnd = new DateTime(2024, 1, 14, 0, 0, 0, DateTimeKind.Utc) };
-            Context.Weeks.AddRange(week1, week2);
-
-            var rotation = new Rotation
-            {
-                RotId = 300,
-                ServiceId = CardiologyServiceId,
-                Name = "Integration Test Rotation",
-                Abbreviation = "INT",
-                Active = true
-            };
-            Context.Rotations.Add(rotation);
-            await Context.SaveChangesAsync();
-
-            // Student schedule data would be added here if needed
-            // Currently the test uses mocked services that return test data
-
-            // Add instructor schedules
-            var instructorSchedule1 = new InstructorSchedule
-            {
-                InstructorScheduleId = 301,
-                MothraId = "instructor1",
-                RotationId = 300,
-                WeekId = 10,
-                Evaluator = true
-            };
-            var instructorSchedule2 = new InstructorSchedule
-            {
-                InstructorScheduleId = 302,
-                MothraId = "instructor2",
-                RotationId = 300,
-                WeekId = 11,
-                Evaluator = false
-            };
-            Context.InstructorSchedules.AddRange(instructorSchedule1, instructorSchedule2);
-            await Context.SaveChangesAsync();
+            // Arrange - one rotation spanning two weeks, plus a schedule on another rotation so
+            // the rotation and week filters have something to exclude
+            const int integrationRotationId = 300;
+            AddStudentSchedule(1, "12345", integrationRotationId, weekId: 10);
+            AddStudentSchedule(2, "67890", CardiologyRotationId, weekId: 11);
+            AddInstructorSchedule(301, "instructor1", integrationRotationId, weekId: 10, evaluator: true);
+            AddInstructorSchedule(302, "instructor2", integrationRotationId, weekId: 11, evaluator: false);
+            await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Test complete flow through services
             var rotationStudents = await _studentScheduleService.GetStudentScheduleAsync(
-                classYear: null, mothraId: null, rotationId: 300, serviceId: null,
+                classYear: null, mothraId: null, rotationId: integrationRotationId, serviceId: null,
                 weekId: null, startDate: null, endDate: null
             );
             var rotationInstructors = await _instructorScheduleService.GetInstructorScheduleAsync(
-                classYear: null, mothraId: null, rotationId: 300, serviceId: null,
+                classYear: null, mothraId: null, rotationId: integrationRotationId, serviceId: null,
                 weekId: null, startDate: null, endDate: null, active: null
             );
             var evaluators = rotationInstructors.Where(i => i.Evaluator).ToList();
@@ -487,16 +430,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             await _personService.GetClinicianFromAaudAsync("instructor1");
             // Person might be null if AAUD data is not seeded
 
-            var instructorSchedule = new InstructorSchedule
-            {
-                InstructorScheduleId = 401,
-                MothraId = "instructor1",
-                RotationId = CardiologyRotationId,
-                WeekId = 1,
-                Evaluator = true
-            };
-            Context.InstructorSchedules.Add(instructorSchedule);
-            await Context.SaveChangesAsync();
+            AddInstructorSchedule(401, "instructor1", CardiologyRotationId, weekId: 1, evaluator: true);
+            await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Verify data consistency across services
             var schedules = await _instructorScheduleService.GetInstructorScheduleAsync(

--- a/test/ClinicalScheduler/IntegrationTestBase.cs
+++ b/test/ClinicalScheduler/IntegrationTestBase.cs
@@ -190,9 +190,9 @@ namespace Viper.test.ClinicalScheduler
 
             // Add Week and WeekGradYear data
             var (week1, weekGradYear1) = TestDataBuilder.CreateWeekScenario(10, currentYear + 3,
-                new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+                new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Local));
             var (week2, weekGradYear2) = TestDataBuilder.CreateWeekScenario(11, currentYear + 3,
-                new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Utc));
+                new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Local));
 
             Context.Weeks.AddRange(week1, week2);
             Context.WeekGradYears.AddRange(weekGradYear1, weekGradYear2);

--- a/test/ClinicalScheduler/RotationsControllerTest.cs
+++ b/test/ClinicalScheduler/RotationsControllerTest.cs
@@ -109,7 +109,7 @@ namespace Viper.test.ClinicalScheduler
 
         private void SetupMockWeekService()
         {
-            var baseDate = new DateTime(TestYear, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            var baseDate = new DateTime(TestYear, 6, 1, 0, 0, 0, DateTimeKind.Local);
             var mockWeeks = new List<WeekDto>
             {
                 new WeekDto

--- a/test/ClinicalScheduler/ScheduleAuditServiceTest.cs
+++ b/test/ClinicalScheduler/ScheduleAuditServiceTest.cs
@@ -247,7 +247,7 @@ namespace Viper.test.ClinicalScheduler
                 WeekId = weekId,
                 Action = action,
                 ModifiedBy = modifiedBy,
-                TimeStamp = DateTime.UtcNow,
+                TimeStamp = DateTime.Now,
                 Area = area
             };
         }

--- a/test/ClinicalScheduler/ScheduleEditServiceTest.cs
+++ b/test/ClinicalScheduler/ScheduleEditServiceTest.cs
@@ -137,11 +137,11 @@ namespace Viper.test.ClinicalScheduler
             // Add basic weeks and week grad years using TestDataBuilder
             var weekData = new[]
             {
-                TestDataBuilder.CreateWeekScenario(1, testGradYear, new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
-                TestDataBuilder.CreateWeekScenario(2, testGradYear, new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Utc)),
-                TestDataBuilder.CreateWeekScenario(10, testGradYear, new DateTime(currentYear, 3, 1, 0, 0, 0, DateTimeKind.Utc)),
-                TestDataBuilder.CreateWeekScenario(15, testGradYear, new DateTime(currentYear, 4, 1, 0, 0, 0, DateTimeKind.Utc)),
-                TestDataBuilder.CreateWeekScenario(20, testGradYear, new DateTime(currentYear, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+                TestDataBuilder.CreateWeekScenario(1, testGradYear, new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Local)),
+                TestDataBuilder.CreateWeekScenario(2, testGradYear, new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Local)),
+                TestDataBuilder.CreateWeekScenario(10, testGradYear, new DateTime(currentYear, 3, 1, 0, 0, 0, DateTimeKind.Local)),
+                TestDataBuilder.CreateWeekScenario(15, testGradYear, new DateTime(currentYear, 4, 1, 0, 0, 0, DateTimeKind.Local)),
+                TestDataBuilder.CreateWeekScenario(20, testGradYear, new DateTime(currentYear, 5, 1, 0, 0, 0, DateTimeKind.Local))
             };
 
             foreach (var (week, weekGradYear) in weekData)

--- a/test/ClinicalScheduler/TestDataBuilder.cs
+++ b/test/ClinicalScheduler/TestDataBuilder.cs
@@ -179,7 +179,7 @@ namespace Viper.test.ClinicalScheduler
         /// </summary>
         public static Week CreateWeek(int weekId, DateTime? startDate = null)
         {
-            var start = startDate ?? DateTime.UtcNow.AddDays(-7.0 * (10 - weekId));
+            var start = startDate ?? DateTime.Now.AddDays(-7.0 * (10 - weekId));
             return new Week
             {
                 WeekId = weekId,
@@ -371,8 +371,8 @@ namespace Viper.test.ClinicalScheduler
                 // Create weeks and grad years
                 var weeks = new[]
                 {
-                    CreateWeek(10, new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
-                    CreateWeek(11, new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Utc))
+                    CreateWeek(10, new DateTime(currentYear, 1, 1, 0, 0, 0, DateTimeKind.Local)),
+                    CreateWeek(11, new DateTime(currentYear, 1, 8, 0, 0, 0, DateTimeKind.Local))
                 };
                 context.Weeks.AddRange(weeks);
 

--- a/test/Directory/DirectoryControllerTests.cs
+++ b/test/Directory/DirectoryControllerTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.Directory.Controllers;
+using Viper.Classes.SQLContext;
+using Viper.Models.AAUD;
+
+// Not Viper.test.Directory: a namespace segment named "Directory" shadows System.IO.Directory
+// for every file under Viper.test.*
+// ReSharper disable once CheckNamespace
+namespace Viper.test.DirectoryArea;
+
+/// <summary>
+/// Tests for the shared directory search query, run against the relational SQLite
+/// provider so the predicate goes through EF's SQL translator like it does on SQL
+/// Server (the InMemory provider executes LINQ in memory and skips translation).
+/// SQLite string matching is case-sensitive where SQL Server's default collation is
+/// not, so seed data matches the search term's exact case.
+/// </summary>
+public sealed class DirectoryControllerTests : IDisposable
+{
+    /// <summary>
+    /// A trimmed AAUDContext mapping only AaudUser: the full AAUD warehouse model has
+    /// computed columns and views SQLite EnsureCreated cannot build (same pattern as
+    /// StudentGroupServiceQueryTests). Current is a plain column here, so tests set it
+    /// directly instead of via the production computed column.
+    /// </summary>
+    private sealed class TestAaudContext(DbContextOptions<AAUDContext> options) : AAUDContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            foreach (var clrType in modelBuilder.Model.GetEntityTypes()
+                         .Select(e => e.ClrType)
+                         .Where(t => t != typeof(AaudUser))
+                         .Distinct()
+                         .ToList())
+            {
+                modelBuilder.Ignore(clrType);
+            }
+            modelBuilder.Entity<AaudUser>().HasKey(e => e.AaudUserId);
+        }
+    }
+
+    private readonly SqliteConnection _connection;
+    private readonly AAUDContext _context;
+
+    public DirectoryControllerTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _context = new TestAaudContext(
+            new DbContextOptionsBuilder<AAUDContext>().UseSqlite(_connection).Options);
+        _context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task SearchCurrentAaudUsers_MatchesNameAndEveryIdentifierField()
+    {
+        SeedUser(1, lastName: "Delfigo", firstName: "Ann");
+        SeedUser(2, lastName: "Berry", firstName: "Bo", mailId: "fig@ucdavis.edu");
+        SeedUser(3, lastName: "Cherry", firstName: "Cy", loginId: "figuser");
+        SeedUser(4, lastName: "Damson", firstName: "Di", spridenId: "fig123");
+        SeedUser(5, lastName: "Elder", firstName: "Ed", pidm: "00fig");
+        SeedUser(6, lastName: "Fennel", firstName: "Flo", mothraId: "fig999");
+        SeedUser(7, lastName: "Guava", firstName: "Gil", employeeId: "emp-fig");
+        SeedUser(8, lastName: "Haw", firstName: "Hal", iamId: "iam-fig");
+        SeedUser(9, lastName: "Ivy", firstName: "Ira");
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await DirectoryController.SearchCurrentAaudUsers(_context, "fig");
+
+        // One match per field, none for user 9, ordered by last name
+        Assert.Equal([2, 3, 4, 1, 5, 6, 7, 8], results.Select(u => u.AaudUserId));
+    }
+
+    [Fact]
+    public async Task SearchCurrentAaudUsers_MatchesTermSpanningFirstAndLastName()
+    {
+        SeedUser(1, lastName: "Graham", firstName: "Anna");
+        SeedUser(2, lastName: "Graham", firstName: "Steve");
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await DirectoryController.SearchCurrentAaudUsers(_context, "na Gra");
+
+        Assert.Equal([1], results.Select(u => u.AaudUserId));
+    }
+
+    [Fact]
+    public async Task SearchCurrentAaudUsers_ExcludesUsersNoLongerCurrent()
+    {
+        SeedUser(1, lastName: "Figworth", firstName: "Cur");
+        SeedUser(2, lastName: "Figworth", firstName: "Old", current: 0);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await DirectoryController.SearchCurrentAaudUsers(_context, "Figworth");
+
+        Assert.Equal([1], results.Select(u => u.AaudUserId));
+    }
+
+    [Fact]
+    public async Task SearchCurrentAaudUsers_OrdersByLastNameThenFirstName()
+    {
+        SeedUser(1, lastName: "Fig", firstName: "Zoe");
+        SeedUser(2, lastName: "Fig", firstName: "Al");
+        SeedUser(3, lastName: "Elm", firstName: "Bea", mailId: "Fig@ucdavis.edu");
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await DirectoryController.SearchCurrentAaudUsers(_context, "Fig");
+
+        Assert.Equal([3, 2, 1], results.Select(u => u.AaudUserId));
+    }
+
+    private void SeedUser(int id, string lastName, string firstName, string? mailId = null,
+        string? loginId = null, string? spridenId = null, string? pidm = null,
+        string? mothraId = null, string? employeeId = null, string? iamId = null, int current = 1)
+    {
+        _context.AaudUsers.Add(new AaudUser
+        {
+            AaudUserId = id,
+            ClientId = "test",
+            MothraId = mothraId ?? $"m-{id}",
+            LoginId = loginId,
+            MailId = mailId,
+            SpridenId = spridenId,
+            Pidm = pidm,
+            EmployeeId = employeeId,
+            IamId = iamId,
+            LastName = lastName,
+            FirstName = firstName,
+            DisplayLastName = lastName,
+            DisplayFirstName = firstName,
+            DisplayFullName = firstName + " " + lastName,
+            Current = current
+        });
+    }
+}

--- a/test/Effort/HarvestTimeParserTests.cs
+++ b/test/Effort/HarvestTimeParserTests.cs
@@ -90,7 +90,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_SameDay_OneHourSession_Returns60()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "0800", date, "0900");
@@ -101,7 +101,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_SameDay_TwoHourSession_Returns120()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "1400", date, "1600");
@@ -112,7 +112,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_SameDay_90MinuteSession_Returns90()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "0930", date, "1100");
@@ -123,7 +123,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_EndTime2400_CalculatesCorrectly()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "2200", date, "2400");
@@ -134,8 +134,8 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_CrossesMidnight_CalculatesCorrectly()
     {
-        var startDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
-        var endDate = new DateTime(2024, 1, 16, 0, 0, 0, DateTimeKind.Utc);
+        var startDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
+        var endDate = new DateTime(2024, 1, 16, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             startDate, "2200", endDate, "0100");
@@ -146,7 +146,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_EndBeforeStart_ReturnsZero()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "1400", date, "1300");
@@ -157,7 +157,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_SameStartAndEnd_ReturnsZero()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "1400", date, "1400");
@@ -168,7 +168,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_InvalidTimeFormat_ReturnsZero()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "invalid", date, "0900");
@@ -179,7 +179,7 @@ public sealed class HarvestTimeParserTests
     [Fact]
     public void CalculateSessionMinutes_WithStandardTimeFormat_ParsesCorrectly()
     {
-        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local);
 
         var result = HarvestTimeParser.CalculateSessionMinutes(
             date, "8:00 AM", date, "9:30 AM");

--- a/test/Effort/PercentagesControllerTests.cs
+++ b/test/Effort/PercentagesControllerTests.cs
@@ -64,7 +64,7 @@ public sealed class PercentagesControllerTests
         Modifier = null,
         Comment = null,
         PercentageValue = 50,
-        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local),
         EndDate = null,
         Compensated = false,
         IsActive = true,
@@ -79,7 +79,7 @@ public sealed class PercentagesControllerTests
         Modifier = null,
         Comment = null,
         PercentageValue = 50,
-        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local),
         EndDate = null,
         Compensated = false
     };
@@ -91,7 +91,7 @@ public sealed class PercentagesControllerTests
         Modifier = null,
         Comment = "Updated",
         PercentageValue = 60,
-        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        StartDate = new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local),
         EndDate = null,
         Compensated = false
     };

--- a/test/RAPS/AdGroupsControllerTests.cs
+++ b/test/RAPS/AdGroupsControllerTests.cs
@@ -1,0 +1,50 @@
+using System.Runtime.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Viper.Areas.RAPS.Controllers;
+using Viper.Areas.RAPS.Models;
+using Viper.Classes.SQLContext;
+using Viper.Models.RAPS;
+
+namespace Viper.test.RAPS
+{
+    [SupportedOSPlatform("windows")]
+    public class AdGroupsControllerTests
+    {
+        [Fact]
+        public async Task UpdateGroup_RejectsMismatchedGroupId_AndLeavesGroupUnchanged()
+        {
+            using var sqlLiteConnection = new SqliteConnection("Filename=:memory:");
+            await sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
+            var sqlLiteContextOptions = new DbContextOptionsBuilder<RAPSContext>()
+                .UseSqlite(sqlLiteConnection)
+                .Options;
+            using var context = new RAPSContext(sqlLiteContextOptions);
+            await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+            // arrange
+            var ouGroup = new OuGroup { Name = "OriginalName", Description = "Original description" };
+            context.OuGroups.Add(ouGroup);
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            var adGroupsController = new AdGroupsController(context);
+            var mismatchedEdit = new GroupAddEdit
+            {
+                GroupId = ouGroup.OugroupId + 1,
+                Name = "ChangedName",
+                Description = "Changed description"
+            };
+
+            // act
+            var result = await adGroupsController.UpdateGroup(ouGroup.OugroupId, mismatchedEdit);
+
+            // assert
+            Assert.IsType<BadRequestResult>(result);
+            var unchangedGroup = await context.OuGroups.FindAsync(new object?[] { ouGroup.OugroupId }, TestContext.Current.CancellationToken);
+            Assert.NotNull(unchangedGroup);
+            Assert.Equal("OriginalName", unchangedGroup.Name);
+            Assert.Equal("Original description", unchangedGroup.Description);
+        }
+    }
+}

--- a/test/RAPS/RAPSControllerTests.cs
+++ b/test/RAPS/RAPSControllerTests.cs
@@ -1,0 +1,260 @@
+using System.Runtime.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Viper.Areas.RAPS.Controllers;
+using Viper.Classes.SQLContext;
+using Viper.Models.RAPS;
+
+namespace Viper.test.RAPS
+{
+    [SupportedOSPlatform("windows")]
+    public class RAPSControllerTests
+    {
+        [Fact]
+        public async Task RoleMembers_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.RoleMembers("VIPER", 1));
+        }
+
+        [Fact]
+        public async Task RolePermissions_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.RolePermissions(1));
+        }
+
+        [Fact]
+        public async Task PermissionMembers_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.PermissionMembers(1));
+        }
+
+        [Fact]
+        public async Task PermissionRoles_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.PermissionRoles(1));
+        }
+
+        [Fact]
+        public async Task PermissionRolesRO_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.PermissionRolesRO(1));
+        }
+
+        [Fact]
+        public async Task AllMembersWithPermission_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.AllMembersWithPermission(1));
+        }
+
+        [Fact]
+        public async Task ExportToVMACS_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.ExportToVMACS("VMTH-test"));
+        }
+
+        [Fact]
+        public async Task GroupSync_ReturnsBadRequest_WhenModelBindingFailed()
+        {
+            await AssertBadRequestForInvalidModelStateAsync(c => c.GroupSync(1));
+        }
+
+        [Fact]
+        public async Task RolePermissions_ReturnsView_ForValidRoleId()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+
+            var result = await controller.RolePermissions(5);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Equal(5, view.ViewData["roleId"]);
+        }
+
+        [Fact]
+        public async Task PermissionMembers_ReturnsView_WhenPermissionExists()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var permission = await SeedPermissionAsync(context);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionMembers(permission.PermissionId);
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task PermissionMembers_ReturnsNotFound_WhenPermissionMissing()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionMembers(9999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task PermissionRoles_ReturnsView_WhenPermissionExists()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var permission = await SeedPermissionAsync(context);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionRoles(permission.PermissionId);
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task PermissionRoles_ReturnsNotFound_WhenPermissionMissing()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionRoles(9999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task PermissionRolesRO_ReturnsView_WhenPermissionExists()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var permission = await SeedPermissionAsync(context);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionRolesRO(permission.PermissionId);
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task PermissionRolesRO_ReturnsNotFound_WhenPermissionMissing()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+
+            var result = await controller.PermissionRolesRO(9999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task AllMembersWithPermission_ReturnsView_WhenPermissionExists()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var permission = await SeedPermissionAsync(context);
+            var controller = CreateController(context);
+
+            var result = await controller.AllMembersWithPermission(permission.PermissionId);
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task AllMembersWithPermission_ReturnsNotFound_WhenPermissionMissing()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+
+            var result = await controller.AllMembersWithPermission(9999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GroupSync_RendersWithoutSyncing_WhenGroupMissing()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var scopeFactory = Substitute.For<IServiceScopeFactory>();
+            var controller = CreateController(context, scopeFactory);
+
+            var result = await controller.GroupSync(9999);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Null(view.ViewData["Group"]);
+            scopeFactory.DidNotReceive().CreateScope();
+        }
+
+        [Fact]
+        public async Task GroupSync_RunsSyncInItsOwnScope_WhenGroupExists()
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var group = new OuGroup { Name = "CN=Test Group,OU=SVM,DC=ou", Description = "Test group" };
+            context.OuGroups.Add(group);
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            // The scope resolves no RAPSContext, so the sync fails immediately and is swallowed by the
+            // background task's catch. That keeps AD out of the test while still proving the sync runs
+            // off a scope of its own rather than the request-scoped context.
+            var scope = Substitute.For<IServiceScope>();
+            scope.ServiceProvider.Returns(Substitute.For<IServiceProvider>());
+            var scopeFactory = Substitute.For<IServiceScopeFactory>();
+            scopeFactory.CreateScope().Returns(scope);
+            var controller = CreateController(context, scopeFactory);
+
+            var result = await controller.GroupSync(group.OugroupId);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(group, view.ViewData["Group"]);
+            scopeFactory.Received(1).CreateScope();
+            scope.Received(1).Dispose();
+        }
+
+        private static async Task AssertBadRequestForInvalidModelStateAsync(Func<RAPSController, Task<IActionResult>> action)
+        {
+            using var connection = await OpenConnectionAsync();
+            using var context = await CreateContextAsync(connection);
+            var controller = CreateController(context);
+            controller.ModelState.AddModelError("param", "The value is not valid.");
+
+            var result = await action(controller);
+
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        private static async Task<SqliteConnection> OpenConnectionAsync()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            await connection.OpenAsync(TestContext.Current.CancellationToken);
+            return connection;
+        }
+
+        private static async Task<RAPSContext> CreateContextAsync(SqliteConnection connection)
+        {
+            var options = new DbContextOptionsBuilder<RAPSContext>()
+                .UseSqlite(connection)
+                .Options;
+            var context = new RAPSContext(options);
+            await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            return context;
+        }
+
+        private static RAPSController CreateController(RAPSContext context, IServiceScopeFactory? scopeFactory = null)
+        {
+            return new RAPSController(context, scopeFactory ?? Substitute.For<IServiceScopeFactory>());
+        }
+
+        private static async Task<TblPermission> SeedPermissionAsync(RAPSContext context)
+        {
+            var permission = new TblPermission { Permission = "SVMSecure.Test" };
+            context.TblPermissions.Add(permission);
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+            return permission;
+        }
+    }
+}

--- a/web/Areas/CMS/Controllers/CMSController.cs
+++ b/web/Areas/CMS/Controllers/CMSController.cs
@@ -14,12 +14,13 @@ namespace Viper.Areas.CMS.Controllers
         private readonly IHtmlSanitizerService _sanitizerService;
         private readonly ILogger<Data.CMS> _cmsLogger;
 
-        public CMSController(RAPSContext rapsContext, VIPERContext viperContext, IHtmlSanitizerService sanitizerService, ILogger<Data.CMS> cmsLogger)
+        public CMSController(RAPSContext rapsContext, VIPERContext viperContext, IHtmlSanitizerService sanitizerService, ILoggerFactory loggerFactory)
         {
             _rapsContext = rapsContext;
             _viperContext = viperContext;
             _sanitizerService = sanitizerService;
-            _cmsLogger = cmsLogger;
+            //the logger belongs to Data.CMS (which does the logging), not this controller
+            _cmsLogger = loggerFactory.CreateLogger<Data.CMS>();
         }
 
         [HttpGet]

--- a/web/Areas/CTS/Controllers/CTSController.cs
+++ b/web/Areas/CTS/Controllers/CTSController.cs
@@ -28,13 +28,16 @@ namespace Viper.Areas.CTS.Controllers
         /// <param name="context"></param>
         /// <param name="next"></param>
         /// <returns></returns>
+#pragma warning disable S6967 // filter override, not an action: returning BadRequest is impossible and checking ModelState here would blanket-validate every CTS action
         public override async Task OnActionExecutionAsync(ActionExecutingContext context,
                                          ActionExecutionDelegate next)
         {
             await base.OnActionExecutionAsync(context, next);
             ViewData["ViperLeftNav"] = Nav();
         }
+#pragma warning restore S6967
 
+        [NonAction]
         public NavMenu Nav()
         {
             var nav = new List<NavMenuItem>

--- a/web/Areas/Directory/Controllers/DirectoryController.cs
+++ b/web/Areas/Directory/Controllers/DirectoryController.cs
@@ -13,6 +13,7 @@ using Web.Authorization;
 namespace Viper.Areas.Directory.Controllers
 {
     [Area("Directory")]
+    [Route("/[area]")]
     [Permission(Allow = "SVMSecure")]
     [Authorize(Roles = "VMDO SVM-IT")] //locking directory for now until it's complete
     public class DirectoryController : AreaController
@@ -31,7 +32,7 @@ namespace Viper.Areas.Directory.Controllers
         /// <summary>
         /// Directory home page
         /// </summary>
-        [Route("/[area]/")]
+        [Route("")]
         public async Task<ActionResult> Index(string? useExample)
         {
             return await Task.Run(() => View("~/Areas/Directory/Views/Card.cshtml"));
@@ -40,7 +41,7 @@ namespace Viper.Areas.Directory.Controllers
         /// <summary>
         /// Directory home page
         /// </summary>
-        [Route("/[area]/nav")]
+        [Route("nav")]
         public async Task<ActionResult<IEnumerable<NavMenuItem>>> Nav()
         {
             var nav = new List<NavMenuItem>();
@@ -53,7 +54,7 @@ namespace Viper.Areas.Directory.Controllers
         /// </summary>
         /// <param name="search">search string</param>
         [SupportedOSPlatform("windows")]
-        [Route("/[area]/search/{search}")]
+        [Route("search/{search}")]
         public async Task<ActionResult<IEnumerable<IndividualSearchResult>>> Get(string search)
         {
             var individuals = await _aaud.AaudUsers
@@ -97,7 +98,7 @@ namespace Viper.Areas.Directory.Controllers
         /// </summary>
         /// <param name="search">search string</param>
         [SupportedOSPlatform("windows")]
-        [Route("/[area]/search/{search}/ucd")]
+        [Route("search/{search}/ucd")]
         public async Task<ActionResult<IEnumerable<IndividualSearchResult>>> GetUCD(string search)
         {
             List<IndividualSearchResult> results = new();
@@ -141,7 +142,7 @@ namespace Viper.Areas.Directory.Controllers
         /// Directory results
         /// </summary>
         /// <param name="uid">User ID</param>
-        [Route("/[area]/userInfo/{mothraID}")]
+        [Route("userInfo/{mothraID}")]
         public async Task<IActionResult> DirectoryResult(string mothraID)
         {
             // pull in the user based on uid

--- a/web/Areas/Directory/Controllers/DirectoryController.cs
+++ b/web/Areas/Directory/Controllers/DirectoryController.cs
@@ -57,24 +57,11 @@ namespace Viper.Areas.Directory.Controllers
         [Route("search/{search}")]
         public async Task<ActionResult<IEnumerable<IndividualSearchResult>>> Get(string search)
         {
-            var individuals = await _aaud.AaudUsers
-                     .Where(u => (u.DisplayFirstName + " " + u.DisplayLastName).Contains(search)
-                         || (u.MailId != null && u.MailId.Contains(search))
-                         || (u.LoginId != null && u.LoginId.Contains(search))
-                         || (u.SpridenId != null && u.SpridenId.Contains(search))
-                         || (u.Pidm != null && u.Pidm.Contains(search))
-                         || (u.MothraId != null && u.MothraId.Contains(search))
-                         || (u.EmployeeId != null && u.EmployeeId.Contains(search))
-                         || (u.IamId != null && u.IamId.Contains(search))
-            )
-            .Where(u => u.Current != 0)
-            .OrderBy(u => u.DisplayLastName)
-            .ThenBy(u => u.DisplayFirstName)
-                     .ToListAsync();
+            var individuals = await SearchCurrentAaudUsers(_aaud, search);
             List<IndividualSearchResult> results = new();
             AaudUser? currentUser = UserHelper.GetCurrentUser();
             bool hasDetailPermission = UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure.DirectoryDetail");
-            individuals.ForEach(m =>
+            foreach (var m in individuals)
             {
                 LdapUserContact? l = LdapService.GetUserByID(m.IamId);
                 var result = hasDetailPermission
@@ -82,14 +69,8 @@ namespace Viper.Areas.Directory.Controllers
                     : new IndividualSearchResult(m, l);
                 result.LookupEmailHost(_aaud);
                 results.Add(result);
-
-                var vmsearch = VMACSService.Search(result.LoginId);
-                var vm = vmsearch.Result;
-                if (vm != null && vm.item != null && vm.item.Nextel != null) result.Nextel = vm.item.Nextel[0];
-                if (vm != null && vm.item != null && vm.item.LDPager != null) result.LDPager = vm.item.LDPager[0];
-                if (vm != null && vm.item != null && vm.item.Unit != null) result.Department = vm.item.Unit[0];
-
-            });
+                await AddVmacsContactInfoAsync(result);
+            }
             return results;
         }
 
@@ -103,36 +84,19 @@ namespace Viper.Areas.Directory.Controllers
         {
             List<IndividualSearchResult> results = new();
             List<LdapUserContact> ldap = LdapService.GetUsersContact(search);
-            var individuals = await _aaud.AaudUsers
-                    .Where(u => (u.DisplayFirstName + " " + u.DisplayLastName).Contains(search)
-                        || (u.MailId != null && u.MailId.Contains(search))
-                        || (u.LoginId != null && u.LoginId.Contains(search))
-                        || (u.SpridenId != null && u.SpridenId.Contains(search))
-                        || (u.Pidm != null && u.Pidm.Contains(search))
-                        || (u.MothraId != null && u.MothraId.Contains(search))
-                        || (u.EmployeeId != null && u.EmployeeId.Contains(search))
-                        || (u.IamId != null && u.IamId.Contains(search))
-           )
-           .Where(u => u.Current != 0)
-           .OrderBy(u => u.DisplayLastName)
-           .ThenBy(u => u.DisplayFirstName)
-                    .ToListAsync();
+            var individuals = await SearchCurrentAaudUsers(_aaud, search);
+            var individualsByIamId = individuals.ToLookup(m => m.IamId);
             AaudUser? currentUser = UserHelper.GetCurrentUser();
             bool hasDetailPermission = UserHelper.HasPermission(_rapsContext, currentUser, "SVMSecure.DirectoryDetail");
             foreach (var l in ldap)
             {
-                AaudUser? userInfo = individuals.Find(m => m.IamId == l.IamId);
+                AaudUser? userInfo = individualsByIamId[l.IamId].FirstOrDefault();
                 var result = hasDetailPermission
                     ? new IndividualSearchResultWithIDs(userInfo, l)
                     : new IndividualSearchResult(userInfo, l);
                 result.LookupEmailHost(_aaud);
                 results.Add(result);
-
-                var vmsearch = VMACSService.Search(result.LoginId);
-                var vm = vmsearch.Result;
-                if (vm != null && vm.item != null && vm.item.Nextel != null) result.Nextel = vm.item.Nextel[0];
-                if (vm != null && vm.item != null && vm.item.LDPager != null) result.LDPager = vm.item.LDPager[0];
-                if (vm != null && vm.item != null && vm.item.Unit != null) result.Department = vm.item.Unit[0];
+                await AddVmacsContactInfoAsync(result);
             }
 
             return results;
@@ -147,6 +111,50 @@ namespace Viper.Areas.Directory.Controllers
         {
             // pull in the user based on uid
             return await Task.Run(() => View("~/Areas/Directory/Views/UserInfo.cshtml"));
+        }
+
+        /// <summary>
+        /// Current AAUD users matching the search term on name or any directory identifier,
+        /// ordered for display. Shared by Get and GetUCD.
+        /// </summary>
+        /// <remarks>
+        /// The identifiers are checked through an inline collection rather than an OR chain on purpose. The
+        /// chain trips cs/complex-condition, and its MothraId null check is dead code since MothraId is the
+        /// one non-nullable identifier on AaudUser.
+        /// </remarks>
+        internal static Task<List<AaudUser>> SearchCurrentAaudUsers(AAUDContext aaud, string search)
+        {
+            return aaud.AaudUsers
+                .AsNoTracking()
+                .Where(u => (u.DisplayFirstName + " " + u.DisplayLastName).Contains(search)
+                    || new[] { u.MailId, u.LoginId, u.SpridenId, u.Pidm, u.MothraId, u.EmployeeId, u.IamId }
+                        .Any(id => id != null && id.Contains(search)))
+                .Where(u => u.Current != 0)
+                .OrderBy(u => u.DisplayLastName)
+                .ThenBy(u => u.DisplayFirstName)
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Add VMACS phone/pager/department info to a search result when the lookup finds a match.
+        /// </summary>
+        private static async Task AddVmacsContactInfoAsync(IndividualSearchResult result)
+        {
+            // Without a login ID the VMACS query would run with an empty find value;
+            // skip the pointless lookup. Empty element lists deserialize as empty
+            // arrays (not null), so guard on length before indexing.
+            if (string.IsNullOrWhiteSpace(result.LoginId))
+            {
+                return;
+            }
+            var item = (await VMACSService.Search(result.LoginId))?.item;
+            if (item == null)
+            {
+                return;
+            }
+            if (item.Nextel is { Length: > 0 }) result.Nextel = item.Nextel[0];
+            if (item.LDPager is { Length: > 0 }) result.LDPager = item.LDPager[0];
+            if (item.Unit is { Length: > 0 }) result.Department = item.Unit[0];
         }
     }
 }

--- a/web/Areas/RAPS/Controllers/AdGroupsController.cs
+++ b/web/Areas/RAPS/Controllers/AdGroupsController.cs
@@ -81,7 +81,7 @@ namespace Viper.Areas.RAPS.Controllers
         {
             if (groupId != group.GroupId)
             {
-                BadRequest();
+                return BadRequest();
             }
 
             OuGroup? ouGroup = await _context.OuGroups.FindAsync(groupId);

--- a/web/Areas/RAPS/Controllers/RAPSController.cs
+++ b/web/Areas/RAPS/Controllers/RAPSController.cs
@@ -35,6 +35,9 @@ namespace Viper.Areas.RAPS.Controllers
         /// Getting left nav for each page. This is a little complicated - alternatively, ViewData["ViperLeftNav"] = await Nav() 
         /// could be added to each action.
         /// </summary>
+#pragma warning disable S6967, S6932 // filter override, not an action: returning BadRequest is impossible and checking ModelState here would
+        // blanket-validate every RAPS action; the raw query-string values read here only feed left-nav context
+        // (never authorization), are TryParse-guarded, and model binding is not available in a filter
         public override async Task OnActionExecutionAsync(ActionExecutingContext context,
                                          ActionExecutionDelegate next)
         {
@@ -64,6 +67,7 @@ namespace Viper.Areas.RAPS.Controllers
                 instance,
                 page);
         }
+#pragma warning restore S6967, S6932
 
         /// <summary>
         /// RAPS home page
@@ -85,6 +89,7 @@ namespace Viper.Areas.RAPS.Controllers
             };
         }
 
+        [NonAction]
         public async Task<NavMenu> Nav(int? roleId, int? permissionId, string? memberId, string instance = "VIPER", string page = "")
         {
             TblRole? selectedRole = (roleId != null) ? await _RAPSContext.TblRoles.FindAsync(roleId) : null;
@@ -292,6 +297,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{instance}/[action]")]
         public async Task<IActionResult> RoleMembers(string instance, int RoleId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["RoleId"] = RoleId;
             ViewData["canEditPermissions"] = _securityService.IsAllowedTo("EditMemberPermissions", instance);
 
@@ -330,6 +339,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> RolePermissions(int roleId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["roleId"] = roleId;
             return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/Permissions.cshtml"));
         }
@@ -355,6 +368,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> PermissionMembers(int? permissionId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["permissionId"] = permissionId;
 
             TblPermission? permission = await _RAPSContext.TblPermissions.FindAsync(permissionId);
@@ -373,6 +390,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> PermissionRoles(int? permissionId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["permissionId"] = permissionId;
 
             TblPermission? permission = await _RAPSContext.TblPermissions.FindAsync(permissionId);
@@ -388,6 +409,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> PermissionRolesRO(int? permissionId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["permissionId"] = permissionId;
 
             TblPermission? permission = await _RAPSContext.TblPermissions.FindAsync(permissionId);
@@ -403,6 +428,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> AllMembersWithPermission(int? permissionId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             ViewData["permissionId"] = permissionId;
 
             TblPermission? permission = await _RAPSContext.TblPermissions.FindAsync(permissionId);
@@ -506,6 +535,10 @@ namespace Viper.Areas.RAPS.Controllers
         [Route("/[area]/{Instance}/[action]")]
         public async Task<IActionResult> ExportToVMACS(string? server = null, string? loginId = null, bool? debugOnly = false)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             var vmacsExport = new VMACSExport(_RAPSContext);
             var servers = vmacsExport.GetServers();
             if (server != null && servers.Contains(server))
@@ -557,6 +590,10 @@ namespace Viper.Areas.RAPS.Controllers
         [SupportedOSPlatform("windows")]
         public async Task<IActionResult> GroupSync(int groupId)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
             OuGroup? group = await _RAPSContext.OuGroups.FindAsync(groupId);
             if (group != null)
             {

--- a/web/Areas/RAPS/Controllers/RAPSController.cs
+++ b/web/Areas/RAPS/Controllers/RAPSController.cs
@@ -1,9 +1,13 @@
+using System.DirectoryServices.Protocols;
 using System.Runtime.Versioning;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using NLog;
 using Viper.Areas.RAPS.Services;
 using Viper.Classes;
 using Viper.Classes.SQLContext;
@@ -19,16 +23,18 @@ namespace Viper.Areas.RAPS.Controllers
     {
         private readonly RAPSContext _RAPSContext;
         private readonly RAPSSecurityService _securityService;
+        private readonly IServiceScopeFactory _scopeFactory;
         public IUserHelper UserHelper { get; private set; }
 
         public int Count { get; set; }
         public string? UserName { get; set; }
 
-        public RAPSController(RAPSContext context)
+        public RAPSController(RAPSContext context, IServiceScopeFactory scopeFactory)
         {
             _RAPSContext = context;
             _securityService = new RAPSSecurityService(context);
             UserHelper = new UserHelper();
+            _scopeFactory = scopeFactory;
         }
 
         /// <summary>
@@ -42,7 +48,6 @@ namespace Viper.Areas.RAPS.Controllers
                                          ActionExecutionDelegate next)
         {
             await base.OnActionExecutionAsync(context, next);
-            await next();
             bool roleIdValid = int.TryParse(HttpContext?.Request?.Query["roleId"].FirstOrDefault(), out int roleId);
             bool permIdValid = int.TryParse(HttpContext?.Request?.Query["permissionId"].FirstOrDefault(), out int permissionId);
             string? memberId = HttpContext?.Request?.Query["memberId"].FirstOrDefault();
@@ -94,7 +99,7 @@ namespace Viper.Areas.RAPS.Controllers
         {
             TblRole? selectedRole = (roleId != null) ? await _RAPSContext.TblRoles.FindAsync(roleId) : null;
             TblPermission? selectedPermission = (permissionId != null) ? await _RAPSContext.TblPermissions.FindAsync(permissionId) : null;
-            VwAaudUser? selecteduser = (memberId != null) ? await _RAPSContext.VwAaudUser.SingleAsync(r => r.MothraId == memberId) : null;
+            VwAaudUser? selecteduser = (memberId != null) ? await _RAPSContext.VwAaudUser.AsNoTracking().SingleOrDefaultAsync(r => r.MothraId == memberId) : null;
 
             var nav = new List<NavMenuItem>
             {
@@ -597,11 +602,36 @@ namespace Viper.Areas.RAPS.Controllers
             OuGroup? group = await _RAPSContext.OuGroups.FindAsync(groupId);
             if (group != null)
             {
-                _ = new OuGroupService(_RAPSContext).Sync(groupId, group.Name);
+                _ = SyncGroupInBackground(groupId, group.Name);
             }
 
             ViewData["Group"] = group;
             return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/Sync.cshtml"));
+        }
+
+        /// <summary>
+        /// Run the AD/OU group sync outside the request scope so it can keep running after the response
+        /// is returned (the sync page tells users it may take a few minutes). Resolves its own RAPSContext
+        /// from a fresh DI scope, since the request-scoped _RAPSContext is disposed once the request ends.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        private async Task SyncGroupInBackground(int groupId, string groupName)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var context = scope.ServiceProvider.GetRequiredService<RAPSContext>();
+                await new OuGroupService(context).Sync(groupId, groupName);
+            }
+            // Every I/O boundary Sync crosses: EF/DI, the LDAP searches behind the OU path, and the
+            // uInform HTTP calls behind the AD3 path. The task is discarded, so an escaping exception
+            // becomes an unobserved one and the sync fails with no log entry.
+            catch (Exception ex) when (ex is SqlException or DbUpdateException or InvalidOperationException
+                or LdapException or DirectoryOperationException
+                or HttpRequestException or TaskCanceledException or JsonException)
+            {
+                LogManager.GetCurrentClassLogger().Error(ex, "Group sync failed for group {GroupId}", groupId);
+            }
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]

--- a/web/Areas/RAPS/Models/GroupAddEdit.cs
+++ b/web/Areas/RAPS/Models/GroupAddEdit.cs
@@ -1,12 +1,12 @@
 namespace Viper.Areas.RAPS.Models
 {
     /// <summary>
-    /// DTO for creating/editing groups. GroupId is 0 for new groups.
+    /// DTO for creating/editing groups. GroupId is null for new groups.
     /// This class is also a base class for Group which sets GroupId in constructor.
     /// </summary>
     public class GroupAddEdit
     {
-        public int GroupId { get; set; }
+        public int? GroupId { get; set; }
 
         public string Name { get; set; } = null!;
 

--- a/web/Areas/Students/Controllers/StudentsController.cs
+++ b/web/Areas/Students/Controllers/StudentsController.cs
@@ -38,6 +38,7 @@ namespace Viper.Areas.Students.Controllers
         }
 #pragma warning restore S6967
 
+        [NonAction]
         public NavMenu Nav()
         {
             var menu = new LeftNavMenu(_viperContext, _rapsContext).GetLeftNavMenus(friendlyName: "viper-students")?.FirstOrDefault();


### PR DESCRIPTION
## Summary

First branch of the .NET warnings cleanup plan: closes 26 of 44 code-analysis warnings via low-risk fixes and justified suppressions, plus four real bugs found along the way, a test file that could not fail, test time that did not match production, and a fix to how the build reports warnings at all. Seven commits, one per theme.

| Commit | Scope |
|---|---|
| `chore(warnings)` | most of the analyzer cleanup, across `.editorconfig`, CMS, CTS, Directory, RAPS, Students |
| `fix(raps)` | the four bugs, with regression tests |
| `refactor(directory)` | the `GetUCD` duplication that drove its CA1502, with tests |
| `chore(scripts)` | build warning reporting |
| `fix(test)` | ClinicalScheduler integration tests now exercise real services |
| `fix(test)` | ClinicalScheduler test time aligned with production |
| `fix(test)` | Effort test time aligned with production |

## Warning cleanup (26 closed)

| Rule | Fix |
|---|---|
| S6967 x11 | ModelState guards on 8 RAPS view actions (bad params now 400 instead of proceeding with defaults); justified suppressions on the 2 nav filter overrides; `[NonAction]` on `Nav` removes unintended endpoints on the RAPS, CTS, and Students controllers, none of which has a caller in the repo |
| S6964 x5 | `.editorconfig` suppression for `ApiPagination` (never model-bound, always constructed server-side); `GroupAddEdit.GroupId` made nullable |
| CA1505 x3 | `.editorconfig` suppression for scaffolded EF `*Context.cs`, following the existing S3251 precedent |
| S6932 x3 | Justified suppression (nav filter reads query params for left-nav context only; model binding unavailable in a filter) |
| S6672 | CMS logger created via `ILoggerFactory` for `Data.CMS`; log category unchanged |
| S6931 | Directory route prefix moved to controller-level `[Route]`; all 5 URLs provably unchanged |
| CA1502 (test ctor) | `ServiceLayerIntegrationTest`'s constructor is no longer complex because the canned-data mocks it built are gone entirely, see the test section below |
| CA1502 (`GetUCD`) | Directory search query and VMACS enrichment, duplicated verbatim between `Get` and `GetUCD`, extracted into shared helpers; SQLite-backed tests pin the query helper (field matches, name-span match, current-user filter, ordering) |

The directory search checks its identifiers through an inline collection rather than an OR chain. That is deliberate and there is a `<remarks>` on the method saying so: the chain trips `cs/complex-condition`, and its `MothraId` null check is dead code because `MothraId` is the one non-nullable identifier on `AaudUser`.

## Bug fixes (behavior changes to note)

- **`AdGroupsController.UpdateGroup`**: missing `return` meant a PUT with a mismatched group ID fell through and updated the group anyway; now 400. Regression test added (the group-edit UI always sends a matching ID, so normal use is unaffected).
- **RAPS action pipeline ran twice**: `OnActionExecutionAsync` awaited both the `AreaController` base (which already invokes `next()`) and `next()` again. The second call re-enters the invoker with the filter cursor exhausted, so it falls through to invoking the action method a second time, including for `ExportToVMACS` and `GroupSync`.
- **RAPS nav member lookup**: `SingleAsync` 500ed every RAPS page when `?memberId=` matched no user; now `SingleOrDefaultAsync` with the existing null handling.
- **`GroupSync` background sync**: fire-and-forget task captured the request-scoped `RAPSContext` (disposed when the response returns); now resolves a fresh context from `IServiceScopeFactory`, catches the EF, LDAP, and uInform HTTP types `Sync` can throw, and logs failures instead of losing them to an unobserved task.

## Integration tests that could not fail

Raised by CodeRabbit on this PR and worth calling out, because it was not a style problem.

`ServiceLayerIntegrationTest` assigned NSubstitute mocks to `_studentScheduleService` and `_instructorScheduleService`, so tests named `WorksIndependently` seeded a database the services never read and asserted against roughly 135 lines of hand-rolled canned data. They passed regardless of whether the services worked. One did not even use the shared fields: it built a local mock, stubbed it, called it, and asserted the stub returned the stub.

The seeding was inert twice over. It wrote `Viper.Models.ClinicalScheduler` entities into `ClinicalSchedulerContext`, while the services read `Viper.Models.CTS` entities out of `VIPERContext`. Different type, different database.

- the tests now get a real in-memory `VIPERContext` and real `StudentScheduleService` / `InstructorScheduleService` instances
- seeding goes through helpers that also add the `Week`, `Service`, and `Rotation` rows the services `Include`, and each case seeds a second non-matching row so the assertions prove the filter rather than the seed
- the one genuine delegation test keeps mocks, but builds its own and now asserts the collaborators were actually called
- net `-218 / +154` lines

Verified by mutation rather than by the suite going green: disabling the `mothraId` filter in `ApplyScheduleFilters` now fails `ServiceDecomposition_InstructorScheduleService_WorksIndependently`, and dropping `rotationId` on the way through `ClinicalScheduleService` now fails the delegation test. Both passed before this change.

## Test time that did not match production

Found while resolving review feedback on the section above, and the same class of problem: fixtures that did not reflect the code under test.

ClinicalScheduler and Effort production code is entirely local time (`DateTime.Now` / `DateTime.Today`, no `UtcNow`, no Kind-sensitive logic anywhere), but their tests seeded UTC.

- 11 `DateTimeKind.Utc` seed dates in `test/ClinicalScheduler` and 13 in `test/Effort` become `Local`
- 5 `DateTime.UtcNow` calls in `test/ClinicalScheduler` become `DateTime.Now`

The `UtcNow` ones were the ones that could actually bite. `ScheduleAuditServiceTest` stamped `TimeStamp = DateTime.UtcNow` while `ScheduleAuditService` stamps `DateTime.Now`, and `EmailNotificationTest` and `TestDataBuilder` derived week `DateStart`/`DateEnd` from `UtcNow` while the services filter against `DateTime.Today`. Being relative to now, those can land on a different date than production wherever the machine is behind UTC. Nothing was failing, so this is latent rather than an active bug, but it is the kind that surfaces as an unreproducible near-midnight flake.

`test/HealthChecks` and `test/Scheduler` were deliberately left on UTC. Those are correct, not stragglers: `HangfireHealthCheck` measures staleness as `DateTime.UtcNow - Heartbeat`, and Hangfire's `BackgroundJob.CreatedAt` is UTC by its own contract, so converting either would skew them by the machine's UTC offset.

## Build warning reporting

Separate from the cleanup itself, and the reason the counts above can be trusted.

MSBuild prints every diagnostic inline as it compiles, then repeats the whole list in its end-of-build summary, so `verify:build` showed 3076 warning lines for 1538 warnings and the lint script counted every finding twice. `-clp:NoSummary` does not fix this on the .NET 10 SDK: the switch parses and `ErrorsOnly` takes effect, but `NoSummary` is ignored. The repeats are now filtered out, keeping the summary's header, counts, and elapsed time.

- `verify:build` filters displayed output only, so the captured output feeding the build cache and error reporting stays complete
- stripped on cache read too, since entries are written by whichever script ran first and `verify:build` caches MSBuild's raw output
- the cached path now reports the warning count, where before it printed nothing and gave no hint warnings existed

## Verification

- Clean `verify:build`: all 26 targeted warnings gone, no new ones; the 18 remaining code-analysis warnings match the plan's deferred list exactly
- Full backend suite green (2,672 tests, rebased onto current `main` including the .NET 10.0.10 bump)
- Note on counts: the 44 / 26 / 18 figures are code-analysis (CA and S) rules. The build reports 1538 warnings in total; the other 1494 are xUnit1051 and NU1902, tracked separately and out of scope here.

Playwright smoke re-run against dev on the final commit, every behaviour change exercised end to end:

| Check | Result |
|---|---|
| `?roleId=abc` on a RAPS view action | 400 (also confirms dev is running this branch, since a stale build returns 200) |
| `?memberId=doesnotexist99999` | 200, page renders (previously 500) |
| `/raps/Nav` | falls through to the 403 view, endpoint gone |
| `/CTS/Nav`, `/Students/Nav` | no nav JSON, fall through to the SPA |
| `/Directory`, `/Directory/nav` | 200, `[]` |
| `/Directory/search/lorenzo` and `/ucd` | real results from SQL Server and LDAP |
| `/Directory/userInfo/{mothraId}` | 200 |
| `/CTS` | 200 |
| Group PUT, mismatched ID | 400 |
| Group PUT, matching ID (nonexistent group) | 404 |

The last two are a paired control: the mismatch is rejected by the guard rather than by generic model validation, and a matching ID gets past the guard to the lookup. A nonexistent group ID was used deliberately so that a regressed guard would 404 rather than modify real dev data.

The directory search returning real rows also settles the one open question about the inline-collection predicate: it translates and executes correctly against real SQL Server, not just the SQLite test harness.
