### PR TITLE
refactor(cms): clear CodeQL alerts from the CMS content merge

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,8 +3,15 @@ name: "VIPER CodeQL config"
 queries:
   - uses: security-and-quality
 
-# Generated and build-output code. The *.g.cs / *.Designer.cs globs catch
-# source-generator output that C# autobuild extracts despite obj/ being ignored.
+# Generated and build-output code.
+#
+# These filters only reach the file-indexing extractors (they are passed on as
+# LGTM_INDEX_FILTERS), so they work for JavaScript but NOT for C#: the C# extractor
+# traces the Roslyn build and extracts every syntax tree the compiler sees, including
+# source-generator output written under obj/. Alerts in obj/**/*.g.cs therefore still
+# appear for C# and have to be dismissed in the code-scanning UI. The only config that
+# would filter them is build-mode: none, which is not worth the loss in analysis
+# fidelity for what are style-level findings in generated code.
 paths-ignore:
   - "**/obj/**"
   - "**/bin/**"

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -36,6 +36,7 @@ public sealed class CMSContentControllerTests : IDisposable
     private readonly VIPERContext _context;
     private readonly RAPSContext _rapsContext;
     private readonly CMSContentController _controller;
+    private readonly List<MemoryStream> _formFileStreams = [];
 
     public CMSContentControllerTests()
     {
@@ -64,6 +65,10 @@ public sealed class CMSContentControllerTests : IDisposable
     {
         _context.Dispose();
         _rapsContext.Dispose();
+        foreach (var stream in _formFileStreams)
+        {
+            stream.Dispose();
+        }
     }
 
     private void SetupControllerContext()
@@ -154,7 +159,7 @@ public sealed class CMSContentControllerTests : IDisposable
         // A genuinely missing block: not editable AND no section-path row, so 404 (not 403), and the
         // full block is never loaded on this path.
         _blockService.CanEditAsync(999, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(999, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(999, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.GetContentBlock(999, TestContext.Current.CancellationToken);
 
@@ -466,7 +471,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistory_Returns403_WhenExistsButCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.GetHistory(5, TestContext.Current.CancellationToken);
 
@@ -478,7 +483,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistory_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.GetHistory(5, TestContext.Current.CancellationToken);
 
@@ -490,7 +495,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistoryVersion_Returns403_WhenExistsButCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.GetHistoryVersion(5, 12, TestContext.Current.CancellationToken);
 
@@ -502,7 +507,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistoryVersion_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.GetHistoryVersion(5, 12, TestContext.Current.CancellationToken);
 
@@ -514,7 +519,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistoryVersionDiff_Returns403_WhenExistsButCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.GetHistoryVersionDiff(5, 12, TestContext.Current.CancellationToken);
 
@@ -526,7 +531,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task GetHistoryVersionDiff_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.GetHistoryVersionDiff(5, 12, TestContext.Current.CancellationToken);
 
@@ -538,7 +543,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task DiffAgainstHistoryVersion_Returns403_WhenExistsButCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
         var request = new DiffAgainstHistoryRequest { Content = "<p>draft</p>" };
 
         var result = await _controller.DiffAgainstHistoryVersion(5, 12, request, TestContext.Current.CancellationToken);
@@ -551,7 +556,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task DiffAgainstHistoryVersion_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
         var request = new DiffAgainstHistoryRequest { Content = "<p>draft</p>" };
 
         var result = await _controller.DiffAgainstHistoryVersion(5, 12, request, TestContext.Current.CancellationToken);
@@ -636,10 +641,14 @@ public sealed class CMSContentControllerTests : IDisposable
 
     #region Delegated editing gates + content-scoped file ops
 
-    private static IFormFile FakeFormFile(string name, byte[]? bytes = null)
+    // FormFile does not take ownership of the stream, so the fixture holds it open for the
+    // duration of the test and disposes it in Dispose.
+    private IFormFile FakeFormFile(string name, byte[]? bytes = null)
     {
         bytes ??= new byte[] { 1, 2, 3 };
-        return new FormFile(new MemoryStream(bytes), 0, bytes.Length, "file", name);
+        var content = new MemoryStream(bytes);
+        _formFileStreams.Add(content);
+        return new FormFile(content, 0, bytes.Length, "file", name);
     }
 
     [Fact]
@@ -647,7 +656,7 @@ public sealed class CMSContentControllerTests : IDisposable
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
         // Block exists (section-path row present) but the user may not edit it -> 403, not 404.
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.GetContentBlock(5, TestContext.Current.CancellationToken);
 
@@ -660,7 +669,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task UpdateContentOnly_Returns403_WhenCannotEdit()
     {
         _blockService.CanEditAsync(4, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((true, null));
         var update = new ContentOnlyUpdate { Content = "<p>x</p>", LastModifiedOn = DateTime.Now };
 
         var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
@@ -675,7 +684,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task UpdateContentOnly_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(4, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(4, Arg.Any<CancellationToken>()).Returns((false, null));
         var update = new ContentOnlyUpdate { Content = "<p>x</p>", LastModifiedOn = DateTime.Now };
 
         var result = await _controller.UpdateContentOnly(4, update, TestContext.Current.CancellationToken);
@@ -698,7 +707,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task SearchAttachableFiles_EditMode_Returns403_WhenCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.SearchAttachableFiles("report", 5, TestContext.Current.CancellationToken);
 
@@ -711,7 +720,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task SearchAttachableFiles_EditMode_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.SearchAttachableFiles("report", 5, TestContext.Current.CancellationToken);
 
@@ -752,7 +761,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task CheckBlockFileName_ReturnsBadRequest_WhenBlockHasNoSectionPath()
     {
         // Matches UploadBlockFile: the block exists but is not configured for uploads.
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
 
@@ -762,7 +771,7 @@ public sealed class CMSContentControllerTests : IDisposable
     [Fact]
     public async Task CheckBlockFileName_ReturnsNotFound_WhenBlockMissing()
     {
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
 
@@ -773,7 +782,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task CheckBlockFileName_Returns403_WhenExistsButCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.CheckBlockFileName(5, "doc.pdf", TestContext.Current.CancellationToken);
 
@@ -808,7 +817,7 @@ public sealed class CMSContentControllerTests : IDisposable
         // Mirrors CheckBlockFileName: without a section path there is no upload folder, and the
         // request must not fall back to the storage root.
         _blockService.GetUploadSettingsAsync(5, Arg.Any<CancellationToken>())
-            .Returns((true, (string?)null, false, new List<string>()));
+            .Returns((true, null, false, new List<string>()));
 
         var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
             TestContext.Current.CancellationToken);
@@ -822,7 +831,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task UploadBlockFile_Returns403_WhenCannotEdit()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
             TestContext.Current.CancellationToken);
@@ -837,7 +846,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task UploadBlockFile_Returns404_WhenBlockMissing()
     {
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.UploadBlockFile(5, new ContentBlockFileUpload(), FakeFormFile("doc.pdf"),
             TestContext.Current.CancellationToken);
@@ -893,7 +902,7 @@ public sealed class CMSContentControllerTests : IDisposable
     public async Task DeleteBlockFile_Returns404_WhenFileMissing()
     {
         var fileGuid = Guid.NewGuid();
-        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns((bool?)null);
+        _blockService.IsFileRollbackDeletableAsync(5, fileGuid, Arg.Any<CancellationToken>()).Returns(default(bool?));
 
         var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
 
@@ -906,7 +915,7 @@ public sealed class CMSContentControllerTests : IDisposable
     {
         var fileGuid = Guid.NewGuid();
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((true, null));
 
         var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
 
@@ -921,7 +930,7 @@ public sealed class CMSContentControllerTests : IDisposable
     {
         var fileGuid = Guid.NewGuid();
         _blockService.CanEditAsync(5, Arg.Any<CancellationToken>()).Returns(false);
-        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, (string?)null));
+        _blockService.GetSectionPathAsync(5, Arg.Any<CancellationToken>()).Returns((false, null));
 
         var result = await _controller.DeleteBlockFile(5, fileGuid, TestContext.Current.CancellationToken);
 

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -1123,4 +1123,174 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Attach authorization (AssertFilesAttachableAsync)
+
+    // Attaching a file to a block is a read-access decision: the block would surface a download
+    // link for it, so a user may only attach files they could already download. Five independent
+    // rules grant that, and each is exercised here because a regression in any one silently widens
+    // access. The deny case is the fail-closed default.
+    //
+    // The check hangs off the content-only PATCH (the delegated-editor path), which is the one
+    // route that accepts attachments from a user who may not manage the block, so every scenario
+    // drives UpdateContentOnlyAsync rather than the manager's full save.
+
+    private Task<global::Viper.Areas.CMS.Models.DTOs.ContentBlockDto?> AttachAsync(ContentBlock block,
+        Models.VIPER.File file) =>
+        _service.UpdateContentOnlyAsync(block.ContentBlockId, "<p>edit</p>", block.ModifiedOn,
+            new List<Guid> { file.FileGuid }, TestContext.Current.CancellationToken);
+
+    private async Task AssertAttachAllowedAsync(Models.VIPER.File file, string sectionPath = "cats")
+    {
+        var block = await SeedBlockAsync(b => b.ViperSectionPath = sectionPath);
+
+        var dto = await AttachAsync(block, file);
+
+        Assert.NotNull(dto);
+        Assert.Equal(file.FriendlyName, Assert.Single(dto.Files).FriendlyName);
+    }
+
+    private async Task<ArgumentException> AssertAttachRejectedAsync(Models.VIPER.File file,
+        string sectionPath = "cats")
+    {
+        var block = await SeedBlockAsync(b => b.ViperSectionPath = sectionPath);
+
+        return await Assert.ThrowsAsync<ArgumentException>(() => AttachAsync(block, file));
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenFileIsPublic()
+    {
+        var file = await SeedFileAsync("public.pdf", customize: f => f.AllowPublicAccess = true);
+        // Holds nothing at all, so only the public flag can carry this.
+        SignInAs(DelegateUser(), isManager: false);
+
+        await AssertAttachAllowedAsync(file);
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenFileUnrestrictedAndUserHasSvmSecure()
+    {
+        // No permission rows on the file means "any VIPER user", which SVMSecure represents.
+        var file = await SeedFileAsync("open.pdf");
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        await AssertAttachAllowedAsync(file);
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenUserHoldsOneOfTheFilePermissions()
+    {
+        var file = await SeedFileAsync("restricted.pdf", customize: f =>
+        {
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Other" });
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Cats" });
+        });
+        // Holding any ONE of the file's permissions is enough; the user lacks SVMSecure.Other.
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure.Cats");
+
+        await AssertAttachAllowedAsync(file);
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenGrantedToThePersonDirectly()
+    {
+        var user = new AaudUser { AaudUserId = 11, LoginId = "person", MothraId = "m11", IamId = "iam-11" };
+        var file = await SeedFileAsync("person-only.pdf", customize: f =>
+        {
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Unheld" });
+            f.FileToPeople.Add(new FileToPerson { IamId = "iam-11" });
+        });
+        // Person-level access stands alone: the user holds none of the file's permissions.
+        SignInAs(user, isManager: false);
+
+        await AssertAttachAllowedAsync(file);
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenUploaderAttachesOwnFileFromTheBlockFolder()
+    {
+        // The inline-upload path: a delegate's own upload inherits the block's VIEW permissions,
+        // which the delegate need not hold, so the uploader+folder match is what lets them attach it.
+        var file = await SeedFileAsync("mine.pdf", folder: "cats", modifiedBy: "delegate",
+            customize: f => f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Unheld" }));
+        SignInAs(DelegateUser(), isManager: false);
+
+        await AssertAttachAllowedAsync(file, sectionPath: "cats");
+    }
+
+    [Fact]
+    public async Task AttachFile_Rejected_WhenUploadedFileSitsInADifferentFolder()
+    {
+        // Scopes the uploader exception to this block: a delegate may not move a restricted file
+        // they uploaded elsewhere onto a block with broader visibility.
+        var file = await SeedFileAsync("elsewhere.pdf", folder: "admin", modifiedBy: "delegate",
+            customize: f => f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Unheld" }));
+        SignInAs(DelegateUser(), isManager: false);
+
+        var ex = await AssertAttachRejectedAsync(file, sectionPath: "cats");
+
+        Assert.Contains("do not have access", ex.Message);
+    }
+
+    [Fact]
+    public async Task AttachFile_Rejected_WhenUserMatchesNoRule()
+    {
+        var file = await SeedFileAsync("secret.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Unheld" }));
+        SignInAs(DelegateUser(), isManager: false, "SVMSecure");
+
+        var ex = await AssertAttachRejectedAsync(file);
+
+        Assert.Contains("do not have access", ex.Message);
+    }
+
+    [Fact]
+    public async Task AttachFile_Rejected_WhenAnonymous()
+    {
+        // Fail closed: an anonymous caller resolves to an empty permission set, so even the
+        // unrestricted-file rule (which keys off SVMSecure) must not let the attach through.
+        var file = await SeedFileAsync("open.pdf");
+        _userHelper.GetCurrentUser().ReturnsNull();
+
+        var ex = await AssertAttachRejectedAsync(file);
+
+        Assert.Contains("do not have access", ex.Message);
+    }
+
+    [Fact]
+    public async Task AttachFile_Rejected_WhenFileIsSoftDeleted()
+    {
+        // A deleted file comes back missing from the active-only lookup, so it reports as missing
+        // rather than as an access failure; attaching by GUID must not resurrect it.
+        var file = await SeedFileAsync("trashed.pdf", customize: f =>
+        {
+            f.AllowPublicAccess = true;
+            f.DeletedOn = DateTime.Now.AddDays(-1);
+        });
+        SignInAs(DelegateUser(), isManager: false);
+
+        var ex = await AssertAttachRejectedAsync(file);
+
+        Assert.Contains("deleted or missing", ex.Message);
+    }
+
+    [Fact]
+    public async Task AttachFile_Allowed_WhenManagerAlreadyAttachedARestrictedFile()
+    {
+        // Only NEWLY-added guids are checked: a delegate resending the block's existing
+        // attachments must not be blocked by a restricted file a manager attached earlier.
+        var file = await SeedFileAsync("manager-attached.pdf", customize: f =>
+            f.FileToPermissions.Add(new FileToPermission { Permission = "SVMSecure.Unheld" }));
+        var block = await SeedBlockAsync(b =>
+            b.ContentBlockToFiles.Add(new ContentBlockToFile { FileGuid = file.FileGuid }));
+        SignInAs(DelegateUser(), isManager: false);
+
+        var dto = await AttachAsync(block, file);
+
+        Assert.NotNull(dto);
+        Assert.Equal("manager-attached.pdf", Assert.Single(dto.Files).FriendlyName);
+    }
+
+    #endregion
 }

--- a/test/CMS/CmsContentBlockServiceTests.cs
+++ b/test/CMS/CmsContentBlockServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Areas.CMS.Constants;
 using Viper.Areas.CMS.Models;
 using Viper.Areas.CMS.Services;
@@ -642,7 +643,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     {
         var block = await SeedBlockAsync(b =>
             b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         Assert.False(await _service.CanEditAsync(block.ContentBlockId, TestContext.Current.CancellationToken));
     }
@@ -926,7 +927,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     {
         await SeedBlockAsync(b =>
             b.ContentBlockToEditPermissions.Add(new ContentBlockToEditPermission { Permission = "SVMSecure.Editors" }));
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var blocks = await _service.GetEditableBlocksAsync(TestContext.Current.CancellationToken);
 
@@ -994,7 +995,7 @@ public sealed class CmsContentBlockServiceTests : IDisposable
     public async Task SearchAttachableFiles_Anonymous_ReturnsEmpty()
     {
         await SeedFileAsync("report-match.pdf");
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         Assert.Empty(await _service.SearchAttachableFilesAsync("match", TestContext.Current.CancellationToken));
     }

--- a/test/CMS/CmsLeftNavDisplayTests.cs
+++ b/test/CMS/CmsLeftNavDisplayTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
 using Viper.Models.VIPER;
@@ -86,7 +87,7 @@ public sealed class CmsLeftNavDisplayTests : IDisposable
     {
         var friendlyName = await SeedMixedMenuAsync();
         // An anonymous request has no signed-in user; GetCurrentUser returns null.
-        _userHelper.GetCurrentUser().Returns((AaudUser?)null);
+        _userHelper.GetCurrentUser().ReturnsNull();
 
         var menus = new DataLeftNav(_context, _rapsContext, _userHelper)
             .GetLeftNavMenus(friendlyName: friendlyName);

--- a/web/Areas/CMS/Services/CmsContentBlockService.cs
+++ b/web/Areas/CMS/Services/CmsContentBlockService.cs
@@ -905,13 +905,29 @@ namespace Viper.Areas.CMS.Services
             // forged; the folder match scopes the exception to a file uploaded FOR this block, so a
             // delegate cannot move a restricted file they uploaded elsewhere onto a block with broader
             // visibility. This mirrors the uploader+folder check in IsFileRollbackDeletableAsync.
-            bool allAttachable = files.All(f => f.AllowPublicAccess
-                || (f.Permissions.Count == 0 && hasSvmSecure)
-                || f.Permissions.Any(p => userPermissions.Contains(p))
-                || (currentUser?.IamId != null && f.People.Contains(currentUser.IamId))
-                || (login != null
+            var iamId = currentUser?.IamId;
+            bool allAttachable = files.All(f =>
+            {
+                if (f.AllowPublicAccess)
+                {
+                    return true;
+                }
+                if (f.Permissions.Count == 0 && hasSvmSecure)
+                {
+                    return true;
+                }
+                if (f.Permissions.Any(p => userPermissions.Contains(p)))
+                {
+                    return true;
+                }
+                if (iamId != null && f.People.Contains(iamId))
+                {
+                    return true;
+                }
+                return login != null
                     && string.Equals(f.ModifiedBy, login, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(f.Folder, blockFolder, StringComparison.OrdinalIgnoreCase)));
+                    && string.Equals(f.Folder, blockFolder, StringComparison.OrdinalIgnoreCase);
+            });
             if (!allAttachable)
             {
                 throw new ArgumentException("One or more files cannot be attached because you do not have access to them.");

--- a/web/Areas/CMS/Services/CmsLeftNavService.cs
+++ b/web/Areas/CMS/Services/CmsLeftNavService.cs
@@ -62,9 +62,9 @@ namespace Viper.Areas.CMS.Services
             }
             if (!string.IsNullOrEmpty(search))
             {
-                query = query.Where(m => (m.MenuHeaderText != null && m.MenuHeaderText.Contains(search))
-                    || (m.FriendlyName != null && m.FriendlyName.Contains(search))
-                    || (m.Page != null && m.Page.Contains(search)));
+                query = query.Where(m => (m.MenuHeaderText ?? "").Contains(search)
+                    || (m.FriendlyName ?? "").Contains(search)
+                    || (m.Page ?? "").Contains(search));
             }
 
             var menus = await query


### PR DESCRIPTION
Clears the 32 code-scanning alerts from the CMS merge (#255 and the VPR-59 series): 30 fixed, 2 dismissed as generated code. Commit 2 adds tests for an authorization check that had none.

## Fixed

| Rule | Count | Change |
| --- | --- | --- |
| `cs/useless-upcast` | 27 | 22 tuple casts `(true, (string?)null)` -> `(true, null)`; 4 `Returns((AaudUser?)null)` -> `ReturnsNull()`; 1 `(bool?)null` -> `default(bool?)` |
| `cs/complex-condition` | 2 | `CmsContentBlockService` attachability check rewritten as guard clauses; `CmsLeftNavService` search filter uses `(col ?? "")` |
| `cs/local-not-disposed` | 1 | `FakeFormFile` streams tracked in a field, disposed in the fixture's existing `Dispose()` |

The bare-`null` casts keep an explicit type on purpose: NSubstitute's `Returns<T>(T)` and `Returns<T>(Func<CallInfo, T>)` are both applicable to a bare `null`, so deleting the cast is an ambiguity error. Tuple literals have no such problem.

The left-nav search rewrite is semantically identical. The `!= null` guards were for the C# nullable analyzer, not for SQL, where `NULL LIKE '%x%'` already excludes the row.

## Dismissed

Alerts 727 and 728 are in `web/obj/.../RegexGenerator.g.cs`, source-generator output rather than repository source. `paths-ignore` cannot filter them: it is forwarded as `LGTM_INDEX_FILTERS`, which only reaches the file-indexing extractors, while the C# extractor traces the Roslyn build. Only `build-mode: none` would, at the cost of analysis fidelity. The config comment claimed these globs caught that output; it is corrected here.

## Tests (commit 2)

`AssertFilesAttachableAsync` had no direct tests. It is an authorization boundary: attaching a file to a block surfaces a download link for it, so the check stops a user attaching a file they could not already download. Five independent rules grant access, and a regression in any one silently widens it.

10 tests, all driving `UpdateContentOnlyAsync` (the method's only call site, and the only route that accepts attachments from a non-manager):

- One per allow rule: public file, unrestricted file plus `SVMSecure`, matching file permission, person-level grant, uploader-in-the-block's-folder.
- Fail-closed: no rule matches, anonymous caller, soft-deleted file.
- Folder scoping: a delegate cannot move a restricted file they uploaded elsewhere onto a more visible block.
- Only newly-added GUIDs are checked, so a delegate resending a manager's restricted attachment is not blocked.

## Verification

2658 backend tests pass; lint and `verify:build` clean. CodeQL on this PR reports 0 open alerts. The left-nav `COALESCE` translation, which the in-memory test provider cannot exercise, was verified in the browser against SQL Server.
