### PR TITLE
chore(claude): share team hooks, normalize line endings, refresh agent docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,11 @@ indent_style = space
 indent_size = 4
 end_of_line = crlf
 
+# Shell scripts - must stay LF, matching the .gitattributes pin. Jenkins runs
+# the husky hooks on Linux, where a CR on the shebang line breaks execution.
+[{*.sh,.husky/*}]
+end_of_line = lf
+
 # JavaScript, TypeScript, Vue files - matches Prettier config
 [*.{js,ts,jsx,tsx,vue}]
 max_line_length = 120

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize every text file to LF in the repository, on every clone, without
+# depending on each developer's core.autocrlf being set. Working-tree endings
+# still follow local git config, so Windows checkouts stay CRLF.
+* text=auto
+
+# Shell scripts must stay LF in the working tree. Jenkins runs the husky hooks
+# on Linux, where a CR on the shebang line breaks execution.
+*.sh        text eol=lf
+.husky/*    text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ When I ask a question or make an observation, respond with an answer - do NOT ju
 
 ## Environment & Commands
 
-**Line endings must be CRLF (`\r\n`)** - never use bare LF.
+**Line endings need no attention.** `.gitattributes` normalizes every text file to LF in the repository on commit, whatever the working copy has. Do not "fix" a file's endings; see [HOOKS.md](HOOKS.md).
 
 - Run via npm scripts, never direct .NET/dotnet commands (avoids lock-file conflicts): Dev `npm run dev` | Test `npm run test` (`test:backend`, `test:frontend`; single test: `npm run test:backend -- <TestClassName>` / `npm run test:frontend -- <file-pattern>`) | Lint `npm run lint <path>` | Build `npm run verify:build`
 - **Stale cache**: Add `-- --clear-cache` to `verify:build` or `lint` if builds fail with cached errors
@@ -14,46 +14,43 @@ When I ask a question or make an observation, respond with an answer - do NOT ju
 - **Backend**: ASP.NET 10, `web/Areas/{AreaName}/` | **Frontend**: Vue 3 multi-SPA, Vite → `wwwroot/vue/`
 - **DB**: SQL Server 2016 + EF Core (CTS, RAPS, AAUD schemas) | **Auth**: CAS + `[Permission]` (see API & Cross-Environment)
 - **Identity:** `AaudUser.AaudUserId` = `Person.PersonId`. If mismatched, TEST DB needs refresh.
-- **Design system (UI)**: All UI rules (colors, typography, components, `<main>` landmark, WCAG-AA contrast) live in [DESIGN.md](DESIGN.md) — read it before building or changing UI. Always use Quasar components.
+- **Design system (UI)**: All UI rules (colors, typography, components, `<main>` landmark, WCAG-AA contrast) live in [DESIGN.md](DESIGN.md). Read it before building or changing UI. Always use Quasar components.
 - **VueUse**: Prefer VueUse composables over hand-rolled reactive logic.
-- **O(n²) lookups (JS & C#)**: Never nest per-item searches (`.find()`/`.some()`/`.FirstOrDefault()`/`.Any()`) inside a loop over another growable list. Pre-build a `Map`/`Set`/`Dictionary` once, then look up in the loop. Small fixed reference lists (~10 items) are fine. In EF this is N+1 — see Correlated subqueries.
-- **Plurals**: Use `inflect("word", count)` from the `inflection` package — never hand-roll ternaries for noun pluralization
+- **O(n²) lookups**: Pre-build a `Map`/`Set`/`Dictionary` rather than nesting `.find()`/`.FirstOrDefault()` in a loop over a growable list. In EF this is N+1, see Correlated subqueries.
+- **Plurals**: Use `inflect("word", count)` from the `inflection` package, never hand-roll ternaries for noun pluralization
 
 ## Database & EF Core
 
-- **SQL Server 2016** — no `STRING_AGG`, `TRIM`, `CONCAT_WS`, `GREATEST/LEAST`
+- **SQL Server 2016**: no `STRING_AGG`, `TRIM`, `CONCAT_WS`, `GREATEST/LEAST`
 - Prefer EF entities over raw SQL. Raw SQL only for non-EF tables via `GetConnectionString()`. Never mix raw SQL + EF entities (causes auth failures).
-- **Read-only queries**: Always `.AsNoTracking()` | `.Include()` before `.Select()` is unnecessary — EF resolves navigations in projections
-- **Correlated subqueries**: Avoid `.Any()` on large tables inside `.Where()`/`.CountAsync()` — pre-load ID sets then use `.Contains()`, or replace with `.Join()`
+- **Read-only queries**: Always `.AsNoTracking()` | `.Include()` before `.Select()` is unnecessary, EF resolves navigations in projections
+- **Correlated subqueries**: Avoid `.Any()` on large tables inside `.Where()`/`.CountAsync()`: pre-load ID sets then use `.Contains()`, or replace with `.Join()`
 - **`.Contains()` with large collections (10+)**: Wrap with `EF.Parameter()` for `OPENJSON` translation: `.Where(x => EF.Parameter(largeList).Contains(x.Id))`. Small collections (<10) are fine without it.
-- **Thread safety**: DbContext not thread-safe — no parallel EF queries
+- **Thread safety**: DbContext not thread-safe, no parallel EF queries
 
 ## API & Cross-Environment
 
 - **Routes**: Absolute `/api/{area}/{controller}` + `ApiController` base. Never `[Area]` on APIs (causes 403)
 - **Frontend API calls**: Service layer + `useFetch()`, never raw `fetch()` (must unwrap `{ result, success }`)
-- **API URL**: `${import.meta.env.VITE_API_URL}` — never hardcode `/api/` (TEST uses `/2/` prefix)
+- **API URL**: `${import.meta.env.VITE_API_URL}`, never hardcode `/api/` (TEST uses `/2/` prefix)
 - **Subpath PathBase (`/2`)**: TEST/PROD run VIPER 2 under a `/2` PathBase (IIS sub-app), legacy VIPER 1 at `/`; with no base locally, these bugs surface only on TEST/PROD (not in unit tests). Use `~/` for app-root redirects, never bare `/` (escapes to the legacy site). Guards matching root-relative paths (`/api`, `/welcome`) must strip the base off the base-prefixed `ReturnUrl` (`/2/...`) or use `Request.PathBase`. `RedirectToAction`, `@Url.Content("~/")`, and tag-helpers include the base; raw string paths (`Redirect("/x")`, `returnUrl.StartsWith("/api")`) don't.
-- **Auth**: `[Permission(Allow = "SVMSecure.{Area}")]`, or finer `"SVMSecure.{Area}.{Permission}"` — authenticate before validating params
+- **Auth**: `[Permission(Allow = "SVMSecure.{Area}")]`, or finer `"SVMSecure.{Area}.{Permission}"`. Authenticate before validating params
 
 ## C# Standards
 
 - **Exceptions**: Catch specific types (`DbUpdateException`, `SqlException`, `InvalidOperationException`). Never generic `catch (Exception ex)`.
-- **Paths**: `Path.Join()` not `Path.Combine()` | **DateTime**: prefer `DateTimeKind.Local`
-- **LINQ**: `.Where()` for filtering (not `if` inside foreach), `.Select()` for mapping (not foreach + Add)
-- **Mapperly**: Prefer over manual property mapping. Static partial mapper class per area with `[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.None)]`. Use `[MapperIgnoreTarget]` for computed properties, manual wrappers for transforms. Align entity/DTO names — use EF `HasColumnName()` to decouple from DB columns.
-- **Scrutor**: Convention-based DI auto-registers `*Service`/`*Validator` from configured namespaces — prefer over manual `AddScoped`. Follow `IFooService`/`FooService` naming. Explicit `AddScoped` before Scrutor takes precedence (`RegistrationStrategy.Skip`).
-- **Comments**: Sparingly, why-not-what, complex logic only.
-- **Bug fixes**: Verify ALL code paths using affected logic. Check for duplicate/parallel implementations and fix consistently or DRY into shared method.
+- **Paths**: `Path.Join()` not `Path.Combine()` (`Combine` silently discards everything before a rooted segment) | **DateTime**: prefer `DateTimeKind.Local`
+- **Mapperly**: Prefer over manual property mapping. Static partial mapper class per area with `[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.None)]`. Use `[MapperIgnoreTarget]` for computed properties, manual wrappers for transforms. Align entity/DTO names: use EF `HasColumnName()` to decouple from DB columns.
+- **Scrutor**: Convention-based DI auto-registers `*Service`/`*Validator` from configured namespaces, prefer over manual `AddScoped`. Follow `IFooService`/`FooService` naming. Explicit `AddScoped` before Scrutor takes precedence (`RegistrationStrategy.Skip`).
+- **Bug fixes**: Check for duplicate/parallel implementations of the affected logic and fix consistently, or DRY into a shared method.
 - **Log injection**: Sanitize user input before logging via `LogSanitizer` (`SanitizeId()`, `SanitizeString()`, `SanitizeYear()`). Skip hard-coded strings, enums, DB values.
 
 ## Testing & Git
 
 - **UI**: Test UI changes with Playwright MCP (modals, forms, keyboard nav)
-- **API**: Use Playwright MCP to visit endpoints — APIs require browser auth, `curl` fails
-- **Git**: NEVER stage files until after code review. Workflow: changes → test → lint → summary → approval → stage
+- **API**: Use Playwright MCP to visit endpoints, APIs require browser auth, `curl` fails
 - **Branch & merge flow**: Branch off `main`, named `feature/`|`fix/`|etc. plus the JIRA ticket if applicable (e.g. `feature/VPR-104-clinical-scheduler`). After code review, merge into `Development` and push, which deploys to TEST. After the PR is approved on TEST, merge into `main`. Every change goes through `Development` first.
 - **Never branch off `Development`**: it is a merge/deploy target, never a base. A branch being "behind `Development`" is expected and not a concern (you never sync or rebase from it). Its history is messy by design and never rewritten.
 - **Squash during review**: If a branch is still unmerged and worked by a single developer, squash code-review fixes into the relevant existing commit for cleaner history rather than stacking "address review" commits.
-- **Plan/smoketest notes**: `PLAN-*.md` and `SMOKETEST-*.md` files at the repo root are local working notes — never stage or commit them. They are intentionally left untracked.
+- **Plan/smoketest notes**: `PLAN-*.md` and `SMOKETEST-*.md` at the repo root are local working notes, gitignored by design.
 - **Commit messages**: Conventional Commits `type(scope): subject` (`feat`|`fix`|`refactor`|`docs`|`test`|`chore`; prefer `feat` for new behavior), ticket ID from branch as prefix (e.g. `VPR-104 fix(a11y): ...`). Subject: imperative, max 72 chars, no trailing period, intent not implementation. Body only when the subject is insufficient: `-` bullets that each earn their place (skip plumbing/helpers/test scaffolding), wrapped at 72.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,11 +3,15 @@ name: VIPER
 description: Internal web application suite for the UC Davis Weill School of Veterinary Medicine.
 colors:
   aggie-blue: "#022851"
-  blue-hover: "#033266"
-  blue-secondary: "#4b6983"
+  blue-90: "#033266"
+  blue-80: "#1d4776"
+  blue-70: "#355b85"
+  blue-10: "#cdd6e0"
   aggie-gold: "#ffbf00"
-  gold-accent: "#ffc519"
-  gold-nav: "#ffd24c"
+  gold-90: "#ffc519"
+  gold-70: "#ffd24c"
+  gold-40: "#ffe599"
+  gold-text: "#664d03"
   redwood: "#266041"
   merlot: "#79242f"
   tahoe: "#00b2e3"
@@ -15,40 +19,42 @@ colors:
   arboretum: "#00c4b3"
   cabernet: "#481268"
   ink: "#1d1d1d"
+  dark-page: "#121212"
   body-grey: "#666666"
   surface: "#ffffff"
   table-header: "#eeeeee"
-  blue-10: "#cdd6e0"
+  focus-blue: "#258cfb"
+  warning-banner-text: "#5d4600"
+  splash-card-ink: "#13253f"
+  splash-card-muted: "#64748b"
 typography:
   display:
     fontFamily: "Proxima Nova, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Arial, sans-serif"
     fontSize: "clamp(2.75rem, 5.5vw, 4.25rem)"
     fontWeight: 800
-    lineHeight: 1
+    lineHeight: "1"
     letterSpacing: "-0.02em"
   chrome:
     fontFamily: "Proxima Nova, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Arial, sans-serif"
     fontWeight: 500
-    letterSpacing: "normal"
   heading:
     fontFamily: "Roboto, -apple-system, Helvetica Neue, Helvetica, Arial, sans-serif"
     fontSize: "1.2rem"
     fontWeight: 700
-    lineHeight: 1.2
+    lineHeight: "1.2rem"
   body:
-    fontFamily: "Roboto, -apple-system, Helvetica Neue, Helvetica, Arial, sans-serif"
+    fontFamily: "Roboto, -apple-system, Helvetica Neue, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif"
     fontSize: "1rem"
     fontWeight: 400
-    lineHeight: 1.5
   label:
     fontFamily: "Roboto, -apple-system, Helvetica Neue, Helvetica, Arial, sans-serif"
     fontSize: "0.75rem"
-    fontWeight: 500
-    letterSpacing: "0.04em"
+    fontWeight: 400
 rounded:
   none: "0"
   sm: "0.25rem"
   default: "4px"
+  pill: "1rem"
 spacing:
   xs: "4px"
   sm: "8px"
@@ -58,6 +64,10 @@ spacing:
 components:
   button-primary:
     backgroundColor: "{colors.aggie-blue}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.default}"
+  button-secondary:
+    backgroundColor: "{colors.blue-70}"
     textColor: "{colors.surface}"
     rounded: "{rounded.default}"
   button-positive:
@@ -73,201 +83,348 @@ components:
     textColor: "{colors.ink}"
     rounded: "{rounded.default}"
   button-warning:
-    backgroundColor: "{colors.gold-accent}"
+    backgroundColor: "{colors.gold-90}"
     textColor: "{colors.ink}"
-    rounded: "{rounded.default}"
-  button-secondary:
-    backgroundColor: "{colors.blue-secondary}"
-    textColor: "{colors.surface}"
     rounded: "{rounded.default}"
   card:
     backgroundColor: "{colors.surface}"
     textColor: "{colors.ink}"
     rounded: "{rounded.default}"
     padding: "16px"
-  welcome-cta:
+  header-bar:
     backgroundColor: "{colors.aggie-blue}"
     textColor: "{colors.surface}"
+    typography: "{typography.chrome}"
+    height: "86px"
+  brand-mark:
+    backgroundColor: "{colors.aggie-gold}"
+    height: "2.75rem"
+    width: "2.75rem"
     rounded: "{rounded.none}"
-    padding: "16px 20px"
-  welcome-cta-hover:
-    backgroundColor: "{colors.blue-hover}"
+  section-nav:
+    backgroundColor: "{colors.gold-70}"
+    textColor: "{colors.aggie-blue}"
+    height: "36px"
+  section-nav-selected:
+    backgroundColor: "{colors.gold-40}"
+    textColor: "{colors.aggie-blue}"
+  nav-item-active:
+    backgroundColor: "{colors.blue-10}"
+    textColor: "{colors.aggie-blue}"
+  table-header:
+    backgroundColor: "{colors.table-header}"
+    textColor: "{colors.ink}"
+  input-outlined:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.default}"
+  banner-success:
+    backgroundColor: "color-mix(in srgb, #266041 12%, white)"
+    textColor: "{colors.redwood}"
+    rounded: "{rounded.default}"
+  banner-error:
+    backgroundColor: "color-mix(in srgb, #79242f 12%, white)"
+    textColor: "{colors.merlot}"
+    rounded: "{rounded.default}"
+  banner-warning:
+    backgroundColor: "color-mix(in srgb, #ffc519 15%, white)"
+    textColor: "{colors.warning-banner-text}"
+    rounded: "{rounded.default}"
+  banner-info:
+    backgroundColor: "color-mix(in srgb, #00b2e3 12%, white)"
+    textColor: "{colors.blue-80}"
+    rounded: "{rounded.default}"
+  field-error-chip:
+    backgroundColor: "{colors.merlot}"
     textColor: "{colors.surface}"
+    typography: "{typography.label}"
+    rounded: "{rounded.pill}"
+    padding: "0.125rem 0.5rem 0.125rem 0.25rem"
+  env-badge:
+    backgroundColor: "{colors.merlot}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.default}"
+  skip-link:
+    backgroundColor: "{colors.aggie-blue}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.sm}"
+    padding: "0.5rem 1rem"
+  status-toast:
+    backgroundColor: "{colors.redwood}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.sm}"
+    padding: "0.75rem 1.5rem"
+  splash-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.splash-card-ink}"
+    rounded: "{rounded.none}"
+    padding: "2.5rem"
 ---
 
 # Design System: VIPER
 
-## 1. Overview
+## Overview
 
 **Creative North Star: "The Teaching Hospital"**
 
-VIPER wears two faces, and the system is the building that holds both. The public face is the lobby: a full-bleed photographic welcome where the work of the school (an eye exam, a foal, the SVM building under California sky) is the hero, framed in Aggie Blue with a thin gold rule, calm and institutional. The working interior is the clinic floor: dense, fast, legible, every pixel earning its place because the people here are mid-task and the screen is a tool, not a destination. The brand greets you at the door; the product gets out of your way once you are inside.
+VIPER wears two faces, and the system is the building that holds both. The public face is the lobby: a full-bleed photographic welcome where the work of the school (an eye exam, a foal, the SVM building under California sky) is the hero, framed in Aggie Blue with a thin gold rule, calm and institutional. The working interior is the clinic floor: dense, fast, legible, every pixel earning its place because the people here are mid-task and the screen is a tool rather than a destination. The brand greets you at the door; the product gets out of your way once you are inside.
 
-This is institutional software for a public university veterinary school, not a consumer SaaS product, and it refuses the tells of one. No hero-metric template, no gradient text, no glassmorphism, no identical icon-card grids, no marketing-deck buzzwords. The color discipline is the UC Davis brand discipline: Aggie Blue carries the surface, gold is a rare accent that never dominates, and everything is held to WCAG AA because the audience includes clinicians, staff, faculty, and students using this daily under real time pressure. Built on Quasar, the visual vocabulary is deliberately restrained: flat surfaces, compressed headings, tight rem-based spacing, and components reused rather than reinvented.
+That split is the whole system in one sentence, and it governs every choice below. The lobby is the one place VIPER goes drenched, photographic, and display-scale. The moment a user signs in, the vocabulary changes: white surfaces, compressed headings, flat panels, and no decoration that a working screen has to pay for. Two typefaces carry the divide, and they never mix on the same surface.
 
-The system is bilingual by design. Brand chrome (the blue header bar, the unauthenticated welcome splash) speaks in **Proxima Nova**, the UC Davis campus typeface. The application workspace speaks in **Roboto**, narrower and quieter so dense tables and forms stay readable. The two never mix on the same surface.
+This is institutional software for a public university veterinary school and it refuses the tells of a consumer SaaS product: no hero-metric template, no gradient text, no glassmorphism, no identical icon-card grids. The color discipline is UC Davis brand discipline, with the full official 10 to 100 ramps for blue, gold, and black living in `VueApp/src/styles/colors.css`. Every foreground and background pair is held to WCAG AA because the audience is clinicians, staff, faculty, and students using this daily under real time pressure. The system also runs twice over, once in Razor (`web/wwwroot/css/site.css`) and once in the Vue SPAs (`VueApp/src/styles/`), and the two are kept deliberately in sync.
 
 **Key Characteristics:**
-- Aggie Blue surface, gold as a disciplined accent (never dominant)
+- Aggie Blue chrome, a thin gold band, white workspace, no third surface
 - Two typefaces with one job each: Proxima Nova for brand chrome, Roboto for the workspace
-- Flat by default; elevation is reserved, not decorative
-- WCAG AA is a floor, not a goal: greys, gold, and tab states are all contrast-corrected
-- Dense, compressed, functional product UI; warm, photographic brand surfaces
-- rem everywhere, no inline styles, no `!important` outside documented contrast overrides
+- Display type exists in exactly one place, the welcome splash; in-app headings top out at 1.2rem bold
+- Flat by default; shadow is spent on fixed chrome, keyboard focus, transient toasts, and the one card that lifts off a photograph
+- WCAG AA is a floor: greys, gold text, tab fade, clear-button opacity, and tree arrows are all contrast-corrected
+- Root font-size steps 14px to 16px at 768px, so rem-based sizing carries the density change
+- Every override exists twice, once for Razor and once for the SPA, on purpose
 
-## 2. Colors: The Aggie Palette
+## Colors
 
-A UC Davis institutional palette: Aggie Blue is the foundation, Aggie Gold is the signature accent, and a small secondary set adds status and emphasis. All values are canonical UC Davis brand hex; the blue, gold, and black scales each run a full 10–100 ramp in `VueApp/src/styles/colors.css`.
+A UC Davis institutional palette: Aggie Blue is the foundation, Aggie Gold is the signature accent, and a small secondary set carries status. All values are canonical UC Davis brand hex, with full 10 to 100 ramps for blue, gold, and black.
 
 ### Primary
 
-- **Aggie Blue** (#022851): The load-bearing brand color. The top header chrome, primary buttons, the welcome splash background, active nav text, link color, and skip-to-content chip. This is the surface that says "UC Davis." Quasar `primary`. The full blue ramp (`--ucdavis-blue-10` #cdd6e0 → `--ucdavis-blue-100` #022851) provides hover (`blue-90` #033266), active-row tints (`blue-10`), and tree/arrow strokes.
-- **Aggie Gold** (#ffbf00, accent shade #ffc519): The signature accent. The 3px rule under the header bar, the gold brand-mark tile behind the rod-of-asclepius, the welcome card's top border, the CTA arrow, and focus rings on dark surfaces. Quasar `accent` and `warning` both map to `gold-90` (#ffc519). The gold section-nav bar uses lighter ramp steps (`gold-70` #ffd24c band, `gold-40` #ffe599 selected).
+- **Aggie Blue** (`aggie-blue`): The load-bearing brand color and Quasar `primary`. The top header bar, primary buttons, link color, active nav text, section-nav item text on the gold band, the skip-to-content chip, and the welcome splash background. This is the surface that says UC Davis.
+- **Blue 90** (`blue-90`): Hover and pressed states for blue chrome, including the splash sign-in call to action.
+- **Blue 80** (`blue-80`): The main-nav loading placeholder fill, and the text color of informational status banners.
+- **Blue 70** (`blue-70`): Tree expand and collapse arrows, sized up to 1.4rem so they clear AA as UI. Also the intended fill for `color="secondary"`. See the Blue 70 Parity Rule below.
+- **Blue 10** (`blue-10`): The active left-nav row tint under `primary` text at weight 500.
+- **Aggie Gold** (`aggie-gold`): The signature accent, gold ramp step 100. The 2.75rem brand-mark tile behind the rod of asclepius, and the welcome card's top border. Quasar `accent` and `warning` both map to Gold 90 (`gold-90`), which is the shade that pairs with dark text.
+- **Gold 70** (`gold-70`) and **Gold 40** (`gold-40`): The section-nav band and its selected item.
 
 ### Secondary
 
-- **Blue 70** (#4b6983): Quasar `secondary`. Secondary buttons and muted blue chrome. (Note: the CSS ramp token `--ucdavis-blue-70` is `#355b85`; the Quasar semantic `secondary` is `#4b6983`. Treat the Quasar value as canonical for `color="secondary"`.)
-- **Tahoe** (#00b2e3): Quasar `info`. Informational/tertiary actions. Light enough that it always pairs with `text-color="dark"`.
+- **Tahoe** (`tahoe`): Quasar `info`. Informational and tertiary actions. Light enough that it always pairs with `text-color="dark"`.
 
 ### Tertiary
 
-- **Redwood** (#266041): Quasar `positive`. Success and create actions.
-- **Merlot** (#79242f): Quasar `negative`. Danger and delete actions.
-- **Poppy** (#f18a00): Tips and highlights only. A warm orange used sparingly for callouts.
-- **Arboretum** (#00c4b3) / **Cabernet** (#481268): Secondary-palette accents, never dominant. Reserve for charts, tags, and categorical distinction.
+- **Redwood** (`redwood`): Quasar `positive`. Success and create actions, and the status-toast fill.
+- **Merlot** (`merlot`): Quasar `negative`. Danger and delete actions, validation error chips, and the environment badge.
+- **Poppy** (`poppy`): Tips and highlights only. A warm orange used sparingly for callouts.
+- **Arboretum** (`arboretum`) and **Cabernet** (`cabernet`): Secondary-palette accents, never dominant. Reserve for charts, tags, and categorical distinction.
 
 ### Neutral
 
-- **Ink** (#1d1d1d): Quasar `dark`; default high-contrast text. `dark-page` is #121212.
-- **Body Grey** (#666666): `--ucdavis-black-60`, the AA-safe muted text color. Quasar's default `.text-grey`/`.bg-grey` are remapped to this so muted text still clears 4.5:1.
-- **Surface** (#ffffff): Card and panel background.
-- **Table Header** (#eeeeee): Sticky `q-table` header fill.
+- **Ink** (`ink`): Quasar `dark`; default high-contrast text. `dark-page` is the dark page background.
+- **Body Grey** (`body-grey`): The AA-safe muted text color, `--ucdavis-black-60`. Quasar's default `.text-grey` and `.bg-grey` are remapped to this so muted text still clears 4.5:1.
+- **Surface** (`surface`): Card, panel, and workspace background, and the welcome card over the hero photo.
+- **Table Header** (`table-header`): Sticky `q-table` header fill, and the fill on `q-table__top` and `q-table__bottom`.
+- **Gold Text** (`gold-text`): The darkened gold used for gold-colored *text* on light backgrounds, since bright gold fails AA at text sizes.
+- **Focus Blue** (`focus-blue`): The outer ring of the keyboard focus halo in the app. The only non-brand hue in the system.
+- **Splash Card Ink** (`splash-card-ink`) and **Splash Card Muted** (`splash-card-muted`): Body and secondary text inside the white sign-in card. Slightly warmer and softer than the workspace pairing, because the card sits on a photograph rather than on a page.
+
+### On-Dark Text Alphas
+
+The splash sets white text over a darkened photograph, where a flat hex cannot adapt. Four alpha steps carry the hierarchy: full white for the headline, 0.92 for body copy (raised from the design mock's 0.85 to clear AA at body sizes), 0.7 for footer text, and 0.22 for dividers. These `rgba()` literals are the one sanctioned exception to the no-hardcoded-color rule, because CSS has no syntax for alpha-modifying a custom property in a static sheet.
 
 ### Named Rules
-**The Gold-Is-Accent Rule.** Gold is never a dominant surface and never body text. Per the UC Davis secondary-palette guidance, accents are "never dominant." Gold appears as a thin rule, a focus ring, a brand-mark tile, or a single arrow — measured in pixels of width, not percent of screen. Aggie Blue carries weight; gold punctuates it.
 
-**The Bright-Gold-Never-On-White Rule.** `#ffbf00`/`#ffc519` on white fails AA at text sizes. For gold *text* on light backgrounds, use the darkened `--text-warning` (#664d03). Bright gold is a background and accent color only.
+**The Gold-Is-Accent Rule.** Gold is never a page surface and never body text. It appears as the 36px section-nav band, the 2.75rem brand tile, a 3px rule on the welcome card, and the splash call-to-action arrow. Measured in pixels of width, not percent of screen. Aggie Blue carries weight; gold punctuates it. Per UC Davis secondary-palette guidance, accents are never dominant.
 
-**The AA-Floor Rule.** Every foreground/background pair clears WCAG AA (4.5:1 body, 3:1 large/UI). Quasar greys (`grey`, `grey-5`, `grey-6`) are remapped to `grey-7`; inactive tabs are de-faded (`tabs-no-fade`); input clear-button and tree-arrow opacities are bumped. Contrast correction is a system-level commitment, not a per-screen afterthought.
+**The Bright-Gold-Never-On-White Rule.** `aggie-gold` and `gold-90` on white fail AA at text sizes. For gold text on light backgrounds use `gold-text` (#664d03), applied through the `.text-warning` override. Bright gold is a background and accent color only.
 
-## 3. Typography
+**The AA-Floor Rule.** Every foreground and background pair clears WCAG AA, 4.5:1 for body and 3:1 for large text and UI. The enforcement is concrete and lives in code: Quasar `grey`, `grey-5`, and `grey-6` are remapped to `grey-7` by `toContrastSafeColor`; `warning`, `info`, and `accent` backgrounds are auto-paired with dark text by `getAccessibleTextColor`; inactive tabs are de-faded with `tabs-no-fade`; input clear-button opacity is forced to 1; tree arrows are recolored and enlarged; on-dark body text was raised to 0.92 alpha. Contrast correction is a system-level commitment, not a per-screen afterthought.
 
-**Display / Brand Font:** Proxima Nova (with Roboto, then system-sans fallback). Self-hosted woff2 at weights 400/500/700/800; weight 900 downshifts to 800 (the family caps there).
-**Body / Workspace Font:** Roboto (variable woff2, weights 100–900, with system-sans fallback).
-**Icon Font:** Material Icons (self-hosted woff2).
-**Print-Only:** Ryman Eco is the UC Davis print display face; it is **not** loaded on the web. Arial / Aptos are the brand-approved fallbacks when Proxima is unavailable.
+**The Blue 70 Parity Rule.** Two values ship under this name: the ramp step `--ucdavis-blue-70` (#355b85, used by tree arrows) and the Quasar `secondary` brand value in `VueApp/src/config/colors.ts` (#4b6983). The ramp is canonical. The config value is a small inconsistency to reconcile toward #355b85, not a second legitimate token. Do not introduce a third.
 
-**Character:** Proxima Nova is the warm, confident geometric campus voice; Roboto is the neutral, space-efficient workhorse for data-dense screens. The contrast axis between them is *role*, not style: brand vs. work. Pairing them keeps the institutional identity at the edges while letting the interior breathe.
+**The Two-Sided Parity Rule.** Razor and the SPAs are separate stylesheet worlds that must render identically. `.text-grey`, `.bg-grey`, `.error-surface`, the heading compression, the skip link, the focus ring, the clear-button opacity fix, and the Proxima Nova `@font-face` block are each defined more than once, across `web/wwwroot/css/site.css`, `web/wwwroot/css/welcome.css`, and `VueApp/src/styles/`. Change one, change the others in the same commit. The splash redeclares the brand tokens outright, since it loads with `Layout = null` and cannot see the Vue token files.
+
+## Typography
+
+**Display and Brand Font:** Proxima Nova, the UC Davis campus typeface, self-hosted as woff2 at 400, 500, 700, and 800, with `-apple-system`, BlinkMacSystemFont, Segoe UI, Roboto, then Arial as fallbacks. Weight 900 downshifts to 800, since the family caps there. Font files carry a `?v=1` cache-buster because they are served with long-lived immutable headers; bump it in every stylesheet when a file is replaced.
+**Body and Workspace Font:** Roboto, self-hosted as a variable woff2 covering weights 100 to 900, with the system sans stack behind it, extended with Apple Color Emoji, Segoe UI Emoji, and Noto Color Emoji so emoji render in the user's native set.
+**Icon Font:** Material Icons, self-hosted woff2, with a remote `fonts.gstatic.com` fallback declared in `site.css`.
+**Print-Only:** Ryman Eco is the UC Davis print display face and is deliberately not loaded on the web. Arial and Aptos are the brand-approved fallbacks when Proxima is unavailable.
+
+**Character:** Proxima Nova is the warm, confident geometric campus voice; Roboto is the neutral, space-efficient workhorse for data-dense screens. The contrast axis between them is *role*, not style: brand versus work. Pairing them keeps the institutional identity at the edges while letting the interior breathe.
 
 ### Hierarchy
 
-- **Display** (Proxima Nova 800, `clamp(2.75rem, 5.5vw, 4.25rem)`, line-height 1, letter-spacing −0.02em): The welcome-splash headline only. The single place display-scale type appears.
-- **Chrome / Brand Title** (Proxima Nova 500, ~1.6em): The blue top header bar and brand lockup text.
-- **Heading** (Roboto 700, 1.2rem, line-height 1.2): In-app page and dialog headings (`h1`–`h3` inside `q-page-container`/`q-dialog` are deliberately compressed to 1.2rem). `h4` is 1.1rem, `h5` 1rem bold, `h6` 1rem regular.
-- **Body** (Roboto 400, base 14px → 16px ≥768px): All application copy. Root font-size scales up at the 768px breakpoint, so rem-based sizing grows with it. Cap prose at 65–75ch.
-- **Label** (Roboto 500, 0.75rem, letter-spacing 0.04em): Left-nav subheaders, footer text, breadcrumbs, skip-to-content. Short labels only.
+- **Display** (Proxima Nova 800, `clamp(2.75rem, 5.5vw, 4.25rem)`, line-height 1, letter-spacing -0.02em, `text-wrap: balance`): The welcome-splash headline, and the single place display-scale type appears. Below 1024px it retunes to `clamp(2.5rem, 11vw, 3.25rem)` at line-height 0.98 so it still fits a phone.
+- **Chrome** (Proxima Nova 500): The blue top header bar and the footer. Applied to `#mainLayoutHeader` and `.q-footer` as a whole, so everything inside inherits it except the gold section nav, which overrides back to Roboto.
+- **Heading** (Roboto 700, 1.2rem, line-height 1.2rem): In-app page and dialog headings. `h1`, `h2`, and `h3` inside `q-page-container` and `q-dialog` are all deliberately compressed to the same 1.2rem bold. `h4` is 1.1rem, `h5` is 1rem bold, `h6` is 1rem regular. The splash card's own heading is the exception at 1.5rem bold with -0.01em tracking, since it is brand surface.
+- **Body** (Roboto 400, 1rem): All application copy. Root font-size is 14px, stepping to 16px at 768px, so 1rem means 14px on phones and 16px on desktop. The splash tagline sits at 1.125rem. Cap prose at 65 to 75ch.
+- **Label** (Roboto 400, 0.75rem): Breadcrumbs, validation error chips, and small metadata. Short strings only.
 
 ### Named Rules
-**The Two-Font Rule.** Proxima Nova belongs to brand chrome (the blue header bar, the welcome splash). Roboto belongs to the workspace (everything inside `q-page-container` and the gold section nav, which is intentionally Roboto so its many items fit). Never set workspace body copy in Proxima; never set brand chrome in Roboto.
 
-**The Compressed-Heading Rule.** Inside the app, headings are 1–1.2rem and bold, not display-scale. Hierarchy in the workspace comes from weight and spacing, not size. Display-scale type (>2.75rem) is reserved for brand surfaces. An in-app `h1` that looks like a marketing hero is wrong.
+**The Two-Font Rule.** Proxima Nova belongs to brand chrome: the blue header bar, the footer, and the welcome splash. Roboto belongs to the workspace, meaning everything inside `q-page-container` plus the gold section nav, which is intentionally Roboto because it is narrower and the nav carries many items. Never set workspace body copy in Proxima; never set brand chrome in Roboto. The one deliberate crossing is that section nav, and it is documented in the code that does it.
 
-## 4. Elevation
+**The Compressed-Heading Rule.** Inside the app, headings are 1rem to 1.2rem and bold, never display-scale. Hierarchy in the workspace comes from weight and spacing, not size. Display type above 2.75rem is brand-surface only. An in-app `h1` that looks like a marketing hero is wrong, and the global heading overrides will fight it.
 
-The system is flat by default. Surfaces sit on the page with borders and tonal fills rather than drop shadows; depth is the exception, earned by state or by the one dramatic brand moment. Per CLAUDE.md, "cards are the lazy answer" — containers are used only when they are the right affordance, and never nested.
+**The Root-Scale Rule.** Size in rem, never px, because the root font-size itself is the responsive mechanism. A px value silently opts out of the 14px to 16px step at 768px and breaks density parity between phone and desktop.
+
+## Layout
+
+The authenticated shell is a Quasar layout in `hHh lpR fFf` configuration: a header spanning full width and staying put, a left drawer below it, and a footer. The header carries `height-hint="98"` so the layout reserves space before hydration, backed by `#headerPlaceholder` and `#mainNavPlaceholder` blocks that paint blue at the right heights while the page loads.
+
+**Vertical structure**, top to bottom: the Aggie Blue toolbar (min-height 86px at 768px and up) holding the brand lockup, the wordmark, mobile menu buttons, and the profile picture; then the 36px gold section-nav band; then the left drawer beside the page container; then the page body at `q-pa-md` (16px); with `body` reserving a 60px bottom margin for the footer.
+
+**Density and breakpoints.** Root font-size is the primary responsive lever: 14px below 768px, 16px at 768px and above, which also raises the header to 86px and the left drawer to a 300px minimum. Quasar's own breakpoints govern visibility: `gt-sm` (1024px and up) shows the desktop wordmark button and the section-nav band, while `lt-md` (below 1024px) swaps in the hamburger MiniNav and a compact button, and drops the school-name half of the brand lockup so the toolbar still fits. The left drawer becomes an overlay at mobile widths.
+
+**Tables** are the dominant working layout. `.sticky-header-table` fixes height at 600px so the header can stick, with a 48px offset accounting for one header row (`top: 48px` when the loading row appears, and a matching `scroll-margin-top` so focus does not scroll rows under the sticky header). Table containers carry 1.5rem of bottom margin to separate stacked tables.
+
+**Forms** use the shared `.compact-form` treatment, which removes Quasar's reserved hint and error space so fields sit tight, then expands only when a validation error appears.
+
+**The welcome splash** is the exception to all of this: a standalone page with `Layout = null`, no Quasar shell, and its own full-viewport composition of hero photograph, editorial column, and sign-in card.
+
+### Named Rules
+
+**The Reserved-Space Rule.** Chrome that appears after hydration gets a placeholder at its exact final height (50px placeholders, `height-hint="98"`, 86px header). The page must not reflow when the app boots.
+
+## Elevation & Depth
+
+The system is flat by default. Workspace surfaces sit on the page with borders, tonal fills, and left accent rules rather than drop shadows. Depth is spent deliberately, and each place it appears is either fixed chrome, a response to focus, something transient, or the single brand moment.
 
 ### Shadow Vocabulary
 
-- **Focus ring** (`box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb`): The keyboard-focus halo on form controls and buttons. On the dark welcome splash this becomes a gold ring (`0 0 0 0.1875rem rgba(255,197,25,0.85)`) since default outlines vanish on the photo.
-- **Splash card** (`box-shadow: 0 1.875rem 5rem rgba(0,0,0,0.45)`): The single heavy elevation in the system — the white sign-in card lifting off the full-bleed hero photo. Dramatic on purpose, and used exactly once.
-- **Sticky table header** (`background-color: #eee`): Tonal layering, not shadow — the sticky `q-table` header reads as elevated through fill and stickiness alone.
+- **Header lift** (`box-shadow: 0 0 10px 2px rgba(0, 0, 0, 0.2), 0 0px 10px rgba(0, 0, 0, 0.24)`): Quasar's `elevated` prop on `q-header`, rendered onto a `.q-layout__shadow` overlay. Separates the fixed blue chrome from scrolling content.
+- **Focus ring** (`box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb`): The keyboard-focus halo on form controls and buttons. A white inner ring separates the blue outer ring from the control's own edge, so it reads on both light and colored backgrounds.
+- **Splash focus ring** (`box-shadow: 0 0 0 0.1875rem rgba(255, 197, 25, 0.85)`): The gold focus halo on the splash, because default outlines and the blue app ring both disappear against a gradient-darkened photograph.
+- **Splash card lift** (`box-shadow: 0 1.875rem 5rem rgba(2, 40, 81, 0.5)`): The heaviest elevation in the system, and the white sign-in card is the only thing that earns it. Dramatic on purpose, and used exactly once.
+- **Splash text halo** (`box-shadow: 0 0.125rem 0.5rem rgba(2, 40, 81, 0.5)`) and **footer halo** (`0 0.0625rem 0.1875rem rgba(2, 40, 81, 0.6)`): Legibility backing for white text sitting directly on photography.
+- **Status toast** (`box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.3)`): The fixed bottom-center `.viper-status-notification`. Transient, so it may float.
+
+### Tonal Layering
+
+Everything else conveys depth without shadow. Sticky table headers read as elevated through the `table-header` fill plus stickiness alone. Status surfaces use a 12% tint of their semantic color mixed into white (15% for warning) with a 0.25rem left border in the full-strength color. Active nav rows use the `blue-10` tint. No routine card, panel, or dialog in the workspace carries a drop shadow.
+
+### Motion
+
+Motion is nearly absent by design. The status toast is the only custom transition in the authenticated app: opacity and transform over 0.3s, sliding up 1rem as it fades in. Quasar is configured with `animations: "all"`, so its component transitions are available, and the loading overlay uses `QSpinnerOval` after a 100ms delay so brief waits never flash a spinner.
 
 ### Named Rules
-**The Flat-By-Default Rule.** Workspace surfaces are flat at rest. Shadow appears as a response to focus, or as the single deliberate lift of the welcome card over its hero photo. If a routine panel or card has a drop shadow "for depth," remove it.
 
-## 5. Components
+**The Flat-By-Default Rule.** Workspace surfaces are flat at rest. Shadow appears only as fixed chrome, as a response to keyboard focus, on something transient that floats above the page, or as the single deliberate lift of the welcome card over its hero photo. If a routine panel or card has a drop shadow for depth, remove it.
 
-VIPER is built on Quasar; the prescription is **always use Quasar components**, styled with brand tokens, not bespoke markup. The pieces below are the ones that carry the system's character.
+**The Blue-Shadow Rule.** On the splash, every darkening layer derives from Aggie Blue rather than black: the hero gradient, the legibility bands, the text halos, and the card lift all tint `rgba(2, 40, 81, ...)`. Black shadows over brand photography read as dirt; blue ones read as atmosphere. Alphas sit slightly above their black equivalents to preserve perceived depth.
+
+**The Delayed-Spinner Rule.** Loading indicators wait 100ms before appearing. Work that finishes faster than that shows nothing at all.
+
+## Shapes
+
+The form language is rectangular and quiet, at Quasar's default scale. Corners are softened just enough to read as interface rather than as document, and the brand surfaces are squarer still.
+
+- **4px** is the system default, applied by Quasar to buttons, cards, inputs, badges, and dialogs. Radius is not used expressively; nothing is more rounded to draw attention.
+- **Square (0 radius)** on the brand surfaces: the 2.75rem gold brand-mark tile, and the welcome sign-in card with its 0.1875rem (3px) gold top border. Squareness is what makes them read as institutional rather than as app furniture.
+- **0.25rem** on chrome affordances authored by hand: the skip-to-content chip (bottom corners only, so it reads as pulling down from the top edge) and the status toast.
+- **1rem pill** appears exactly once, on validation error chips under form fields, where the pill shape plus a Merlot fill plus an inline Material Icons `error` glyph make an error read as a label rather than as body text.
+- **50% circles** come from Quasar for round icon buttons.
+- **Portrait rectangles** for people. Avatars are not circles: 40 by 31px in the header and in small photo contexts, 111 by 87px in directory results. The roughly 0.78 ratio is an ID-photo shape, and it is a deliberate institutional signal rather than a social-app one.
+- **Left accent rules** at 0.25rem carry status on banners and on `.error-surface`, reinforcing the border-and-tint approach to depth.
+- **Hairline borders** separate chrome: 1px under the gold section-nav band, and vertical `q-separator` rules between its items.
+
+### Named Rules
+
+**The One-Pill Rule.** The 1rem pill radius belongs to validation error chips and nothing else. Any other pill-shaped element is either a Quasar badge at 4px or a mistake.
+
+**The Square-Brand Rule.** Brand elements are square; product elements are 4px. If a brand mark or a splash surface picks up a radius, it has started to look like an app component, which is the opposite of the intent.
+
+## Components
+
+VIPER is built on Quasar and the prescription is to always use Quasar components, styled with brand tokens, rather than bespoke markup. The splash is the sanctioned exception, since it renders without the Quasar shell.
 
 ### Buttons
 
-- **Shape:** Quasar default radius (~4px); the brand-splash CTA is square (0 radius) with a gold top accent.
-- **Color roles (brand-mapped):** Primary action → `primary` (Aggie Blue); Success/Create → `positive` (Redwood); Danger/Delete → `negative` (Merlot); Info/Tertiary → `info text-color="dark"` (Tahoe); Warning/Caution → `warning text-color="dark"` (Gold); Secondary → `secondary` (Blue 70).
-- **Loading state:** A `q-btn` with a text label plus `:loading` needs a `#loading` slot (`<q-spinner size="1em" class="q-mr-sm" />` + the label text). Icon-only buttons use the default spinner.
-- **Interactive non-buttons:** Anything clickable that isn't a `q-btn` needs `@keyup.enter` + `@keyup.space` + `tabindex="0"` + `role="button"` + `aria-label`.
+- **Shape:** Quasar default (4px); the brand-splash call to action is square with a gold accent.
+- **Color roles:** Primary action `primary` (Aggie Blue); Success or create `positive` (Redwood); Danger or delete `negative` (Merlot); Info or tertiary `info` with `text-color="dark"` (Tahoe); Warning or caution `warning` with `text-color="dark"` (Gold 90); Secondary `secondary` (Blue 70).
+- **Loading state:** A `q-btn` with a text label plus `:loading` needs a `#loading` slot (`<q-spinner size="1em" class="q-mr-sm" />` plus the label text), otherwise the label vanishes. Icon-only buttons use the default spinner.
+- **Interactive non-buttons:** Anything clickable that is not a `q-btn` needs `@keyup.enter`, `@keyup.space`, `tabindex="0"`, `role="button"`, and `aria-label`.
 
 ### Badges
 
-- **Use `StatusBadge`** (wraps `q-badge`, auto-pairs `text-color` with `color` for contrast). Pass the label via the `label` prop or default slot. Avoid raw `q-badge` with manual `getAccessibleTextColor`.
+Use **`StatusBadge`**, which wraps `q-badge` and does two things automatically: `toContrastSafeColor` remaps Quasar's contrast-dead-zone greys, and `getAccessibleTextColor` pairs light backgrounds (`warning`, `info`, `accent`) with dark text. Pass the label via the `label` prop or the default slot. Avoid raw `q-badge` with hand-written text colors in SPAs.
 
 ### Banners
 
-- **Use `StatusBanner`** in Vue SPAs (`type="success|error|warning|info"`). Only `type="error"` is assertive (`role="alert"`) by default; everything else is polite (`role="status"`). Override with the `live` prop only when needed: `live="assertive"` for a warning/info banner shown in direct response to a user action (post-submit validation, time-sensitive notice), `live="off"` for a purely decorative banner with no dynamic content (drops the role entirely). Don't reach for `type="warning"` to force an assertive announcement on a persistent state indicator — that's what `live="assertive"` is for, and most page-load warnings should stay polite. Razor pages use `q-banner` with accessible classes (`bg-warning text-dark`, `role="status"`/`"alert"`). Error surfaces outside `StatusBanner` use the `.error-surface` treatment (12% Merlot tint, Merlot left accent, Merlot text).
+Use **`StatusBanner`** in Vue SPAs with `type="success|error|warning|info"`. Each type carries its own Material icon (`check_circle`, `error`, `warning`, `info`), a 12% tint background (15% for warning), a 0.25rem left border, and matching text color. Only `type="error"` is assertive (`role="alert"`) by default; everything else is polite (`role="status"`). Override with `live`: `live="assertive"` for a warning or info banner shown in direct response to a user action, `live="off"` for a decorative banner with no dynamic content. Do not reach for `type="warning"` to force an assertive announcement on a persistent state indicator. Banners are `rounded` with `inline-actions`, sit on `q-mb-md`, and accept an optional dismiss button. Razor pages use `q-banner` with accessible classes. Error surfaces outside `StatusBanner` use the shared `.error-surface` treatment so `GenericError` and expired-session dialogs match.
 
-### Cards / Containers
+### Cards and Containers
 
-- **Corner Style:** Quasar default (~4px); brand splash card is square with a 3px gold top border.
-- **Background:** White surface on the workspace; the welcome card is white over the Aggie Blue hero.
-- **Shadow Strategy:** Flat in the workspace (see Elevation). Never nest cards.
-- **Internal Padding:** rem-based Quasar spacing (`md` 16px typical).
+- **Corner style:** Quasar default (4px); the splash card is square with a 3px gold top border.
+- **Background:** `surface` white on the workspace, and white over the Aggie Blue hero on the splash.
+- **Shadow strategy:** Flat in the workspace. See Elevation & Depth.
+- **Internal padding:** Quasar `md` (16px) is typical; the splash card takes 2.5rem.
+- Never nest cards, and do not reach for a card when a list or plain section is the better affordance.
 
-### Inputs / Fields
+### Inputs and Fields
 
-- **Style:** Quasar `q-field` / `q-input` / `q-select`. Selects are **always `dense` + `options-dense`**.
-- **Focus:** The white+blue focus ring (see Elevation). Clear-button opacity is forced to 1 for contrast.
+- **Style:** Quasar `q-field`, `q-input`, `q-select`, always `outlined`. This is settled convention rather than preference: 180 of the 181 field-style props across the SPAs are `outlined`, with a single stray `filled`. A bordered box reads more clearly than an underline in dense forms and against table backgrounds. Selects are always `dense` plus `options-dense`.
+- **Focus:** The white-then-blue focus ring. Clear-button opacity is forced to 1 for contrast.
+- **Compact form:** Wrap a form in `.compact-form` to drop Quasar's reserved bottom space. Validation errors then render as Merlot pill chips at 0.75rem with a leading `error` glyph.
 
 ### Dialogs
 
-- **Every `q-dialog`** needs (1) an accessible name via `aria-labelledby` → the title `id` (or `aria-label` if there's no visible title), and (2) a visible close affordance. Persistent SPA dialogs use `@click="handleClose"` instead of `v-close-popup`. Error banners go in a separate `q-card-section` below the header. **Footer actions:** confirmation and simple action dialogs use Submit + Delete only, with no Cancel (the X and Escape dismiss). **Data-entry form dialogs may add a footer Cancel** beside the primary action: once a user has been filling in fields, an explicit Cancel reads more clearly than relying on the X to discard. When present, Cancel, the X, and Escape all route through the same `handleClose` (carrying the unsaved-changes guard on persistent dialogs). Canonical header pattern:
+Every `q-dialog` needs an accessible name via `aria-labelledby` pointing at the title's `id` (or `aria-label` when there is no visible title), and a visible close affordance. Persistent SPA dialogs use `@click="handleClose"` rather than `v-close-popup`. Error banners go in a separate `q-card-section` below the header. Confirmation and simple action dialogs use Submit plus Delete only, with no Cancel, since the X and Escape both dismiss. Data-entry form dialogs may add a footer Cancel beside the primary action, because once a user has been filling in fields an explicit Cancel reads more clearly. When present, Cancel, the X, and Escape all route through the same `handleClose`, carrying the unsaved-changes guard.
 
-  ```html
-  <q-dialog aria-labelledby="my-dialog-title" ...>
-      <q-card>
-          <q-card-section class="row items-center q-pb-none">
-              <div id="my-dialog-title" class="text-h6">Dialog Title</div>
-              <q-space />
-              <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup />
-          </q-card-section>
-  ```
+```html
+<q-dialog aria-labelledby="my-dialog-title" ...>
+    <q-card>
+        <q-card-section class="row items-center q-pb-none">
+            <div id="my-dialog-title" class="text-h6">Dialog Title</div>
+            <q-space />
+            <q-btn icon="close" flat round dense aria-label="Close dialog" v-close-popup />
+        </q-card-section>
+```
 
 ### Navigation
 
-- **Top chrome:** Aggie Blue bar (`#mainLayoutHeader`, min-height 86px ≥768px) in Proxima Nova 500, carrying the `.viper-brand` lockup — a gold tile (`--ucdavis-gold-100`) holding the white rod-of-asclepius mark, beside the school-name lockup image (lockup name hidden below 1024px).
-- **Section nav:** A gold band (`gold-70` #ffd24c) in Roboto 400; the selected item gets `gold-40` (#ffe599).
-- **Left drawer:** `#leftNavMenu` with bold section headers, 500-weight subheaders, indent tiers; active router links tint to `blue-10` with `primary` text at weight 500. The mobile overlay-drawer glow is suppressed.
+- **Top chrome:** The Aggie Blue bar (`#mainLayoutHeader`, min-height 86px at 768px and up) in Proxima Nova 500, carrying the `.viper-brand` lockup, the `VIPER 2.0` wordmark button, an environment badge when applicable, and the profile picture. Below 1024px the wordmark button is replaced by a hamburger MiniNav, a drawer-toggle button, and a compact label button.
+- **Brand lockup:** `.viper-brand` is a flex row with 0.75rem gap: a 2.75rem square gold tile (`aggie-gold`) holding the white rod-of-asclepius mark at 2.5rem, leaving a thin inset, beside the school-name lockup image at 2.75rem tall. The name half hides below 1024px, where the toolbar cannot fit it alongside the nav buttons and profile; the splash header has room and keeps both. Factored into `_ViperBrand.cshtml` so Razor and the SPAs share one lockup.
+- **Section nav:** The gold band (`#mainLayoutHeaderSections`, `gold-70`, min-height 36px) with a 1px bottom border, items in Aggie Blue at regular weight, vertical separators between them, and a trailing help button with a tooltip. The selected item takes `gold-40`. Set in Roboto rather than the header's Proxima, deliberately, because it is narrower and the band carries many items. Desktop-only (`gt-sm`), populated from `layout/topnav`.
+- **Left drawer:** `#leftNavMenu` with bold `h2` section titles at 1.2rem, bold 1rem headers, 500-weight subheaders, and two indent tiers at 1.5rem and 2.5rem. Active router links tint to `blue-10` with `primary` text at weight 500. The Razor side uses `.leftNavActive` for the same purpose.
+
+### Tables
+
+Tables are the primary working surface. `q-table` headers, tops, and bottoms take the `table-header` fill with `white-space: nowrap`. Add `.sticky-header-table` for a fixed 600px viewport with a sticky header. Containers carry 1.5rem bottom margin.
 
 ### Welcome Splash (signature component)
-The unauthenticated landing (`web/Views/Home/Welcome.cshtml`, `Layout = null`): full-bleed hero photo (one of five, randomized per load, served `image-set` AVIF→JPG) under an Aggie-Blue gradient, with an editorial column (gold rule + Proxima 800 headline + tagline) and a white sign-in card carrying a single CAS "Sign in →" CTA. The one place in the system that goes drenched, photographic, and display-scale. A standalone stylesheet (`welcome.css`) redeclares the brand tokens because it cannot load the Vue/Quasar token files.
+
+The unauthenticated landing (`web/Views/Home/Welcome.cshtml`, `Layout = null`, backed by `WelcomePageHelper.cs`): a full-bleed hero photograph, one of five randomized per load and served `image-set` AVIF then JPG, under an Aggie Blue gradient, with an editorial column (gold rule, display headline, tagline) and a white sign-in card carrying a single CAS sign-in call to action. The five photographs live at `web/wwwroot/images/login/`: guinea pig, horse and foal, ophthalmology, the SVM building, and vetmed admin. The card is square with a 3px gold top border, 2.5rem padding, and the system's one heavy elevation. Focus rings go gold here. A standalone `welcome.css` redeclares the brand tokens because the page cannot load the Vue and Quasar token files, and its `:root` block is a mirror of `colors.css` that must be updated alongside it.
+
+This is the one place in the system that goes drenched, photographic, and display-scale. Nothing else may borrow its vocabulary.
+
+### Other Signature Components
+
+- **The environment badge.** A Merlot `q-badge` reading `Development` or `Test`, sitting inline against the wordmark, marked `role="presentation"` since it is decorative to screen readers. It is the one place the workspace deliberately shouts, and it exists so nobody edits production data thinking they are on TEST. In production it renders nothing at all.
+- **The status toast.** `.viper-status-notification`, fixed bottom-center, Redwood, 0.25rem radius, `role="status"`, fading and sliding up 1rem over 0.3s. The app's only custom motion.
+- **The skip-to-content chip.** Parked at `top: -2.5rem` and dropping to `top: 0` on focus, in Aggie Blue with white text and rounded bottom corners. Present on every page, visible only to keyboard users.
 
 ### Landmarks
 
-- **Exactly one `<main>` per page.** Razor pages get it from `_VIPERLayout.cshtml`; Vue SPAs get it from `ViewerLayout`/`ViperLayout.vue` inside `q-page-container`. Never add `<main>` to an SPA `App.vue` or page component.
+Exactly one `<main>` per page. Razor pages get it from `_VIPERLayout.cshtml` (`<main id="main-content" tabindex="-1">`); Vue SPAs get it from `ViperLayout.vue` inside `q-page-container`. Never add `<main>` to an SPA `App.vue` or page component. The `tabindex="-1"` exists so route changes can move focus for screen-reader announcements, which is why `#main-content:focus` suppresses its outline.
 
-## 6. Do's and Don'ts
+## Do's and Don'ts
 
 ### Do:
 
-- **Do** carry brand color through Quasar roles: `primary` Aggie Blue, `positive` Redwood, `negative` Merlot, `info`+`text-color="dark"` Tahoe, `warning`+`text-color="dark"` Gold, `secondary` Blue 70.
-- **Do** reference tokens, not literals: `var(--q-primary)`, `var(--ucdavis-blue-100)`, `var(--ucdavis-gold-90)`. Route any new color through the canonical token files.
-- **Do** use rem for spacing, sizing, and typography — never px.
-- **Do** prefer Quasar utility classes over custom CSS, and combine selectors when rules overlap.
-- **Do** use Proxima Nova for brand chrome and Roboto for the workspace, and keep them off each other's surfaces.
-- **Do** keep gold as a thin accent (rule, ring, mark, arrow). Aggie Blue carries the surface.
-- **Do** verify ≥4.5:1 body / ≥3:1 large-and-UI contrast; lean on the remapped greys (`grey-7`) and darkened gold text (#664d03).
-- **Do** use `StatusBadge` and `StatusBanner` instead of raw `q-badge`/`q-banner` in SPAs, and set `dense` + `options-dense` on every select.
-- **Do** give every dialog an accessible name and a close affordance, with Submit/Delete-only footers.
+- **Do** carry brand color through Quasar roles: `primary` Aggie Blue, `positive` Redwood, `negative` Merlot, `info` Tahoe, `warning` Gold 90, `secondary` Blue 70. Pair `info` and `warning` with `text-color="dark"`.
+- **Do** reference tokens, not literals, routing new colors through `colors.css` and mirroring them into `welcome.css` when the splash needs them.
+- **Do** size in rem, never px.
+- **Do** use Proxima Nova for brand chrome and Roboto for the workspace.
+- **Do** mirror every override across `site.css`, `welcome.css`, and `VueApp/src/styles/` in one commit, bumping the font `?v=` when a woff2 changes.
+- **Do** use `StatusBadge` and `StatusBanner` over raw `q-badge` and `q-banner`, and set `dense` plus `options-dense` on selects.
+- **Do** set `outlined` on every field.
+- **Do** give every dialog an accessible name and a close affordance.
 - **Do** keep exactly one `<main>` landmark per page.
-- **Do** use `text-wrap: balance` on display/brand headings.
+- **Do** give post-hydration chrome a placeholder at its exact final height.
+- **Do** keep gold to a band, a tile, a rule, or an arrow.
+- **Do** use `text-wrap: balance` on display and brand headings.
 
 ### Don't:
 
-- **Don't** use inline `style=""`. Extract to a class.
-- **Don't** use `!important` except for the documented Quasar contrast overrides (`.text-grey`, `.text-warning`, `tabs-no-fade`).
-- **Don't** put bright gold (#ffbf00 / #ffc519) on white as text — it fails AA. Gold is a background and accent only.
-- **Don't** let gold become a dominant surface; the secondary palette is "never dominant."
-- **Don't** set in-app headings at display scale — workspace `h1`–`h3` are 1.2rem bold. Display type (>2.75rem) is brand-surface only.
-- **Don't** add drop shadows to routine cards/panels; the system is flat by default.
-- **Don't** nest cards, or reach for a card when a list or plain section is the better affordance.
-- **Don't** hardcode hex in component or page CSS — derive from the brand tokens.
-- **Don't** render two `<main>` landmarks on one page (one from layout + one from a component).
-- **Don't** import consumer-SaaS tells: gradient text, glassmorphism, hero-metric templates, identical icon-card grids, or marketing buzzwords. This is institutional veterinary-school software.
+- **Don't** use inline `style=""`. Two ship today and should go when those files are next touched: `_VIPERLayout.cshtml` and `MainNav.vue`.
+- **Don't** use `!important` outside the documented contrast overrides (`.text-grey`, `.bg-grey`, `.text-warning`, `tabs-no-fade`, avatar sizes).
+- **Don't** put bright gold on white as text. Use `gold-text` (#664d03).
+- **Don't** add a third darkened gold. `#664d03` and `#5d4600` both ship and should converge.
+- **Don't** hardcode an untokenized color. Three ship and should stop spreading: `silver` on the section-nav border, `#e6ecf2` on the Razor active row, and a stale `#335379` where `--ucdavis-blue-80` is `#1d4776`. The splash on-dark alphas are the one exception.
+- **Don't** set in-app headings at display scale; `h1` through `h3` are 1.2rem bold.
+- **Don't** add drop shadows to routine cards or panels.
+- **Don't** use black shadows over brand photography.
+- **Don't** nest cards, or use a card where a list or plain section fits.
+- **Don't** render two `<main>` landmarks on one page.
+- **Don't** import consumer-SaaS tells: gradient text, glassmorphism, hero-metric templates, identical icon-card grids, neon-on-dark accents, marketing buzzwords, or an undifferentiated Material or Bootstrap admin look.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,72 @@
+# HOOKS.md
+
+Claude Code hooks run shell commands at fixed points in the agent lifecycle, so
+they enforce conventions that a prompt rule can only request. **This repo ships
+none**, deliberately. Everything under `.claude/` is gitignored and personal,
+including `settings.local.json` (your permission allowlist, MCP servers, default
+mode). Run `/hooks` in Claude Code to see what you have configured locally.
+
+This file exists because hooks were a tempting answer to two problems here. One
+had a better answer a layer down; the other was not worth enforcing. Both are
+written up below so the same ground is not retrodden. If you add a hook anyway,
+the gotchas at the bottom cost real debugging time to find.
+
+## Prefer a mechanism one layer down
+
+A hook is the wrong place to enforce something git can enforce itself. It runs
+only on this tool's writes, needs external binaries installed, and fails open by
+convention, so it can stop working with no sign at all.
+
+Line endings are the worked example. The agent's Write and Edit tools emit bare
+LF while this working tree is CRLF, which looks like it needs normalizing on
+every write, and a `PostToolUse` hook running `unix2dos` was the first answer.
+`.gitattributes` is the better one.
+
+`* text=auto` normalizes every text file to LF in the repository on commit,
+whatever the working copy happens to have. That beats a hook on every axis: no
+external tools to install, no extension allowlist to keep current, it covers
+files the agent never touches, it applies to teammates whose `core.autocrlf` is
+unset, and it cannot silently stop working. Working-tree endings still follow
+local git config, so Windows checkouts stay CRLF.
+
+`*.sh` and `.husky/*` are pinned to `eol=lf`, matching `.editorconfig`, because
+Jenkins runs the husky hooks on Linux where a CR on the shebang line breaks
+execution.
+
+## Do not gate staging
+
+A `PreToolUse` hook returning `permissionDecision: "ask"` on `git add` was tried
+here and removed. It forces a prompt that deliberately overrides any allowlist
+entry, so every commit stalls waiting for a human, and an unattended run cannot
+answer at all. That forecloses goal-directed agentic sessions, which are worth
+more than the failure it guarded against: a premature commit on an unmerged
+branch costs an amend.
+
+The concrete hazard it named, sweeping `PLAN-*.md` or `SMOKETEST-*.md` into a
+commit, is already handled deterministically by `.gitignore`.
+
+## Gotchas
+
+These all fail with exit code 0. **Check the side effect, never the exit code.**
+
+**`jq` writes CRLF to stdout on Windows.** Any hook that reads the tool payload
+with `jq -r ... | { read -r f; ... }` gets a trailing `\r` on `$f`, and every
+downstream use silently misbehaves: a `case "$f" in *.cs)` stops matching and the
+hook does nothing at all. Always pipe through `tr -d '\r'` first.
+
+**`git check-ignore -v` exits 0 for negated matches too.** So a path rescued by a
+`!pattern` rule is reported as though it were ignored. Use the quiet form (`-q`)
+to test ignored-ness, and `-v` only to name the rule afterwards.
+
+**Do not test a hook command with `eval`.** `eval "$CMD"` expands `$f` in the outer
+shell before the command runs, so `case "$f"` sees an empty string and matches
+nothing. Write the command to a file and run `bash file.sh` instead.
+
+**Hooks run under Git Bash, not PowerShell.** Use POSIX syntax.
+
+To check a file's line endings, ask git rather than `file`, which reports "CRLF"
+even when only some lines are:
+
+```bash
+git ls-files --eol path/to/file   # i/ = repository, w/ = working tree
+```

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,53 +1,79 @@
 # Product
 
-## Register
+<!-- impeccable:product-schema 1 -->
 
-product
+## Platform
+
+web
 
 ## Users
 
-The UC Davis Weill School of Veterinary Medicine community: faculty, clinicians, staff, and students. They authenticate through campus CAS and use VIPER as the internal hub for the school's operational systems — role and permission administration (RAPS), effort reporting, clinical scheduling, competency tracking (CTS), the directory, and CMS-managed content.
+The UC Davis Weill School of Veterinary Medicine community: faculty, clinicians, staff, and students. They authenticate through campus CAS and use VIPER as the internal hub for the school's operational systems: role and permission administration (RAPS), effort reporting, clinical scheduling, competency tracking (CTS), the directory, and CMS-managed content.
 
-These are mandatory, repeat users, not visitors. They arrive mid-workflow, often under time pressure, to get a specific administrative, academic, or clinical task done — the app is a tool, not a destination. Technical comfort ranges widely, from daily power users to occasional ones, and the same screens are used across desktop and mobile.
+These are mandatory, repeat users, not visitors. They arrive mid-workflow, often under time pressure, to get a specific administrative, academic, or clinical task done. The app is a tool, not a destination. Technical comfort ranges widely, from daily power users to occasional ones, and the same screens are used across desktop and mobile.
 
 ## Product Purpose
 
 VIPER (2.0) is the School of Veterinary Medicine's internal web application suite: a single authenticated home, behind the UC Davis brand, for the operational systems the school runs on. It consolidates permission management, effort reporting, clinical scheduling, competency tracking, directory, and content into one consistent shell so staff and faculty don't juggle disconnected tools.
 
-Success looks like: tasks completed quickly and correctly with minimal training, consistent behavior across every area, and full accessibility for every user — on any device. The product earns trust by being reliable and clear, not by being novel.
+Success looks like: tasks completed quickly and correctly with minimal training, consistent behavior across every area, and full accessibility for every user, on any device. The product earns trust by being reliable and clear, not by being novel.
+
+## Positioning
+
+VIPER 2 is the incremental replacement for the legacy VIPER 1 site. The two run in parallel indefinitely: VIPER 2 under a `/2` PathBase, VIPER 1 at the root, with each area moving over when it is ready. That migration posture is the durable fact, not a phase to be finished and forgotten.
+
+What no neighboring product could truthfully copy is the school's own operational data and identity graph. VIPER sits directly on the SVM and campus systems of record (RAPS roles, AAUD identity, effort, rotations, competencies) rather than modeling a generic institution. A campus-wide system does not know a fourth-year rotation or a clinician's effort split; an off-the-shelf admin tool does not know UC Davis CAS or RAPS. VIPER's position is the shell that speaks both, so a user crosses between permission administration, effort, and scheduling without changing tools or mental models.
+
+Because migration is incremental, every new surface has to be legible next to a VIPER 1 page a user may hit in the same session, and a user's sense of "the school's system" spans both. Continuity of behavior across the boundary is part of the product, not a transitional courtesy.
+
+## Operating Context
+
+- **Access is never anonymous.** Every working surface is behind campus CAS single sign-on, gated by RAPS roles through `[Permission(Allow = "SVMSecure.{Area}")]`. The only unauthenticated surface in the product is the login and welcome page.
+- **Two sites, one perceived system.** TEST and PROD run VIPER 2 as an IIS sub-application under `/2`, beside legacy VIPER 1 at `/`. Local development has no base path, so subpath bugs surface only on TEST and PROD.
+- **Areas in the suite today.** Backend areas: CMS, CTS, ClinicalScheduler, Computing, Curriculum, Directory, Effort, RAPS, Scheduler, Students. Vue SPAs: CAHFS, CMS, CTS, ClinicalScheduler, Computing, Effort, Students.
+- **Release path.** Feature branch off `main`, merged to `Development` to deploy to TEST, then to `main` after approval on TEST. Jenkins runs the deploys.
+- **Usage scene.** Mid-task, time-pressured, often with a specific record in hand (a person, a rotation, a reporting period). Screens are used on desktop and on mobile from 390px up, including in clinical settings.
+
+## Capabilities and Constraints
+
+- **Stack.** ASP.NET 10 backend organized per area under `web/Areas/{AreaName}/`, with a Vue 3 multi-SPA frontend built by Vite into `wwwroot/vue/`. Quasar is the component vocabulary; new screens compose it rather than introducing bespoke markup.
+- **Data.** SQL Server 2016 with EF Core, spanning the CTS, RAPS, and AAUD schemas plus `effort` and `users`. The 2016 target rules out `STRING_AGG`, `TRIM`, `CONCAT_WS`, and `GREATEST`/`LEAST`.
+- **Identity.** `AaudUser.AaudUserId` equals `Person.PersonId`. Records are de-duplicated by MothraId.
+- **Terminology future work must preserve.** RAPS (roles and permissions), CTS (competency tracking), AAUD (campus identity), effort (reporting), rotation (clinical scheduling), MothraId, area.
+- **Open and undecided.** Which remaining VIPER 1 areas migrate next, and in what order, is not recorded here.
 
 ## Brand Personality
 
-Institutional, trustworthy, and efficient — the voice of a public university veterinary school. Three words: **authoritative, clear, accessible.**
+Institutional, trustworthy, and efficient: the voice of a public university veterinary school. Three words: **authoritative, clear, accessible.** It should feel unmistakably like UC Davis, calm and credible, with warmth coming from the school's mission rather than from decorative UI.
 
-It should feel unmistakably like UC Davis: Aggie Blue and gold, calm and credible, brand-disciplined. Warmth comes from the school's mission — animal and public health, teaching, the people and patients — surfaced through brand imagery on welcome surfaces, not from decorative UI inside the workspace. The copy voice is plain, direct, and respectful of the user's time: say what a control does and what will happen.
+The copy voice is plain, direct, and respectful of the user's time: say what a control does and what will happen. Never reach for marketing buzzwords (streamline, empower, supercharge, leverage, seamless, world-class, enterprise-grade, next-generation, game-changer); use specific nouns and verbs for what the product literally does.
 
-## Anti-references
+The visual expression of all this, including what VIPER must not look like, is specified in [DESIGN.md](DESIGN.md).
 
-VIPER should **not** look like a consumer SaaS marketing site, a trendy startup dashboard, or a generic off-the-shelf admin template. Specifically avoid:
+## Evidence on Hand
 
-- **Consumer-SaaS tells**: gradient text, glassmorphism, the hero-metric template (big number + small label + gradient accent), and identical icon-card grids.
-- **Marketing buzzwords**: streamline, empower, supercharge, leverage, seamless, world-class, enterprise-grade, next-generation, game-changer. Use specific nouns and verbs for what the product literally does.
-- **Off-brand color**: bright gold as a dominant surface or as text on white; dark-mode-with-neon-accents; anything that fights the UC Davis institutional palette.
-- **Marketing-scale UI inside the app**: display-scale hero headings on working screens (those belong only to brand surfaces like the login splash).
-- **Generic Material/Bootstrap admin look**: undifferentiated framework defaults with no brand discipline.
+Real assets that design work may rely on:
 
-## Design Principles
+- **Proxima Nova**, the UC Davis campus typeface, self-hosted as woff2 at regular, medium, bold, and extrabold, in both `VueApp/src/assets/fonts/proxima-nova/` and `web/wwwroot/fonts/proxima-nova/`.
+- **Self-hosted Roboto and Material Icons**: `VueApp/src/assets/fonts/roboto-v51-latin.woff2`, `roboto-v51-latin-ext.woff2`, and `material-icons.woff2`, built to `web/wwwroot/vue/assets/`.
+- **Five login hero photographs** in AVIF and JPG at `web/wwwroot/images/login/`: guinea pig, horse and foal, ophthalmology, the SVM building, and vetmed admin.
+- **Brand marks**: the rod of asclepius (`rod-of-asclepius-white.avif` and `.png`), the `_ViperBrand.cshtml` lockup partial, `web/wwwroot/images/UCDSVMLogo.png`, and `nopic.jpg` as the person-photo placeholder.
+- **The welcome splash**: `web/Views/Home/Welcome.cshtml`, `web/wwwroot/css/welcome.css`, and `WelcomePageHelper.cs` with tests.
 
-1. **The tool gets out of the way.** Inside the app, density, speed, and legibility beat decoration; every element earns its place. The brand greets users at the door (the login splash); the workspace stays quiet.
-2. **Accessibility is a floor, not a feature.** WCAG AA on every surface — contrast, landmarks, keyboard operation, screen-reader semantics — because the audience is mandatory daily users across a full range of needs.
-3. **Brand discipline over novelty.** Carry the UC Davis identity faithfully: Aggie Blue carries the weight, gold accents but never dominates, consistency wins. The school's credibility is the design's job.
-4. **Reuse over reinvention.** One Quasar component vocabulary, one token source, shared patterns (StatusBadge, StatusBanner, the dialog pattern). New screens compose existing parts rather than introducing one-offs.
+Absences that future work must not paper over:
+
+- **No marketing evidence exists.** There are no testimonials, customer logos, adoption metrics, benchmarks, or press. VIPER is mandatory internal software; never fabricate social proof for it. Real user, permission, and effort data lives only in the TEST and PROD databases.
+
+## Product Principles
+
+1. **The tool gets out of the way.** Density, speed, and legibility beat decoration; every element earns its place. The brand greets users at the door; the workspace stays quiet.
+2. **Accessibility is a floor, not a feature.** WCAG AA on every surface, for an audience that has no choice but to use this software.
+3. **Brand discipline over novelty.** Carry the UC Davis identity faithfully and consistently. The school's credibility is the design's job.
+4. **Reuse over reinvention.** One component vocabulary, one token source, shared patterns. New screens compose existing parts rather than introducing one-offs.
 5. **Correctness earns trust.** This is institutional software handling permissions, effort, and schedules. Clarity and predictability outrank cleverness; never surprise the user with what an action does.
 
 ## Accessibility & Inclusion
 
-WCAG 2.1 AA is the system-wide standard, enforced rather than aspired to:
+WCAG 2.1 AA is the system-wide standard, enforced rather than aspired to, because the audience is mandatory daily users across a full range of needs and abilities. Layouts work from mobile (390px) up, reduced-motion preferences are respected, and fonts are self-hosted for reliable rendering.
 
-- **Contrast**: ≥4.5:1 for body text, ≥3:1 for large text and UI. Quasar's mid-greys are remapped to AA-safe shades, bright gold is corrected before use as text, and inactive tab text is kept above the fade threshold.
-- **Structure**: exactly one `<main>` landmark per page; a visible skip-to-content link.
-- **Components**: every dialog has an accessible name and a close affordance; interactive non-buttons get full keyboard semantics (`enter`/`space`, `tabindex`, `role`, `aria-label`).
-- **Announcements**: screen-reader live regions are polite by default and assertive only in direct response to a user action.
-- **Motion & responsiveness**: reduced-motion preferences respected; layouts work from mobile (390px) up. Fonts are self-hosted for reliable rendering.
-
-Visual and component-level specifics live in [DESIGN.md](DESIGN.md).
+The component-level contract that delivers this (contrast ratios, landmarks, keyboard semantics, dialog naming, live-region politeness) is specified in [DESIGN.md](DESIGN.md).


### PR DESCRIPTION
## What

Four independent changes to the agent and repo configuration, one commit each.

**1. Trim CLAUDE.md** of rules the model already follows by default (LINQ style, comment style), and reduce two others to their non-obvious half. Prompted by Anthropic cutting 80% of Claude Code's own system prompt: as models improve, generic instructions dilute the project-specific ones rather than adding to them. No project-specific rule was removed.

**2. Share the team's Claude Code hooks** by tracking `.claude/settings.json`. Everything else under `.claude/` stays personal and gitignored.

**3. Normalize line endings with `.gitattributes`** instead of a per-write agent hook.

**4. Refresh the agent-facing design docs,** prompted by the Impeccable v4 update. v4 retired the `## Register` axis in favor of per-surface visitor modes, and added four sections to the product record, so its doctor flagged `PRODUCT.md` as predating the current schema. Bringing that up to date surfaced drift in `DESIGN.md` too: `Layout` and `Shapes` were missing entirely, the headings had been renumbered away from the DESIGN.md spec so tooling could not find them, and several shipped components were undocumented. Both are now rewritten from the implemented UI.

## Why a hook rather than more documentation

One rule in CLAUDE.md was being violated silently, with no error:

- **"Never stage files until after code review."** A `PreToolUse` hook now forces a prompt on `git add`, `git stage`, and `git commit -a`. It uses `ask` rather than `deny` so legitimate post-approval staging still works.

## Why .gitattributes rather than a hook

CRLF was the other silently-violated rule. The agent's Write and Edit tools emit bare LF, so edits landed as LF inside otherwise-CRLF files, and `file` still reports "CRLF line terminators" when only some lines are LF, so the obvious check misses it.

The first attempt here was a `PostToolUse` hook running `unix2dos`. `.gitattributes` turned out to be the better fix, one layer down:

- `* text=auto` normalizes every text file to LF on commit, on every clone, regardless of anyone's `core.autocrlf`
- no external tools to install, no extension allowlist to maintain, and it covers files the agent never touches
- it fixes the case a hook cannot: a teammate who clones without `core.autocrlf` set would otherwise commit CRLF against LF blobs and rewrite whole files in the diff

Content is unchanged. Every blob in the repo was already LF, and `git add --renormalize .` stages nothing. `*.sh` and `.husky/*` are pinned to `eol=lf` in both `.gitattributes` and `.editorconfig`, since Jenkins runs the husky hooks on Linux where a CR breaks the shebang line.

## What this means for you

Pulling this changes what runs on your machine: Claude Code executes the hook in `.claude/settings.json` when you open the project. In plain terms, before `git add` it shows a confirmation prompt.

It is in the diff. Nothing else under `.claude/` is tracked, so your `settings.local.json`, MCP servers and permissions stay personal.

## If the file does not appear

A bare `.claude` line in `.gitignore` or `.git/info/exclude` hides it, and git reports no error when it does. `npm install` now warns. Fix with:

```
.claude/*
!.claude/settings.json
```

## What the design-doc pass turned up

Rewriting `DESIGN.md` from source rather than from memory surfaced small inconsistencies. None are fixed here, and all are recorded as Don'ts so whoever next touches those files has the context:

- Two darkened golds ship: `#664d03` in `.text-warning`, `#5d4600` in `StatusBanner`
- Three untokenized literals: `silver` on the section-nav border, `#e6ecf2` on the Razor active row, and a stale `#335379` fallback where `--ucdavis-blue-80` is `#1d4776`
- `blue-70` names two values: `#355b85` in the ramp, `#4b6983` as Quasar `secondary`
- The splash card lift and text halos tint from Aggie Blue (`rgba(2, 40, 81, ...)`); DESIGN.md had them recorded as black
- Two inline `style=""` attributes, in `_VIPERLayout.cshtml` and `MainNav.vue`

Newly documented: the status toast, the header's Quasar elevation, the `.viper-brand` lockup, the environment badge, the splash shadow vocabulary, and the `outlined` field convention (180 of 181 field-style props).

The `.impeccable/design.json` sidecar written alongside is not in the diff, since `.gitignore` excludes `.impeccable/`.

## Notes

`HOOKS.md` documents the staging hook, why line endings are deliberately not a hook, and two gotchas that cost real time here: `jq` emits CRLF on stdout on Windows, and `git check-ignore -v` exits 0 for negated matches (which made the first version of the warning script fire on correctly configured repos).
