### PR TITLE
fix(cms): stop serving trashed files, and restore the legacy delete-now action

### DIFF
--- a/VueApp/src/CMS/__tests__/files.test.ts
+++ b/VueApp/src/CMS/__tests__/files.test.ts
@@ -52,7 +52,7 @@ function lastListUrl(): string {
     return listCalls.at(-1) ?? ""
 }
 
-function routeGet(opts: { rows?: unknown[]; total?: number } = {}) {
+function routeGet(opts: { rows?: unknown[]; total?: number; canPermanentlyDelete?: boolean } = {}) {
     const rows = opts.rows ?? [FILE_ROW]
     mockGet.mockReset()
     mockDel.mockReset()
@@ -64,6 +64,12 @@ function routeGet(opts: { rows?: unknown[]; total?: number } = {}) {
         }
         if (url.includes("folders")) {
             return Promise.resolve({ success: true, result: ["Apps", "Reports"] })
+        }
+        if (url.includes("options/capabilities")) {
+            return Promise.resolve({
+                success: true,
+                result: { canPermanentlyDelete: opts.canPermanentlyDelete ?? false },
+            })
         }
         // The paged list request.
         return Promise.resolve({
@@ -241,6 +247,96 @@ describe("Files.vue - delete and restore actions", () => {
         await flushPromises()
 
         expect(document.body.textContent).toContain("Failed to restore file")
+    })
+})
+
+// The legacy CMS "delete now": skips the 30-day trash. Admin-only, and the SPA can't tell from its
+// own permission list (loaded with the SVMSecure.CMS prefix), so it asks the capabilities endpoint.
+describe("Files.vue - permanent delete", () => {
+    const trashedRow = [{ ...FILE_ROW, deletedOn: "2024-02-01T00:00:00" }]
+
+    it("offers no permanent delete to a non-admin", async () => {
+        routeGet({ rows: trashedRow, canPermanentlyDelete: false })
+        const wrapper = await mountPage({ status: "deleted" })
+
+        expect(wrapper.find('[aria-label="Permanently delete file"]').exists()).toBeFalsy()
+    })
+
+    it("offers permanent delete to an admin, on trashed rows only", async () => {
+        routeGet({ rows: trashedRow, canPermanentlyDelete: true })
+        const wrapper = await mountPage({ status: "deleted" })
+
+        expect(wrapper.find('[aria-label="Permanently delete file"]').exists()).toBeTruthy()
+
+        routeGet({ rows: [FILE_ROW], canPermanentlyDelete: true })
+        const active = await mountPage()
+        expect(active.find('[aria-label="Permanently delete file"]').exists()).toBeFalsy()
+    })
+
+    it("permanently deletes with permanent=true and reloads once confirmed", async () => {
+        routeGet({ rows: trashedRow, canPermanentlyDelete: true })
+        mockDel.mockResolvedValue({ success: true, result: null })
+        const wrapper = await mountPage({ status: "deleted" })
+        const before = listCallCount()
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("permanentDelete")
+        await flushPromises()
+        expect(document.body.textContent).toContain('Permanently delete "a.pdf"?')
+        clickBodyButton("Delete Permanently")
+        await flushPromises()
+        await flushPromises()
+
+        expect(mockDel).toHaveBeenCalledOnce()
+        expect(mockDel.mock.calls[0]![0]).toContain("cms/files/g1?")
+        expect(mockDel.mock.calls[0]![0]).toContain("permanent=true")
+        expect(document.body.textContent).toContain("File permanently deleted")
+        expect(listCallCount()).toBeGreaterThan(before)
+    })
+
+    it("does not permanently delete when the confirm dialog is cancelled", async () => {
+        routeGet({ rows: trashedRow, canPermanentlyDelete: true })
+        const wrapper = await mountPage({ status: "deleted" })
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("permanentDelete")
+        await flushPromises()
+        clickBodyButton("Cancel")
+        await flushPromises()
+
+        expect(mockDel).not.toHaveBeenCalled()
+    })
+
+    it("notifies and keeps the row when the permanent delete fails", async () => {
+        routeGet({ rows: trashedRow, canPermanentlyDelete: true })
+        mockDel.mockResolvedValue({ success: false, errors: ["nope"] })
+        const wrapper = await mountPage({ status: "deleted" })
+
+        wrapper.findComponent({ name: "DeleteRestoreButtons" }).vm.$emit("permanentDelete")
+        await flushPromises()
+        clickBodyButton("Delete Permanently")
+        await flushPromises()
+        await flushPromises()
+
+        expect(document.body.textContent).toContain("Failed to permanently delete file")
+    })
+
+    it("hides permanent delete when the capabilities request fails", async () => {
+        routeGet({ rows: trashedRow })
+        mockGet.mockImplementation((...args: unknown[]) => {
+            const url = args[0] as string
+            if (url.includes("options/capabilities")) {
+                return Promise.resolve({ success: false, errors: ["boom"] })
+            }
+            if (url.includes("folder-counts")) {
+                return Promise.resolve({ success: true, result: [] })
+            }
+            if (url.includes("folders")) {
+                return Promise.resolve({ success: true, result: ["Apps"] })
+            }
+            return Promise.resolve({ success: true, result: trashedRow })
+        })
+        const wrapper = await mountPage({ status: "deleted" })
+
+        expect(wrapper.find('[aria-label="Permanently delete file"]').exists()).toBeFalsy()
     })
 })
 

--- a/VueApp/src/CMS/components/DeleteRestoreButtons.vue
+++ b/VueApp/src/CMS/components/DeleteRestoreButtons.vue
@@ -12,26 +12,46 @@
     >
         <q-tooltip>Delete</q-tooltip>
     </q-btn>
-    <q-btn
-        v-else
-        dense
-        flat
-        no-caps
-        size="sm"
-        color="positive"
-        icon="restore_from_trash"
-        :aria-label="`Restore ${entityName}`"
-        @click="emit('restore')"
-    >
-        <q-tooltip>Restore</q-tooltip>
-    </q-btn>
+    <template v-else>
+        <q-btn
+            dense
+            flat
+            no-caps
+            size="sm"
+            color="positive"
+            icon="restore_from_trash"
+            :aria-label="`Restore ${entityName}`"
+            @click="emit('restore')"
+        >
+            <q-tooltip>Restore</q-tooltip>
+        </q-btn>
+        <!-- Legacy "delete now": skips the 30-day trash. Admin-only, so the parent passes the
+             server-decided capability rather than this component guessing at permissions. -->
+        <q-btn
+            v-if="canPermanentlyDelete"
+            dense
+            flat
+            no-caps
+            size="sm"
+            color="negative"
+            icon="delete_forever"
+            :aria-label="`Permanently delete ${entityName}`"
+            @click="emit('permanentDelete')"
+        >
+            <q-tooltip>Delete now</q-tooltip>
+        </q-btn>
+    </template>
 </template>
 
 <script setup lang="ts">
-defineProps<{
-    deleted: boolean
-    entityName: string
-}>()
+withDefaults(
+    defineProps<{
+        deleted: boolean
+        entityName: string
+        canPermanentlyDelete?: boolean
+    }>(),
+    { canPermanentlyDelete: false },
+)
 
-const emit = defineEmits<{ delete: []; restore: [] }>()
+const emit = defineEmits<{ delete: []; restore: []; permanentDelete: [] }>()
 </script>

--- a/VueApp/src/CMS/pages/Files.vue
+++ b/VueApp/src/CMS/pages/Files.vue
@@ -196,8 +196,10 @@
                     <DeleteRestoreButtons
                         :deleted="!!cellProps.row.deletedOn"
                         entity-name="file"
+                        :can-permanently-delete="canPermanentlyDelete"
                         @delete="deleteFile(cellProps.row)"
                         @restore="restoreFile(cellProps.row)"
+                        @permanent-delete="permanentlyDeleteFile(cellProps.row)"
                     />
                 </q-td>
             </template>
@@ -244,8 +246,10 @@
                                 <DeleteRestoreButtons
                                     :deleted="!!row.deletedOn"
                                     entity-name="file"
+                                    :can-permanently-delete="canPermanentlyDelete"
                                     @delete="deleteFile(row)"
                                     @restore="restoreFile(row)"
+                                    @permanent-delete="permanentlyDeleteFile(row)"
                                 />
                             </div>
                         </div>
@@ -315,6 +319,7 @@ import { useQuasar, type QTableProps } from "quasar"
 import { useFetch } from "@/composables/ViperFetch"
 import { useConfirmDialog } from "@/composables/use-confirm-dialog"
 import { useServerTable } from "@/CMS/composables/use-server-table"
+import { getCapabilities } from "@/CMS/services/cms-options-service"
 import StatusBadge from "@/components/StatusBadge.vue"
 import FileFormDialog from "@/CMS/components/FileFormDialog.vue"
 import DeleteRestoreButtons from "@/CMS/components/DeleteRestoreButtons.vue"
@@ -341,6 +346,11 @@ type FolderOption = { label: string; value: string }
 const filterFolders = ref<FolderOption[]>([{ label: ALL_FOLDERS, value: ALL_FOLDERS }])
 const showDialog = ref(false)
 const editingFile = ref<CmsFile | null>(null)
+const canPermanentlyDelete = ref(false)
+
+async function loadCapabilities() {
+    canPermanentlyDelete.value = (await getCapabilities()).canPermanentlyDelete
+}
 
 // Maps the URL query into the filter shape, shared by the initial state and the re-sync watcher
 // below so the two can't drift.
@@ -505,6 +515,27 @@ async function deleteFile(file: CmsFile) {
     reload()
 }
 
+// The legacy "delete now": bypasses the 30-day trash and removes record and bytes immediately.
+// Server-gated to CMS admins; canPermanentlyDelete only decides whether the button is offered.
+async function permanentlyDeleteFile(file: CmsFile) {
+    const confirmed = await confirmAction({
+        title: "Delete File Permanently",
+        message:
+            `Permanently delete "${file.friendlyName}"? The file and its record are removed ` +
+            `immediately and this cannot be undone.`,
+        okLabel: "Delete Permanently",
+        okColor: "negative",
+    })
+    if (!confirmed) return
+    const res = await del(`${apiURL}${file.fileGuid}?${createUrlSearchParams({ permanent: "true" })}`)
+    if (!res.success) {
+        $q.notify({ type: "negative", message: "Failed to permanently delete file" })
+        return
+    }
+    $q.notify({ type: "positive", message: "File permanently deleted" })
+    reload()
+}
+
 async function restoreFile(file: CmsFile) {
     const res = await post(apiURL + file.fileGuid + "/restore")
     if (!res.success) {
@@ -576,6 +607,7 @@ watch(
 
 onMounted(() => {
     loadFolders()
+    void loadCapabilities()
     reload()
 })
 </script>

--- a/VueApp/src/CMS/services/cms-options-service.ts
+++ b/VueApp/src/CMS/services/cms-options-service.ts
@@ -1,5 +1,5 @@
 import { useFetch } from "@/composables/ViperFetch"
-import type { CmsPersonOption } from "@/CMS/types"
+import type { CmsCapabilities, CmsPersonOption } from "@/CMS/types"
 
 /**
  * Shared CMS option-list lookups (people, permissions) so the selector components don't each
@@ -25,4 +25,12 @@ async function searchPeopleOptions(search: string): Promise<CmsPersonOption[] | 
     return res.success ? (res.result as CmsPersonOption[]) : null
 }
 
-export { getPermissionOptions, searchPeopleOptions }
+// Falls back to no extra capabilities when the request fails, so a hiccup hides an admin-only
+// action rather than offering one the server will refuse.
+async function getCapabilities(): Promise<CmsCapabilities> {
+    const { get } = useFetch()
+    const res = await get(`${optionsUrl}capabilities`)
+    return res.success ? (res.result as CmsCapabilities) : { canPermanentlyDelete: false }
+}
+
+export { getPermissionOptions, searchPeopleOptions, getCapabilities }

--- a/VueApp/src/CMS/types/index.ts
+++ b/VueApp/src/CMS/types/index.ts
@@ -46,6 +46,12 @@ type CmsPersonOption = {
     mailId: string | null
 }
 
+// Server-decided capabilities the SPA can't derive from its own permission list, which only holds
+// SVMSecure.CMS-prefixed entries. The server enforces these regardless; they gate the UI only.
+type CmsCapabilities = {
+    canPermanentlyDelete: boolean
+}
+
 type CmsContentBlock = {
     contentBlockId: number
     content: string
@@ -234,6 +240,7 @@ export type {
     CmsFilePerson,
     CmsFileNameCheck,
     CmsPersonOption,
+    CmsCapabilities,
     CmsFileAudit,
     CmsContentHistoryAudit,
     CmsContentHistoryDiff,

--- a/test/CMS/CMSOptionsControllerTests.cs
+++ b/test/CMS/CMSOptionsControllerTests.cs
@@ -1,4 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Controllers;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
@@ -8,13 +11,14 @@ namespace Viper.test.CMS;
 
 /// <summary>
 /// Controller wiring tests for CMSOptionsController: the person search's minimum-length guard,
-/// 25-result cap, name/id matching, and last-name/first-name ordering, plus the instance-scoped
-/// permission list used by CMS tagging forms.
+/// 25-result cap, name/id matching, and last-name/first-name ordering, the instance-scoped
+/// permission list used by CMS tagging forms, and the per-user capability flags.
 /// </summary>
 public sealed class CMSOptionsControllerTests : IDisposable
 {
     private readonly RAPSContext _rapsContext;
     private readonly AAUDContext _aaudContext;
+    private readonly IUserHelper _userHelper;
     private readonly CMSOptionsController _controller;
 
     public CMSOptionsControllerTests()
@@ -23,8 +27,9 @@ public sealed class CMSOptionsControllerTests : IDisposable
             .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
         _aaudContext = new AAUDContext(new DbContextOptionsBuilder<AAUDContext>()
             .UseInMemoryDatabase("AAUD_" + Guid.NewGuid()).Options);
+        _userHelper = Substitute.For<IUserHelper>();
 
-        _controller = new CMSOptionsController(_rapsContext, _aaudContext);
+        _controller = new CMSOptionsController(_rapsContext, _aaudContext, _userHelper);
     }
 
     public void Dispose()
@@ -139,6 +144,34 @@ public sealed class CMSOptionsControllerTests : IDisposable
         var result = await _controller.GetPermissions(TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { "SVMSecure.CMS.Alpha", "SVMSecure.CMS.Zeta" }, result.Value);
+    }
+
+    #endregion
+
+    #region GetCapabilities
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetCapabilities_ReportsPermanentDelete_FromAdminPermission(bool isAdmin)
+    {
+        var user = MakeUser(1, "Smith", "Amy", loginId: "asmith");
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.HasPermission(_rapsContext, user, CmsPermissions.Admin).Returns(isAdmin);
+
+        var result = _controller.GetCapabilities();
+
+        Assert.Equal(isAdmin, result.Value!.CanPermanentlyDelete);
+    }
+
+    [Fact]
+    public void GetCapabilities_ReportsNoPermanentDelete_WhenNoCurrentUser()
+    {
+        _userHelper.GetCurrentUser().ReturnsNull();
+
+        var result = _controller.GetCapabilities();
+
+        Assert.False(result.Value!.CanPermanentlyDelete);
     }
 
     #endregion

--- a/test/CMS/CmsTrashAccessTests.cs
+++ b/test/CMS/CmsTrashAccessTests.cs
@@ -1,0 +1,88 @@
+using Viper.Areas.CMS.Constants;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// Tests for the trash-visibility rule behind the file download handler.
+///
+/// A soft-deleted CMS file keeps its bytes on disk for the whole 30-day retention window, so this
+/// predicate is the only thing that stops a "deleted" file from staying downloadable at its old
+/// URL. Legacy VIPER 1 had no such check at all (cms/CFC/FileDB.cfc get() never filtered
+/// deletedOn), which is the bug these tests pin closed.
+///
+/// The rule intentionally matches CMSFilesController.OwnerRestriction, which scopes the trash
+/// listing: admins see everything, other file managers only what they deleted themselves.
+/// </summary>
+public sealed class CmsTrashAccessTests
+{
+    private const string Owner = "asmith";
+
+    [Fact]
+    public void CanAccessTrashed_AllowsAdmin_RegardlessOfWhoDeletedIt()
+    {
+        Assert.True(CmsTrash.CanAccessTrashed(isAdmin: true, hasAllFiles: false,
+            deletedBy: "someone-else", loginId: Owner));
+    }
+
+    [Fact]
+    public void CanAccessTrashed_AllowsFileManager_ForTheirOwnDeletion()
+    {
+        Assert.True(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: Owner, loginId: Owner));
+    }
+
+    [Fact]
+    public void CanAccessTrashed_IsCaseInsensitiveOnLoginId()
+    {
+        // RAPS login ids arrive with inconsistent casing; a case mismatch must not lock an owner
+        // out of a file they can already see listed in their own trash.
+        Assert.True(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: "ASmith", loginId: "asmith"));
+    }
+
+    [Fact]
+    public void CanAccessTrashed_DeniesFileManager_ForSomeoneElsesDeletion()
+    {
+        Assert.False(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: "bjones", loginId: Owner));
+    }
+
+    [Fact]
+    public void CanAccessTrashed_DeniesUserWithoutFilePermissions_EvenForTheirOwnDeletion()
+    {
+        // Losing AllFiles removes the trash UI, so it must remove the download with it.
+        Assert.False(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: false,
+            deletedBy: Owner, loginId: Owner));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CanAccessTrashed_DeniesAnonymousRequest(string? loginId)
+    {
+        // The main regression: an anonymous request could download a trashed file at its old URL.
+        Assert.False(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: Owner, loginId: loginId));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void CanAccessTrashed_DeniesWhenBothOwnerAndLoginAreBlank(string? deletedBy, string? loginId)
+    {
+        // Two blanks must not compare equal into an accidental grant.
+        Assert.False(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: deletedBy, loginId: loginId));
+    }
+
+    [Fact]
+    public void CanAccessTrashed_DeniesWhenOwnerIsUnknown()
+    {
+        // A pre-migration row with no ModifiedBy has no provable owner, so only admins get it.
+        Assert.False(CmsTrash.CanAccessTrashed(isAdmin: false, hasAllFiles: true,
+            deletedBy: null, loginId: Owner));
+        Assert.True(CmsTrash.CanAccessTrashed(isAdmin: true, hasAllFiles: true,
+            deletedBy: null, loginId: Owner));
+    }
+}

--- a/test/CMS/CmsTrashDownloadTests.cs
+++ b/test/CMS/CmsTrashDownloadTests.cs
@@ -1,0 +1,280 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using Viper.Areas.CMS.Constants;
+using Viper.Classes.SQLContext;
+using Viper.Models.AAUD;
+using Viper.Models.RAPS;
+using Viper.Services;
+using CmsFileRecord = Viper.Models.VIPER.File;
+using DataCms = Viper.Areas.CMS.Data.CMS;
+
+namespace Viper.test.CMS;
+
+/// <summary>
+/// End-to-end tests for the trash gate on the two file delivery paths, Data.CMS.ProvideFile
+/// (/CMS/Files?id=|fn=) and Data.CMS.DownloadZip (/CMS/Files?ids=).
+///
+/// A soft-deleted file keeps its bytes on disk for the whole retention window, so without this gate
+/// a "deleted" file stays downloadable at its old URL - which is what legacy VIPER 1 did
+/// (cms/CFC/FileDB.cfc get() never filtered deletedOn). CmsTrashAccessTests covers the rule itself;
+/// these prove both handlers apply it, and that it only ever takes access away.
+///
+/// The trash check runs ahead of the on-disk check in both handlers, so these reach the decision
+/// without seeding real bytes - which a test cannot do anyway, since ReplaceRootFolder rewrites
+/// every path under the deployment storage root.
+///
+/// Every outcome here is NotFound, so asserting on the status alone would pass whether or not the
+/// gate fired. The assertions read the [CMS-FILE-404] reason the handler logs instead.
+/// </summary>
+public sealed class CmsTrashDownloadTests : IDisposable
+{
+    private readonly VIPERContext _context;
+    private readonly RAPSContext _rapsContext;
+    private readonly IUserHelper _userHelper;
+    private readonly ILogger<DataCms> _logger;
+    private readonly DataCms _cms;
+    private readonly Controller _controller;
+
+    public CmsTrashDownloadTests()
+    {
+        _context = new VIPERContext(new DbContextOptionsBuilder<VIPERContext>()
+            .UseInMemoryDatabase("VIPER_" + Guid.NewGuid()).Options);
+        _rapsContext = new RAPSContext(new DbContextOptionsBuilder<RAPSContext>()
+            .UseInMemoryDatabase("RAPS_" + Guid.NewGuid()).Options);
+        var sanitizer = Substitute.For<IHtmlSanitizerService>();
+        sanitizer.Sanitize(Arg.Any<string>()).Returns(c => c.ArgAt<string>(0));
+        _userHelper = Substitute.For<IUserHelper>();
+        _logger = Substitute.For<ILogger<DataCms>>();
+
+        _cms = new DataCms(_context, _rapsContext, sanitizer, _logger) { UserHelper = _userHelper };
+        _controller = new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _rapsContext.Dispose();
+    }
+
+    private sealed class TestController : Controller;
+
+    private const string Owner = "adeleter";
+
+    private async Task<CmsFileRecord> SeedFileAsync(DateTime? deletedOn, string modifiedBy = Owner)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var file = new CmsFileRecord
+        {
+            FileGuid = Guid.NewGuid(),
+            // Deliberately never created on disk. Everything asserted here is decided before the
+            // existence check, so the handler reaching disk is itself the "allowed through" signal.
+            FilePath = @"S:\Files\Misc\trash-gate-" + suffix + ".txt",
+            Folder = "Misc",
+            FriendlyName = "Misc-trash-gate-" + suffix + ".txt",
+            Description = string.Empty,
+            AllowPublicAccess = false,
+            ModifiedOn = DateTime.Now,
+            ModifiedBy = modifiedBy,
+            DeletedOn = deletedOn
+        };
+        _context.Files.Add(file);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return file;
+    }
+
+    private AaudUser SignIn(string loginId, params string[] permissions)
+    {
+        var user = new AaudUser { AaudUserId = 1, LoginId = loginId, MothraId = "m1" };
+        _userHelper.GetCurrentUser().Returns(user);
+        _userHelper.GetAllPermissions(_rapsContext, user)
+            .Returns(permissions.Select(p => new TblPermission { Permission = p }).ToList());
+        foreach (var permission in permissions)
+        {
+            _userHelper.HasPermission(_rapsContext, user, permission).Returns(true);
+        }
+        return user;
+    }
+
+    private void SignOut() => _userHelper.GetCurrentUser().ReturnsNull();
+
+    // The logged [CMS-FILE-404] lines, which carry the reason the request was turned away.
+    private List<string> NotFoundLogs() =>
+        _logger.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(ILogger.Log))
+            .Select(c => c.GetArguments()[2]?.ToString() ?? string.Empty)
+            .Where(m => m.Contains("[CMS-FILE-404]", StringComparison.Ordinal))
+            .ToList();
+
+    private void AssertRefusedAsTrashed() =>
+        Assert.Contains(NotFoundLogs(), m => m.Contains("reason=deleted", StringComparison.Ordinal));
+
+    // Past the gate: the handler went on to the (absent) bytes rather than refusing it as deleted.
+    private void AssertReachedTheFile()
+    {
+        var logs = NotFoundLogs();
+        Assert.DoesNotContain(logs, m => m.Contains("reason=deleted", StringComparison.Ordinal));
+        Assert.Contains(logs, m => m.Contains("reason=missing-on-disk", StringComparison.Ordinal));
+    }
+
+    #region ProvideFile
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_IsRefusedForAnonymousRequest()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now);
+        SignOut();
+
+        var result = _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        Assert.IsType<NotFoundResult>(result);
+        AssertRefusedAsTrashed();
+    }
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_IsRefusedByFriendlyNameToo()
+    {
+        // The friendly-name URL is the shape legacy content embeds, so it must gate identically.
+        var file = await SeedFileAsync(deletedOn: DateTime.Now);
+        SignOut();
+
+        var result = _cms.ProvideFile(_controller, string.Empty, file.FriendlyName, string.Empty);
+
+        Assert.IsType<NotFoundResult>(result);
+        AssertRefusedAsTrashed();
+    }
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_IsRefusedForAnotherUsersDeletion()
+    {
+        // A file manager may only reach what they trashed themselves, matching the trash listing.
+        var file = await SeedFileAsync(deletedOn: DateTime.Now, modifiedBy: "someone-else");
+        SignIn("bmanager", CmsPermissions.AllFiles);
+
+        var result = _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        Assert.IsType<NotFoundResult>(result);
+        AssertRefusedAsTrashed();
+    }
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_IsRefusedForUserWithoutFilePermissions()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now);
+        SignIn(Owner, "SVMSecure");
+
+        var result = _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        Assert.IsType<NotFoundResult>(result);
+        AssertRefusedAsTrashed();
+    }
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_ReachesTheDeleterWhoHoldsAllFiles()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now);
+        SignIn(Owner, CmsPermissions.AllFiles);
+
+        _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        AssertReachedTheFile();
+    }
+
+    [Fact]
+    public async Task ProvideFile_TrashedFile_ReachesAnAdminForAnotherUsersDeletion()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now, modifiedBy: "someone-else");
+        SignIn("cadmin", CmsPermissions.Admin);
+
+        _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        AssertReachedTheFile();
+    }
+
+    [Fact]
+    public async Task ProvideFile_ActiveFile_IsUnaffectedByTheTrashGate()
+    {
+        // The gate must only ever take access away: an active file keeps its previous treatment.
+        var file = await SeedFileAsync(deletedOn: null);
+        SignOut();
+
+        _cms.ProvideFile(_controller, file.FileGuid.ToString(), string.Empty, string.Empty);
+
+        AssertReachedTheFile();
+    }
+
+    [Fact]
+    public async Task ProvideFile_UnknownFile_IsRefusedAsNoDbMatch()
+    {
+        await SeedFileAsync(deletedOn: DateTime.Now);
+        SignOut();
+
+        var result = _cms.ProvideFile(_controller, Guid.NewGuid().ToString(), string.Empty, string.Empty);
+
+        Assert.IsType<NotFoundResult>(result);
+        Assert.Contains(NotFoundLogs(), m => m.Contains("reason=no-db-match", StringComparison.Ordinal));
+    }
+
+    #endregion
+
+    #region DownloadZip
+
+    // DownloadZip logs nothing per skipped entry, and a file absent from disk is skipped whether or
+    // not the trash gate fired, so the NotFound alone proves nothing here (it holds even with the
+    // gate deleted). What does discriminate is whether the gate was consulted at all: only it asks
+    // for CmsPermissions.Admin. CheckFilePermission asks for "SVMSecure" instead, and on this path
+    // is never reached. So these assert the endpoint's contract plus the consultation, and
+    // CmsTrashAccessTests pins what the consultation decides.
+
+    [Fact]
+    public async Task DownloadZip_TrashedFile_IsNotFoundForAnonymousRequest()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now);
+        SignOut();
+
+        var result = _cms.DownloadZip(_controller, [file.FileGuid.ToString()]);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task DownloadZip_TrashedFile_ConsultsTheTrashGateAndIsNotFoundForAnotherUsersDeletion()
+    {
+        var file = await SeedFileAsync(deletedOn: DateTime.Now, modifiedBy: "someone-else");
+        var user = SignIn("bmanager", CmsPermissions.AllFiles);
+
+        var result = _cms.DownloadZip(_controller, [file.FileGuid.ToString()]);
+
+        Assert.IsType<NotFoundResult>(result);
+        _userHelper.Received().HasPermission(_rapsContext, user, CmsPermissions.Admin);
+    }
+
+    [Fact]
+    public async Task DownloadZip_ActiveFile_DoesNotConsultTheTrashGate()
+    {
+        // The counterpart: an active file never reaches the gate, so the same assertion must not
+        // hold - which is what makes the check above a real signal rather than an always-true one.
+        var file = await SeedFileAsync(deletedOn: null);
+        var user = SignIn("bmanager", CmsPermissions.AllFiles);
+
+        _cms.DownloadZip(_controller, [file.FileGuid.ToString()]);
+
+        _userHelper.DidNotReceive().HasPermission(_rapsContext, user, CmsPermissions.Admin);
+    }
+
+    [Fact]
+    public void DownloadZip_NoUsableGuids_IsBadRequest()
+    {
+        var result = _cms.DownloadZip(_controller, [" ", string.Empty]);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    #endregion
+}

--- a/web/Areas/CMS/Constants/CmsTrash.cs
+++ b/web/Areas/CMS/Constants/CmsTrash.cs
@@ -16,5 +16,37 @@ namespace Viper.Areas.CMS.Constants
         /// so the two never purge in parallel; flipped to true (via SSM in deployed envs) at cutover.
         /// </summary>
         public const string PurgeEnabledConfigKey = "Cms:TrashPurgeEnabled";
+
+        /// <summary>
+        /// Whether a user may still reach a trashed file at all (its listing, and its bytes through
+        /// the download handler). A soft-deleted file keeps its bytes on disk until the purge job
+        /// runs, so this is the only thing standing between "deleted" and a still-live download URL.
+        /// <para>
+        /// Deliberately the same rule as CMSFilesController.OwnerRestriction, which scopes the trash
+        /// listing: admins see the whole trash, other file managers only what they deleted themselves
+        /// (SoftDeleteFileAsync stamps ModifiedBy with the deleter). Keeping the download gate and the
+        /// listing gate identical means a file is downloadable exactly when the user can see it in
+        /// the trash UI, so neither can quietly become more permissive than the other.
+        /// </para>
+        /// </summary>
+        /// <param name="isAdmin">Holds <see cref="CmsPermissions.Admin"/>.</param>
+        /// <param name="hasAllFiles">Holds <see cref="CmsPermissions.AllFiles"/>.</param>
+        /// <param name="deletedBy">The file's ModifiedBy, which soft delete sets to the deleter.</param>
+        /// <param name="loginId">The requesting user's login id; null for an anonymous request.</param>
+        public static bool CanAccessTrashed(bool isAdmin, bool hasAllFiles, string? deletedBy, string? loginId)
+        {
+            if (isAdmin)
+            {
+                return true;
+            }
+
+            // Fail closed on a missing login or owner rather than letting two blanks match.
+            if (!hasAllFiles || string.IsNullOrEmpty(loginId) || string.IsNullOrEmpty(deletedBy))
+            {
+                return false;
+            }
+
+            return string.Equals(deletedBy, loginId, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/web/Areas/CMS/Controllers/CMSOptionsController.cs
+++ b/web/Areas/CMS/Controllers/CMSOptionsController.cs
@@ -19,11 +19,29 @@ namespace Viper.Areas.CMS.Controllers
     {
         private readonly RAPSContext _rapsContext;
         private readonly AAUDContext _aaudContext;
+        private readonly IUserHelper _userHelper;
 
-        public CMSOptionsController(RAPSContext rapsContext, AAUDContext aaudContext)
+        public CMSOptionsController(RAPSContext rapsContext, AAUDContext aaudContext, IUserHelper userHelper)
         {
             _rapsContext = rapsContext;
             _aaudContext = aaudContext;
+            _userHelper = userHelper;
+        }
+
+        /// <summary>
+        /// Per-user capabilities the CMS SPA cannot work out for itself. Its permission list is
+        /// loaded with the SVMSecure.CMS prefix (CMS/router/index.ts), so an admin-only affordance
+        /// keyed on SVMSecure.CATS.Admin is invisible to the client without an explicit flag.
+        /// The server still enforces every one of these; this only decides what the UI offers.
+        /// </summary>
+        [HttpGet("capabilities")]
+        public ActionResult<CmsCapabilities> GetCapabilities()
+        {
+            return new CmsCapabilities
+            {
+                CanPermanentlyDelete = _userHelper.HasPermission(
+                    _rapsContext, _userHelper.GetCurrentUser(), CmsPermissions.Admin)
+            };
         }
 
         /// <summary>
@@ -72,6 +90,15 @@ namespace Viper.Areas.CMS.Controllers
                 })
                 .ToListAsync(ct);
         }
+    }
+
+    public class CmsCapabilities
+    {
+        /// <summary>
+        /// Whether this user may skip the 30-day trash and delete a file outright
+        /// (the legacy CMS "delete now" option, admin-only).
+        /// </summary>
+        public bool CanPermanentlyDelete { get; set; }
     }
 
     public class CmsPersonOption

--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -374,6 +374,32 @@ namespace Viper.Areas.CMS.Data
         }
         #endregion
 
+        #region private bool CanAccessTrashedFile(CMSFile file, AaudUser? currentUser)
+        /// <summary>
+        /// Resolves the RAPS permissions behind <see cref="Constants.CmsTrash.CanAccessTrashed"/>.
+        /// Only called for files that are actually trashed, so the extra permission lookups stay off
+        /// the normal download path.
+        /// </summary>
+        private bool CanAccessTrashedFile(CMSFile file, AaudUser? currentUser)
+        {
+            if (_rapsContext == null || currentUser == null)
+            {
+                return false;
+            }
+
+            var isAdmin = UserHelper.HasPermission(_rapsContext, currentUser, Constants.CmsPermissions.Admin);
+
+            // Only resolved when it can still change the answer: an admin is allowed regardless, and
+            // each HasPermission call rebuilds the user's permission set (union/except over the
+            // cached role and assigned lists). CanAccessTrashed ignoring hasAllFiles for admins is
+            // pinned by CanAccessTrashed_AllowsAdmin_RegardlessOfWhoDeletedIt.
+            var hasAllFiles = !isAdmin
+                && UserHelper.HasPermission(_rapsContext, currentUser, Constants.CmsPermissions.AllFiles);
+
+            return Constants.CmsTrash.CanAccessTrashed(isAdmin, hasAllFiles, file.ModifiedBy, currentUser.LoginId);
+        }
+        #endregion
+
         #region public IActionResult DownloadZip(Controller controller, string[] fileGUIDs, string fileName = "FileDownload.zip")
         public IActionResult DownloadZip(Controller controller, string[] fileGUIDs, string fileName = "FileDownload.zip")
         {
@@ -399,8 +425,22 @@ namespace Viper.Areas.CMS.Data
             {
                 CMSFile? file = GetFile(guid, null, null, null, null);
 
+                if (file == null)
+                {
+                    continue;
+                }
+
+                // Same trash rule as ProvideFile, and ahead of the disk check for the same reason,
+                // so a zip request can't be used to pull down deleted files the single-file handler
+                // refuses. Skipped like a missing file (no deny audit): to this user the record
+                // isn't visible in the first place.
+                if (file.DeletedOn != null && !CanAccessTrashedFile(file, currentUser))
+                {
+                    continue;
+                }
+
                 // only add files that exist and where the user has permission
-                if (file == null || !System.IO.File.Exists(file.FilePath))
+                if (!System.IO.File.Exists(file.FilePath))
                 {
                     continue;
                 }
@@ -504,6 +544,17 @@ namespace Viper.Areas.CMS.Data
             if (file == null)
             {
                 LogFileNotFound(controller, id, friendlyName, oldURL, reason: "no-db-match");
+                return controller.NotFound();
+            }
+
+            // Decided before the disk is touched, and before the permission check: to anyone who
+            // cannot reach the trash a deleted file simply does not exist, so this answers 404
+            // rather than the 403 a permission failure returns and does not disclose that the
+            // record is still there. Being an authorization decision it should not depend on, or
+            // pay for, a filesystem stat.
+            if (file.DeletedOn != null && !CanAccessTrashedFile(file, currentUser))
+            {
+                LogFileNotFound(controller, id, friendlyName, oldURL, reason: "deleted");
                 return controller.NotFound();
             }
 


### PR DESCRIPTION
Found while smoke-testing the CMS merge on a local production build.

## Trashed files stayed downloadable

Deleting a file marks it deleted and leaves the bytes on disk for the 30-day retention window. Nothing on the download path looked at `DeletedOn`, so for those 30 days the file kept serving to anyone holding its permission, at both `/CMS/Files?id=` and `/CMS/Files?fn=`, and through the zip handler.

This is inherited from legacy VIPER 1, not new: `cms/CFC/FileDB.cfc` `get()` selects `deletedOn` but never filters on it, and `Files.cfc` documents soft delete as "marks the DB record as deleted and leaves the file in place". The list queries filter by status in both systems; only the single-file lookup missed it.

The download gate now uses the same rule that scopes the trash listing (`CMSFilesController.OwnerRestriction`): admins reach anything in the trash, other file managers reach what they deleted themselves. So a file is downloadable exactly while the user can still see it in the trash UI, and the two can't drift apart. Anyone else gets a 404 rather than a 403, so a trashed record's existence isn't disclosed.

Verified on a local Release build against a real trashed file:

| Request | Before | After |
| --- | --- | --- |
| Anonymous, by GUID | 403 | 404 |
| Anonymous, by friendly name | 403 | 404 |
| Anonymous, via zip | 200 | 404 |
| Deleter (holds AllFiles), all three | 200 | 200, bytes intact |

## Delete now

The permanent-delete API already existed and matched legacy's `finalDelete=true`, gated on `SVMSecure.CATS.Admin`, but nothing in the UI ever called it, so the legacy "delete now" had no replacement. It is now an admin-only action on trashed rows, behind a confirm dialog that states it cannot be undone and labels its button `Delete Permanently` so it can't be mistaken for the ordinary delete.

The SPA loads its permission list with the `SVMSecure.CMS` prefix and so cannot see `SVMSecure.CATS.Admin`. A small `GET /api/cms/options/capabilities` returns that one flag; it decides only what the UI offers, and the server still enforces the permission on every call. A failed capabilities request hides the action rather than offering one the server will refuse.

## Testing

- `CmsTrashAccessTests` covers the visibility rule: admin, owner, case-insensitive login match, another user's deletion, no-AllFiles, anonymous, and blank owner/login (which must not compare equal into a grant).
- `CMSOptionsControllerTests` covers the capability flag including the no-current-user case.
- `files.test.ts` covers the button's visibility for admin vs non-admin, active vs trashed rows, the `permanent=true` call, the cancel path, the failure toast, and a failed capabilities request.
- Full suite green: 2,662 backend, 1,116 frontend.
