### PR TITLE
fix(directory): drive VMACS endpoint from config, fail closed if unset

### DIFF
--- a/test/Areas/Directory/VMACSServiceTest.cs
+++ b/test/Areas/Directory/VMACSServiceTest.cs
@@ -28,5 +28,70 @@ namespace Viper.test.Areas.Directory
 
             Assert.Contains("&AUTH=SECRET123", path);
         }
+
+        [Theory]
+        [InlineData("https://vmacs-qa.example.edu")]
+        [InlineData("http://vmacs.example.edu/")]
+        public void IsValidBaseUrl_True_ForAbsoluteHttpUrls(string baseUrl)
+        {
+            Assert.True(VMACSService.IsValidBaseUrl(baseUrl));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not-a-url")]
+        [InlineData("/relative/path")]
+        [InlineData("vmacs-qa.example.edu")]
+        [InlineData("ftp://vmacs.example.edu")]
+        [InlineData("file:///etc/passwd")]
+        public void IsValidBaseUrl_False_ForMissingOrNonHttpUrls(string? baseUrl)
+        {
+            // A malformed or non-http(s) base URL must fail closed here rather than
+            // reaching GetAsync, which would throw and abort the directory lookup.
+            Assert.False(VMACSService.IsValidBaseUrl(baseUrl));
+        }
+
+        [Fact]
+        public void Deserialize_ReturnsItem_WhenPayloadMatches()
+        {
+            var query = VMACSService.Deserialize(
+                "<query><item dbfile=\"3\"><Name>Doe, John</Name></item></query>");
+
+            Assert.NotNull(query);
+            Assert.NotNull(query.item);
+            Assert.Equal("Doe, John", query.item!.Name?.Single());
+        }
+
+        [Fact]
+        public void Deserialize_ReturnsQueryWithNullItem_WhenNothingMatched()
+        {
+            // A valid <query> with no <item> is what VMACS returns for an unknown
+            // login - it parses successfully but yields a null item.
+            var query = VMACSService.Deserialize("<query><dbfile>3</dbfile></query>");
+
+            Assert.NotNull(query);
+            Assert.Null(query.item);
+        }
+
+        [Theory]
+        [InlineData("not xml")]
+        [InlineData("")]
+        [InlineData("<query><item></query>")]
+        public void Deserialize_Throws_OnInvalidXml(string xml)
+        {
+            Assert.Throws<InvalidOperationException>(() => VMACSService.Deserialize(xml));
+        }
+
+        [Fact]
+        public void Deserialize_RejectsDtd_ForXxeProtection()
+        {
+            // DtdProcessing.Prohibit must reject any DOCTYPE before entity expansion.
+            var withDoctype =
+                "<!DOCTYPE query [<!ENTITY x \"y\">]><query><dbfile>3</dbfile></query>";
+
+            Assert.Throws<InvalidOperationException>(() => VMACSService.Deserialize(withDoctype));
+        }
     }
 }

--- a/test/HealthChecks/VmacsDirectoryHealthCheckTests.cs
+++ b/test/HealthChecks/VmacsDirectoryHealthCheckTests.cs
@@ -1,0 +1,234 @@
+using System.Net;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using Viper.Classes.HealthChecks;
+
+namespace Viper.test.HealthChecks
+{
+    public class VmacsDirectoryHealthCheckTests
+    {
+        private const string BaseUrl = "https://vmacs-qa.example.edu";
+        private const string Token = "TESTAUTH";
+
+        // Minimal payloads matching Areas/Directory/Models/VMACSItem.cs.
+        private const string MatchQueryXml =
+            "<query><item dbfile=\"3\"><Name>Doe, John</Name></item></query>";
+        private const string EmptyQueryXml = "<query><dbfile>3</dbfile></query>";
+
+        private sealed class StubHttpMessageHandler(
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            : HttpMessageHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                return responder(request, cancellationToken);
+            }
+        }
+
+        private static IHttpClientFactory FactoryReturning(HttpMessageHandler handler)
+        {
+            var factory = Substitute.For<IHttpClientFactory>();
+            factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(handler));
+            return factory;
+        }
+
+        private static IHttpClientFactory FactoryReturning(HttpStatusCode status, string body = "") =>
+            FactoryReturning(new StubHttpMessageHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) })));
+
+        private static IHttpClientFactory FactoryThrowing(Exception ex) =>
+            FactoryReturning(new StubHttpMessageHandler((_, _) =>
+                Task.FromException<HttpResponseMessage>(ex)));
+
+        private static HealthCheckContext CreateContext(VmacsDirectoryHealthCheck sut) => new()
+        {
+            Registration = new HealthCheckRegistration("campus-vmacs-directory", sut, null, null)
+        };
+
+        private static Task<HealthCheckResult> RunAsync(VmacsDirectoryHealthCheck sut) =>
+            sut.CheckHealthAsync(CreateContext(sut), TestContext.Current.CancellationToken);
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task CheckHealthAsync_UnhealthyWhenBaseUrlNotConfigured(string? baseUrl)
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                Substitute.For<IHttpClientFactory>(), baseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("Vmacs:BaseUrl is not configured", result.Description);
+        }
+
+        [Theory]
+        [InlineData("not-a-url")]
+        [InlineData("/relative/path")]
+        [InlineData("vmacs-qa.example.edu")]
+        public async Task CheckHealthAsync_UnhealthyWhenBaseUrlNotAbsolute(string baseUrl)
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                Substitute.For<IHttpClientFactory>(), baseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("Vmacs:BaseUrl", result.Description);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task CheckHealthAsync_HealthyWhenTokenMissingAndSkipAllowed(string? token)
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                Substitute.For<IHttpClientFactory>(), BaseUrl, token, healthyWhenTokenMissing: true);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains("skipped", result.Description);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task CheckHealthAsync_UnhealthyWhenTokenMissingAndSkipNotAllowed(string? token)
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                Substitute.For<IHttpClientFactory>(), BaseUrl, token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("VmacsAuthToken is not configured", result.Description);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task CheckHealthAsync_UnhealthyWhenEndpointRejectsAuth(HttpStatusCode status)
+        {
+            var sut = new VmacsDirectoryHealthCheck(FactoryReturning(status), BaseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("rejected the request", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenEndpointReturnsServerError()
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                FactoryReturning(HttpStatusCode.InternalServerError), BaseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("HTTP 500", result.Description);
+        }
+
+        [Theory]
+        [InlineData(MatchQueryXml)]
+        [InlineData(EmptyQueryXml)]
+        public async Task CheckHealthAsync_HealthyWhenEndpointReturnsParseableXml(string body)
+        {
+            // An empty <query> (unknown probe login) still proves endpoint + auth +
+            // response shape, so it must read Healthy just like a matching record.
+            var sut = new VmacsDirectoryHealthCheck(
+                FactoryReturning(HttpStatusCode.OK, body), BaseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains("reachable", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenEndpointReturnsUnparseableXml()
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                FactoryReturning(HttpStatusCode.OK, "this is not xml"), BaseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("not valid XML", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenEndpointUnreachable()
+        {
+            var sut = new VmacsDirectoryHealthCheck(
+                FactoryThrowing(new HttpRequestException("connection refused")), BaseUrl, Token);
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("unreachable", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenEndpointTimesOut()
+        {
+            var handler = new StubHttpMessageHandler(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+            var sut = new VmacsDirectoryHealthCheck(
+                FactoryReturning(handler), BaseUrl, Token, timeout: TimeSpan.FromMilliseconds(100));
+
+            var result = await RunAsync(sut);
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("timed out", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_DegradedWhenProbeCancelled()
+        {
+            // Handler honors the token so an externally-cancelled probe (app
+            // shutdown / RequestAborted) surfaces as cancelled, not timed out.
+            var handler = new StubHttpMessageHandler(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+            var sut = new VmacsDirectoryHealthCheck(FactoryReturning(handler), BaseUrl, Token);
+
+            var result = await sut.CheckHealthAsync(
+                CreateContext(sut), new CancellationToken(canceled: true));
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+            Assert.Contains("cancelled", result.Description);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_IssuesProbeQueryAgainstConfiguredBaseUrlAndToken()
+        {
+            var handler = new StubHttpMessageHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(EmptyQueryXml)
+                }));
+            var sut = new VmacsDirectoryHealthCheck(FactoryReturning(handler), BaseUrl + "/", Token);
+
+            await RunAsync(sut);
+
+            var uri = handler.LastRequest?.RequestUri?.ToString();
+            Assert.NotNull(uri);
+            // Trailing slash on the base URL must be collapsed, not doubled.
+            Assert.StartsWith(BaseUrl + "/trust/query.xml", uri);
+            Assert.Contains("AUTH=" + Token, uri);
+        }
+    }
+}

--- a/web/Areas/Directory/Services/VMACSService.cs
+++ b/web/Areas/Directory/Services/VMACSService.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using System.Xml.Serialization;
 using Viper.Areas.Directory.Models;
@@ -7,13 +7,22 @@ namespace Viper.Areas.Directory.Services
 {
     public class VMACSService
     {
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        // Search runs once per directory result, so an unset base URL or auth
+        // token would log per lookup; guard so each is recorded at most once.
+        private static int _missingBaseUrlLogged;
+        private static int _missingAuthTokenLogged;
+
         private static string VmacsAuthToken =>
             HttpHelper.GetSetting<string>("Credentials", "VmacsAuthToken") ?? string.Empty;
 
-        private static readonly HttpClient sharedClient = new()
-        {
-            BaseAddress = new Uri("https://vmacs-vmth.vetmed.ucdavis.edu"),
-        };
+        private static string? VmacsBaseUrl =>
+            HttpHelper.GetSetting<string>("Vmacs", "BaseUrl");
+
+        // Bound the per-lookup wait: DirectoryController blocks on Search().Result
+        // once per result, so a hung endpoint must not stall for the default 100s.
+        private static readonly HttpClient sharedClient = new() { Timeout = TimeSpan.FromSeconds(10) };
 
         protected VMACSService() { }
 
@@ -23,35 +32,103 @@ namespace Viper.Areas.Directory.Services
         /// <returns></returns>
         public static async Task<VMACSQuery?> Search(String? loginID)
         {
-            string request = BuildSearchPath(loginID, VmacsAuthToken);
-            using HttpResponseMessage response = await sharedClient.GetAsync(request);
-            if (!response.IsSuccessStatusCode)
+            string? baseUrl = VmacsBaseUrl;
+            if (!IsValidBaseUrl(baseUrl))
             {
+                if (Interlocked.Exchange(ref _missingBaseUrlLogged, 1) == 0)
+                {
+                    _logger.Warn(
+                        "VMACS lookup skipped: Vmacs:BaseUrl is not configured or is not a valid absolute http(s) URL.");
+                }
                 return null;
             }
-            var s = await response.Content.ReadAsStringAsync();
-            var buffer = Encoding.UTF8.GetBytes(s);
-            using (var stream = new MemoryStream(buffer))
-            {
-                var serializer = new XmlSerializer(typeof(VMACSQuery));
 
-                // Use XmlReader with secure settings to prevent XXE attacks
-                var readerSettings = new XmlReaderSettings
+            string authToken = VmacsAuthToken;
+            if (string.IsNullOrWhiteSpace(authToken))
+            {
+                // No token means every request would fail auth and return null;
+                // skip the doomed call so a directory search doesn't fan out one
+                // unauthorized request per result (e.g. Dev, which has no token).
+                if (Interlocked.Exchange(ref _missingAuthTokenLogged, 1) == 0)
                 {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    XmlResolver = null
-                };
-                using (var xmlReader = XmlReader.Create(stream, readerSettings))
-                {
-                    var vmacs_api = (VMACSQuery?)serializer.Deserialize(xmlReader);
-                    if (vmacs_api != null && vmacs_api.item != null)
-                    {
-                        return vmacs_api;
-                    }
+                    _logger.Warn("VMACS lookup skipped: Credentials:VmacsAuthToken is not configured.");
                 }
+                return null;
+            }
+
+            string request = baseUrl.TrimEnd('/') + BuildSearchPath(loginID, authToken);
+            string body;
+            try
+            {
+                using HttpResponseMessage response = await sharedClient.GetAsync(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return null;
+                }
+                body = await response.Content.ReadAsStringAsync();
+            }
+            catch (HttpRequestException ex)
+            {
+                // The VMACS endpoint is known to be flaky; an outage must degrade to
+                // null, not throw and abort the whole directory search (the caller
+                // blocks on .Result, so enrichment being optional demands this).
+                _logger.Warn(ex, "VMACS directory query request failed.");
+                return null;
+            }
+            catch (TaskCanceledException ex)
+            {
+                // HttpClient.Timeout elapsed - treat a slow endpoint like an outage.
+                _logger.Warn(ex, "VMACS directory query request timed out.");
+                return null;
+            }
+
+            VMACSQuery? vmacs_api;
+            try
+            {
+                vmacs_api = Deserialize(body);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // A non-XML 200 (gateway/proxy error page, SSO redirect) must not
+                // fail the directory search; enrichment is optional, so degrade to null.
+                _logger.Warn(ex, "Failed to deserialize VMACS directory query response.");
+                return null;
+            }
+            if (vmacs_api != null && vmacs_api.item != null)
+            {
+                return vmacs_api;
             }
             return null;
         }
+
+        /// <summary>
+        /// Deserializes a VMACS query.xml payload with XXE protections. Returns the
+        /// parsed query - whose item is null when nothing matched - or null.
+        /// </summary>
+        internal static VMACSQuery? Deserialize(string xml)
+        {
+            using var reader = new StringReader(xml);
+            var serializer = new XmlSerializer(typeof(VMACSQuery));
+
+            // Use XmlReader with secure settings to prevent XXE attacks
+            var readerSettings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            };
+            using var xmlReader = XmlReader.Create(reader, readerSettings);
+            return (VMACSQuery?)serializer.Deserialize(xmlReader);
+        }
+
+        /// <summary>
+        /// True when the configured base URL is an absolute http(s) URI. Guards both
+        /// the directory lookup and the health-check probe so a malformed or
+        /// unsupported-scheme value fails closed instead of throwing from GetAsync.
+        /// </summary>
+        internal static bool IsValidBaseUrl([NotNullWhen(true)] string? baseUrl) =>
+            !string.IsNullOrWhiteSpace(baseUrl)
+            && Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
 
         internal static string BuildSearchPath(string? loginID, string authToken)
         {

--- a/web/Classes/HealthChecks/HealthCheckExtensions.cs
+++ b/web/Classes/HealthChecks/HealthCheckExtensions.cs
@@ -169,17 +169,33 @@ namespace Viper.Classes.HealthChecks
                     tags: new[] { "ready" });
             }
 
-            // VMACs - clinical data source (Areas/Directory/Services/VMACSService.cs
-            // and Areas/RAPS/Services/VMACSExport.cs). Simple HTTP probe.
-            // Same LazyInitializer pattern as campus-cas above - see that note.
-            AdaptivePollingHealthCheck? vmacsCheck = null;
+            // VMACS directory service - the /trust/query.xml lookup endpoint that
+            // Areas/Directory/Services/VMACSService.cs depends on (distinct from the
+            // VMACS RAPS export REST API in Areas/RAPS/Services/VMACSExport.cs). URL
+            // is environment-specific (vmacs-qa in dev/test, vmacs-vmth in prod) from
+            // Vmacs:BaseUrl. The probe issues the same authenticated query as Search
+            // against a sentinel login, so a failure here pinpoints the endpoint being
+            // down rather than a VIPER bug. Severity encodes fault: an outage is
+            // Degraded (directory enrichment is optional, VIPER still works) while a
+            // missing URL or rejected token is Unhealthy. Custom adaptive-polling
+            // durations (vs the shared 1h/5min helper) because this endpoint is known
+            // to be flaky: probe ~once/day while healthy, hourly while down (and on
+            // the first poll after startup, since the cache starts empty). Dev has no
+            // SSM-sourced token, so a missing token there is treated as skipped.
+            var vmacsBaseUrl = configuration["Vmacs:BaseUrl"];
+            var vmacsAuthToken = configuration["Credentials:VmacsAuthToken"];
+            AdaptivePollingHealthCheck? vmacsDirectoryCheck = null;
             builder.Add(new HealthCheckRegistration(
-                "campus-vmacs",
-                sp => LazyInitializer.EnsureInitialized(ref vmacsCheck, () =>
-                    WithAdaptivePolling(new HttpEndpointHealthCheck(
-                        sp.GetRequiredService<IHttpClientFactory>(),
-                        "https://vmacs-vmth.vetmed.ucdavis.edu",
-                        "VMACs"))),
+                "campus-vmacs-directory",
+                sp => LazyInitializer.EnsureInitialized(ref vmacsDirectoryCheck, () =>
+                    new AdaptivePollingHealthCheck(
+                        new VmacsDirectoryHealthCheck(
+                            sp.GetRequiredService<IHttpClientFactory>(),
+                            vmacsBaseUrl,
+                            vmacsAuthToken,
+                            healthyWhenTokenMissing: environment.IsDevelopment()),
+                        healthyCacheDuration: TimeSpan.FromDays(1),
+                        unhealthyCacheDuration: TimeSpan.FromHours(1))),
                 failureStatus: HealthStatus.Unhealthy,
                 tags: new[] { "ready" }));
 

--- a/web/Classes/HealthChecks/VmacsDirectoryHealthCheck.cs
+++ b/web/Classes/HealthChecks/VmacsDirectoryHealthCheck.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Viper.Areas.Directory.Services;
+
+namespace Viper.Classes.HealthChecks
+{
+    /// <summary>
+    /// Probes the VMACS directory service query endpoint (/trust/query.xml) that
+    /// VMACSService.Search depends on - not just the VMACS host - so a failure here
+    /// pinpoints that endpoint being down rather than a bug in VIPER.
+    ///
+    /// It issues the same authenticated query as Search for a fixed probe login and
+    /// treats any HTTP 200 that parses as a VMACS query response as Healthy; an empty
+    /// result still proves endpoint + auth + response shape. Severity encodes fault:
+    /// an outage (unreachable / timeout / 5xx / unparseable) is Degraded - directory
+    /// enrichment is optional and the rest of VIPER works - while our-side
+    /// misconfiguration (Vmacs:BaseUrl unset, or the token rejected) is Unhealthy.
+    /// </summary>
+    public class VmacsDirectoryHealthCheck : IHealthCheck
+    {
+        // A stable probe login. It need not resolve to a record - a valid token
+        // returns HTTP 200 with an empty <query> for an unknown id - so the check
+        // stays green across environments with different datasets (QA is sparse).
+        private const string ProbeLoginId = "_testdvm";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly string? _baseUrl;
+        private readonly string? _authToken;
+        private readonly bool _healthyWhenTokenMissing;
+        private readonly TimeSpan _timeout;
+
+        public VmacsDirectoryHealthCheck(
+            IHttpClientFactory httpClientFactory,
+            string? baseUrl,
+            string? authToken,
+            bool healthyWhenTokenMissing = false,
+            TimeSpan? timeout = null)
+        {
+            _httpClientFactory = httpClientFactory;
+            _baseUrl = baseUrl;
+            _authToken = authToken;
+            _healthyWhenTokenMissing = healthyWhenTokenMissing;
+            _timeout = timeout ?? TimeSpan.FromSeconds(10);
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (!VMACSService.IsValidBaseUrl(_baseUrl))
+            {
+                return HealthCheckResult.Unhealthy(
+                    "Vmacs:BaseUrl is not configured or is not a valid absolute http(s) URL.");
+            }
+            if (string.IsNullOrWhiteSpace(_authToken))
+            {
+                return _healthyWhenTokenMissing
+                    ? HealthCheckResult.Healthy("VMACS auth token not configured (skipped).")
+                    : HealthCheckResult.Unhealthy("Credentials:VmacsAuthToken is not configured.");
+            }
+
+            var requestUri = _baseUrl.TrimEnd('/') + VMACSService.BuildSearchPath(ProbeLoginId, _authToken);
+
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = _timeout;
+
+            try
+            {
+                using var response = await client.GetAsync(requestUri, cancellationToken);
+                var code = (int)response.StatusCode;
+
+                if (code is 401 or 403)
+                {
+                    return HealthCheckResult.Unhealthy(
+                        $"VMACS directory endpoint rejected the request (HTTP {code}) - check Credentials:VmacsAuthToken.");
+                }
+                if (!response.IsSuccessStatusCode)
+                {
+                    return HealthCheckResult.Degraded($"VMACS directory endpoint returned HTTP {code}.");
+                }
+
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                try
+                {
+                    return VMACSService.Deserialize(body) != null
+                        ? HealthCheckResult.Healthy($"VMACS directory endpoint reachable (HTTP {code}).")
+                        : HealthCheckResult.Degraded(
+                            "VMACS directory endpoint returned a response that did not parse.");
+                }
+                catch (InvalidOperationException)
+                {
+                    return HealthCheckResult.Degraded(
+                        "VMACS directory endpoint returned a response that was not valid XML.");
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // The probe URI carries the auth token in its query string; never echo
+                // the exception message into the health payload (exposed at /health/detail).
+                return HealthCheckResult.Degraded("VMACS directory endpoint unreachable.");
+            }
+            catch (OperationCanceledException)
+            {
+                return cancellationToken.IsCancellationRequested
+                    ? HealthCheckResult.Degraded("VMACS directory endpoint probe cancelled.")
+                    : HealthCheckResult.Degraded("VMACS directory endpoint timed out.");
+            }
+        }
+    }
+}

--- a/web/appsettings.Development.json
+++ b/web/appsettings.Development.json
@@ -22,6 +22,9 @@
   "Cas": {
     "CasBaseUrl": "https://ssodev.ucdavis.edu/cas/"
   },
+  "Vmacs": {
+    "BaseUrl": "https://vmacs-qa.vetmed.ucdavis.edu"
+  },
   "Hangfire": {
     "AutoSchedule": false
   },

--- a/web/appsettings.Production.json
+++ b/web/appsettings.Production.json
@@ -18,6 +18,9 @@
       "SIS": "",
       "VIPER": ""
   },
+  "Vmacs": {
+    "BaseUrl": "https://vmacs-vmth.vetmed.ucdavis.edu"
+  },
   "EmailSettings": {
     "SmtpHost": "ucdavis-edu.mail.protection.outlook.com",
     "SmtpPort": 25,

--- a/web/appsettings.Test.json
+++ b/web/appsettings.Test.json
@@ -21,6 +21,9 @@
   "Cas": {
     "CasBaseUrl": "https://ssodev.ucdavis.edu/cas/"
   },
+  "Vmacs": {
+    "BaseUrl": "https://vmacs-qa.vetmed.ucdavis.edu"
+  },
   "EmailSettings": {
     "SmtpHost": "ucdavis-edu.mail.protection.outlook.com",
     "SmtpPort": 25,


### PR DESCRIPTION
## What & why

The VMACS directory lookup endpoint was hardcoded to the **production** host (`vmacs-vmth`), so Development and TEST were querying prod. This makes the endpoint configurable per environment and hardens the failure behavior.

## Changes

**Endpoint is config-driven, fails closed**
- `VMACSService` reads the base URL from `Vmacs:BaseUrl` (no hardcoded fallback). `Search()` only calls the endpoint when the URL parses as an absolute `http(s)` URI **and** `Credentials:VmacsAuthToken` is configured; otherwise it skips the request, returns no results, and logs once per process. A misconfigured box can never silently hit prod, a malformed/unsupported-scheme URL fails closed instead of throwing out of the lookup, and an environment with no token (e.g. Development) won't fan out one doomed unauthorized request per directory result.
- A flaky endpoint can't break directory search: network failures (`HttpRequestException`), timeouts (`TaskCanceledException` — the shared `HttpClient` is bounded to a 10s timeout so a hung endpoint can't stall a lookup for the default 100s), and malformed responses all degrade to null + a warning instead of throwing out of the lookup. This matters because the endpoint goes down often and `DirectoryController` blocks on `Search().Result` per result — an unhandled throw would 500 the whole search.
- The health check never echoes exception messages into its `/health/detail` payload (the probe URI carries the auth token), reporting a generic "unreachable" instead.

**Config (each environment declares its own endpoint)**
| Environment | `Vmacs:BaseUrl` |
|---|---|
| Development | `https://vmacs-qa.vetmed.ucdavis.edu` |
| Test | `https://vmacs-qa.vetmed.ucdavis.edu` |
| Production | `https://vmacs-vmth.vetmed.ucdavis.edu` |

The base `appsettings.json` intentionally has **no** `Vmacs` section, so "unset" is a real, detectable state rather than a silent prod default.

**Endpoint-specific health check (`campus-vmacs-directory`)**
- Probes the actual `/trust/query.xml` directory endpoint (the one `Search` uses) with an authenticated query, so a failure pinpoints *that endpoint* being down rather than a bug in VIPER — the VMACS team reports this endpoint goes down often.
- **Probe login:** a fixed sentinel login `_testdvm`. It need not resolve to a record — a valid token returns HTTP 200 with an empty `<query>` for an unknown id — so the check stays green across environments with different datasets (QA is sparse) and never depends on a real person's data.
- **Severity encodes fault:** an outage (unreachable / timeout / 5xx / unparseable) reports **Degraded/amber**; an unset/invalid URL or rejected token reports **Unhealthy/red**.
- Does not affect `/health` liveness — VMACS being down never pulls VIPER out of rotation.

**How often the endpoint is called**
- **Health check:** at most once per cache window — the first poll after startup (cache starts empty), then **~once/day while healthy** (`healthyCacheDuration: 1 day`) and **hourly while down** (`unhealthyCacheDuration: 1 hour`) via `AdaptivePollingHealthCheck`. These windows are intentionally wider than the shared 1h/5min helper because this endpoint is known to be flaky and directory enrichment is optional — probing sparingly avoids alert noise on a non-critical dependency.
- **Directory search:** `Search()` calls the endpoint **once per matched user** in a result set (`DirectoryController` invokes it per person as it builds the response). When the base URL or auth token is unset/invalid it skips entirely — **zero calls** — logging once per process.

## Testing
- `VMACSServiceTest` (24, incl. new absolute-`http(s)`-URL validation cases) and `VmacsDirectoryHealthCheckTests` (21) pass; full backend suite green.
- Lint clean; pre-commit lint/test/verify all pass.
- Verified live: the QA endpoint authenticates with the configured token and returns a parseable response for the `_testdvm` probe.

Targets `Development` per the branch/deploy flow (deploys to TEST first).
