### PR TITLE
fix(deps): use uniform 7-day cooldown for all dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       day: monday
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       dotnet:
         patterns: ["*"]
@@ -21,7 +20,6 @@ updates:
       day: monday
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       npm-root:
         patterns: ["*"]
@@ -34,7 +32,6 @@ updates:
       day: monday
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       npm-vueapp:
         patterns: ["*"]


### PR DESCRIPTION
Makes the Dependabot cooldown uniform at 7 days across every ecosystem by dropping the `semver-major-days: 14` override from the nuget, npm `/`, and npm `/VueApp` entries. `github-actions` was already 7-only (it does not support the semver keys).

This lines the cooldown up with the `min-release-age=7` gate already set in `.npmrc` and `VueApp/.npmrc`, so a release has to sit on the registry for the same 7 days regardless of which tool sees it first.

Cooldown applies to version updates only. Security updates still open immediately.