### PR TITLE
refactor(async): drop fake-async wrappers

### DIFF
--- a/test/RAPS/RAPSControllerTests.cs
+++ b/test/RAPS/RAPSControllerTests.cs
@@ -68,7 +68,7 @@ namespace Viper.test.RAPS
             using var context = await CreateContextAsync(connection);
             var controller = CreateController(context);
 
-            var result = await controller.RolePermissions(5);
+            var result = controller.RolePermissions(5);
 
             var view = Assert.IsType<ViewResult>(result);
             Assert.Equal(5, view.ViewData["roleId"]);
@@ -213,6 +213,11 @@ namespace Viper.test.RAPS
             Assert.Same(group, view.ViewData["Group"]);
             scopeFactory.Received(1).CreateScope();
             scope.Received(1).Dispose();
+        }
+
+        private static Task AssertBadRequestForInvalidModelStateAsync(Func<RAPSController, IActionResult> action)
+        {
+            return AssertBadRequestForInvalidModelStateAsync(c => Task.FromResult(action(c)));
         }
 
         private static async Task AssertBadRequestForInvalidModelStateAsync(Func<RAPSController, Task<IActionResult>> action)

--- a/web/Areas/Directory/Controllers/DirectoryController.cs
+++ b/web/Areas/Directory/Controllers/DirectoryController.cs
@@ -33,19 +33,19 @@ namespace Viper.Areas.Directory.Controllers
         /// Directory home page
         /// </summary>
         [Route("")]
-        public async Task<ActionResult> Index(string? useExample)
+        public ActionResult Index(string? useExample)
         {
-            return await Task.Run(() => View("~/Areas/Directory/Views/Card.cshtml"));
+            return View("~/Areas/Directory/Views/Card.cshtml");
         }
 
         /// <summary>
         /// Directory home page
         /// </summary>
         [Route("nav")]
-        public async Task<ActionResult<IEnumerable<NavMenuItem>>> Nav()
+        public ActionResult<IEnumerable<NavMenuItem>> Nav()
         {
             var nav = new List<NavMenuItem>();
-            return await Task.Run(() => nav);
+            return nav;
         }
 
 
@@ -105,12 +105,12 @@ namespace Viper.Areas.Directory.Controllers
         /// <summary>
         /// Directory results
         /// </summary>
-        /// <param name="uid">User ID</param>
+        /// <param name="mothraID">Mothra ID</param>
         [Route("userInfo/{mothraID}")]
-        public async Task<IActionResult> DirectoryResult(string mothraID)
+        public IActionResult DirectoryResult(string mothraID)
         {
             // pull in the user based on uid
-            return await Task.Run(() => View("~/Areas/Directory/Views/UserInfo.cshtml"));
+            return View("~/Areas/Directory/Views/UserInfo.cshtml");
         }
 
         /// <summary>

--- a/web/Areas/RAPS/Controllers/RAPSController.cs
+++ b/web/Areas/RAPS/Controllers/RAPSController.cs
@@ -78,19 +78,19 @@ namespace Viper.Areas.RAPS.Controllers
         /// RAPS home page
         /// </summary>
         [Route("/[area]/{instance?}")]
-        public async Task<ActionResult> Index(string? instance)
+        public ActionResult Index(string? instance)
         {
             ViewData["KeyColumnName"] = "RoleId";
             instance ??= _securityService.GetDefaultInstanceForUser();
 
             return instance.ToUpper() switch
             {
-                "VIPER" => await Task.Run(() => Redirect("~/raps/VIPER/rolelist")),
-                "VMACS.VMTH" => await Task.Run(() => Redirect("~/raps/VMACS.VMTH/rolelist")),
-                "VMACS.VMLF" => await Task.Run(() => Redirect("~/raps/VMACS.VMLF/rolelist")),
-                "VMACS.UCVMCSD" => await Task.Run(() => Redirect("~/raps/VMACS.UCVMCSD/rolelist")),
-                "VIPERFORMS" => await Task.Run(() => Redirect("~/raps/ViperForms/rolelist")),
-                _ => await Task.Run(() => View("~/Views/Home/403.cshtml")),
+                "VIPER" => Redirect("~/raps/VIPER/rolelist"),
+                "VMACS.VMTH" => Redirect("~/raps/VMACS.VMTH/rolelist"),
+                "VMACS.VMLF" => Redirect("~/raps/VMACS.VMLF/rolelist"),
+                "VMACS.UCVMCSD" => Redirect("~/raps/VMACS.UCVMCSD/rolelist"),
+                "VIPERFORMS" => Redirect("~/raps/ViperForms/rolelist"),
+                _ => View("~/Views/Home/403.cshtml"),
             };
         }
 
@@ -221,23 +221,23 @@ namespace Viper.Areas.RAPS.Controllers
         /// RAPS Role List. Will show ListAdmin or List view.
         /// Open to admins, IT people for VMACS roles, and Role "owners" for their roles.
         /// </summary>
-        /// <param name="Instance">RAPS Instance</param>
+        /// <param name="instance">RAPS Instance</param>
         [Route("/[area]/{instance}/[action]")]
-        public async Task<IActionResult> RoleList(string instance)
+        public IActionResult RoleList(string instance)
         {
             if (UserHelper.HasPermission(_RAPSContext, UserHelper.GetCurrentUser(), "RAPS.Admin"))
             {
-                return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/ListAdmin.cshtml"));
+                return View("~/Areas/RAPS/Views/Roles/ListAdmin.cshtml");
             }
 
             if (_securityService.IsAllowedTo("ViewAllRoles", instance) ||
                 !_securityService.GetControlledRoleIds(UserHelper.GetCurrentUser()?.MothraId).IsNullOrEmpty())
             {
-                return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/List.cshtml"));
+                return View("~/Areas/RAPS/Views/Roles/List.cshtml");
             }
 
             //TODO: Should probably have a deny access helper function that writes logs and sets view
-            return await Task.Run(() => View("~/Views/Home/403.cshtml"));
+            return View("~/Views/Home/403.cshtml");
         }
 
         /// <summary>
@@ -245,15 +245,15 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Route("/[area]/{instance}/[action]")]
         [Permission(Allow = "RAPS.Admin,RAPS.ViewRoles")]
-        public async Task<IActionResult> RoleTemplateList(string instance)
+        public IActionResult RoleTemplateList(string instance)
         {
             if (!_securityService.IsAllowedTo("ViewRoles", instance))
             {
-                return await Task.Run(() => View("~/Views/Home/403.cshtml"));
+                return View("~/Views/Home/403.cshtml");
             }
             ViewData["canEditRoleTemplates"] = _securityService.IsAllowedTo("EditRoleTemplates", instance);
             ViewData["canApplyTemplates"] = _securityService.IsAllowedTo("EditRoleMembership", instance);
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/Templates.cshtml"));
+            return View("~/Areas/RAPS/Views/Roles/Templates.cshtml");
         }
 
         /// <summary>
@@ -261,13 +261,13 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Route("/[area]/{instance}/[action]")]
         [Permission(Allow = "RAPS.Admin,RAPS.EditRoleMembership")]
-        public async Task<IActionResult> RoleTemplateApply(string instance)
+        public IActionResult RoleTemplateApply(string instance)
         {
             if (!_securityService.IsAllowedTo("EditRoleMembership", instance))
             {
-                return await Task.Run(() => View("~/Views/Home/403.cshtml"));
+                return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml"));
+            return View("~/Areas/RAPS/Views/Roles/ApplyTemplate.cshtml");
         }
 
         /// <summary>
@@ -275,13 +275,13 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Route("/[area]/{instance}/[action]")]
         [Permission(Allow = "RAPS.Admin,RAPS.EditRoles")]
-        public async Task<IActionResult> RoleTemplateRoles(string instance)
+        public IActionResult RoleTemplateRoles(string instance)
         {
             if (!_securityService.IsAllowedTo("EditRoleTemplates", instance))
             {
-                return await Task.Run(() => View("~/Views/Home/403.cshtml"));
+                return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/TemplateRoles.cshtml"));
+            return View("~/Areas/RAPS/Views/Roles/TemplateRoles.cshtml");
         }
 
         /// <summary>
@@ -289,10 +289,10 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin")]
         [Route("/[area]/{instance}/DelegateRoles")]
-        public async Task<IActionResult> DelegateRoles()
+        public IActionResult DelegateRoles()
 
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/DelegateRoles.cshtml"));
+            return View("~/Areas/RAPS/Views/Roles/DelegateRoles.cshtml");
         }
 
         /// <summary>
@@ -329,12 +329,11 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.ViewPermissions")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> PermissionList()
+        public IActionResult PermissionList()
         {
-            return await Task.Run(() =>
-                UserHelper.HasPermission(_RAPSContext, UserHelper.GetCurrentUser(), "RAPS.Admin")
-                    ? View("~/Areas/RAPS/Views/Permissions/ListAdmin.cshtml")
-                    : View("~/Areas/RAPS/Views/Permissions/List.cshtml"));
+            return UserHelper.HasPermission(_RAPSContext, UserHelper.GetCurrentUser(), "RAPS.Admin")
+                ? View("~/Areas/RAPS/Views/Permissions/ListAdmin.cshtml")
+                : View("~/Areas/RAPS/Views/Permissions/List.cshtml");
         }
 
         /// <summary>
@@ -342,28 +341,28 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.ManageAllPermissions")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> RolePermissions(int roleId)
+        public IActionResult RolePermissions(int roleId)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest();
             }
             ViewData["roleId"] = roleId;
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/Permissions.cshtml"));
+            return View("~/Areas/RAPS/Views/Roles/Permissions.cshtml");
         }
 
         /// <summary>
         /// Compare permissions for two roles
         /// </summary>
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> RolePermissionsComparison(string instance)
+        public IActionResult RolePermissionsComparison(string instance)
         {
             if (_securityService.IsAllowedTo("EditRoleMembership", instance))
             {
-                return await Task.Run(() => View("~/Areas/RAPS/Views/Roles/PermissionComparison.cshtml"));
+                return View("~/Areas/RAPS/Views/Roles/PermissionComparison.cshtml");
             }
 
-            return await Task.Run(() => View("~/Views/Home/403.cshtml"));
+            return View("~/Views/Home/403.cshtml");
         }
 
         /// <summary>
@@ -385,7 +384,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return NotFound();
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Permissions/Members.cshtml"));
+            return View("~/Areas/RAPS/Views/Permissions/Members.cshtml");
         }
 
         /// <summary>
@@ -407,7 +406,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return NotFound();
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Permissions/Roles.cshtml"));
+            return View("~/Areas/RAPS/Views/Permissions/Roles.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.ViewPermissions")]
@@ -426,7 +425,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return NotFound();
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Permissions/RolesRO.cshtml"));
+            return View("~/Areas/RAPS/Views/Permissions/RolesRO.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.ViewPermissions")]
@@ -445,7 +444,7 @@ namespace Viper.Areas.RAPS.Controllers
             {
                 return NotFound();
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Permissions/AllMembers.cshtml"));
+            return View("~/Areas/RAPS/Views/Permissions/AllMembers.cshtml");
         }
 
         /**
@@ -457,13 +456,13 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.UserLookup")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> UserSearch(string instance)
+        public IActionResult UserSearch(string instance)
         {
             ViewData["canRSOP"] = _securityService.IsAllowedTo("RSOP", instance);
             ViewData["canEditRoleMembership"] = _securityService.IsAllowedTo("EditRoleMembership", instance);
             ViewData["canEditMemberPermissions"] = _securityService.IsAllowedTo("EditMemberPermissions", instance);
             ViewData["canViewHistory"] = _securityService.IsAllowedTo("ViewHistory", instance);
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/List.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/List.cshtml");
         }
 
         /// <summary>
@@ -471,7 +470,7 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.EditRoleMembership")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> MemberRoles(string instance)
+        public IActionResult MemberRoles(string instance)
         {
             ViewData["canEditPermissions"] = _securityService.IsAllowedTo("ManageAllPermissions", instance);
             //EditRoleMembership grants access only to the VMACS instance
@@ -480,7 +479,7 @@ namespace Viper.Areas.RAPS.Controllers
                 //TODO: Should probably have a deny access helper function that writes logs and sets view
                 return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/Roles.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/Roles.cshtml");
         }
 
         /// <summary>
@@ -488,9 +487,9 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.EditMemberPermissions")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> MemberPermissions()
+        public IActionResult MemberPermissions()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/Permissions.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/Permissions.cshtml");
         }
 
         /// <summary>
@@ -498,7 +497,7 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.RSOP")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> RSOP(string instance)
+        public IActionResult RSOP(string instance)
         {
             //RSOP grants access only to the VMACS instance
             if (!_securityService.IsAllowedTo("RSOP", instance))
@@ -506,7 +505,7 @@ namespace Viper.Areas.RAPS.Controllers
                 //TODO: Should probably have a deny access helper function that writes logs and sets view
                 return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/RSOP.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/RSOP.cshtml");
         }
 
         /// <summary>
@@ -514,7 +513,7 @@ namespace Viper.Areas.RAPS.Controllers
         /// </summary>
         [Permission(Allow = "RAPS.Admin,RAPS.EditRoleMembership")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> MemberHistory(string instance)
+        public IActionResult MemberHistory(string instance)
         {
             //EditRoleMembership grants access only to the VMACS instance
             if (!_securityService.IsAllowedTo("ViewHistory", instance))
@@ -522,18 +521,18 @@ namespace Viper.Areas.RAPS.Controllers
                 //TODO: Should probably have a deny access helper function that writes logs and sets view
                 return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/History.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/History.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.Clone")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> UserClone(string instance)
+        public IActionResult UserClone(string instance)
         {
             if (!_securityService.IsAllowedTo("Clone", instance))
             {
                 return View("~/Views/Home/403.cshtml");
             }
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Members/Clone.cshtml"));
+            return View("~/Areas/RAPS/Views/Members/Clone.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin")]
@@ -557,7 +556,7 @@ namespace Viper.Areas.RAPS.Controllers
                 ViewData["Servers"] = servers;
             }
 
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Export.cshtml"));
+            return View("~/Areas/RAPS/Views/Export.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin")]
@@ -566,28 +565,28 @@ namespace Viper.Areas.RAPS.Controllers
         {
             ViewData["Messages"] = await new RoleViews(_RAPSContext)
                     .UpdateRoles(debugOnly: true);
-            return await Task.Run(() => View("~/Areas/RAPS/Views/RoleViewUpdate.cshtml"));
+            return View("~/Areas/RAPS/Views/RoleViewUpdate.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> GroupList()
+        public IActionResult GroupList()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/List.cshtml"));
+            return View("~/Areas/RAPS/Views/Groups/List.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> GroupRoles()
+        public IActionResult GroupRoles()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/Roles.cshtml"));
+            return View("~/Areas/RAPS/Views/Groups/Roles.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> GroupMembers()
+        public IActionResult GroupMembers()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/Members.cshtml"));
+            return View("~/Areas/RAPS/Views/Groups/Members.cshtml");
         }
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]
@@ -606,7 +605,7 @@ namespace Viper.Areas.RAPS.Controllers
             }
 
             ViewData["Group"] = group;
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/Sync.cshtml"));
+            return View("~/Areas/RAPS/Views/Groups/Sync.cshtml");
         }
 
         /// <summary>
@@ -636,16 +635,16 @@ namespace Viper.Areas.RAPS.Controllers
 
         [Permission(Allow = "RAPS.Admin,RAPS.OUGroupsView")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> CreateADGroup()
+        public IActionResult CreateADGroup()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/Groups/CreateADGroup.cshtml"));
+            return View("~/Areas/RAPS/Views/Groups/CreateADGroup.cshtml");
         }
 
         [Permission(Allow = "RAPS.ViewAuditTrail")]
         [Route("/[area]/{Instance}/[action]")]
-        public async Task<IActionResult> AuditTrail()
+        public IActionResult AuditTrail()
         {
-            return await Task.Run(() => View("~/Areas/RAPS/Views/AuditLog.cshtml"));
+            return View("~/Areas/RAPS/Views/AuditLog.cshtml");
         }
     }
 }

--- a/web/Areas/Students/Services/PhotoService.cs
+++ b/web/Areas/Students/Services/PhotoService.cs
@@ -118,6 +118,8 @@ namespace Viper.Areas.Students.Services
                 return false;
             }
 
+            // Legitimate Task.Run: File.Exists is blocking I/O (photo store may be a
+            // network share) and callers fan these checks out with Task.WhenAll.
             return await Task.Run(() =>
             {
                 var photoPath = GetPhotoPath(mailId);

--- a/web/Areas/Students/Services/StudentGroupService.cs
+++ b/web/Areas/Students/Services/StudentGroupService.cs
@@ -526,13 +526,15 @@ namespace Viper.Areas.Students.Services
             }
         }
 
-        public async Task<List<string>> GetEighthsGroupsAsync()
+        // Eighths are a fixed set with no data source behind them. Returns a completed
+        // task to satisfy the interface without allocating an async state machine.
+        public Task<List<string>> GetEighthsGroupsAsync()
         {
-            return await Task.FromResult(new List<string>
-              {
-                  "1A1", "1A2", "1B1", "1B2",
-                  "2A1", "2A2", "2B1", "2B2"
-              });
+            return Task.FromResult(new List<string>
+            {
+                "1A1", "1A2", "1B1", "1B2",
+                "2A1", "2A2", "2B1", "2B2"
+            });
         }
 
         public async Task<List<string>> GetTwentiethsGroupsAsync()

--- a/web/Classes/HealthChecks/LdapHealthCheck.cs
+++ b/web/Classes/HealthChecks/LdapHealthCheck.cs
@@ -32,6 +32,8 @@ namespace Viper.Classes.HealthChecks
 
             try
             {
+                // Legitimate Task.Run: S.DS.Protocols has no async API, so the
+                // blocking LDAP bind is offloaded to keep the caller responsive.
                 await Task.Run(() =>
                 {
                     var ldapIdentifier = new LdapDirectoryIdentifier(_ldapServer, _ldapSSLPort);

--- a/web/Views/Shared/Components/CMSBlocks/CMSBlocks.cs
+++ b/web/Views/Shared/Components/CMSBlocks/CMSBlocks.cs
@@ -16,11 +16,11 @@ namespace Viper.Views.Shared.Components.ProfilePic
             CMS = new CMS(viperContext, rapsContext, sanitizerService);
         }
 
-        public async Task<IViewComponentResult> InvokeAsync(int? contentBlockID, string? friendlyName, string? system, string? viperSectionPath, string? page, int? blockOrder, bool? allowPublicAccess, int? status)
+        public IViewComponentResult Invoke(int? contentBlockID, string? friendlyName, string? system, string? viperSectionPath, string? page, int? blockOrder, bool? allowPublicAccess, int? status)
         {
             List<ContentBlock>? blocks = CMS.GetContentBlocksAllowed(contentBlockID, friendlyName, system, viperSectionPath, page, blockOrder, allowPublicAccess, status)?.ToList();
 
-            return await Task.Run(() => View("Default", blocks));
+            return View("Default", blocks);
         }
 
     }

--- a/web/Views/Shared/Components/EmulationBanner/EmulationBanner.cs
+++ b/web/Views/Shared/Components/EmulationBanner/EmulationBanner.cs
@@ -5,16 +5,16 @@ namespace Viper.Views.Shared.Components.EmulationBanner
     [ViewComponent(Name = "EmulationBanner")]
     public class EmulationBannerViewComponent : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync()
+        public IViewComponentResult Invoke()
         {
             IUserHelper UserHelper = new UserHelper();
             if (!UserHelper.IsEmulating())
             {
-                return await Task.Run(() => (IViewComponentResult)Content(string.Empty));
+                return Content(string.Empty);
             }
 
             string? displayFullName = UserHelper.GetCurrentUser()?.DisplayFullName;
-            return await Task.Run(() => View("Default", displayFullName));
+            return View("Default", displayFullName);
         }
     }
 }

--- a/web/Views/Shared/Components/LeftNav/LeftNav.cs
+++ b/web/Views/Shared/Components/LeftNav/LeftNav.cs
@@ -6,12 +6,12 @@ namespace Viper.Views.Shared.Components.LeftNav
     [ViewComponent(Name = "LeftNav")]
     public class LeftNavViewComponent : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync(AaudUser user, int nav)
+        public IViewComponentResult Invoke(AaudUser user, int nav)
         {
 
 
 
-            return await Task.Run(() => View("Default", user));
+            return View("Default", user);
         }
 
     }

--- a/web/Views/Shared/Components/MainNav/MainNav.cs
+++ b/web/Views/Shared/Components/MainNav/MainNav.cs
@@ -40,7 +40,7 @@ namespace Viper.Views.Shared.Components.MainNav
             _context = context;
         }
 
-        public async Task<IViewComponentResult> InvokeAsync(AaudUser user)
+        public IViewComponentResult Invoke(AaudUser user)
         {
             ViewData["OldViperURL"] = oldViperURL;
             var userHelper = new UserHelper();
@@ -67,7 +67,7 @@ namespace Viper.Views.Shared.Components.MainNav
                 "scheduler" => "Computing",
                 _ => "VIPER Home",
             };
-            return await Task.Run(() => View("Default", user));
+            return View("Default", user);
         }
 
     }

--- a/web/Views/Shared/Components/MiniNav/MiniNav.cs
+++ b/web/Views/Shared/Components/MiniNav/MiniNav.cs
@@ -8,10 +8,10 @@ namespace Viper.Views.Shared.Components.MiniNav
     {
         private readonly string oldViperURL = HttpHelper.GetOldViperRootURL();
 
-        public async Task<IViewComponentResult> InvokeAsync(AaudUser user)
+        public IViewComponentResult Invoke(AaudUser user)
         {
             ViewData["OldViperURL"] = oldViperURL;
-            return await Task.Run(() => View("Default", user));
+            return View("Default", user);
         }
 
     }

--- a/web/Views/Shared/Components/ProfilePic/ProfilePic.cs
+++ b/web/Views/Shared/Components/ProfilePic/ProfilePic.cs
@@ -14,12 +14,12 @@ namespace Viper.Views.Shared.Components.ProfilePic
             _AAUDContext = context;
         }
 
-        public async Task<IViewComponentResult> InvokeAsync(string? userName)
+        public IViewComponentResult Invoke(string? userName)
         {
             IUserHelper UserHelper = new UserHelper();
             AaudUser? user = UserHelper.GetByLoginId(_AAUDContext, userName);
 
-            return await Task.Run(() => View("Default", user));
+            return View("Default", user);
         }
 
     }

--- a/web/Views/Shared/Components/SessionTimeout/SessionTimeout.cs
+++ b/web/Views/Shared/Components/SessionTimeout/SessionTimeout.cs
@@ -5,7 +5,7 @@ namespace Viper.Views.Shared.Components.SessionTimeout
     [ViewComponent(Name = "SessionTimeout")]
     public class SessionTimeout : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync()
+        public IViewComponentResult Invoke()
         {
             UserHelper userHelper = new UserHelper();
             string? loginId = userHelper.GetCurrentUser()?.LoginId;
@@ -14,7 +14,7 @@ namespace Viper.Views.Shared.Components.SessionTimeout
                 + "/public/timeout/seconds_until_timeout_v2.cfm?id="
                 + (loginId ?? "")
                 + "&service=" + (onDev ? "Viper2-dev" : "Viper2");
-            return await Task.Run(() => View("Default"));
+            return View("Default");
         }
 
     }

--- a/web/Views/Shared/Components/VueCdn/VueCdnCreate.cs
+++ b/web/Views/Shared/Components/VueCdn/VueCdnCreate.cs
@@ -5,9 +5,9 @@ namespace Viper.Views.Shared.Components.VueCdn
     [ViewComponent(Name = "VueCdnCreate")]
     public class VueCdnCreate : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync()
+        public IViewComponentResult Invoke()
         {
-            return await Task.Run(() => View("~/Views/Shared/Components/VueCdn/VueCdnCreate.cshtml"));
+            return View("~/Views/Shared/Components/VueCdn/VueCdnCreate.cshtml");
         }
     }
 }

--- a/web/Views/Shared/Components/VueCdn/VueCdnInit.cs
+++ b/web/Views/Shared/Components/VueCdn/VueCdnInit.cs
@@ -5,9 +5,9 @@ namespace Viper.Views.Shared.Components.VueCdn
     [ViewComponent(Name = "VueCdnInit")]
     public class VueCdnInit : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync()
+        public IViewComponentResult Invoke()
         {
-            return await Task.Run(() => View("~/Views/Shared/Components/VueCdn/VueCdnInit.cshtml"));
+            return View("~/Views/Shared/Components/VueCdn/VueCdnInit.cshtml");
         }
 
     }

--- a/web/Views/Shared/Components/VueTableDefault/VueTableDefault.cs
+++ b/web/Views/Shared/Components/VueTableDefault/VueTableDefault.cs
@@ -8,7 +8,7 @@ namespace Viper.Views.Shared.Components.VueTableDefault
 
     public class VueTableDefaultViewComponent : ViewComponent
     {
-        public async Task<IViewComponentResult> InvokeAsync(IEnumerable<Object>? data, string keyColumnName,
+        public IViewComponentResult Invoke(IEnumerable<Object>? data, string keyColumnName,
              IEnumerable<string>? skipColumns = null, IEnumerable<Tuple<string, string>>? altColumnNames = null,
              IEnumerable<string>? skipColumnsVisible = null
              )
@@ -25,7 +25,7 @@ namespace Viper.Views.Shared.Components.VueTableDefault
             ViewData["Rows"] = GetDefaultRows(dataList, skipList);
             ViewData["VisibleColumns"] = GetDefaultVisibleColumns(dataList, skipVisibleList);
 
-            return await Task.Run(() => View("Default"));
+            return View("Default");
         }
 
         #region public static string GetDefaultColumnNames(IEnumerable<Object>? data, IEnumerable<string>? skipColumns = null, IEnumerable<Tuple<string,string>>? altColumnNames = null)


### PR DESCRIPTION
## Summary
- Removes the fake-async `await Task.Run(() => ...)` wrappers that scheduled trivial synchronous work (mostly `View(...)` allocations) onto the thread pool
- Converts the affected RAPS and Directory controller actions plus 10 shared view components (`InvokeAsync` to `Invoke`) to synchronous signatures; actions with real awaits stay async
- Drops the async state machine from `StudentGroupService.GetEighthsGroupsAsync`, which awaited `Task.FromResult` over a hardcoded list. The interface signature stays `Task<List<string>>` because its three sibling group getters are genuinely DB-backed, so no call sites change
- Keeps the two `Task.Run` calls that offload genuinely blocking sync work (LdapHealthCheck's LDAP bind, PhotoService's network-share `File.Exists`) with comments explaining why. The repo's other `Task.Run` sites are untouched and are not fake async: the Effort harvest/import/rollover controllers use it for fire-and-forget background jobs, and `BiorenderStudentLookup` uses it for a throttled fan-out
- Adapts `RAPSControllerTests` to the sync `RolePermissions` signature via a sync overload of the bad-request helper
- Fixes two `<param>` tags that did not resolve to their parameter: `RoleList` documented `Instance` against a parameter named `instance` (XML doc param names are case-sensitive), and `DirectoryResult` documented `uid` against a parameter named `mothraID`. Both were flagged by the ReSharper gate once the signature lines entered the diff

## Testing
- All 2708 backend tests pass
- `npm run verify:build` clean, with no new analyzer warnings
- Verified there are no remaining CS1998 (async method without await) warnings anywhere in the project
- The one warning on touched files, CA1502 on `RAPSController.Nav` (complexity 35), is pre-existing and on untouched lines. It is one of 17 pre-existing CA1502 warnings in the repo and belongs in a separate refactor
