### PR TITLE
chore(deps): bump .NET packages to 10.0.10 for July 2026 CVEs

### DIFF
--- a/test/Viper.test.csproj
+++ b/test/Viper.test.csproj
@@ -12,16 +12,16 @@
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
     <PackageReference Include="MockQueryable.NSubstitute" Version="10.0.8" />

--- a/web/Viper.csproj
+++ b/web/Viper.csproj
@@ -57,19 +57,19 @@
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageReference Include="NLog.MailKit" Version="6.1.4" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageReference Include="QuestPDF" Version="2026.6.0" />
@@ -79,8 +79,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.DirectoryServices" Version="10.0.9" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
+    <PackageReference Include="System.DirectoryServices" Version="10.0.10" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="MimeKit" Version="4.17.0" />


### PR DESCRIPTION
## What

Bumps 16 Microsoft package references from `10.0.9` to `10.0.10`, the July 14, 2026 servicing release.

- `web/Viper.csproj` (9): ASP.NET Core Diagnostics.EFCore, JsonPatch, EF Core Design/SqlServer/Tools, HealthChecks.EFCore, Http.Polly, System.DirectoryServices, System.DirectoryServices.AccountManagement
- `test/Viper.test.csproj` (7): Data.Sqlite.Core, EF Core InMemory/Sqlite/Sqlite.Core/Tools/SqlServer, Extensions.Logging

## Why

.NET 10.0.10 addresses 17 CVEs. All are rated Important (none Critical), all marked *Exploitation Less Likely*, none publicly disclosed or exploited in the wild. Overall this is a routine patch, not an emergency.

Relevant to how VIPER2 actually runs (CAS cookie auth, in-process IIS hosting, no SAML, no Negotiate):

| CVE | CVSS | Issue | Relevance |
|---|---|---|---|
| CVE-2026-50528 | 8.2 | SslStream incorrect authorization / fail-open, allows impersonation | Highest real exposure. Outbound .NET TLS: CAS validate calls, LDAP over TLS, SQL Server |
| CVE-2026-57108 | 7.5 | X.509 parsing type confusion, unauthenticated network DoS | Reachable via the same outbound TLS paths |
| CVE-2026-50651 | 7.5 | HTTP/2 unbounded allocation, OOM DoS | Kestrel-side. In-process hosting means http.sys terminates HTTP/2 on TEST/PROD, so this mostly hits local dev |
| CVE-2026-50659 | 6.5 | Improper output encoding, network spoofing | Requires an authenticated attacker; small blast radius |

Low impact for a server app (local vector, requires user interaction): CVE-2026-50646, CVE-2026-50649, CVE-2026-50650 (all 7.8, `AV:L/UI:R`), CVE-2026-50526 (7.0). The "remote code execution" headlines are misleading; these are dev-workstation and build-agent concerns.

Not applicable to this codebase: the `EncryptedXml` family (CVE-2026-47304 at 8.1, plus 47302 / 50525 / 50527 / 50648 / 50524) needs SAML-style encrypted XML, which we do not use. The two highest-scoring CVEs in the release, CVE-2026-47300 and CVE-2026-47303 (both 8.8), are ASP.NET Core Negotiate auth EoP and need `Microsoft.AspNetCore.Authentication.Negotiate`, which we do not reference.

## Deployment note

These package bumps do not by themselves close the CVEs. Most of the 17 live in the shared framework, so the **10.0.10 runtime must be installed on TEST and PROD** for the patch to take effect. This PR keeps the build in sync with that.

## Out of scope

- `global.json` stays at `10.0.300`. `rollForward: latestFeature` already accepts SDK 10.0.302, and CI floats on `10.0.x`.
- `web/Areas/Effort/Scripts/EffortMigration.csproj` keeps its three `Microsoft.Extensions.Configuration*` refs at `10.0.8`. It is not in `Viper.sln`, so nothing builds or ships it.
- The `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 pin stays. EF Core 10.0.10 still depends on 2.1.11, so the existing comment is still accurate.
- No third-party packages that coincidentally use 10.0.x versioning were touched.

## Testing

`npm run test:backend`: 2185 passed, 0 failed. Pre-commit lint, test, and build verification all green.
