### PR TITLE
chore(test): pass TestContext.Current.CancellationToken everywhere

### DIFF
--- a/test/ClinicalScheduler/EmailNotificationTest.cs
+++ b/test/ClinicalScheduler/EmailNotificationTest.cs
@@ -165,18 +165,18 @@ namespace Viper.test.ClinicalScheduler
             await AddTestPersonAsync(mothraId, "John", "Doe");
             await AddTestWeekGradYearAsync(weekId, 2025, weekNum);
             await AddTestRotationAsync(rotationId, "Cardiology Rotation", "CARD");
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Create primary evaluator and another instructor (so removal is allowed)
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(mothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other456", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Refresh to get the generated IDs
             var savedPrimarySchedule = await _context.InstructorSchedules
-                .FirstAsync(s => s.MothraId == mothraId && s.RotationId == rotationId && s.WeekId == weekId);
+                .FirstAsync(s => s.MothraId == mothraId && s.RotationId == rotationId && s.WeekId == weekId, TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -190,7 +190,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act
-            var result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
+            var result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result.success);
@@ -222,21 +222,21 @@ namespace Viper.test.ClinicalScheduler
 
             // Add required service, week and rotation data
             // First add a service that the rotation will reference
-            if (!await _context.Services.AnyAsync(s => s.ServiceId == 1))
+            if (!await _context.Services.AnyAsync(s => s.ServiceId == 1, TestContext.Current.CancellationToken))
             {
                 await _context.Services.AddAsync(new Service
                 {
                     ServiceId = 1,
                     ServiceName = "Test Service",
                     ShortName = "TEST"
-                });
+                }, TestContext.Current.CancellationToken);
             }
 
             await AddTestWeekGradYearAsync(weekId, 2025, 1);
             await AddTestRotationAsync(rotationId, "Test Rotation", "TEST");
 
             // Add Person entity for the instructor
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "test123"))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "test123", TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -248,15 +248,15 @@ namespace Viper.test.ClinicalScheduler
                 }, TestContext.Current.CancellationToken);
             }
 
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var schedule = TestDataBuilder.CreateInstructorSchedule("test123", rotationId, weekId); // Not primary
-            await _context.InstructorSchedules.AddAsync(schedule);
-            await _context.SaveChangesAsync();
+            await _context.InstructorSchedules.AddAsync(schedule, TestContext.Current.CancellationToken);
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Get the actual saved entity with the database-assigned ID
             var savedSchedule = await _context.InstructorSchedules
-                .FirstAsync(s => s.MothraId == "test123" && s.RotationId == rotationId && s.WeekId == 1 && !s.Evaluator);
+                .FirstAsync(s => s.MothraId == "test123" && s.RotationId == rotationId && s.WeekId == 1 && !s.Evaluator, TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -272,7 +272,7 @@ namespace Viper.test.ClinicalScheduler
             var debugSchedule = await _context.InstructorSchedules
                 .Include(s => s.Rotation)
                 .Include(s => s.Person)
-                .FirstOrDefaultAsync(s => s.InstructorScheduleId == savedSchedule.InstructorScheduleId);
+                .FirstOrDefaultAsync(s => s.InstructorScheduleId == savedSchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
             Console.WriteLine($"Debug schedule found: {debugSchedule != null}, Rotation: {debugSchedule?.Rotation?.Name}, Person: {debugSchedule?.Person?.PersonDisplayFullName}");
 
             // Act
@@ -280,7 +280,7 @@ namespace Viper.test.ClinicalScheduler
             Exception? caughtException = null;
             try
             {
-                result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId);
+                result = await _service.RemoveInstructorScheduleAsync(savedSchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
             }
             catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
@@ -290,7 +290,7 @@ namespace Viper.test.ClinicalScheduler
 
             // Debug: Check if schedule exists after calling service
             var scheduleExistsAfterCall = await _context.InstructorSchedules
-                .AnyAsync(s => s.InstructorScheduleId == savedSchedule.InstructorScheduleId);
+                .AnyAsync(s => s.InstructorScheduleId == savedSchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
             Console.WriteLine($"Schedule exists after call: {scheduleExistsAfterCall}, ID: {savedSchedule.InstructorScheduleId}");
             Console.WriteLine($"Result: success={result.success}, wasPrimary={result.wasPrimaryEvaluator}, name={result.instructorName}");
             if (caughtException != null)
@@ -326,13 +326,13 @@ namespace Viper.test.ClinicalScheduler
             await AddTestPersonAsync(mothraId, "John", "Doe");
             await AddTestWeekGradYearAsync(weekId);
             await AddTestRotationAsync(rotationId);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(mothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other456", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -355,11 +355,11 @@ namespace Viper.test.ClinicalScheduler
                 .Throws(new Exception("Email service unavailable"));
 
             // Act
-            var result = await _service.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId);
+            var result = await _service.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert - removal should still succeed despite email failure
             Assert.True(result.success);
-            var removedSchedule = await _context.InstructorSchedules.FindAsync(primarySchedule.InstructorScheduleId);
+            var removedSchedule = await _context.InstructorSchedules.FindAsync(new object?[] { primarySchedule.InstructorScheduleId }, TestContext.Current.CancellationToken);
             Assert.Null(removedSchedule);
 
             // Verify email was attempted
@@ -386,14 +386,14 @@ namespace Viper.test.ClinicalScheduler
             var weekNum = 20;
 
             // Add required service that the rotation will reference
-            if (!await _context.Services.AnyAsync(s => s.ServiceId == 1))
+            if (!await _context.Services.AnyAsync(s => s.ServiceId == 1, TestContext.Current.CancellationToken))
             {
                 await _context.Services.AddAsync(new Service
                 {
                     ServiceId = 1,
                     ServiceName = "Test Service",
                     ShortName = "TEST"
-                });
+                }, TestContext.Current.CancellationToken);
             }
 
             await AddTestWeekGradYearAsync(weekId, 2025, weekNum);
@@ -401,7 +401,7 @@ namespace Viper.test.ClinicalScheduler
 
             // Add Person for "other456" so Include query works
             // Also add minimal Person for mothraId to allow Include query to work, but with minimal data to test graceful handling
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "other456"))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "other456", TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -414,7 +414,7 @@ namespace Viper.test.ClinicalScheduler
             }
 
             // Add minimal Person for unknown123 to allow Include query to work
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == mothraId))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == mothraId, TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -427,17 +427,17 @@ namespace Viper.test.ClinicalScheduler
                 }, TestContext.Current.CancellationToken);
             }
 
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(mothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other456", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Get the actual saved entity with the database-assigned ID
             var savedPrimarySchedule = await _context.InstructorSchedules
-                .FirstAsync(s => s.MothraId == mothraId && s.RotationId == rotationId && s.WeekId == weekId && s.Evaluator);
+                .FirstAsync(s => s.MothraId == mothraId && s.RotationId == rotationId && s.WeekId == weekId && s.Evaluator, TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -454,7 +454,7 @@ namespace Viper.test.ClinicalScheduler
             var debugSchedule = await _context.InstructorSchedules
                 .Include(s => s.Rotation)
                 .Include(s => s.Person)
-                .FirstOrDefaultAsync(s => s.InstructorScheduleId == savedPrimarySchedule.InstructorScheduleId);
+                .FirstOrDefaultAsync(s => s.InstructorScheduleId == savedPrimarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
             Console.WriteLine($"Debug schedule found: {debugSchedule != null}, Rotation: {debugSchedule?.Rotation?.Name}, Person: {debugSchedule?.Person?.PersonDisplayFullName}");
 
             // Act
@@ -462,7 +462,7 @@ namespace Viper.test.ClinicalScheduler
             Exception? caughtException = null;
             try
             {
-                result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId);
+                result = await _service.RemoveInstructorScheduleAsync(savedPrimarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
             }
             catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or SqlException or OperationCanceledException)
             {
@@ -504,13 +504,13 @@ namespace Viper.test.ClinicalScheduler
             await AddTestRotationAsync(rotationId, "Surgery Rotation", "SURG");
 
             // Note: NOT adding WeekGradYear data to test fallback behavior
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(mothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other456", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -524,7 +524,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act
-            var result = await _service.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId);
+            var result = await _service.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result.success);
@@ -578,13 +578,13 @@ namespace Viper.test.ClinicalScheduler
             await AddTestPersonAsync(mothraId, "John", "Doe");
             await AddTestWeekGradYearAsync(weekId);
             await AddTestRotationAsync(rotationId, "Oncology", "ONC");
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(mothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other456", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -598,7 +598,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act
-            var result = await serviceWithMultipleRecipients.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId);
+            var result = await serviceWithMultipleRecipients.RemoveInstructorScheduleAsync(primarySchedule.InstructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result.success);
@@ -652,7 +652,7 @@ namespace Viper.test.ClinicalScheduler
             await AddTestPersonAsync(oldPrimaryMothraId, "Jane", "Smith");
             await AddTestPersonAsync(newPrimaryMothraId, "John", "Doe");
             // Add the current user person - need to manually set the display name to match expected output
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser"))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser", TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -664,14 +664,14 @@ namespace Viper.test.ClinicalScheduler
             }
             await AddTestWeekGradYearAsync(weekId, 2025, weekNum);
             await AddTestRotationAsync(rotationId, "Cardiology Rotation", "CARD");
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Create existing primary evaluator and new instructor
             var oldPrimarySchedule = TestDataBuilder.CreateInstructorSchedule(oldPrimaryMothraId, rotationId, weekId, true);
             var newInstructorSchedule = TestDataBuilder.CreateInstructorSchedule(newPrimaryMothraId, rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(oldPrimarySchedule, newInstructorSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -685,7 +685,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act - Set new instructor as primary evaluator (should NOT trigger email for replacement)
-            var result = await _service.SetPrimaryEvaluatorAsync(newInstructorSchedule.InstructorScheduleId, true);
+            var result = await _service.SetPrimaryEvaluatorAsync(newInstructorSchedule.InstructorScheduleId, true, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result.success);
@@ -721,7 +721,7 @@ namespace Viper.test.ClinicalScheduler
             await AddTestPersonAsync(oldPrimaryMothraId, "Alice", "Johnson");
             await AddTestPersonAsync(newPrimaryMothraId, "Bob", "Wilson");
             // Add the current user person - need to manually set the display name to match expected output
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser"))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser", TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -733,12 +733,12 @@ namespace Viper.test.ClinicalScheduler
             }
             await AddTestWeekGradYearAsync(weekIds[0], testYear, weekNum);
             await AddTestRotationAsync(rotationId, "Surgery Rotation", "SURG");
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Create existing primary evaluator
             var oldPrimarySchedule = TestDataBuilder.CreateInstructorSchedule(oldPrimaryMothraId, rotationId, weekIds[0], true);
-            await _context.InstructorSchedules.AddAsync(oldPrimarySchedule);
-            await _context.SaveChangesAsync();
+            await _context.InstructorSchedules.AddAsync(oldPrimarySchedule, TestContext.Current.CancellationToken);
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -755,7 +755,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act - Add new instructor as primary evaluator (should NOT trigger email for replacement)
-            var result = await _service.AddInstructorAsync(newPrimaryMothraId, rotationId, weekIds, testYear, true);
+            var result = await _service.AddInstructorAsync(newPrimaryMothraId, rotationId, weekIds, testYear, true, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotEmpty(result);
@@ -788,7 +788,7 @@ namespace Viper.test.ClinicalScheduler
             // Add test data
             await AddTestPersonAsync(primaryMothraId, "Charlie", "Brown");
             // Add the current user person - need to manually set the display name to match expected output
-            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser"))
+            if (!await _context.Persons.AnyAsync(p => p.IdsMothraId == "currentuser", TestContext.Current.CancellationToken))
             {
                 await _context.Persons.AddAsync(new Person
                 {
@@ -800,14 +800,14 @@ namespace Viper.test.ClinicalScheduler
             }
             await AddTestWeekGradYearAsync(weekId, 2025, weekNum);
             await AddTestRotationAsync(rotationId, "Neurology Rotation", "NEURO");
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Create primary evaluator and another instructor (so unsetting is allowed)
             var primarySchedule = TestDataBuilder.CreateInstructorSchedule(primaryMothraId, rotationId, weekId, true);
             var otherSchedule = TestDataBuilder.CreateInstructorSchedule("other789", rotationId, weekId);
 
             await _context.InstructorSchedules.AddRangeAsync(primarySchedule, otherSchedule);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var user = TestDataBuilder.CreateUser("currentuser");
             _mockUserHelper.GetCurrentUser().Returns(user);
@@ -818,7 +818,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(new ScheduleAudit());
 
             // Act - Unset primary evaluator (no replacement)
-            var result = await _service.SetPrimaryEvaluatorAsync(primarySchedule.InstructorScheduleId, false);
+            var result = await _service.SetPrimaryEvaluatorAsync(primarySchedule.InstructorScheduleId, false, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result.success);

--- a/test/ClinicalScheduler/InstructorScheduleControllerTest.cs
+++ b/test/ClinicalScheduler/InstructorScheduleControllerTest.cs
@@ -219,7 +219,7 @@ namespace Viper.test.ClinicalScheduler
             // Note: Audit service is not called directly by controller in this flow
 
             // Act
-            var result = await _controller.AddInstructor(request);
+            var result = await _controller.AddInstructor(request, TestContext.Current.CancellationToken);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
@@ -260,7 +260,7 @@ namespace Viper.test.ClinicalScheduler
                 .Returns(false);
 
             // Act
-            var result = await _controller.AddInstructor(request);
+            var result = await _controller.AddInstructor(request, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.IsType<ForbidResult>(result);
@@ -290,7 +290,7 @@ namespace Viper.test.ClinicalScheduler
             };
 
             // Act
-            var result = await _controller.AddInstructor(request);
+            var result = await _controller.AddInstructor(request, TestContext.Current.CancellationToken);
 
             // Assert
             var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);

--- a/test/ClinicalScheduler/Integration/ControllerServiceIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/ControllerServiceIntegrationTest.cs
@@ -153,7 +153,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 Abbreviation = "TEST"
             };
             Context.Rotations.Add(rotation);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Get rotation details
             var result = await controller.GetRotation(100);

--- a/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
@@ -100,8 +100,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 serviceId: null,
                 weekId: null,
                 startDate: null,
-                endDate: null
-            , TestContext.Current.CancellationToken);
+                endDate: null,
+                TestContext.Current.CancellationToken);
 
             var instructorScheduleResult = await _permissionService.CheckInstructorScheduleParamsAsync(
                 mothraId: null,
@@ -109,8 +109,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 serviceId: null,
                 weekId: null,
                 startDate: null,
-                endDate: null
-            , TestContext.Current.CancellationToken);
+                endDate: null,
+                TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(studentScheduleResult);
@@ -178,8 +178,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 serviceId: null,
                 weekId: null,
                 startDate: null,
-                endDate: null
-            , TestContext.Current.CancellationToken);
+                endDate: null,
+                TestContext.Current.CancellationToken);
 
             var otherScheduleResult = await _permissionService.CheckInstructorScheduleParamsAsync(
                 mothraId: "otheruser",
@@ -187,8 +187,8 @@ namespace Viper.test.ClinicalScheduler.Integration
                 serviceId: null,
                 weekId: null,
                 startDate: null,
-                endDate: null
-            , TestContext.Current.CancellationToken);
+                endDate: null,
+                TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(ownScheduleResult);

--- a/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/PermissionServiceIntegrationTest.cs
@@ -34,8 +34,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithManagePermission();
 
             // Act - Test methods that were previously in ClinicalScheduleSecurityService
-            var hasEditPermission = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
-            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId);
+            var hasEditPermission = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
+            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert - Verify consolidation maintains backward compatibility
             Assert.True(hasEditPermission);
@@ -49,15 +49,15 @@ namespace Viper.test.ClinicalScheduler.Integration
             var dynamicPermission = "SVMSecure.ClnSched.Edit.Dynamic";
             var service = TestDataBuilder.CreateService(99, "Dynamic Service", "DYN", dynamicPermission);
             Context.Services.Add(service);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Add permission to RAPS context
             TestDataBuilder.IntegrationHelpers.AddMemberPermissions(RapsContext, TestUserMothraId, dynamicPermission);
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { dynamicPermission });
 
             // Act
-            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(99);
-            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(99);
+            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(99, TestContext.Current.CancellationToken);
+            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(99, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(dynamicPermission, requiredPermission);
@@ -71,8 +71,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { ClinicalSchedulePermissions.Manage });
 
             // Act - Check permission for service with specific permission requirement
-            var hasCardiologyPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId);
-            var hasSurgeryPermission = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId);
+            var hasCardiologyPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId, TestContext.Current.CancellationToken);
+            var hasSurgeryPermission = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId, TestContext.Current.CancellationToken);
 
             // Assert - Manage permission should override all service-specific permissions
             Assert.True(hasCardiologyPermission);
@@ -91,7 +91,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local));
             Context.Weeks.Add(week);
             Context.WeekGradYears.Add(weekGradYear);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Test new async methods added during consolidation
             var studentScheduleResult = await _permissionService.CheckStudentScheduleParamsAsync(
@@ -101,7 +101,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 weekId: null,
                 startDate: null,
                 endDate: null
-            );
+            , TestContext.Current.CancellationToken);
 
             var instructorScheduleResult = await _permissionService.CheckInstructorScheduleParamsAsync(
                 mothraId: null,
@@ -110,7 +110,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 weekId: null,
                 startDate: null,
                 endDate: null
-            );
+            , TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(studentScheduleResult);
@@ -124,9 +124,9 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { CardiologyEditPermission });
 
             // Act
-            var hasCardiologyPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId);
-            var hasSurgeryPermission = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId);
-            var hasInternalMedicinePermission = await _permissionService.HasEditPermissionForServiceAsync(InternalMedicineServiceId);
+            var hasCardiologyPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId, TestContext.Current.CancellationToken);
+            var hasSurgeryPermission = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId, TestContext.Current.CancellationToken);
+            var hasInternalMedicinePermission = await _permissionService.HasEditPermissionForServiceAsync(InternalMedicineServiceId, TestContext.Current.CancellationToken);
 
             // Assert - Should only have permission for Cardiology
             Assert.True(hasCardiologyPermission);
@@ -141,8 +141,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupNullUser();
 
             // Act
-            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId);
-            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(CardiologyServiceId);
+            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId, TestContext.Current.CancellationToken);
+            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(CardiologyServiceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(hasPermission);
@@ -157,8 +157,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithManagePermission();
 
             // Act
-            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(nonExistentServiceId);
-            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(nonExistentServiceId);
+            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(nonExistentServiceId, TestContext.Current.CancellationToken);
+            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(nonExistentServiceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(ClinicalSchedulePermissions.Manage, requiredPermission);
@@ -179,7 +179,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 weekId: null,
                 startDate: null,
                 endDate: null
-            );
+            , TestContext.Current.CancellationToken);
 
             var otherScheduleResult = await _permissionService.CheckInstructorScheduleParamsAsync(
                 mothraId: "otheruser",
@@ -188,7 +188,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 weekId: null,
                 startDate: null,
                 endDate: null
-            );
+            , TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(ownScheduleResult);
@@ -206,8 +206,8 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { InternalMedicineEditPermission });
 
             // Act - Full permission check flow
-            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId);
-            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var requiredPermission = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
+            var hasPermission = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Simulate checking for a rotation in this service
             Context.Rotations.Add(new Rotation
@@ -217,9 +217,9 @@ namespace Viper.test.ClinicalScheduler.Integration
                 Name = "IM Rotation",
                 Abbreviation = "IM"
             });
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var rotationPermission = await _permissionService.HasEditPermissionForRotationAsync(99);
+            var rotationPermission = await _permissionService.HasEditPermissionForRotationAsync(99, TestContext.Current.CancellationToken);
 
             // Assert - Complete flow works correctly
             Assert.Equal(InternalMedicineEditPermission, requiredPermission);
@@ -234,13 +234,13 @@ namespace Viper.test.ClinicalScheduler.Integration
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { CardiologyEditPermission });
 
             // Act - Check permission initially
-            var firstCheck = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId);
+            var firstCheck = await _permissionService.HasEditPermissionForServiceAsync(CardiologyServiceId, TestContext.Current.CancellationToken);
 
             // Change permissions mid-test (simulating permission update)
             SetupUserWithPermissionsForIntegration(TestUserMothraId, new[] { ClinicalSchedulePermissions.Manage });
 
             // Check permission again
-            var secondCheck = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId);
+            var secondCheck = await _permissionService.HasEditPermissionForServiceAsync(SurgeryServiceId, TestContext.Current.CancellationToken);
 
             // Assert - Permissions should reflect current state, not cached
             Assert.True(firstCheck);

--- a/test/ClinicalScheduler/Integration/ServiceLayerIntegrationTest.cs
+++ b/test/ClinicalScheduler/Integration/ServiceLayerIntegrationTest.cs
@@ -253,8 +253,8 @@ namespace Viper.test.ClinicalScheduler.Integration
         public async Task PersonService_AAUDDataFetching_ReturnsCorrectData()
         {
             // Act - Test various PersonService methods
-            var allAffiliates = await _personService.GetAllActiveEmployeeAffiliatesAsync();
-            var specificPerson = await _personService.GetClinicianFromAaudAsync("instructor1");
+            var allAffiliates = await _personService.GetAllActiveEmployeeAffiliatesAsync(TestContext.Current.CancellationToken);
+            var specificPerson = await _personService.GetClinicianFromAaudAsync("instructor1", TestContext.Current.CancellationToken);
 
             // Assert
             // Note: GetAllActiveEmployeeAffiliatesAsync queries AaudUsers which we didn't seed
@@ -285,7 +285,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 Active = true
             };
             Context.Rotations.Add(rotation);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Use EvaluationPolicyService (now has different methods)
             // The service now has RequiresPrimaryEvaluator method with different signature
@@ -316,7 +316,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 Active = true
             };
             Context.Rotations.Add(rotation);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Convert entity to DTO using extension method
             var rotationDto = rotation.ToDto();
@@ -398,7 +398,7 @@ namespace Viper.test.ClinicalScheduler.Integration
                 Active = false
             };
             Context.Rotations.AddRange(rotation1, rotation2);
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act - Test DTO structures individually since ServiceSummaryDto doesn't exist
             var rotation1Dto = rotation1.ToDto();
@@ -427,7 +427,7 @@ namespace Viper.test.ClinicalScheduler.Integration
         public async Task CrossServiceDataConsistency_MaintainedAcrossLayers()
         {
             // Arrange - Complex scenario with multiple services interacting
-            await _personService.GetClinicianFromAaudAsync("instructor1");
+            await _personService.GetClinicianFromAaudAsync("instructor1", TestContext.Current.CancellationToken);
             // Person might be null if AAUD data is not seeded
 
             AddInstructorSchedule(401, "instructor1", CardiologyRotationId, weekId: 1, evaluator: true);

--- a/test/ClinicalScheduler/PersonServiceTest.cs
+++ b/test/ClinicalScheduler/PersonServiceTest.cs
@@ -129,7 +129,7 @@ namespace Viper.test.ClinicalScheduler
             // In a real scenario, these properties would be populated by SQL views/joins
 
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -145,7 +145,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansAsync_WithLimitedHistory_ExcludesOldRecords()
         {
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -157,7 +157,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansAsync_WithSpecificGradYearRange_ReturnsExpectedClinicians()
         {
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -175,7 +175,7 @@ namespace Viper.test.ClinicalScheduler
             // Properties like FullName come from database views in production
 
             // Act
-            var result = await _personService.GetPersonAsync("12345");
+            var result = await _personService.GetPersonAsync("12345", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -187,7 +187,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetPersonAsync_WithInvalidMothraId_ReturnsNull()
         {
             // Act
-            var result = await _personService.GetPersonAsync("INVALID");
+            var result = await _personService.GetPersonAsync("INVALID", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Null(result);
@@ -197,7 +197,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetPersonAsync_WithNullMothraId_ReturnsNull()
         {
             // Act
-            var result = await _personService.GetPersonAsync(null!);
+            var result = await _personService.GetPersonAsync(null!, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Null(result);
@@ -207,7 +207,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetPersonAsync_WithEmptyMothraId_ReturnsNull()
         {
             // Act
-            var result = await _personService.GetPersonAsync("");
+            var result = await _personService.GetPersonAsync("", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Null(result);
@@ -217,7 +217,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansByYearAsync_WithValidYear_ReturnsClinicians()
         {
             // Act - Using year from the test data (2023)
-            var result = await _personService.GetCliniciansByYearAsync(2023);
+            var result = await _personService.GetCliniciansByYearAsync(2023, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -235,7 +235,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansByYearAsync_WithYear2022_ReturnsHistoricalClinician()
         {
             // Act - Test with 2022 where we have test data for MothraId 99999
-            var result = await _personService.GetCliniciansByYearAsync(2022);
+            var result = await _personService.GetCliniciansByYearAsync(2022, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -251,7 +251,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetAllMothraIdsAsync_ReturnsAllUniqueMothraIds()
         {
             // Act
-            var result = await _personService.GetAllMothraIdsAsync();
+            var result = await _personService.GetAllMothraIdsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -271,7 +271,7 @@ namespace Viper.test.ClinicalScheduler
             // This tests that clinicians with multiple schedule entries are properly grouped
 
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(2022, 2024);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(2022, 2024, TestContext.Current.CancellationToken);
 
             // Assert
             var johnSmith = result.FirstOrDefault(c => ((dynamic)c).MothraId == "12345");
@@ -286,7 +286,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansAsync_ReturnsCorrectDataStructure()
         {
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(2023, 2024, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -308,7 +308,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetCliniciansAsync_WithDifferentGradYearRanges_ReturnsAppropriateResults(int startYear, int endYear, int expectedCount)
         {
             // Act
-            var result = await _personService.GetCliniciansByGradYearRangeAsync(startYear, endYear);
+            var result = await _personService.GetCliniciansByGradYearRangeAsync(startYear, endYear, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);

--- a/test/ClinicalScheduler/RotationServiceTest.cs
+++ b/test/ClinicalScheduler/RotationServiceTest.cs
@@ -108,7 +108,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsAsync_ReturnsExpectedRotations()
         {
             // Act
-            var result = await _rotationService.GetRotationsAsync();
+            var result = await _rotationService.GetRotationsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -130,7 +130,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsAsync_IncludesServiceData()
         {
             // Act
-            var result = await _rotationService.GetRotationsAsync();
+            var result = await _rotationService.GetRotationsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -147,7 +147,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsAsync_SortsCorrectly()
         {
             // Act
-            var result = await _rotationService.GetRotationsAsync();
+            var result = await _rotationService.GetRotationsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -171,7 +171,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationAsync_WithValidId_ReturnsRotation()
         {
             // Act
-            var result = await _rotationService.GetRotationAsync(101);
+            var result = await _rotationService.GetRotationAsync(101, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -186,7 +186,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationAsync_WithInvalidId_ReturnsNull()
         {
             // Act
-            var result = await _rotationService.GetRotationAsync(999);
+            var result = await _rotationService.GetRotationAsync(999, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Null(result);
@@ -196,7 +196,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsByCourseAsync_FiltersCorrectly()
         {
             // Act
-            var result = await _rotationService.GetRotationsByCourseAsync("456");
+            var result = await _rotationService.GetRotationsByCourseAsync("456", cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -211,7 +211,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsByCourseAsync_WithSubjectCode_FiltersCorrectly()
         {
             // Act
-            var result = await _rotationService.GetRotationsByCourseAsync("456", "VM");
+            var result = await _rotationService.GetRotationsByCourseAsync("456", "VM", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -224,7 +224,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetRotationsByServiceAsync_FiltersCorrectly()
         {
             // Act
-            var result = await _rotationService.GetRotationsByServiceAsync(1); // Anatomic Pathology service
+            var result = await _rotationService.GetRotationsByServiceAsync(1, TestContext.Current.CancellationToken); // Anatomic Pathology service
 
             // Assert
             Assert.NotNull(result);
@@ -240,7 +240,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetServicesAsync_ReturnsAllServices()
         {
             // Act
-            var result = await _rotationService.GetServicesAsync();
+            var result = await _rotationService.GetServicesAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -262,7 +262,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetServiceAsync_WithValidId_ReturnsService()
         {
             // Act
-            var result = await _rotationService.GetServiceAsync(1);
+            var result = await _rotationService.GetServiceAsync(1, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -274,7 +274,7 @@ namespace Viper.test.ClinicalScheduler
         public async Task GetServiceAsync_WithInvalidId_ReturnsNull()
         {
             // Act
-            var result = await _rotationService.GetServiceAsync(999);
+            var result = await _rotationService.GetServiceAsync(999, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Null(result);
@@ -293,7 +293,7 @@ namespace Viper.test.ClinicalScheduler
             var emptyService = new RotationService(_mockLogger, emptyContext);
 
             // Act
-            var result = await emptyService.GetRotationsAsync();
+            var result = await emptyService.GetRotationsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -313,7 +313,7 @@ namespace Viper.test.ClinicalScheduler
             // This test verifies that the service handles unique RotIds correctly
 
             // Act
-            var result = await _rotationService.GetRotationsAsync();
+            var result = await _rotationService.GetRotationsAsync(TestContext.Current.CancellationToken);
 
             // Assert - Each RotId should appear exactly once
             var anatomicPathRotations = result.Where(r => r.RotId == 101).ToList();

--- a/test/ClinicalScheduler/ScheduleAuditServiceTest.cs
+++ b/test/ClinicalScheduler/ScheduleAuditServiceTest.cs
@@ -37,7 +37,7 @@ namespace Viper.test.ClinicalScheduler
             var modifiedBy = "modifier456";
 
             // Act
-            var result = await _service.LogInstructorAddedAsync(mothraId, rotationId, weekId, modifiedBy);
+            var result = await _service.LogInstructorAddedAsync(mothraId, rotationId, weekId, modifiedBy, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -49,7 +49,7 @@ namespace Viper.test.ClinicalScheduler
             Assert.True(result.TimeStamp > DateTime.MinValue);
 
             // Verify entry was saved to database
-            var savedEntry = await _context.ScheduleAudits.FindAsync(result.ScheduleAuditId);
+            var savedEntry = await _context.ScheduleAudits.FindAsync(new object?[] { result.ScheduleAuditId }, TestContext.Current.CancellationToken);
             Assert.NotNull(savedEntry);
             Assert.Equal(result.Action, savedEntry.Action);
         }
@@ -64,7 +64,7 @@ namespace Viper.test.ClinicalScheduler
             var modifiedBy = "modifier456";
 
             // Act
-            var result = await _service.LogInstructorRemovedAsync(mothraId, rotationId, weekId, modifiedBy);
+            var result = await _service.LogInstructorRemovedAsync(mothraId, rotationId, weekId, modifiedBy, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -85,7 +85,7 @@ namespace Viper.test.ClinicalScheduler
             var modifiedBy = "modifier456";
 
             // Act
-            var result = await _service.LogPrimaryEvaluatorSetAsync(mothraId, rotationId, weekId, modifiedBy);
+            var result = await _service.LogPrimaryEvaluatorSetAsync(mothraId, rotationId, weekId, modifiedBy, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -106,7 +106,7 @@ namespace Viper.test.ClinicalScheduler
             var modifiedBy = "modifier456";
 
             // Act
-            var result = await _service.LogPrimaryEvaluatorUnsetAsync(mothraId, rotationId, weekId, modifiedBy);
+            var result = await _service.LogPrimaryEvaluatorUnsetAsync(mothraId, rotationId, weekId, modifiedBy, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(result);
@@ -131,13 +131,13 @@ namespace Viper.test.ClinicalScheduler
                 RotationId = 1,
                 WeekId = 1,
                 Evaluator = false
-            });
+            }, TestContext.Current.CancellationToken);
 
             await _context.ScheduleAudits.AddRangeAsync(auditEntry1, auditEntry2, auditEntry3, auditEntry4);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act
-            var result = await _service.GetInstructorScheduleAuditHistoryAsync(1);
+            var result = await _service.GetInstructorScheduleAuditHistoryAsync(1, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(2, result.Count);
@@ -161,10 +161,10 @@ namespace Viper.test.ClinicalScheduler
             var auditEntry5 = CreateAuditEntry("student1", rotationId, weekId, "modifier", ScheduleAuditActions.InstructorAdded, ScheduleAuditAreas.Students); // Student area
 
             await _context.ScheduleAudits.AddRangeAsync(auditEntry1, auditEntry2, auditEntry3, auditEntry4, auditEntry5);
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Act
-            var result = await _service.GetRotationWeekAuditHistoryAsync(rotationId, weekId);
+            var result = await _service.GetRotationWeekAuditHistoryAsync(rotationId, weekId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(2, result.Count);
@@ -218,7 +218,7 @@ namespace Viper.test.ClinicalScheduler
             var nonExistentScheduleId = 999;
 
             // Act
-            var result = await _service.GetInstructorScheduleAuditHistoryAsync(nonExistentScheduleId);
+            var result = await _service.GetInstructorScheduleAuditHistoryAsync(nonExistentScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Empty(result);
@@ -232,7 +232,7 @@ namespace Viper.test.ClinicalScheduler
             var nonExistentWeekId = 999;
 
             // Act
-            var result = await _service.GetRotationWeekAuditHistoryAsync(nonExistentRotationId, nonExistentWeekId);
+            var result = await _service.GetRotationWeekAuditHistoryAsync(nonExistentRotationId, nonExistentWeekId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Empty(result);

--- a/test/ClinicalScheduler/SchedulePermissionServiceTest.cs
+++ b/test/ClinicalScheduler/SchedulePermissionServiceTest.cs
@@ -22,7 +22,7 @@ namespace Viper.test.ClinicalScheduler
             var serviceId = CardiologyServiceId; // Service with custom permission
 
             // Act
-            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(CardiologyEditPermission, result);
@@ -35,7 +35,7 @@ namespace Viper.test.ClinicalScheduler
             var serviceId = SurgeryServiceId; // Service with null permission
 
             // Act
-            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(ClinicalSchedulePermissions.Manage, result);
@@ -48,7 +48,7 @@ namespace Viper.test.ClinicalScheduler
             var serviceId = EmergencyMedicineServiceId; // Service with empty string permission
 
             // Act
-            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.GetRequiredPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(ClinicalSchedulePermissions.Manage, result);
@@ -61,7 +61,7 @@ namespace Viper.test.ClinicalScheduler
             var nonExistentServiceId = 999;
 
             // Act
-            var result = await _permissionService.GetRequiredPermissionForServiceAsync(nonExistentServiceId);
+            var result = await _permissionService.GetRequiredPermissionForServiceAsync(nonExistentServiceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(ClinicalSchedulePermissions.Manage, result);
@@ -75,7 +75,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -89,7 +89,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -103,7 +103,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -117,7 +117,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId);
+            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -131,7 +131,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId);
+            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -145,7 +145,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId);
+            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -159,7 +159,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithManagePermission();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId);
+            var result = await _permissionService.HasEditPermissionForRotationAsync(rotationId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -172,7 +172,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithManagePermission();
 
             // Act
-            var result = await _permissionService.GetUserEditableServicesAsync();
+            var result = await _permissionService.GetUserEditableServicesAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be returned
@@ -185,7 +185,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.GetUserEditableServicesAsync();
+            var result = await _permissionService.GetUserEditableServicesAsync(TestContext.Current.CancellationToken);
 
             // Assert
             // Should return only services where user has specific permissions
@@ -201,7 +201,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithManagePermission();
 
             // Act
-            var result = await _permissionService.GetUserServicePermissionsAsync();
+            var result = await _permissionService.GetUserServicePermissionsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be present
@@ -218,7 +218,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutManagePermission();
 
             // Act
-            var result = await _permissionService.GetUserServicePermissionsAsync();
+            var result = await _permissionService.GetUserServicePermissionsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be present
@@ -236,7 +236,7 @@ namespace Viper.test.ClinicalScheduler
             SetupNullUser();
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -250,7 +250,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithAdminPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -264,7 +264,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditClnSchedulesPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -278,7 +278,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithServiceSpecificPermission(TestUserMothraId, CardiologyEditPermission);
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -292,7 +292,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithServiceSpecificPermission(TestUserMothraId, CardiologyEditPermission);
 
             // Act
-            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId);
+            var result = await _permissionService.HasEditPermissionForServiceAsync(serviceId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -305,7 +305,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithAdminPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.GetUserEditableServicesAsync();
+            var result = await _permissionService.GetUserEditableServicesAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be returned
@@ -318,7 +318,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditClnSchedulesPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.GetUserEditableServicesAsync();
+            var result = await _permissionService.GetUserEditableServicesAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be returned
@@ -331,7 +331,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithAdminPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.GetUserServicePermissionsAsync();
+            var result = await _permissionService.GetUserServicePermissionsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be present
@@ -345,7 +345,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditClnSchedulesPermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.GetUserServicePermissionsAsync();
+            var result = await _permissionService.GetUserServicePermissionsAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(4, result.Count); // All services should be present
@@ -360,7 +360,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId);
+            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(result);
@@ -374,7 +374,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId);
+            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -388,7 +388,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithoutEditOwnSchedulePermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId);
+            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);
@@ -402,7 +402,7 @@ namespace Viper.test.ClinicalScheduler
             SetupUserWithEditOwnSchedulePermission(TestUserMothraId);
 
             // Act
-            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId);
+            var result = await _permissionService.CanEditOwnScheduleAsync(instructorScheduleId, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.False(result);

--- a/test/Effort/ClinicalImportServiceTests.cs
+++ b/test/Effort/ClinicalImportServiceTests.cs
@@ -101,7 +101,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
     public async Task GetPreviewAsync_ReturnsWarning_WhenTermNotFound()
     {
         // Act
-        var result = await _service.GetPreviewAsync(999999, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(999999, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Contains(result.Warnings, w => w.Contains("not found"));
@@ -119,10 +119,10 @@ public sealed class ClinicalImportServiceTests : IDisposable
             OpenedDate = DateTime.Now.AddDays(-1),
             ClosedDate = DateTime.Now
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Contains(result.Warnings, w => w.Contains("not available"));
@@ -141,7 +141,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         await SeedSourceDataAsync("INST0001", "DVM", "453", weekCount: 8);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         var updateAssignment = Assert.Single(result.Assignments, a => a.Status == "Update");
@@ -158,7 +158,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         await SeedSourceDataAsync("INST0002", "DVM", "453", weekCount: 5);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         var skipAssignment = Assert.Single(result.Assignments, a => a.Status == "Skip");
@@ -174,7 +174,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         await SeedSourceDataAsync("INST0003", "DVM", "453", weekCount: 3);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         var newAssignment = Assert.Single(result.Assignments, a => a.Status == "New");
@@ -191,7 +191,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         // No source data seeded
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         var deleteAssignment = Assert.Single(result.Assignments, a => a.Status == "Delete");
@@ -245,13 +245,13 @@ public sealed class ClinicalImportServiceTests : IDisposable
             Weeks = 4,
             Crn = "CRN001"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Seed source data that would match by MothraId if ViperPerson had one
         await SeedSourceDataAsync("INST0050", "DVM", "453", weekCount: 4);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert — existing record's MothraId resolved to "" so it doesn't match source
         // data keyed by "INST0050". The source appears as New and the existing as Delete.
@@ -276,7 +276,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         await SeedSourceDataAsync("INST0005", "DVM", "453", weekCount: 8);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.AddNewOnly);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.AddNewOnly, TestContext.Current.CancellationToken);
 
         // Assert — existing record should be "Skip" with no ExistingWeeks
         var skipAssignment = Assert.Single(result.Assignments, a => a.Status == "Skip");
@@ -306,7 +306,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
             Units = 1,
             CustDept = "VME"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Record 1: will be updated (weeks differ)
         await SeedExistingClinicalRecordAsync("INST0010", 10, courseId: 1, weeks: 4);
@@ -319,7 +319,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
         await SeedSourceDataAsync("INST0012", "DVM", "491", weekCount: 2);
 
         // Act
-        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync);
+        var result = await _service.GetPreviewAsync(TermCode, ClinicalImportMode.Sync, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, result.AddCount);
@@ -346,7 +346,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
             LastName = "Clinical",
             MothraId = "INST0020"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // VIPER People for EnsureEffortPersonAsync name lookup
         _viperContext.People.Add(new Person
@@ -358,7 +358,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
             FullName = "Clinical, New",
             MothraId = "INST0020"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // AAUD data for title code
         _aaudContext.Ids.Add(new Id
@@ -380,15 +380,15 @@ public sealed class ClinicalImportServiceTests : IDisposable
             EmpCbuc = "VETMED",
             EmpStatus = "A"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1);
+        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1, TestContext.Current.CancellationToken);
 
         // Assert — EffortPerson should have been created
         Assert.True(result.Success);
         Assert.True(result.RecordsAdded > 0);
-        var effortPerson = await _context.Persons.FirstOrDefaultAsync(p => p.PersonId == 20 && p.TermCode == TermCode);
+        var effortPerson = await _context.Persons.FirstOrDefaultAsync(p => p.PersonId == 20 && p.TermCode == TermCode, TestContext.Current.CancellationToken);
         Assert.NotNull(effortPerson);
         Assert.Equal("NEW", effortPerson.FirstName);
         Assert.Equal("CLINICAL", effortPerson.LastName);
@@ -401,7 +401,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
     {
         // Arrange - term, source data, person — but NO EffortCourse for the source course
         _context.Terms.Add(new EffortTerm { TermCode = TermCode });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // No course seeded — EnsureEffortCourseAsync should create it
 
@@ -423,7 +423,7 @@ public sealed class ClinicalImportServiceTests : IDisposable
             EffortDept = "VME",
             EffortTitleCode = "1234"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Banner CRN lookup
         _coursesContext.Baseinfos.Add(new Baseinfo
@@ -444,15 +444,15 @@ public sealed class ClinicalImportServiceTests : IDisposable
             BaseinfoXlistFlag = "N",
             BaseinfoXlistGroup = ""
         });
-        await _coursesContext.SaveChangesAsync();
+        await _coursesContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1);
+        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1, TestContext.Current.CancellationToken);
 
         // Assert — EffortCourse should have been created with Banner CRN
         Assert.True(result.Success);
         Assert.True(result.RecordsAdded > 0);
-        var course = await _context.Courses.FirstOrDefaultAsync(c => c.TermCode == TermCode && c.SubjCode == "DVM" && c.CrseNumb == "491");
+        var course = await _context.Courses.FirstOrDefaultAsync(c => c.TermCode == TermCode && c.SubjCode == "DVM" && c.CrseNumb == "491", TestContext.Current.CancellationToken);
         Assert.NotNull(course);
         Assert.Equal("CRN491", course.Crn);
         Assert.Equal(EffortConstants.DefaultClinicalEnrollment, course.Enrollment);
@@ -472,12 +472,12 @@ public sealed class ClinicalImportServiceTests : IDisposable
             LastName = "Aaud",
             MothraId = "INST0022"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // No AAUD data seeded — EnsureEffortPersonAsync should return false
 
         // Act
-        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1);
+        var result = await _service.ExecuteImportAsync(TermCode, ClinicalImportMode.AddNewOnly, modifiedBy: 1, TestContext.Current.CancellationToken);
 
         // Assert — record should be skipped, not added
         Assert.True(result.Success);

--- a/test/Effort/CourseRelationshipServiceTests.cs
+++ b/test/Effort/CourseRelationshipServiceTests.cs
@@ -53,7 +53,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -63,7 +63,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(999, request)
+            () => _service.CreateRelationshipAsync(999, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("999", exception.Message);
         Assert.Contains("not found", exception.Message);
@@ -74,7 +74,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -84,7 +84,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("999", exception.Message);
         Assert.Contains("not found", exception.Message);
@@ -98,7 +98,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" },
             new EffortCourse { Id = 2, TermCode = DifferentTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -108,7 +108,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("same term", exception.Message);
     }
@@ -118,7 +118,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -128,7 +128,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("itself", exception.Message);
     }
@@ -143,7 +143,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 3, TermCode = TestTermCode, Crn = "12347", SubjCode = "APC", CrseNumb = "100", SeqNumb = "001", Enrollment = 15, Units = 2, CustDept = "APC" }
         );
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 3, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -153,7 +153,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("already a child", exception.Message);
     }
@@ -169,7 +169,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -179,7 +179,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert - Will fail on "already a child" check since child is already linked
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("already a child", exception.Message);
     }
@@ -196,7 +196,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         );
         // Course 2 is already a child of course 1
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Try to make course 2 (which is a child) a parent of course 3
         var request = new CreateCourseRelationshipRequest
@@ -207,7 +207,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert - Should fail because course 2 is already a child
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(2, request)
+            () => _service.CreateRelationshipAsync(2, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("cannot be a parent", exception.Message);
         Assert.Contains("already a child", exception.Message);
@@ -225,7 +225,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         );
         // Course 2 is already a parent of course 3
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 2, ChildCourseId = 3, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Try to make course 2 (which has children) a child of course 1
         var request = new CreateCourseRelationshipRequest
@@ -236,7 +236,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
 
         // Act & Assert - Should fail because course 2 already has linked children
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateRelationshipAsync(1, request)
+            () => _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("cannot be a child", exception.Message);
         Assert.Contains("already has linked children", exception.Message);
@@ -254,7 +254,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" },
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -263,7 +263,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         };
 
         // Act
-        var result = await _service.CreateRelationshipAsync(1, request);
+        var result = await _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -273,7 +273,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         Assert.NotNull(result.ChildCourse);
         Assert.Equal("VME", result.ChildCourse.SubjCode);
 
-        var savedRelationship = await _context.CourseRelationships.FirstOrDefaultAsync();
+        var savedRelationship = await _context.CourseRelationships.FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(savedRelationship);
     }
 
@@ -285,7 +285,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" },
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRelationshipRequest
         {
@@ -294,7 +294,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         };
 
         // Act
-        await _service.CreateRelationshipAsync(1, request);
+        await _service.CreateRelationshipAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddCourseChangeAudit(
@@ -316,13 +316,13 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         );
         // Pre-seed the first relationship to avoid tracking issues with sequential creates
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - Add second child
-        await _service.CreateRelationshipAsync(1, new CreateCourseRelationshipRequest { ChildCourseId = 3, RelationshipType = SectionType });
+        await _service.CreateRelationshipAsync(1, new CreateCourseRelationshipRequest { ChildCourseId = 3, RelationshipType = SectionType }, TestContext.Current.CancellationToken);
 
         // Assert
-        var relationships = await _context.CourseRelationships.Where(r => r.ParentCourseId == 1).ToListAsync();
+        var relationships = await _context.CourseRelationships.Where(r => r.ParentCourseId == 1).ToListAsync(TestContext.Current.CancellationToken);
         Assert.Equal(2, relationships.Count);
     }
 
@@ -339,14 +339,14 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.DeleteRelationshipAsync(1);
+        var result = await _service.DeleteRelationshipAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.CourseRelationships.FindAsync(1));
+        Assert.Null(await _context.CourseRelationships.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken));
 
         _auditServiceMock.Received(1).AddCourseChangeAudit(
                 1,
@@ -360,7 +360,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     public async Task DeleteRelationshipAsync_ReturnsFalse_WhenNotFound()
     {
         // Act
-        var result = await _service.DeleteRelationshipAsync(999);
+        var result = await _service.DeleteRelationshipAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -378,10 +378,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" },
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _service.GetAvailableChildCoursesAsync(1);
+        var available = await _service.GetAvailableChildCoursesAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(available);
@@ -399,10 +399,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 4, TermCode = TestTermCode, Crn = "12348", SubjCode = "PMI", CrseNumb = "300", SeqNumb = "001", Enrollment = 12, Units = 3, CustDept = "PMI" }
         );
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 3, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _service.GetAvailableChildCoursesAsync(1);
+        var available = await _service.GetAvailableChildCoursesAsync(1, TestContext.Current.CancellationToken);
 
         // Assert:
         // - Course 2 is already a child of course 3, should not be available
@@ -425,10 +425,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         );
         // Course 2 has a child (course 3), so course 2 cannot become a child of course 1
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 2, ChildCourseId = 3, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _service.GetAvailableChildCoursesAsync(1);
+        var available = await _service.GetAvailableChildCoursesAsync(1, TestContext.Current.CancellationToken);
 
         // Assert:
         // - Course 2 is a parent, should not be available as a child
@@ -446,10 +446,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" },
             new EffortCourse { Id = 3, TermCode = DifferentTermCode, Crn = "12347", SubjCode = "APC", CrseNumb = "100", SeqNumb = "001", Enrollment = 15, Units = 2, CustDept = "APC" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _service.GetAvailableChildCoursesAsync(1);
+        var available = await _service.GetAvailableChildCoursesAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(available);
@@ -460,7 +460,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     public async Task GetAvailableChildCoursesAsync_ReturnsEmpty_WhenParentNotFound()
     {
         // Act
-        var available = await _service.GetAvailableChildCoursesAsync(999);
+        var available = await _service.GetAvailableChildCoursesAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(available);
@@ -481,10 +481,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
         _context.CourseRelationships.Add(
             new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - Get relationships for the child course
-        var result = await _service.GetRelationshipsForCourseAsync(2);
+        var result = await _service.GetRelationshipsForCourseAsync(2, TestContext.Current.CancellationToken);
 
         // Assert - Course 2 should show its parent relationship
         Assert.NotNull(result.ParentRelationship);
@@ -505,10 +505,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType },
             new CourseRelationship { Id = 2, ParentCourseId = 1, ChildCourseId = 3, RelationshipType = SectionType }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - Get relationships for the parent course
-        var result = await _service.GetRelationshipsForCourseAsync(1);
+        var result = await _service.GetRelationshipsForCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert - Course 1 should show its child relationships
         Assert.Null(result.ParentRelationship);
@@ -522,10 +522,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = TestTermCode, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetParentRelationshipAsync(1);
+        var result = await _service.GetParentRelationshipAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -544,10 +544,10 @@ public sealed class CourseRelationshipServiceTests : IDisposable
             new EffortCourse { Id = 2, TermCode = TestTermCode, Crn = "12346", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 3, CustDept = "VME" }
         );
         _context.CourseRelationships.Add(new CourseRelationship { Id = 1, ParentCourseId = 1, ChildCourseId = 2, RelationshipType = CrossListType });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetRelationshipAsync(1);
+        var result = await _service.GetRelationshipAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -561,7 +561,7 @@ public sealed class CourseRelationshipServiceTests : IDisposable
     public async Task GetRelationshipAsync_ReturnsNull_WhenNotFound()
     {
         // Act
-        var result = await _service.GetRelationshipAsync(999);
+        var result = await _service.GetRelationshipAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);

--- a/test/Effort/CourseRelationshipsControllerTests.cs
+++ b/test/Effort/CourseRelationshipsControllerTests.cs
@@ -91,7 +91,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipsForCourseAsync(1, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -106,7 +106,7 @@ public sealed class CourseRelationshipsControllerTests
         _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var actionResult = await _controller.GetRelationships(999);
+        var actionResult = await _controller.GetRelationships(999, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(actionResult.Result);
@@ -122,7 +122,7 @@ public sealed class CourseRelationshipsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(DvmDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(actionResult.Result);
@@ -145,7 +145,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipsForCourseAsync(1, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -181,7 +181,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipsForCourseAsync(1, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -212,7 +212,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipsForCourseAsync(1, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -246,7 +246,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipsForCourseAsync(1, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.GetRelationships(1);
+        var actionResult = await _controller.GetRelationships(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -275,7 +275,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetAvailableChildCoursesAsync(1, Arg.Any<CancellationToken>()).Returns(availableCourses);
 
         // Act
-        var actionResult = await _controller.GetAvailableChildren(1);
+        var actionResult = await _controller.GetAvailableChildren(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -301,7 +301,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetAvailableChildCoursesAsync(1, Arg.Any<CancellationToken>()).Returns(availableCourses);
 
         // Act
-        var actionResult = await _controller.GetAvailableChildren(1);
+        var actionResult = await _controller.GetAvailableChildren(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -337,7 +337,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.CreateRelationshipAsync(1, request, Arg.Any<CancellationToken>()).Returns(relationship);
 
         // Act
-        var actionResult = await _controller.CreateRelationship(1, request);
+        var actionResult = await _controller.CreateRelationship(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(actionResult.Result);
@@ -357,7 +357,7 @@ public sealed class CourseRelationshipsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(DvmDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var actionResult = await _controller.CreateRelationship(1, request);
+        var actionResult = await _controller.CreateRelationship(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(actionResult.Result);
@@ -377,7 +377,7 @@ public sealed class CourseRelationshipsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(VmeDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var actionResult = await _controller.CreateRelationship(1, request);
+        var actionResult = await _controller.CreateRelationship(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(actionResult.Result);
@@ -397,7 +397,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.CreateRelationshipAsync(1, request, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Child course is already a child of another course"));
 
         // Act
-        var actionResult = await _controller.CreateRelationship(1, request);
+        var actionResult = await _controller.CreateRelationship(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult.Result);
@@ -430,7 +430,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.DeleteRelationshipAsync(1, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var actionResult = await _controller.DeleteRelationship(1, 1);
+        var actionResult = await _controller.DeleteRelationship(1, 1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(actionResult);
@@ -443,7 +443,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var actionResult = await _controller.DeleteRelationship(1, 999);
+        var actionResult = await _controller.DeleteRelationship(1, 999, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(actionResult);
@@ -465,7 +465,7 @@ public sealed class CourseRelationshipsControllerTests
         _relationshipServiceMock.GetRelationshipAsync(1, Arg.Any<CancellationToken>()).Returns(relationship);
 
         // Act
-        var actionResult = await _controller.DeleteRelationship(1, 1); // Trying to delete via parent 1
+        var actionResult = await _controller.DeleteRelationship(1, 1, TestContext.Current.CancellationToken); // Trying to delete via parent 1
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(actionResult);
@@ -490,7 +490,7 @@ public sealed class CourseRelationshipsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(DvmDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var actionResult = await _controller.DeleteRelationship(1, 1);
+        var actionResult = await _controller.DeleteRelationship(1, 1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(actionResult);
@@ -517,7 +517,7 @@ public sealed class CourseRelationshipsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(VmeDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var actionResult = await _controller.DeleteRelationship(1, 1);
+        var actionResult = await _controller.DeleteRelationship(1, 1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(actionResult);

--- a/test/Effort/CourseServiceTests.cs
+++ b/test/Effort/CourseServiceTests.cs
@@ -67,10 +67,10 @@ public sealed class CourseServiceTests : IDisposable
             new EffortCourse { Id = 2, TermCode = 202410, Crn = "12346", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" },
             new EffortCourse { Id = 3, TermCode = 202410, Crn = "12347", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "002", Enrollment = 15, Units = 4, CustDept = "DVM" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var courses = await _courseService.GetCoursesAsync(202410);
+        var courses = await _courseService.GetCoursesAsync(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, courses.Count);
@@ -89,10 +89,10 @@ public sealed class CourseServiceTests : IDisposable
             new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" },
             new EffortCourse { Id = 2, TermCode = 202410, Crn = "12346", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var courses = await _courseService.GetCoursesAsync(202410, "DVM");
+        var courses = await _courseService.GetCoursesAsync(202410, "DVM", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(courses);
@@ -103,7 +103,7 @@ public sealed class CourseServiceTests : IDisposable
     public async Task GetCoursesAsync_ReturnsEmptyList_WhenNoCoursesExistForTerm()
     {
         // Act
-        var courses = await _courseService.GetCoursesAsync(999999);
+        var courses = await _courseService.GetCoursesAsync(999999, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(courses);
@@ -118,10 +118,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var course = await _courseService.GetCourseAsync(1);
+        var course = await _courseService.GetCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -134,7 +134,7 @@ public sealed class CourseServiceTests : IDisposable
     public async Task GetCourseAsync_ReturnsNull_WhenCourseDoesNotExist()
     {
         // Act
-        var course = await _courseService.GetCourseAsync(999);
+        var course = await _courseService.GetCourseAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(course);
@@ -149,7 +149,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRequest
         {
@@ -164,7 +164,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.CreateCourseAsync(request);
+        var course = await _courseService.CreateCourseAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -176,7 +176,7 @@ public sealed class CourseServiceTests : IDisposable
         Assert.Equal("DVM", course.CustDept);
 
         // Verify saved to database
-        var savedCourse = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "99999");
+        var savedCourse = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "99999", TestContext.Current.CancellationToken);
         Assert.NotNull(savedCourse);
     }
 
@@ -185,7 +185,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRequest
         {
@@ -200,7 +200,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.CreateCourseAsync(request);
+        var course = await _courseService.CreateCourseAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("99999", course.Crn);
@@ -230,17 +230,17 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "99999", SubjCode = "TST", CrseNumb = "101", SeqNumb = "001", Enrollment = 25, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
-        Assert.True(await _courseService.CourseExistsAsync(202410, "99999", 4));
+        Assert.True(await _courseService.CourseExistsAsync(202410, "99999", 4, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task CourseExistsAsync_ReturnsFalse_WhenCourseDoesNotExist()
     {
         // Act & Assert
-        Assert.False(await _courseService.CourseExistsAsync(202410, "99999", 4));
+        Assert.False(await _courseService.CourseExistsAsync(202410, "99999", 4, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -248,10 +248,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange - course exists with 4 units
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "99999", SubjCode = "TST", CrseNumb = "101", SeqNumb = "001", Enrollment = 25, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert - checking for 2 units should return false
-        Assert.False(await _courseService.CourseExistsAsync(202410, "99999", 2));
+        Assert.False(await _courseService.CourseExistsAsync(202410, "99999", 2, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateCourseRequest
         {
@@ -274,7 +274,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        await _courseService.CreateCourseAsync(request);
+        await _courseService.CreateCourseAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddCourseChangeAudit(
@@ -294,7 +294,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateCourseRequest
         {
@@ -304,7 +304,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.UpdateCourseAsync(1, request);
+        var course = await _courseService.UpdateCourseAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -325,7 +325,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.UpdateCourseAsync(999, request);
+        var course = await _courseService.UpdateCourseAsync(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(course);
@@ -336,7 +336,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateCourseRequest
         {
@@ -347,7 +347,7 @@ public sealed class CourseServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _courseService.UpdateCourseAsync(1, request)
+            () => _courseService.UpdateCourseAsync(1, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("Invalid custodial department", exception.Message);
     }
@@ -357,7 +357,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateCourseRequest
         {
@@ -367,7 +367,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        await _courseService.UpdateCourseAsync(1, request);
+        await _courseService.UpdateCourseAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddCourseChangeAudit(
@@ -387,10 +387,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange - R-course ends with 'R'
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443R", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var course = await _courseService.UpdateCourseEnrollmentAsync(1, 50);
+        var course = await _courseService.UpdateCourseEnrollmentAsync(1, 50, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -402,11 +402,11 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange - Non R-course (doesn't end with 'R')
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _courseService.UpdateCourseEnrollmentAsync(1, 50)
+            () => _courseService.UpdateCourseEnrollmentAsync(1, 50, TestContext.Current.CancellationToken)
         );
         Assert.Contains("not an R-course", exception.Message);
     }
@@ -415,7 +415,7 @@ public sealed class CourseServiceTests : IDisposable
     public async Task UpdateCourseEnrollmentAsync_ReturnsNull_WhenCourseDoesNotExist()
     {
         // Act
-        var course = await _courseService.UpdateCourseEnrollmentAsync(999, 50);
+        var course = await _courseService.UpdateCourseEnrollmentAsync(999, 50, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(course);
@@ -430,21 +430,21 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _courseService.DeleteCourseAsync(1);
+        var result = await _courseService.DeleteCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.Courses.FindAsync(1));
+        Assert.Null(await _context.Courses.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task DeleteCourseAsync_ReturnsFalse_WhenCourseDoesNotExist()
     {
         // Act
-        var result = await _courseService.DeleteCourseAsync(999);
+        var result = await _courseService.DeleteCourseAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -456,20 +456,20 @@ public sealed class CourseServiceTests : IDisposable
         // Arrange
         var course = new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" };
         _context.Courses.Add(course);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.AddRange(
             new EffortRecord { Id = 1, TermCode = 202410, CourseId = 1, PersonId = 100 },
             new EffortRecord { Id = 2, TermCode = 202410, CourseId = 1, PersonId = 101 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _courseService.DeleteCourseAsync(1);
+        var result = await _courseService.DeleteCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Empty(await _context.Records.Where(r => r.CourseId == 1).ToListAsync());
+        Assert.Empty(await _context.Records.Where(r => r.CourseId == 1).ToListAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -477,10 +477,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _courseService.DeleteCourseAsync(1);
+        await _courseService.DeleteCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddCourseChangeAudit(
@@ -500,10 +500,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canDelete, recordCount) = await _courseService.CanDeleteCourseAsync(1);
+        var (canDelete, recordCount) = await _courseService.CanDeleteCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -520,10 +520,10 @@ public sealed class CourseServiceTests : IDisposable
             new EffortRecord { Id = 2, TermCode = 202410, CourseId = 1, PersonId = 101 },
             new EffortRecord { Id = 3, TermCode = 202410, CourseId = 1, PersonId = 102 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canDelete, recordCount) = await _courseService.CanDeleteCourseAsync(1);
+        var (canDelete, recordCount) = await _courseService.CanDeleteCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete); // Always true - deletion is allowed
@@ -566,7 +566,7 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            () => _courseService.SearchBannerCoursesAsync(202410));
+            () => _courseService.SearchBannerCoursesAsync(202410, ct: TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -597,7 +597,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse);
+        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -639,7 +639,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse);
+        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse, TestContext.Current.CancellationToken);
 
         // Assert - DeptCode 72030 maps to VME when subject code is not a valid department
         Assert.Equal("VME", course.CustDept);
@@ -670,7 +670,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse);
+        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, course.Units);
@@ -701,7 +701,7 @@ public sealed class CourseServiceTests : IDisposable
         };
 
         // Act
-        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse);
+        var course = await _courseService.ImportCourseFromBannerAsync(request, bannerCourse, TestContext.Current.CancellationToken);
 
         // Assert - should use UnitLow
         Assert.Equal(1, course.Units);
@@ -739,10 +739,10 @@ public sealed class CourseServiceTests : IDisposable
             Notes = "Test note",
             ModifiedDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Local)
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var records = await _courseService.GetCourseEffortAsync(1);
+        var records = await _courseService.GetCourseEffortAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(records);
@@ -763,10 +763,10 @@ public sealed class CourseServiceTests : IDisposable
     {
         // Arrange
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "DVM", CrseNumb = "443", SeqNumb = "001", Enrollment = 20, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var records = await _courseService.GetCourseEffortAsync(1);
+        var records = await _courseService.GetCourseEffortAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(records);
@@ -793,10 +793,10 @@ public sealed class CourseServiceTests : IDisposable
             new EffortRecord { Id = 2, CourseId = 1, PersonId = 101, TermCode = 202410, EffortTypeId = "LEC", RoleId = 1 },
             new EffortRecord { Id = 3, CourseId = 1, PersonId = 102, TermCode = 202410, EffortTypeId = "LEC", RoleId = 1 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var records = await _courseService.GetCourseEffortAsync(1);
+        var records = await _courseService.GetCourseEffortAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, records.Count);
@@ -822,10 +822,10 @@ public sealed class CourseServiceTests : IDisposable
 
         // Only person 100 has effort on the course
         _context.Records.Add(new EffortRecord { Id = 1, CourseId = 1, PersonId = 100, TermCode = 202410, EffortTypeId = "LEC", RoleId = 1 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _courseService.GetPossibleInstructorsForCourseAsync(1);
+        var result = await _courseService.GetPossibleInstructorsForCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.ExistingInstructors);
@@ -838,7 +838,7 @@ public sealed class CourseServiceTests : IDisposable
     public async Task GetPossibleInstructorsForCourseAsync_ReturnsEmptyDto_WhenCourseNotFound()
     {
         // Act
-        var result = await _courseService.GetPossibleInstructorsForCourseAsync(999);
+        var result = await _courseService.GetPossibleInstructorsForCourseAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result.ExistingInstructors);
@@ -855,10 +855,10 @@ public sealed class CourseServiceTests : IDisposable
             new EffortPerson { PersonId = 100, TermCode = 202410, FirstName = "Jane", LastName = "Smith", EffortTitleCode = "PROF", EffortDept = "VME" },
             new EffortPerson { PersonId = 101, TermCode = 202310, FirstName = "Bob", LastName = "Brown", EffortTitleCode = "PROF", EffortDept = "DVM" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _courseService.GetPossibleInstructorsForCourseAsync(1);
+        var result = await _courseService.GetPossibleInstructorsForCourseAsync(1, TestContext.Current.CancellationToken);
 
         // Assert — person 101 is from a different term, should not appear
         Assert.Empty(result.ExistingInstructors);
@@ -900,9 +900,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_ReturnsNone_WhenCrnNotInTerm()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "99999", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.None, result);
     }
@@ -911,9 +911,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_ReturnsDuplicateSameUnits_WhenCrnAndUnitsMatch()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: false, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.DuplicateSameUnits, result);
     }
@@ -922,9 +922,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_ReturnsNone_WhenCrnMatchesButUnitsDiffer_NonVet4xx()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 2, isVet4xx: false);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 2, isVet4xx: false, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.None, result);
     }
@@ -933,9 +933,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_ReturnsHarvestBlocked_WhenVet4xxAndAnyExistingRow()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 2, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.HarvestBlocked, result);
     }
@@ -944,9 +944,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_ReturnsHarvestBlocked_WhenVet4xxTakesPrecedenceOverDuplicateSameUnits()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.HarvestBlocked, result);
     }
@@ -955,9 +955,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_TrimsCrnBeforeMatching()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345", SubjCode = "VME", CrseNumb = "200", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "VME" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "  12345  ", 4, isVet4xx: false);
+        var result = await _courseService.CheckImportConflictAsync(202410, "  12345  ", 4, isVet4xx: false, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.DuplicateSameUnits, result);
     }
@@ -966,9 +966,9 @@ public sealed class CourseServiceTests : IDisposable
     public async Task CheckImportConflictAsync_IgnoresOtherTerms()
     {
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202310, Crn = "12345", SubjCode = "VET", CrseNumb = "410", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "DVM" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true);
+        var result = await _courseService.CheckImportConflictAsync(202410, "12345", 4, isVet4xx: true, TestContext.Current.CancellationToken);
 
         Assert.Equal(ImportConflict.None, result);
     }

--- a/test/Effort/CoursesControllerTests.cs
+++ b/test/Effort/CoursesControllerTests.cs
@@ -96,7 +96,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCoursesAsync(202410, null, Arg.Any<CancellationToken>()).Returns(courses);
 
         // Act
-        var result = await _controller.GetCourses(202410);
+        var result = await _controller.GetCourses(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -117,7 +117,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCoursesAsync(202410, "DVM", Arg.Any<CancellationToken>()).Returns(courses);
 
         // Act
-        var result = await _controller.GetCourses(202410, "DVM");
+        var result = await _controller.GetCourses(202410, "DVM", TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -138,7 +138,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("DVM", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetCourse(1);
+        var result = await _controller.GetCourse(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -153,7 +153,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetCourse(999);
+        var result = await _controller.GetCourse(999, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -187,7 +187,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CreateCourseAsync(request, Arg.Any<CancellationToken>()).Returns(createdCourse);
 
         // Act
-        var result = await _controller.CreateCourse(request);
+        var result = await _controller.CreateCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -216,7 +216,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.CreateCourse(request);
+        var result = await _controller.CreateCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -245,7 +245,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CourseExistsAsync(202410, "99999", 4, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.CreateCourse(request);
+        var result = await _controller.CreateCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -272,7 +272,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.IsValidCustodialDepartment("INVALID").Returns(false);
 
         // Act
-        var result = await _controller.CreateCourse(request);
+        var result = await _controller.CreateCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -302,7 +302,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CreateCourseAsync(request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("Database constraint violation"));
 
         // Act
-        var result = await _controller.CreateCourse(request);
+        var result = await _controller.CreateCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -333,7 +333,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseAsync(1, request, Arg.Any<CancellationToken>()).Returns(updatedCourse);
 
         // Act
-        var result = await _controller.UpdateCourse(1, request);
+        var result = await _controller.UpdateCourse(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -359,7 +359,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.UpdateCourse(1, request);
+        var result = await _controller.UpdateCourse(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -384,7 +384,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseAsync(1, request, Arg.Any<CancellationToken>()).Returns(updatedCourse);
 
         // Act
-        var result = await _controller.UpdateCourse(1, request);
+        var result = await _controller.UpdateCourse(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -406,7 +406,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.UpdateCourse(999, request);
+        var result = await _controller.UpdateCourse(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -431,7 +431,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseAsync(1, request, Arg.Any<CancellationToken>()).Throws(new ArgumentException("Invalid custodial department: INVALID"));
 
         // Act
-        var result = await _controller.UpdateCourse(1, request);
+        var result = await _controller.UpdateCourse(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -456,7 +456,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseAsync(1, request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("Database constraint violation"));
 
         // Act
-        var result = await _controller.UpdateCourse(1, request);
+        var result = await _controller.UpdateCourse(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -480,7 +480,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseEnrollmentAsync(1, 50, Arg.Any<CancellationToken>()).Returns(updatedCourse);
 
         // Act
-        var result = await _controller.UpdateCourseEnrollment(1, request);
+        var result = await _controller.UpdateCourseEnrollment(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -497,7 +497,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.UpdateCourseEnrollment(999, request);
+        var result = await _controller.UpdateCourseEnrollment(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -515,7 +515,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.UpdateCourseEnrollmentAsync(1, 50, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Course is not an R-course"));
 
         // Act
-        var result = await _controller.UpdateCourseEnrollment(1, request);
+        var result = await _controller.UpdateCourseEnrollment(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -537,7 +537,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.DeleteCourseAsync(1, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.DeleteCourse(1);
+        var result = await _controller.DeleteCourse(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
@@ -550,7 +550,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.DeleteCourse(999);
+        var result = await _controller.DeleteCourse(999, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
@@ -572,7 +572,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CanDeleteCourseAsync(1, Arg.Any<CancellationToken>()).Returns((true, 5));
 
         // Act
-        var result = await _controller.CanDeleteCourse(1);
+        var result = await _controller.CanDeleteCourse(1, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -592,7 +592,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetDepartments();
+        var result = await _controller.GetDepartments(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -623,7 +623,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.ImportCourseFromBannerAsync(request, bannerCourse, Arg.Any<CancellationToken>()).Returns(importedCourse);
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -646,7 +646,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -670,7 +670,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CheckImportConflictAsync(202410, "12345", 4, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ImportConflict.DuplicateSameUnits);
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -695,7 +695,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.CheckImportConflictAsync(202410, "12345", 4, true, Arg.Any<CancellationToken>()).Returns(ImportConflict.HarvestBlocked);
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -716,7 +716,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetBannerCourseAsync(202410, "99999", Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -738,7 +738,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetBannerCourseAsync(202410, "12345", Arg.Any<CancellationToken>()).Returns(bannerCourse);
 
         // Act
-        var result = await _controller.ImportCourse(request);
+        var result = await _controller.ImportCourse(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -760,7 +760,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.SearchBannerCoursesAsync(202410, "DVM", null, null, null, Arg.Any<CancellationToken>()).Returns(bannerCourses);
 
         // Act
-        var result = await _controller.SearchBannerCourses(202410, "DVM");
+        var result = await _controller.SearchBannerCourses(202410, "DVM", ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -772,7 +772,7 @@ public sealed class CoursesControllerTests
     public async Task SearchBannerCourses_ReturnsBadRequest_WhenNoSearchParametersProvided()
     {
         // Act
-        var result = await _controller.SearchBannerCourses(202410);
+        var result = await _controller.SearchBannerCourses(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -799,7 +799,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanEditPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -820,7 +820,7 @@ public sealed class CoursesControllerTests
 
         _courseServiceMock.GetCourseEffortAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns(new List<CourseEffortRecordDto>());
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -840,7 +840,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.IsTermEditableAsync(TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -856,7 +856,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -871,7 +871,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(course.CustDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -897,7 +897,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanEditPersonEffortAsync(nonEditablePersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetCourseEffort(TestCourseId);
+        var result = await _controller.GetCourseEffort(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -929,7 +929,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetPossibleInstructorsForCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns(instructors);
 
         // Act
-        var result = await _controller.GetPossibleInstructors(TestCourseId);
+        var result = await _controller.GetPossibleInstructors(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -944,7 +944,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetPossibleInstructors(TestCourseId);
+        var result = await _controller.GetPossibleInstructors(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -959,7 +959,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(course.CustDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetPossibleInstructors(TestCourseId);
+        var result = await _controller.GetPossibleInstructors(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -984,7 +984,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.GetCourseEvaluationStatusAsync(TestCourseId, Arg.Any<CancellationToken>()).Returns(status);
 
         // Act
-        var result = await _controller.GetCourseEvaluations(TestCourseId);
+        var result = await _controller.GetCourseEvaluations(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -999,7 +999,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetCourseEvaluations(TestCourseId);
+        var result = await _controller.GetCourseEvaluations(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -1014,7 +1014,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.CanViewDepartmentAsync(course.CustDept, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetCourseEvaluations(TestCourseId);
+        var result = await _controller.GetCourseEvaluations(TestCourseId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -1046,7 +1046,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.CreateAdHocEvaluationAsync(request, Arg.Any<CancellationToken>()).Returns(evalResult);
 
         // Act
-        var result = await _controller.CreateEvaluation(TestCourseId, request);
+        var result = await _controller.CreateEvaluation(TestCourseId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -1079,7 +1079,7 @@ public sealed class CoursesControllerTests
             .Returns(new AdHocEvalResultDto { Success = true, QuantId = TestQuantId });
 
         // Act
-        await _controller.CreateEvaluation(TestCourseId, request);
+        await _controller.CreateEvaluation(TestCourseId, request, TestContext.Current.CancellationToken);
 
         // Assert - verify the service was called with CourseId set to the route parameter
         await _evalHarvestServiceMock.Received(1).CreateAdHocEvaluationAsync(
@@ -1105,7 +1105,7 @@ public sealed class CoursesControllerTests
         };
 
         // Act
-        var result = await _controller.CreateEvaluation(TestCourseId, request);
+        var result = await _controller.CreateEvaluation(TestCourseId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -1131,7 +1131,7 @@ public sealed class CoursesControllerTests
         };
 
         // Act
-        var result = await _controller.CreateEvaluation(TestCourseId, request);
+        var result = await _controller.CreateEvaluation(TestCourseId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -1159,7 +1159,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.CreateAdHocEvaluationAsync(request, Arg.Any<CancellationToken>()).Returns(new AdHocEvalResultDto { Success = false, Error = "harvested eval data exists for this course" });
 
         // Act
-        var result = await _controller.CreateEvaluation(TestCourseId, request);
+        var result = await _controller.CreateEvaluation(TestCourseId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -1190,7 +1190,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.UpdateAdHocEvaluationAsync(TestCourseId, TestQuantId, request, Arg.Any<CancellationToken>()).Returns(evalResult);
 
         // Act
-        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request);
+        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -1214,7 +1214,7 @@ public sealed class CoursesControllerTests
         };
 
         // Act
-        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request);
+        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -1238,7 +1238,7 @@ public sealed class CoursesControllerTests
         };
 
         // Act
-        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request);
+        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -1264,7 +1264,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.UpdateAdHocEvaluationAsync(TestCourseId, TestQuantId, request, Arg.Any<CancellationToken>()).Returns(new AdHocEvalResultDto { Success = false, Error = "Evaluation not found" });
 
         // Act
-        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request);
+        var result = await _controller.UpdateEvaluation(TestCourseId, TestQuantId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -1285,7 +1285,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.DeleteAdHocEvaluationAsync(TestCourseId, TestQuantId, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId);
+        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
@@ -1298,7 +1298,7 @@ public sealed class CoursesControllerTests
         _courseServiceMock.GetCourseAsync(TestCourseId, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId);
+        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -1313,7 +1313,7 @@ public sealed class CoursesControllerTests
         _permissionServiceMock.IsTermEditableAsync(TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId);
+        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result);
@@ -1330,7 +1330,7 @@ public sealed class CoursesControllerTests
         _evalHarvestServiceMock.DeleteAdHocEvaluationAsync(TestCourseId, TestQuantId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId);
+        var result = await _controller.DeleteEvaluation(TestCourseId, TestQuantId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);

--- a/test/Effort/DashboardServiceTests.cs
+++ b/test/Effort/DashboardServiceTests.cs
@@ -100,9 +100,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(1, "445");   // regular → counted
         AddCourse(2, "456R");  // R-course → excluded
         AddCourse(3, "410");   // regular → counted
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, stats.TotalCourses);
     }
@@ -115,9 +115,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(3, "420");
         AddRecord(1, courseId: 1, personId: 100);  // course 1 has a record
         AddPerson(100);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(2, stats.CoursesWithoutInstructors);
     }
@@ -128,9 +128,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(1, "445");
         // Record exists but for a different term — should not count
         AddRecord(1, courseId: 1, personId: 100, termCode: OtherTermCode);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         // Course 1 has no records for TermCode, so it's "without instructors"
         Assert.Equal(1, stats.CoursesWithoutInstructors);
@@ -141,9 +141,9 @@ public sealed class DashboardServiceTests : IDisposable
     {
         AddCourse(1, "445");   // regular, no records → counted
         AddCourse(2, "456R");  // R-course, no records → NOT counted
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         // Only the regular course counts as "without instructors"
         Assert.Equal(1, stats.CoursesWithoutInstructors);
@@ -155,9 +155,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(1, "445", custDept: "DVM");
         AddCourse(2, "410", custDept: "VME");
         AddPerson(100, dept: "DVM");
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode, ["DVM"]);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ["DVM"], TestContext.Current.CancellationToken);
 
         Assert.Equal(1, stats.TotalCourses);
         Assert.Equal(1, stats.CoursesWithoutInstructors);
@@ -168,9 +168,9 @@ public sealed class DashboardServiceTests : IDisposable
     {
         AddCourse(1, "445");
         AddPerson(100);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var stats = await _service.GetDashboardStatsAsync(TermCode, []);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, [], TestContext.Current.CancellationToken);
 
         Assert.Equal(0, stats.TotalCourses);
         Assert.Equal(0, stats.TotalInstructors);
@@ -182,9 +182,9 @@ public sealed class DashboardServiceTests : IDisposable
     public async Task NoInstructorsAlerts_ExcludeRCourses()
     {
         AddCourse(1, "456R");  // R-course with no records → no alert
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode);
+        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         Assert.DoesNotContain(alerts, a => a.AlertType == "NoInstructors");
     }
@@ -193,9 +193,9 @@ public sealed class DashboardServiceTests : IDisposable
     public async Task NoInstructorsAlerts_IncludeNonRCourses()
     {
         AddCourse(1, "445");  // regular course with no records → alert
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode);
+        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         var noInstructorAlerts = alerts.Where(a => a.AlertType == "NoInstructors").ToList();
         Assert.Single(noInstructorAlerts);
@@ -208,9 +208,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(1, "445");
         AddRecord(1, courseId: 1, personId: 100);
         AddPerson(100);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode);
+        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         Assert.DoesNotContain(alerts, a => a.AlertType == "NoInstructors");
     }
@@ -221,9 +221,9 @@ public sealed class DashboardServiceTests : IDisposable
         AddCourse(1, "445");
         // Record exists but for a different term
         AddRecord(1, courseId: 1, personId: 100, termCode: OtherTermCode);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode);
+        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         // Course 1 has no records for TermCode → alert should fire
         Assert.Contains(alerts, a => a.AlertType == "NoInstructors" && a.EntityId == "1");
@@ -234,9 +234,9 @@ public sealed class DashboardServiceTests : IDisposable
     {
         AddCourse(1, "445", custDept: "DVM");  // DVM course, no records
         AddCourse(2, "410", custDept: "VME");  // VME course, no records
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ["DVM"]);
+        var alerts = await _service.GetDataHygieneAlertsAsync(TermCode, ["DVM"], TestContext.Current.CancellationToken);
 
         var noInstructorAlerts = alerts.Where(a => a.AlertType == "NoInstructors").ToList();
         Assert.Single(noInstructorAlerts);
@@ -247,7 +247,7 @@ public sealed class DashboardServiceTests : IDisposable
     public async Task Stats_NoCourses_ReturnsZeroCounts()
     {
         // No courses seeded — empty term
-        var stats = await _service.GetDashboardStatsAsync(TermCode);
+        var stats = await _service.GetDashboardStatsAsync(TermCode, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, stats.TotalCourses);
         Assert.Equal(0, stats.CoursesWithoutInstructors);

--- a/test/Effort/EffortRecordServiceTests.cs
+++ b/test/Effort/EffortRecordServiceTests.cs
@@ -142,10 +142,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 40
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -170,10 +170,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Notes = "Test notes"
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -195,10 +195,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 40
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -209,7 +209,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task GetEffortRecordAsync_ReturnsNull_WhenNotFound()
     {
         // Act
-        var result = await _service.GetEffortRecordAsync(999);
+        var result = await _service.GetEffortRecordAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -230,10 +230,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 40
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -257,10 +257,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 40
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -284,10 +284,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 40
         };
         _context.Records.Add(record);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEffortRecordAsync(1);
+        var result = await _service.GetEffortRecordAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -316,7 +316,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, warning) = await _service.CreateEffortRecordAsync(request);
+        var (result, warning) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -353,7 +353,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Failed to create instructor for PersonId 9999", ex.Message);
         Assert.Contains("Person with PersonId 9999 not found", ex.Message);
     }
@@ -374,7 +374,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Course 9999 not found", ex.Message);
     }
 
@@ -394,7 +394,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Effort type 'OLD' not found or inactive", ex.Message);
     }
 
@@ -414,7 +414,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Role 3 not found or inactive", ex.Message);
     }
 
@@ -431,7 +431,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -445,7 +445,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", ex.Message);
     }
 
@@ -463,7 +463,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -476,13 +476,13 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (_, warning) = await _service.CreateEffortRecordAsync(request);
+        var (_, warning) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(warning);
         Assert.Contains("Role was updated", warning);
 
-        var existingRecord = await _context.Records.FindAsync(10);
+        var existingRecord = await _context.Records.FindAsync(new object?[] { 10 }, TestContext.Current.CancellationToken);
         Assert.Equal(2, existingRecord!.RoleId);
     }
 
@@ -490,9 +490,9 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task CreateEffortRecordAsync_ClearsEffortVerified_OnPerson()
     {
         // Arrange
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         person.EffortVerified = DateTime.Now;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -505,10 +505,10 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        await _service.CreateEffortRecordAsync(request);
+        await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.Null(updatedPerson.EffortVerified);
     }
 
@@ -516,10 +516,10 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task CreateEffortRecordAsync_PreservesEffortVerified_OnSelfEdit()
     {
         // Arrange: Set up a verified instructor
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         var originalVerificationDate = DateTime.Now.AddDays(-1);
         person.EffortVerified = originalVerificationDate;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Mock the current user as the instructor themselves (self-edit)
         var selfUser = new AaudUser { AaudUserId = TestPersonId, MothraId = "selfinstructor" };
@@ -536,10 +536,10 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        await _service.CreateEffortRecordAsync(request);
+        await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert: Verification should be preserved for self-edit
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(updatedPerson.EffortVerified);
         Assert.Equal(originalVerificationDate, updatedPerson.EffortVerified);
     }
@@ -554,7 +554,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             ChildCourseId = TestCourseId,
             RelationshipType = "Parent"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -568,7 +568,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Cannot add effort to a child course", ex.Message);
     }
 
@@ -584,7 +584,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             ChildCourseId = 2,
             RelationshipType = "Parent"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -597,7 +597,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert - parent course should accept effort
         Assert.NotNull(result);
@@ -620,7 +620,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("not allowed on DVM courses", ex.Message);
     }
 
@@ -640,7 +640,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("not allowed on 199/299 courses", ex.Message);
     }
 
@@ -660,7 +660,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.CreateEffortRecordAsync(request));
+            () => _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("not allowed on R courses", ex.Message);
     }
 
@@ -679,7 +679,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -717,10 +717,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             LastName = "Instructor",
             EffortDept = "VME"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - should catch the exception and continue successfully
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -747,7 +747,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortRecordRequest
         {
@@ -758,7 +758,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, warning) = await _service.UpdateEffortRecordAsync(1, request);
+        var (result, warning) = await _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -785,7 +785,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, _) = await _service.UpdateEffortRecordAsync(999, request);
+        var (result, _) = await _service.UpdateEffortRecordAsync(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -817,7 +817,7 @@ public sealed class EffortRecordServiceTests : IDisposable
                 Hours = 10
             }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortRecordRequest
         {
@@ -828,7 +828,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.UpdateEffortRecordAsync(1, request));
+            () => _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", ex.Message);
     }
 
@@ -846,7 +846,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Try to change to NDV which is not allowed on DVM
         var request = new UpdateEffortRecordRequest
@@ -858,7 +858,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.UpdateEffortRecordAsync(1, request));
+            () => _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("not allowed on DVM courses", ex.Message);
     }
 
@@ -866,9 +866,9 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task UpdateEffortRecordAsync_ClearsEffortVerified_OnPerson()
     {
         // Arrange: Set up a verified instructor with an existing record
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         person.EffortVerified = DateTime.Now;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -880,7 +880,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortRecordRequest
         {
@@ -890,10 +890,10 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        await _service.UpdateEffortRecordAsync(1, request);
+        await _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.Null(updatedPerson.EffortVerified);
     }
 
@@ -901,10 +901,10 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task UpdateEffortRecordAsync_PreservesEffortVerified_OnSelfEdit()
     {
         // Arrange: Set up a verified instructor with an existing record
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         var originalVerificationDate = DateTime.Now.AddDays(-1);
         person.EffortVerified = originalVerificationDate;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -916,7 +916,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Mock the current user as the instructor themselves (self-edit)
         var selfUser = new AaudUser { AaudUserId = TestPersonId, MothraId = "selfinstructor" };
@@ -930,10 +930,10 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        await _service.UpdateEffortRecordAsync(1, request);
+        await _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert: Verification should be preserved for self-edit
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(updatedPerson.EffortVerified);
         Assert.Equal(originalVerificationDate, updatedPerson.EffortVerified);
     }
@@ -956,14 +956,14 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - pass null for originalModifiedDate (legacy record)
-        var result = await _service.DeleteEffortRecordAsync(1, null);
+        var result = await _service.DeleteEffortRecordAsync(1, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.Records.FindAsync(1));
+        Assert.Null(await _context.Records.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken));
 
         await _auditServiceMock.Received(1).LogRecordChangeAsync(
                 1, TestTermCode, EffortAuditActions.DeleteEffort,
@@ -974,7 +974,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task DeleteEffortRecordAsync_ReturnsFalse_WhenNotFound()
     {
         // Act
-        var result = await _service.DeleteEffortRecordAsync(999, null);
+        var result = await _service.DeleteEffortRecordAsync(999, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -984,9 +984,9 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task DeleteEffortRecordAsync_ClearsEffortVerified_OnPerson()
     {
         // Arrange
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         person.EffortVerified = DateTime.Now;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -998,13 +998,13 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - pass null for originalModifiedDate (legacy record)
-        await _service.DeleteEffortRecordAsync(1, null);
+        await _service.DeleteEffortRecordAsync(1, null, TestContext.Current.CancellationToken);
 
         // Assert
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.Null(updatedPerson.EffortVerified);
     }
 
@@ -1012,10 +1012,10 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task DeleteEffortRecordAsync_PreservesEffortVerified_OnSelfEdit()
     {
         // Arrange: Set up a verified instructor with an existing record
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         var originalVerificationDate = DateTime.Now.AddDays(-1);
         person.EffortVerified = originalVerificationDate;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -1027,17 +1027,17 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Mock the current user as the instructor themselves (self-edit)
         var selfUser = new AaudUser { AaudUserId = TestPersonId, MothraId = "selfinstructor" };
         _userHelperMock.GetCurrentUser().Returns(selfUser);
 
         // Act - pass null for originalModifiedDate (legacy record)
-        await _service.DeleteEffortRecordAsync(1, null);
+        await _service.DeleteEffortRecordAsync(1, null, TestContext.Current.CancellationToken);
 
         // Assert: Verification should be preserved for self-edit
-        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var updatedPerson = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(updatedPerson.EffortVerified);
         Assert.Equal(originalVerificationDate, updatedPerson.EffortVerified);
     }
@@ -1062,7 +1062,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = originalDate
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Request with a DIFFERENT ModifiedDate (simulating stale data)
         var request = new UpdateEffortRecordRequest
@@ -1075,7 +1075,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<ConcurrencyConflictException>(
-            () => _service.UpdateEffortRecordAsync(1, request));
+            () => _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("modified by another user", ex.Message);
     }
 
@@ -1095,7 +1095,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = originalDate
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Request with the SAME ModifiedDate
         var request = new UpdateEffortRecordRequest
@@ -1107,7 +1107,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, _) = await _service.UpdateEffortRecordAsync(1, request);
+        var (result, _) = await _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -1129,7 +1129,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = null // Legacy record
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Request with NULL OriginalModifiedDate
         var request = new UpdateEffortRecordRequest
@@ -1141,7 +1141,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act
-        var (result, _) = await _service.UpdateEffortRecordAsync(1, request);
+        var (result, _) = await _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -1163,7 +1163,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = DateTime.Now // Record was updated after loading
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Request still has NULL (thinks record is legacy)
         var request = new UpdateEffortRecordRequest
@@ -1176,7 +1176,7 @@ public sealed class EffortRecordServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<ConcurrencyConflictException>(
-            () => _service.UpdateEffortRecordAsync(1, request));
+            () => _service.UpdateEffortRecordAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("modified by another user", ex.Message);
     }
 
@@ -1196,15 +1196,15 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = originalDate
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert: Try to delete with stale date
         var ex = await Assert.ThrowsAsync<ConcurrencyConflictException>(
-            () => _service.DeleteEffortRecordAsync(1, new DateTime(2024, 1, 14, 10, 30, 0, DateTimeKind.Local)));
+            () => _service.DeleteEffortRecordAsync(1, new DateTime(2024, 1, 14, 10, 30, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("modified by another user", ex.Message);
 
         // Verify record was NOT deleted
-        Assert.NotNull(await _context.Records.FindAsync(1));
+        Assert.NotNull(await _context.Records.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -1223,14 +1223,14 @@ public sealed class EffortRecordServiceTests : IDisposable
             Hours = 20,
             ModifiedDate = originalDate
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.DeleteEffortRecordAsync(1, originalDate);
+        var result = await _service.DeleteEffortRecordAsync(1, originalDate, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.Records.FindAsync(1));
+        Assert.Null(await _context.Records.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -1250,10 +1250,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             RoleId = 1,
             Hours = 20
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode);
+        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.ExistingCourses);
@@ -1270,10 +1270,10 @@ public sealed class EffortRecordServiceTests : IDisposable
             ChildCourseId = 2,
             RelationshipType = "Parent"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode);
+        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert: 4 courses seeded, 1 excluded as child = 3 remaining
         Assert.Equal(3, result.AllCourses.Count);
@@ -1284,7 +1284,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task GetAvailableCoursesAsync_PopulatesClassificationFlags()
     {
         // Act
-        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode);
+        var result = await _service.GetAvailableCoursesAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert: Course 1 (APC 410) - IsDvm=false (non-DVM subject code)
         var apcCourse = result.AllCourses.First(c => c.Id == TestCourseId);
@@ -1319,7 +1319,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task GetEffortTypeOptionsAsync_ReturnsActiveTypesOnly()
     {
         // Act
-        var result = await _service.GetEffortTypeOptionsAsync();
+        var result = await _service.GetEffortTypeOptionsAsync(TestContext.Current.CancellationToken);
 
         // Assert: 8 seeded, 1 inactive (OLD) = 7 active
         Assert.Equal(7, result.Count);
@@ -1334,7 +1334,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task GetRoleOptionsAsync_ReturnsActiveRolesOnly()
     {
         // Act
-        var result = await _service.GetRoleOptionsAsync();
+        var result = await _service.GetRoleOptionsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -1345,7 +1345,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task GetRoleOptionsAsync_ReturnsSortedBySortOrder()
     {
         // Act
-        var result = await _service.GetRoleOptionsAsync();
+        var result = await _service.GetRoleOptionsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("Instructor of Record", result[0].Description);
@@ -1360,7 +1360,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task CanEditTermAsync_ReturnsTrue_WhenTermIsOpened()
     {
         // Act
-        var result = await _service.CanEditTermAsync(TestTermCode);
+        var result = await _service.CanEditTermAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
@@ -1370,7 +1370,7 @@ public sealed class EffortRecordServiceTests : IDisposable
     public async Task CanEditTermAsync_ReturnsFalse_WhenTermNotFound()
     {
         // Act
-        var result = await _service.CanEditTermAsync(999999);
+        var result = await _service.CanEditTermAsync(999999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -1383,14 +1383,14 @@ public sealed class EffortRecordServiceTests : IDisposable
         // ClosedDate makes status "Closed"
         var closedTerm = new EffortTerm { TermCode = 202301, OpenedDate = DateTime.Now.AddDays(-30), ClosedDate = DateTime.Now.AddDays(-1) };
         _context.Terms.Add(closedTerm);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _userHelperMock.HasPermission(
             Arg.Any<RAPSContext>(), Arg.Any<AaudUser>(), EffortPermissions.EditWhenClosed)
             .Returns(false);
 
         // Act
-        var result = await _service.CanEditTermAsync(202301);
+        var result = await _service.CanEditTermAsync(202301, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -1403,14 +1403,14 @@ public sealed class EffortRecordServiceTests : IDisposable
         // ClosedDate makes status "Closed"
         var closedTerm = new EffortTerm { TermCode = 202301, OpenedDate = DateTime.Now.AddDays(-30), ClosedDate = DateTime.Now.AddDays(-1) };
         _context.Terms.Add(closedTerm);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _userHelperMock.HasPermission(
             Arg.Any<RAPSContext>(), Arg.Any<AaudUser>(), EffortPermissions.EditWhenClosed)
             .Returns(true);
 
         // Act
-        var result = await _service.CanEditTermAsync(202301);
+        var result = await _service.CanEditTermAsync(202301, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
@@ -1463,7 +1463,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             EffortDept = "VME"
         });
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -1476,7 +1476,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act - create the first non-R-course effort record
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert - verify the effort record was created
         Assert.NotNull(result);
@@ -1567,7 +1567,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             Crn = "12345"
         });
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -1580,7 +1580,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act - add a second non-R-course effort record
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert - verify the effort record was created
         Assert.NotNull(result);
@@ -1609,7 +1609,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             EffortDept = "VME"
         });
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -1622,7 +1622,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act - add an R-course as the first effort record
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert - verify the effort record was created
         Assert.NotNull(result);
@@ -1664,7 +1664,7 @@ public sealed class EffortRecordServiceTests : IDisposable
             CustDept = "UNK"
         };
         _context.Courses.Add(genericRCourse);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortRecordRequest
         {
@@ -1677,7 +1677,7 @@ public sealed class EffortRecordServiceTests : IDisposable
         };
 
         // Act - add the generic R-course as the first effort record
-        var (result, _) = await _service.CreateEffortRecordAsync(request);
+        var (result, _) = await _service.CreateEffortRecordAsync(request, TestContext.Current.CancellationToken);
 
         // Assert - verify the effort record was created
         Assert.NotNull(result);

--- a/test/Effort/EffortRecordsControllerTests.cs
+++ b/test/Effort/EffortRecordsControllerTests.cs
@@ -89,7 +89,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanViewPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetRecord(TestRecordId);
+        var result = await _controller.GetRecord(TestRecordId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -104,7 +104,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetRecord(999);
+        var result = await _controller.GetRecord(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -119,7 +119,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanViewPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetRecord(TestRecordId);
+        var result = await _controller.GetRecord(TestRecordId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -149,7 +149,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.CreateEffortRecordAsync(request, Arg.Any<CancellationToken>()).Returns((record, (string?)null));
 
         // Act
-        var result = await _controller.CreateRecord(request);
+        var result = await _controller.CreateRecord(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -174,7 +174,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanEditPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.CreateRecord(request);
+        var result = await _controller.CreateRecord(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -199,7 +199,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.CreateEffortRecordAsync(request, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Duplicate record"));
 
         // Act
-        var result = await _controller.CreateRecord(request);
+        var result = await _controller.CreateRecord(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -225,7 +225,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.CreateEffortRecordAsync(request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("DB error"));
 
         // Act
-        var result = await _controller.CreateRecord(request);
+        var result = await _controller.CreateRecord(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -254,7 +254,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.UpdateEffortRecordAsync(TestRecordId, request, Arg.Any<CancellationToken>()).Returns((existingRecord, (string?)null));
 
         // Act
-        var result = await _controller.UpdateRecord(TestRecordId, request);
+        var result = await _controller.UpdateRecord(TestRecordId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -274,7 +274,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.UpdateRecord(999, request);
+        var result = await _controller.UpdateRecord(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -296,7 +296,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanEditPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.UpdateRecord(TestRecordId, request);
+        var result = await _controller.UpdateRecord(TestRecordId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -321,7 +321,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.UpdateEffortRecordAsync(TestRecordId, request, Arg.Any<CancellationToken>()).Throws(new ConcurrencyConflictException(TestRecordId));
 
         // Act
-        var result = await _controller.UpdateRecord(TestRecordId, request);
+        var result = await _controller.UpdateRecord(TestRecordId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -344,7 +344,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.DeleteEffortRecordAsync(TestRecordId, Arg.Any<DateTime?>(), Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.DeleteRecord(TestRecordId, null);
+        var result = await _controller.DeleteRecord(TestRecordId, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
@@ -357,7 +357,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetEffortRecordAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.DeleteRecord(999, null);
+        var result = await _controller.DeleteRecord(999, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -374,7 +374,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanEditPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeleteRecord(TestRecordId, null);
+        var result = await _controller.DeleteRecord(TestRecordId, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -393,7 +393,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.DeleteEffortRecordAsync(TestRecordId, staleModifiedDate, Arg.Any<CancellationToken>()).Throws(new ConcurrencyConflictException(TestRecordId));
 
         // Act
-        var result = await _controller.DeleteRecord(TestRecordId, staleModifiedDate);
+        var result = await _controller.DeleteRecord(TestRecordId, staleModifiedDate, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<ConflictObjectResult>(result);
@@ -420,7 +420,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetAvailableCoursesAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(courses);
 
         // Act
-        var result = await _controller.GetAvailableCourses(TestPersonId, TestTermCode);
+        var result = await _controller.GetAvailableCourses(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -435,7 +435,7 @@ public sealed class EffortRecordsControllerTests
         _permissionServiceMock.CanViewPersonEffortAsync(TestPersonId, TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetAvailableCourses(TestPersonId, TestTermCode);
+        var result = await _controller.GetAvailableCourses(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -458,7 +458,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetEffortTypeOptionsAsync(Arg.Any<CancellationToken>()).Returns(effortTypes);
 
         // Act
-        var result = await _controller.GetEffortTypes();
+        var result = await _controller.GetEffortTypes(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -483,7 +483,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.GetRoleOptionsAsync(Arg.Any<CancellationToken>()).Returns(roles);
 
         // Act
-        var result = await _controller.GetRoles();
+        var result = await _controller.GetRoles(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -502,7 +502,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.CanEditTermAsync(TestTermCode, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.CanEditTerm(TestTermCode);
+        var result = await _controller.CanEditTerm(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -516,7 +516,7 @@ public sealed class EffortRecordsControllerTests
         _recordServiceMock.CanEditTermAsync(TestTermCode, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.CanEditTerm(TestTermCode);
+        var result = await _controller.CanEditTerm(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/test/Effort/EffortTypeServiceTests.cs
+++ b/test/Effort/EffortTypeServiceTests.cs
@@ -158,10 +158,10 @@ public sealed class EffortTypeServiceTests : IDisposable
             new EffortType { Id = "AAA", Description = "Alpha Type", IsActive = true },
             new EffortType { Id = "MMM", Description = "Middle Type", IsActive = false }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortTypes = await _effortTypeService.GetEffortTypesAsync();
+        var effortTypes = await _effortTypeService.GetEffortTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, effortTypes.Count);
@@ -178,10 +178,10 @@ public sealed class EffortTypeServiceTests : IDisposable
             new EffortType { Id = "ACT", Description = "Active Type", IsActive = true },
             new EffortType { Id = "INA", Description = "Inactive Type", IsActive = false }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortTypes = await _effortTypeService.GetEffortTypesAsync(activeOnly: true);
+        var effortTypes = await _effortTypeService.GetEffortTypesAsync(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(effortTypes);
@@ -193,7 +193,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     public async Task GetEffortTypesAsync_ReturnsEmptyList_WhenNoEffortTypesExist()
     {
         // Act
-        var effortTypes = await _effortTypeService.GetEffortTypesAsync();
+        var effortTypes = await _effortTypeService.GetEffortTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(effortTypes);
@@ -206,7 +206,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         await CreateEffortTypeWithRecordsAsync("TST", "Test Type", recordCount: 2);
 
         // Act
-        var effortTypes = await _effortTypeService.GetEffortTypesAsync();
+        var effortTypes = await _effortTypeService.GetEffortTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(effortTypes);
@@ -219,10 +219,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "NEW", Description = "Unused Type", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortTypes = await _effortTypeService.GetEffortTypesAsync();
+        var effortTypes = await _effortTypeService.GetEffortTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(effortTypes);
@@ -239,10 +239,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "LEC", Description = "Lecture", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortType = await _effortTypeService.GetEffortTypeAsync("LEC");
+        var effortType = await _effortTypeService.GetEffortTypeAsync("LEC", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(effortType);
@@ -255,7 +255,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     public async Task GetEffortTypeAsync_ReturnsNull_WhenNotFound()
     {
         // Act
-        var effortType = await _effortTypeService.GetEffortTypeAsync("XXX");
+        var effortType = await _effortTypeService.GetEffortTypeAsync("XXX", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(effortType);
@@ -268,7 +268,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         await CreateEffortTypeWithRecordsAsync("CLI", "Clinical");
 
         // Act
-        var result = await _effortTypeService.GetEffortTypeAsync("CLI");
+        var result = await _effortTypeService.GetEffortTypeAsync("CLI", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -281,10 +281,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "LEC", Description = "Lecture", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortType = await _effortTypeService.GetEffortTypeAsync("lec");
+        var effortType = await _effortTypeService.GetEffortTypeAsync("lec", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(effortType);
@@ -296,10 +296,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "LEC", Description = "Lecture", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var effortType = await _effortTypeService.GetEffortTypeAsync("  LEC  ");
+        var effortType = await _effortTypeService.GetEffortTypeAsync("  LEC  ", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(effortType);
@@ -326,7 +326,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.CreateEffortTypeAsync(request);
+        var result = await _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -336,7 +336,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         Assert.Equal(0, result.UsageCount);
         Assert.True(result.CanDelete);
 
-        var savedEffortType = await _context.EffortTypes.FirstOrDefaultAsync(s => s.Id == "NEW");
+        var savedEffortType = await _context.EffortTypes.FirstOrDefaultAsync(s => s.Id == "NEW", TestContext.Current.CancellationToken);
         Assert.NotNull(savedEffortType);
     }
 
@@ -345,13 +345,13 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "DUP", Description = "Existing", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateEffortTypeRequest { Id = "DUP", Description = "Duplicate" };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _effortTypeService.CreateEffortTypeAsync(request));
+            () => _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", exception.Message);
     }
 
@@ -362,11 +362,11 @@ public sealed class EffortTypeServiceTests : IDisposable
         var request = new CreateEffortTypeRequest { Id = "low", Description = "Lowercase Test" };
 
         // Act
-        var result = await _effortTypeService.CreateEffortTypeAsync(request);
+        var result = await _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("LOW", result.Id);
-        var savedEffortType = await _context.EffortTypes.FirstOrDefaultAsync(s => s.Id == "LOW");
+        var savedEffortType = await _context.EffortTypes.FirstOrDefaultAsync(s => s.Id == "LOW", TestContext.Current.CancellationToken);
         Assert.NotNull(savedEffortType);
     }
 
@@ -377,7 +377,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         var request = new CreateEffortTypeRequest { Id = "  PAD  ", Description = "  Padded Description  " };
 
         // Act
-        var result = await _effortTypeService.CreateEffortTypeAsync(request);
+        var result = await _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("PAD", result.Id);
@@ -391,7 +391,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         var request = new CreateEffortTypeRequest { Id = "AUD", Description = "Audited Type" };
 
         // Act
-        await _effortTypeService.CreateEffortTypeAsync(request);
+        await _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddEffortTypeChangeAudit(
@@ -417,7 +417,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.CreateEffortTypeAsync(request);
+        var result = await _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.UsesWeeks);
@@ -436,7 +436,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "UPD", Description = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -450,7 +450,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.UpdateEffortTypeAsync("UPD", request);
+        var result = await _effortTypeService.UpdateEffortTypeAsync("UPD", request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -475,7 +475,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.UpdateEffortTypeAsync("XXX", request);
+        var result = await _effortTypeService.UpdateEffortTypeAsync("XXX", request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -486,7 +486,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "UPP", Description = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -500,7 +500,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.UpdateEffortTypeAsync("upp", request);
+        var result = await _effortTypeService.UpdateEffortTypeAsync("upp", request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -512,7 +512,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "AUD", Description = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -526,7 +526,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        await _effortTypeService.UpdateEffortTypeAsync("AUD", request);
+        await _effortTypeService.UpdateEffortTypeAsync("AUD", request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddEffortTypeChangeAudit(
@@ -541,7 +541,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "TRM", Description = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -555,7 +555,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.UpdateEffortTypeAsync("TRM", request);
+        var result = await _effortTypeService.UpdateEffortTypeAsync("TRM", request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -577,7 +577,7 @@ public sealed class EffortTypeServiceTests : IDisposable
             AllowedOn199299 = true,
             AllowedOnRCourses = true
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -591,7 +591,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         };
 
         // Act
-        var result = await _effortTypeService.UpdateEffortTypeAsync("FLG", request);
+        var result = await _effortTypeService.UpdateEffortTypeAsync("FLG", request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -612,14 +612,14 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "DEL", Description = "Deletable", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _effortTypeService.DeleteEffortTypeAsync("DEL");
+        var result = await _effortTypeService.DeleteEffortTypeAsync("DEL", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        var deletedEffortType = await _context.EffortTypes.FindAsync("DEL");
+        var deletedEffortType = await _context.EffortTypes.FindAsync(new object?[] { "DEL" }, TestContext.Current.CancellationToken);
         Assert.Null(deletedEffortType);
     }
 
@@ -630,11 +630,11 @@ public sealed class EffortTypeServiceTests : IDisposable
         var effortType = await CreateEffortTypeWithRecordsAsync("REF", "Referenced Type");
 
         // Act
-        var result = await _effortTypeService.DeleteEffortTypeAsync(effortType.Id);
+        var result = await _effortTypeService.DeleteEffortTypeAsync(effortType.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        var stillExists = await _context.EffortTypes.FindAsync(effortType.Id);
+        var stillExists = await _context.EffortTypes.FindAsync(new object?[] { effortType.Id }, TestContext.Current.CancellationToken);
         Assert.NotNull(stillExists);
     }
 
@@ -642,7 +642,7 @@ public sealed class EffortTypeServiceTests : IDisposable
     public async Task DeleteEffortTypeAsync_ReturnsFalse_WhenNotFound()
     {
         // Act
-        var result = await _effortTypeService.DeleteEffortTypeAsync("XXX");
+        var result = await _effortTypeService.DeleteEffortTypeAsync("XXX", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -653,10 +653,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "AUD", Description = "To Delete", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _effortTypeService.DeleteEffortTypeAsync("AUD");
+        await _effortTypeService.DeleteEffortTypeAsync("AUD", TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddEffortTypeChangeAudit(
@@ -671,14 +671,14 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "LOW", Description = "Lowercase", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _effortTypeService.DeleteEffortTypeAsync("low");
+        var result = await _effortTypeService.DeleteEffortTypeAsync("low", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        var deleted = await _context.EffortTypes.FindAsync("LOW");
+        var deleted = await _context.EffortTypes.FindAsync(new object?[] { "LOW" }, TestContext.Current.CancellationToken);
         Assert.Null(deleted);
     }
 
@@ -691,10 +691,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "CAN", Description = "Unused", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync("CAN");
+        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync("CAN", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -707,7 +707,7 @@ public sealed class EffortTypeServiceTests : IDisposable
         var effortType = await CreateEffortTypeWithRecordsAsync("USE", "Used Type");
 
         // Act
-        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync(effortType.Id);
+        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync(effortType.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canDelete);
@@ -718,10 +718,10 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange
         _context.EffortTypes.Add(new EffortType { Id = "UPP", Description = "Uppercase", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync("upp");
+        var canDelete = await _effortTypeService.CanDeleteEffortTypeAsync("upp", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -736,14 +736,14 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange - create a effort type with uppercase ID
         _context.EffortTypes.Add(new EffortType { Id = "DUP", Description = "Existing", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Try to create with lowercase version of same ID
         var request = new CreateEffortTypeRequest { Id = "dup", Description = "Duplicate Lowercase" };
 
         // Act & Assert - should fail because IDs are case-insensitive
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _effortTypeService.CreateEffortTypeAsync(request));
+            () => _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", exception.Message);
     }
 
@@ -752,14 +752,14 @@ public sealed class EffortTypeServiceTests : IDisposable
     {
         // Arrange - create a effort type with lowercase ID
         _context.EffortTypes.Add(new EffortType { Id = "ABC", Description = "Existing", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Try to create with mixed case version
         var request = new CreateEffortTypeRequest { Id = "AbC", Description = "Mixed Case" };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _effortTypeService.CreateEffortTypeAsync(request));
+            () => _effortTypeService.CreateEffortTypeAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", exception.Message);
     }
 

--- a/test/Effort/EffortTypesControllerIntegrationTests.cs
+++ b/test/Effort/EffortTypesControllerIntegrationTests.cs
@@ -64,7 +64,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         SetupUserWithManageEffortTypesPermission();
 
         // Act
-        var result = await _controller.GetEffortTypes();
+        var result = await _controller.GetEffortTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -86,7 +86,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         SetupUserWithManageEffortTypesPermission();
 
         // Act
-        var result = await _controller.GetEffortTypes(activeOnly: true);
+        var result = await _controller.GetEffortTypes(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -105,10 +105,10 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
 
         // Add an effort record referencing LEC
         EffortContext.Records.Add(CreateTestEffortRecord(1, "LEC"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _controller.GetEffortTypes();
+        var result = await _controller.GetEffortTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -209,7 +209,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         Assert.True(effortType.CanDelete);
 
         // Verify persisted in database
-        var fromDb = await EffortContext.EffortTypes.FindAsync("TST");
+        var fromDb = await EffortContext.EffortTypes.FindAsync(new object?[] { "TST" }, TestContext.Current.CancellationToken);
         Assert.NotNull(fromDb);
         Assert.Equal("Test Session", fromDb.Description);
     }
@@ -329,7 +329,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         Assert.False(effortType.AllowedOnRCourses);
 
         // Verify persisted in database
-        var fromDb = await EffortContext.EffortTypes.FindAsync("LEC");
+        var fromDb = await EffortContext.EffortTypes.FindAsync(new object?[] { "LEC" }, TestContext.Current.CancellationToken);
         Assert.NotNull(fromDb);
         Assert.Equal("Updated Lecture", fromDb.Description);
         Assert.True(fromDb.UsesWeeks);
@@ -401,7 +401,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.DeleteEffortType("DEL", CancellationToken.None);
@@ -410,7 +410,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         Assert.IsType<NoContentResult>(result);
 
         // Verify removed from database
-        var fromDb = await EffortContext.EffortTypes.FindAsync("DEL");
+        var fromDb = await EffortContext.EffortTypes.FindAsync(new object?[] { "DEL" }, TestContext.Current.CancellationToken);
         Assert.Null(fromDb);
     }
 
@@ -435,7 +435,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
 
         // Add an effort record referencing LEC
         EffortContext.Records.Add(CreateTestEffortRecord(100, "LEC"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.DeleteEffortType("LEC", CancellationToken.None);
@@ -458,7 +458,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.DeleteEffortType("del", CancellationToken.None);
@@ -496,7 +496,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
 
         // Add effort records
         EffortContext.Records.Add(CreateTestEffortRecord(200, "LEC"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.CanDeleteEffortType("LEC", CancellationToken.None);
@@ -560,7 +560,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - The controller now uses query parameter [FromQuery] to handle "/" in IDs
         var result = await _controller.GetEffortType("D/L", CancellationToken.None);
@@ -585,7 +585,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateEffortTypeRequest
         {
@@ -621,7 +621,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.DeleteEffortType("T/D", CancellationToken.None);
@@ -630,7 +630,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
         Assert.IsType<NoContentResult>(result);
 
         // Verify deleted
-        var fromDb = await EffortContext.EffortTypes.FindAsync("T/D");
+        var fromDb = await EffortContext.EffortTypes.FindAsync(new object?[] { "T/D" }, TestContext.Current.CancellationToken);
         Assert.Null(fromDb);
     }
 
@@ -647,7 +647,7 @@ public class EffortTypesControllerIntegrationTests : EffortIntegrationTestBase
             UsesWeeks = false,
             IsActive = true
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.CanDeleteEffortType("T-D", CancellationToken.None);

--- a/test/Effort/EffortTypesControllerTests.cs
+++ b/test/Effort/EffortTypesControllerTests.cs
@@ -60,7 +60,7 @@ public sealed class EffortTypesControllerTests
         _effortTypeServiceMock.GetEffortTypesAsync(false, Arg.Any<CancellationToken>()).Returns(effortTypes);
 
         // Act
-        var result = await _controller.GetEffortTypes();
+        var result = await _controller.GetEffortTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -79,7 +79,7 @@ public sealed class EffortTypesControllerTests
         _effortTypeServiceMock.GetEffortTypesAsync(true, Arg.Any<CancellationToken>()).Returns(effortTypes);
 
         // Act
-        var result = await _controller.GetEffortTypes(activeOnly: true);
+        var result = await _controller.GetEffortTypes(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -481,7 +481,7 @@ public sealed class EffortTypesControllerTests
         // Arrange
         _effortTypeServiceMock.GetEffortTypesAsync(false, Arg.Any<CancellationToken>()).Returns(new List<EffortTypeDto>());
         // Act
-        var result = await _controller.GetEffortTypes();
+        var result = await _controller.GetEffortTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/test/Effort/EvalHarvestServiceTests.cs
+++ b/test/Effort/EvalHarvestServiceTests.cs
@@ -256,7 +256,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     [Fact]
     public async Task GetCourseEvaluationStatus_NoEvalData_ReturnsNoneStatus()
     {
-        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId);
+        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId, TestContext.Current.CancellationToken);
 
         Assert.True(result.CanEditAdHoc);
         Assert.Single(result.Instructors);
@@ -275,11 +275,11 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = false });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId, Mean = 4.5, Respondents = 10 });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId);
+        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId, TestContext.Current.CancellationToken);
 
         Assert.False(result.CanEditAdHoc);
         var eval = result.Instructors[0].Evaluations[0];
@@ -296,11 +296,11 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = true });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId, Mean = 3.0, Respondents = 5 });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId);
+        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId, TestContext.Current.CancellationToken);
 
         Assert.True(result.CanEditAdHoc);
         var eval = result.Instructors[0].Evaluations[0];
@@ -317,7 +317,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // Add a second instructor on the child course
         _effortContext.Persons.Add(new EffortPerson { PersonId = 1001, TermCode = TestTermCode, FirstName = "Child", LastName = "Instructor", EffortDept = "DVM" });
         _effortContext.Records.Add(new EffortRecord { Id = 2, CourseId = TestChildCourseId, PersonId = 1001, TermCode = TestTermCode, EffortTypeId = "LEC", RoleId = 1, Crn = TestChildCrn.ToString() });
-        await _effortContext.SaveChangesAsync();
+        await _effortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.People.Add(new Person
         {
@@ -331,9 +331,9 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             ClientId = "C1001",
             Current = 1
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId);
+        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.Courses.Count);
         Assert.Equal(2, result.Instructors.Count);
@@ -346,7 +346,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     public async Task GetCourseEvaluationStatus_CourseNotFound_ThrowsInvalidOperationException()
     {
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.GetCourseEvaluationStatusAsync(9999));
+            () => _service.GetCourseEvaluationStatusAsync(9999, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -355,9 +355,9 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // Harvested eval data on the course — even with no eval data for the specific instructor,
         // canEditAdHoc should be false and "None" entries should not be editable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = false });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId);
+        var result = await _service.GetCourseEvaluationStatusAsync(TestCourseId, TestContext.Current.CancellationToken);
 
         Assert.False(result.CanEditAdHoc);
         var eval = result.Instructors[0].Evaluations[0];
@@ -383,25 +383,25 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 10
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.NotNull(result.QuantId);
 
         // Verify records created in evalHarvest DB
-        var ehCourse = await _evalContext.Courses.FirstOrDefaultAsync(c => c.Crn == TestCrn && c.TermCode == TestTermCode);
+        var ehCourse = await _evalContext.Courses.FirstOrDefaultAsync(c => c.Crn == TestCrn && c.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.NotNull(ehCourse);
         Assert.True(ehCourse.IsAdHoc);
 
-        var ehPerson = await _evalContext.People.FirstOrDefaultAsync(p => p.MailId == TestMailId);
+        var ehPerson = await _evalContext.People.FirstOrDefaultAsync(p => p.MailId == TestMailId, TestContext.Current.CancellationToken);
         Assert.NotNull(ehPerson);
         Assert.Equal(TestMothraId, ehPerson.MothraId);
 
-        var question = await _evalContext.Questions.FirstOrDefaultAsync(q => q.Crn == TestCrn && q.TermCode == TestTermCode);
+        var question = await _evalContext.Questions.FirstOrDefaultAsync(q => q.Crn == TestCrn && q.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.NotNull(question);
         Assert.True(question.IsOverall);
 
-        var quant = await _evalContext.Quants.FirstOrDefaultAsync(q => q.QuantId == result.QuantId);
+        var quant = await _evalContext.Quants.FirstOrDefaultAsync(q => q.QuantId == result.QuantId, TestContext.Current.CancellationToken);
         Assert.NotNull(quant);
         Assert.Equal(20, quant.Respondents);
         Assert.Equal(TestMailId, quant.MailId);
@@ -421,7 +421,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("rating count", result.Error);
@@ -441,7 +441,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("Course not found", result.Error);
@@ -452,7 +452,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     {
         // Seed an effort course whose CRN is non-numeric (data quality edge case)
         _effortContext.Courses.Add(new EffortCourse { Id = 100, TermCode = TestTermCode, Crn = "INVALID", SubjCode = "DVM", CrseNumb = "500", SeqNumb = "001", Enrollment = 10, Units = 4, CustDept = "DVM" });
-        await _effortContext.SaveChangesAsync();
+        await _effortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -465,7 +465,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("Invalid CRN", result.Error);
@@ -476,7 +476,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     {
         // Seed non-adhoc course record (harvested eval data)
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = false });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -489,7 +489,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("harvested eval data exists", result.Error);
@@ -509,7 +509,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("Instructor not found", result.Error);
@@ -531,7 +531,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             ClientId = "C2000",
             Current = 1
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -544,7 +544,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("not associated with this course", result.Error);
@@ -566,10 +566,10 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             ClientId = "C3000",
             Current = 1
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _effortContext.Records.Add(new EffortRecord { Id = 10, CourseId = TestCourseId, PersonId = 3000, TermCode = TestTermCode, EffortTypeId = "LEC", RoleId = 1, Crn = TestCrn.ToString() });
-        await _effortContext.SaveChangesAsync();
+        await _effortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -582,7 +582,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("no email", result.Error);
@@ -594,9 +594,9 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // Seed an existing eval for this instructor + CRN
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId, Mean = 4.0, Respondents = 5 });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -609,7 +609,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("already exists", result.Error);
@@ -620,7 +620,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     {
         // Seed an existing adhoc course record
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = true });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateAdHocEvalRequest
         {
@@ -633,11 +633,11 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
             Count5 = 0
         };
 
-        var result = await _service.CreateAdHocEvaluationAsync(request);
+        var result = await _service.CreateAdHocEvaluationAsync(request, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         // Should not create a duplicate course record
-        var courseCount = await _evalContext.Courses.CountAsync(c => c.Crn == TestCrn && c.TermCode == TestTermCode);
+        var courseCount = await _evalContext.Courses.CountAsync(c => c.Crn == TestCrn && c.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.Equal(1, courseCount);
     }
 
@@ -652,17 +652,17 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = true });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         var quant = new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId, Mean = 3.0, Respondents = 5 };
         _evalContext.Quants.Add(quant);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateAdHocEvalRequest { Count1 = 2, Count2 = 3, Count3 = 5, Count4 = 8, Count5 = 2 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request, TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
-        var updated = await _evalContext.Quants.FirstAsync(q => q.QuantId == 1);
+        var updated = await _evalContext.Quants.FirstAsync(q => q.QuantId == 1, TestContext.Current.CancellationToken);
         Assert.Equal(20, updated.Respondents);
         Assert.Equal(2, updated.Count1N);
         Assert.Equal(8, updated.Count4N);
@@ -673,7 +673,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     {
         var request = new UpdateAdHocEvalRequest { Count1 = 0, Count2 = 0, Count3 = 0, Count4 = 0, Count5 = 0 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("rating count", result.Error);
@@ -684,7 +684,7 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
     {
         var request = new UpdateAdHocEvalRequest { Count1 = 0, Count2 = 0, Count3 = 1, Count4 = 0, Count5 = 0 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 9999, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 9999, request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("not found", result.Error);
@@ -696,13 +696,13 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // Seed a quant on a DIFFERENT CRN than the authorized course
         var question = new EhQuestion { QuestId = 1, Crn = 99999, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateAdHocEvalRequest { Count1 = 0, Count2 = 0, Count3 = 1, Count4 = 0, Count5 = 0 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("does not belong", result.Error);
@@ -715,13 +715,13 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = false });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateAdHocEvalRequest { Count1 = 0, Count2 = 0, Count3 = 1, Count4 = 0, Count5 = 0 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("not an ad-hoc evaluation", result.Error);
@@ -734,13 +734,13 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // the service is fail-closed: no course record means not ad-hoc, so update is rejected.
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateAdHocEvalRequest { Count1 = 0, Count2 = 0, Count3 = 1, Count4 = 0, Count5 = 0 };
 
-        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request);
+        var result = await _service.UpdateAdHocEvaluationAsync(TestCourseId, 1, request, TestContext.Current.CancellationToken);
 
         Assert.False(result.Success);
         Assert.Contains("not an ad-hoc evaluation", result.Error);
@@ -757,20 +757,20 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = true });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1);
+        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1, TestContext.Current.CancellationToken);
 
         Assert.True(deleted);
-        Assert.Null(await _evalContext.Quants.FirstOrDefaultAsync(q => q.QuantId == 1));
+        Assert.Null(await _evalContext.Quants.FirstOrDefaultAsync(q => q.QuantId == 1, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task DeleteAdHocEvaluation_QuantNotFound_ReturnsFalse()
     {
-        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 9999);
+        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 9999, TestContext.Current.CancellationToken);
 
         Assert.False(deleted);
     }
@@ -781,11 +781,11 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         // Quant on a different CRN
         var question = new EhQuestion { QuestId = 1, Crn = 99999, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1);
+        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1, TestContext.Current.CancellationToken);
 
         Assert.False(deleted);
     }
@@ -797,11 +797,11 @@ public sealed class EvalHarvestServiceIntegrationTests : IDisposable
         _evalContext.Courses.Add(new EhCourse { Crn = TestCrn, TermCode = TestTermCode, FacilitatorEvalId = 0, SubjCode = "DVM", CrseNumb = "443", IsAdHoc = false });
         var question = new EhQuestion { QuestId = 1, Crn = TestCrn, TermCode = TestTermCode, IsOverall = true, FacilitatorEvalId = 0, Text = "Overall", Type = "5-pt", Order = 1 };
         _evalContext.Questions.Add(question);
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _evalContext.Quants.Add(new EhQuant { QuantId = 1, QuestionIdFk = question.QuestId, MailId = TestMailId });
-        await _evalContext.SaveChangesAsync();
+        await _evalContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1);
+        var deleted = await _service.DeleteAdHocEvaluationAsync(TestCourseId, 1, TestContext.Current.CancellationToken);
 
         Assert.False(deleted);
     }

--- a/test/Effort/HarvestServiceTests.cs
+++ b/test/Effort/HarvestServiceTests.cs
@@ -152,7 +152,7 @@ public sealed class HarvestServiceTests : IDisposable
     public async Task GeneratePreviewAsync_WithNoData_ReturnsEmptyPreview()
     {
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -186,7 +186,7 @@ public sealed class HarvestServiceTests : IDisposable
             FirstName = "EXISTING",
             LastName = "PERSON"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Also add the person to VIPERContext so MothraId lookup works
         _viperContext.People.Add(new Person
@@ -198,10 +198,10 @@ public sealed class HarvestServiceTests : IDisposable
             LastName = "PERSON",
             FullName = "PERSON, EXISTING"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -214,7 +214,7 @@ public sealed class HarvestServiceTests : IDisposable
     public async Task GeneratePreviewAsync_CallsTermServiceForTermName()
     {
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal($"Term {TestTermCode}", result.TermName);
@@ -233,10 +233,10 @@ public sealed class HarvestServiceTests : IDisposable
         {
             TermCode = TestTermCode
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success, $"Harvest failed with error: {result.ErrorMessage}");
@@ -255,15 +255,15 @@ public sealed class HarvestServiceTests : IDisposable
         {
             TermCode = TestTermCode
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
 
-        var term = await _context.Terms.FirstOrDefaultAsync(t => t.TermCode == TestTermCode);
+        var term = await _context.Terms.FirstOrDefaultAsync(t => t.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.NotNull(term);
         Assert.Equal("Harvested", term.Status); // Status computed from HarvestedDate
         Assert.NotNull(term.HarvestedDate);
@@ -289,17 +289,17 @@ public sealed class HarvestServiceTests : IDisposable
             CrseNumb = "100",
             SeqNumb = "001"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
 
         // Verify old data was cleared
-        var remainingPersons = await _context.Persons.Where(p => p.TermCode == TestTermCode).ToListAsync();
-        var remainingCourses = await _context.Courses.Where(c => c.TermCode == TestTermCode).ToListAsync();
+        var remainingPersons = await _context.Persons.Where(p => p.TermCode == TestTermCode).ToListAsync(TestContext.Current.CancellationToken);
+        var remainingCourses = await _context.Courses.Where(c => c.TermCode == TestTermCode).ToListAsync(TestContext.Current.CancellationToken);
 
         // With no new data to import, should be empty
         Assert.Empty(remainingPersons);
@@ -311,10 +311,10 @@ public sealed class HarvestServiceTests : IDisposable
     {
         // Arrange - no dates = "Created" status
         _context.Terms.Add(new EffortTerm { TermCode = TestTermCode });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -327,12 +327,12 @@ public sealed class HarvestServiceTests : IDisposable
     {
         // Arrange - no dates = "Created" status
         _context.Terms.Add(new EffortTerm { TermCode = TestTermCode });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var beforeHarvest = DateTime.Now;
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -355,7 +355,7 @@ public sealed class HarvestServiceTests : IDisposable
             FirstName = "OLD",
             LastName = "INSTRUCTOR"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.People.Add(new Person
         {
@@ -366,10 +366,10 @@ public sealed class HarvestServiceTests : IDisposable
             LastName = "INSTRUCTOR",
             FullName = "INSTRUCTOR, OLD"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.RemovedInstructors);
@@ -388,10 +388,10 @@ public sealed class HarvestServiceTests : IDisposable
             CrseNumb = "100",
             SeqNumb = "001"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.RemovedCourses);
@@ -405,7 +405,7 @@ public sealed class HarvestServiceTests : IDisposable
         // Arrange - No existing data
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result.RemovedInstructors);
@@ -436,7 +436,7 @@ public sealed class HarvestServiceTests : IDisposable
             SeqNumb = "01"
         };
         _context.Courses.Add(course);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -448,7 +448,7 @@ public sealed class HarvestServiceTests : IDisposable
             Hours = 40,
             Crn = "12345"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.People.Add(new Person
         {
@@ -459,13 +459,13 @@ public sealed class HarvestServiceTests : IDisposable
             LastName = "DOE",
             FullName = "DOE, JANE"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Use a custom phase that adds a preview record matching the existing data
         var service = CreateServiceWithPhase(new TestPreviewHarvestPhase("JDOE001", "DOE, JANE", "12345", "VAR"));
 
         // Act
-        var result = await service.GeneratePreviewAsync(TestTermCode);
+        var result = await service.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         var effortRecord = Assert.Single(result.CrestEffort);
@@ -479,7 +479,7 @@ public sealed class HarvestServiceTests : IDisposable
         var service = CreateServiceWithPhase(new TestPreviewHarvestPhase("JDOE001", "DOE, JANE", "12345", "VAR"));
 
         // Act
-        var result = await service.GeneratePreviewAsync(TestTermCode);
+        var result = await service.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         var effortRecord = Assert.Single(result.CrestEffort);
@@ -506,7 +506,7 @@ public sealed class HarvestServiceTests : IDisposable
             SeqNumb = "01"
         };
         _context.Courses.Add(course);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -518,7 +518,7 @@ public sealed class HarvestServiceTests : IDisposable
             Hours = 40,
             Crn = "12345"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.People.Add(new Person
         {
@@ -529,7 +529,7 @@ public sealed class HarvestServiceTests : IDisposable
             LastName = "DOE",
             FullName = "DOE, JANE"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Phase adds two records: one matching existing (VAR) and one new (LEC)
         var phase = new TestPreviewHarvestPhase(
@@ -541,7 +541,7 @@ public sealed class HarvestServiceTests : IDisposable
         var service = CreateServiceWithPhase(phase);
 
         // Act
-        var result = await service.GeneratePreviewAsync(TestTermCode);
+        var result = await service.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.CrestEffort.Count);
@@ -567,10 +567,10 @@ public sealed class HarvestServiceTests : IDisposable
             CrseNumb = "499R",
             SeqNumb = "001"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert - RESID should NOT appear in removed courses
         Assert.Empty(result.RemovedCourses);
@@ -596,10 +596,10 @@ public sealed class HarvestServiceTests : IDisposable
             CrseNumb = "100",
             SeqNumb = "001"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert - Only the non-RESID course should be in the removed list
         Assert.Single(result.RemovedCourses);
@@ -616,7 +616,7 @@ public sealed class HarvestServiceTests : IDisposable
         // Arrange - No term in database
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(999999, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(999999, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert - When term not found, harvest still runs but fails during preview generation
         Assert.False(result.Success);
@@ -628,10 +628,10 @@ public sealed class HarvestServiceTests : IDisposable
     {
         // Arrange - no dates = "Created" status
         _context.Terms.Add(new EffortTerm { TermCode = TestTermCode });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -655,7 +655,7 @@ public sealed class HarvestServiceTests : IDisposable
         _context.Courses.Add(new EffortCourse { TermCode = TestTermCode, Crn = "22222", SubjCode = "T", CrseNumb = "2", SeqNumb = "1" });
         _context.Courses.Add(new EffortCourse { TermCode = TestTermCode, Crn = "33333", SubjCode = "T", CrseNumb = "3", SeqNumb = "1" });
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Also add the persons to VIPERContext so MothraId lookup works
         _viperContext.People.Add(new Person
@@ -676,10 +676,10 @@ public sealed class HarvestServiceTests : IDisposable
             LastName = "D",
             FullName = "D, C"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _harvestService.GeneratePreviewAsync(TestTermCode);
+        var result = await _harvestService.GeneratePreviewAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.Warnings);
@@ -706,10 +706,10 @@ public sealed class HarvestServiceTests : IDisposable
             AllowedOnRCourses = true,
             IsActive = true
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - Run harvest (R-course generation happens at end)
-        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert - Harvest completes successfully even with no data
         Assert.True(result.Success);
@@ -735,7 +735,7 @@ public sealed class HarvestServiceTests : IDisposable
             AllowedOnRCourses = true,
             IsActive = true
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Create a HarvestService with a custom phase that adds test data during harvest
         // (ExecuteHarvestAsync clears existing data first, so we must add data during phase execution)
@@ -759,7 +759,7 @@ public sealed class HarvestServiceTests : IDisposable
             _loggerMock);
 
         // Act - Run harvest (R-course detection uses inline EndsWith("R") logic)
-        var result = await harvestServiceWithTestPhase.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result = await harvestServiceWithTestPhase.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert - Harvest completes successfully
         Assert.True(result.Success);
@@ -990,11 +990,11 @@ public sealed class HarvestServiceTests : IDisposable
             AllowedOnRCourses = true,
             IsActive = true
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - Run harvest twice
-        var result1 = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
-        var result2 = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123);
+        var result1 = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
+        var result2 = await _harvestService.ExecuteHarvestAsync(TestTermCode, modifiedBy: 123, TestContext.Current.CancellationToken);
 
         // Assert - Both harvests succeed
         Assert.True(result1.Success);

--- a/test/Effort/InstructorServiceTests.cs
+++ b/test/Effort/InstructorServiceTests.cs
@@ -96,10 +96,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortPerson { PersonId = 2, TermCode = 202410, FirstName = "Alice", LastName = "Smith", EffortDept = "VME", EffortTitleCode = "1234" },
             new EffortPerson { PersonId = 3, TermCode = 202410, FirstName = "Bob", LastName = "Doe", EffortDept = "APC", EffortTitleCode = "1234" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructors = await _instructorService.GetInstructorsAsync(202410);
+        var instructors = await _instructorService.GetInstructorsAsync(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, instructors.Count);
@@ -118,10 +118,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" },
             new EffortPerson { PersonId = 2, TermCode = 202410, FirstName = "Jane", LastName = "Smith", EffortDept = "APC", EffortTitleCode = "1234" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructors = await _instructorService.GetInstructorsAsync(202410, "VME");
+        var instructors = await _instructorService.GetInstructorsAsync(202410, "VME", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(instructors);
@@ -132,7 +132,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task GetInstructorsAsync_ReturnsEmptyList_WhenNoInstructorsExistForTerm()
     {
         // Act
-        var instructors = await _instructorService.GetInstructorsAsync(999999);
+        var instructors = await _instructorService.GetInstructorsAsync(999999, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(instructors);
@@ -147,10 +147,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" },
             new EffortPerson { PersonId = 2, TermCode = 202310, FirstName = "Jane", LastName = "Smith", EffortDept = "APC", EffortTitleCode = "5678" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act — termCode 0 means "all terms"
-        var result = await _instructorService.GetInstructorsAsync(0);
+        var result = await _instructorService.GetInstructorsAsync(0, ct: TestContext.Current.CancellationToken);
 
         // Assert — one record per person, latest term wins
         Assert.Equal(2, result.Count);
@@ -168,10 +168,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" },
             new EffortPerson { PersonId = 2, TermCode = 202410, FirstName = "Jane", LastName = "Smith", EffortDept = "APC", EffortTitleCode = "5678" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(0, "VME");
+        var result = await _instructorService.GetInstructorsAsync(0, "VME", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -186,10 +186,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "Merit", LastName = "Prof", EffortDept = "VME", EffortTitleCode = "1234", JobGroupId = "010" },
             new EffortPerson { PersonId = 2, TermCode = 202410, FirstName = "Other", LastName = "Prof", EffortDept = "VME", EffortTitleCode = "1234", JobGroupId = "999" }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(0, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(0, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -205,10 +205,10 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructor = await _instructorService.GetInstructorAsync(1, 202410);
+        var instructor = await _instructorService.GetInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(instructor);
@@ -221,7 +221,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task GetInstructorAsync_ReturnsNull_WhenInstructorDoesNotExist()
     {
         // Act
-        var instructor = await _instructorService.GetInstructorAsync(999, 202410);
+        var instructor = await _instructorService.GetInstructorAsync(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(instructor);
@@ -232,10 +232,10 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructor = await _instructorService.GetInstructorAsync(1, 202320);
+        var instructor = await _instructorService.GetInstructorAsync(1, 202320, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(instructor);
@@ -250,17 +250,17 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
-        Assert.True(await _instructorService.InstructorExistsAsync(1, 202410));
+        Assert.True(await _instructorService.InstructorExistsAsync(1, 202410, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task InstructorExistsAsync_ReturnsFalse_WhenInstructorDoesNotExist()
     {
         // Act & Assert
-        Assert.False(await _instructorService.InstructorExistsAsync(999, 202410));
+        Assert.False(await _instructorService.InstructorExistsAsync(999, 202410, TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -280,13 +280,13 @@ public sealed class InstructorServiceTests : IDisposable
             EffortDept = "VME",
             EffortTitleCode = "1234"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateInstructorRequest { PersonId = 1, TermCode = 202410 };
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InstructorAlreadyExistsException>(
-            () => _instructorService.CreateInstructorAsync(request));
+            () => _instructorService.CreateInstructorAsync(request, TestContext.Current.CancellationToken));
 
         Assert.Equal(1, ex.PersonId);
         Assert.Equal(202410, ex.TermCode);
@@ -302,7 +302,7 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234", VolunteerWos = 0 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateInstructorRequest
         {
@@ -312,7 +312,7 @@ public sealed class InstructorServiceTests : IDisposable
         };
 
         // Act
-        var instructor = await _instructorService.UpdateInstructorAsync(1, 202410, request);
+        var instructor = await _instructorService.UpdateInstructorAsync(1, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(instructor);
@@ -333,7 +333,7 @@ public sealed class InstructorServiceTests : IDisposable
         };
 
         // Act
-        var instructor = await _instructorService.UpdateInstructorAsync(999, 202410, request);
+        var instructor = await _instructorService.UpdateInstructorAsync(999, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(instructor);
@@ -344,7 +344,7 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateInstructorRequest
         {
@@ -355,7 +355,7 @@ public sealed class InstructorServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _instructorService.UpdateInstructorAsync(1, 202410, request)
+            () => _instructorService.UpdateInstructorAsync(1, 202410, request, TestContext.Current.CancellationToken)
         );
         Assert.Contains("Invalid department", exception.Message);
     }
@@ -365,7 +365,7 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateInstructorRequest
         {
@@ -375,7 +375,7 @@ public sealed class InstructorServiceTests : IDisposable
         };
 
         // Act
-        await _instructorService.UpdateInstructorAsync(1, 202410, request);
+        await _instructorService.UpdateInstructorAsync(1, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddPersonChangeAudit(
@@ -395,21 +395,21 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.DeleteInstructorAsync(1, 202410);
+        var result = await _instructorService.DeleteInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.Persons.FirstOrDefaultAsync(p => p.PersonId == 1 && p.TermCode == 202410));
+        Assert.Null(await _context.Persons.FirstOrDefaultAsync(p => p.PersonId == 1 && p.TermCode == 202410, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task DeleteInstructorAsync_ReturnsFalse_WhenInstructorDoesNotExist()
     {
         // Act
-        var result = await _instructorService.DeleteInstructorAsync(999, 202410);
+        var result = await _instructorService.DeleteInstructorAsync(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -421,20 +421,20 @@ public sealed class InstructorServiceTests : IDisposable
         // Arrange
         var person = new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" };
         _context.Persons.Add(person);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.AddRange(
             new EffortRecord { Id = 1, TermCode = 202410, CourseId = 100, PersonId = 1 },
             new EffortRecord { Id = 2, TermCode = 202410, CourseId = 101, PersonId = 1 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.DeleteInstructorAsync(1, 202410);
+        var result = await _instructorService.DeleteInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Empty(await _context.Records.Where(r => r.PersonId == 1).ToListAsync());
+        Assert.Empty(await _context.Records.Where(r => r.PersonId == 1).ToListAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -442,10 +442,10 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _instructorService.DeleteInstructorAsync(1, 202410);
+        await _instructorService.DeleteInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddPersonChangeAudit(
@@ -465,10 +465,10 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // Arrange
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canDelete, recordCount) = await _instructorService.CanDeleteInstructorAsync(1, 202410);
+        var (canDelete, recordCount) = await _instructorService.CanDeleteInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -485,10 +485,10 @@ public sealed class InstructorServiceTests : IDisposable
             new EffortRecord { Id = 2, TermCode = 202410, CourseId = 101, PersonId = 1 },
             new EffortRecord { Id = 3, TermCode = 202410, CourseId = 102, PersonId = 1 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canDelete, recordCount) = await _instructorService.CanDeleteInstructorAsync(1, 202410);
+        var (canDelete, recordCount) = await _instructorService.CanDeleteInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -563,7 +563,7 @@ public sealed class InstructorServiceTests : IDisposable
             MothraId = overrideMothraId, // This MothraId has a department override configured
             CurrentEmployee = true
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Add VMDO job (should be ignored due to override)
         _aaudContext.Ids.Add(new Id
@@ -584,10 +584,10 @@ public sealed class InstructorServiceTests : IDisposable
             EmpCbuc = "99",
             EmpStatus = "A"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var dept = await _instructorService.ResolveInstructorDepartmentAsync(100, 202410);
+        var dept = await _instructorService.ResolveInstructorDepartmentAsync(100, 202410, TestContext.Current.CancellationToken);
 
         // Assert - Should return the configured override department
         Assert.Equal(expectedDept, dept);
@@ -607,7 +607,7 @@ public sealed class InstructorServiceTests : IDisposable
             MothraId = "12345678",
             CurrentEmployee = true
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _aaudContext.Ids.Add(new Id
         {
@@ -643,10 +643,10 @@ public sealed class InstructorServiceTests : IDisposable
             JobBargainingUnit = "99",
             JobSchoolDivision = "VM"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var dept = await _instructorService.ResolveInstructorDepartmentAsync(1, 202410);
+        var dept = await _instructorService.ResolveInstructorDepartmentAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert - Should return VME from jobs table
         Assert.Equal("VME", dept);
@@ -666,7 +666,7 @@ public sealed class InstructorServiceTests : IDisposable
             MothraId = "87654321",
             CurrentEmployee = true
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _aaudContext.Ids.Add(new Id
         {
@@ -691,10 +691,10 @@ public sealed class InstructorServiceTests : IDisposable
         });
 
         // No jobs or only non-academic jobs
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var dept = await _instructorService.ResolveInstructorDepartmentAsync(2, 202410);
+        var dept = await _instructorService.ResolveInstructorDepartmentAsync(2, 202410, TestContext.Current.CancellationToken);
 
         // Assert - Should return APC from employee effort dept
         Assert.Equal("APC", dept);
@@ -704,7 +704,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task ResolveInstructorDepartmentAsync_ReturnsNull_WhenNoPersonFound()
     {
         // Act
-        var dept = await _instructorService.ResolveInstructorDepartmentAsync(99999, 202410);
+        var dept = await _instructorService.ResolveInstructorDepartmentAsync(99999, 202410, TestContext.Current.CancellationToken);
 
         // Assert - Returns null when person doesn't exist (distinct from "UNK" for person exists but no dept)
         Assert.Null(dept);
@@ -724,10 +724,10 @@ public sealed class InstructorServiceTests : IDisposable
             MothraId = "00000000",
             CurrentEmployee = true
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var dept = await _instructorService.ResolveInstructorDepartmentAsync(3, 202410);
+        var dept = await _instructorService.ResolveInstructorDepartmentAsync(3, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("UNK", dept);
@@ -743,11 +743,11 @@ public sealed class InstructorServiceTests : IDisposable
         // Arrange - VolunteerWos is byte? in entity, bool in DTO
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410, FirstName = "John", LastName = "Doe", EffortDept = "VME", EffortTitleCode = "1234", VolunteerWos = 1 });
         _context.Persons.Add(new EffortPerson { PersonId = 2, TermCode = 202410, FirstName = "Jane", LastName = "Smith", EffortDept = "VME", EffortTitleCode = "1234", VolunteerWos = 0 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructor1 = await _instructorService.GetInstructorAsync(1, 202410);
-        var instructor2 = await _instructorService.GetInstructorAsync(2, 202410);
+        var instructor1 = await _instructorService.GetInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
+        var instructor2 = await _instructorService.GetInstructorAsync(2, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(instructor1);
@@ -771,10 +771,10 @@ public sealed class InstructorServiceTests : IDisposable
             PercentAdmin = 12.5,
             PercentClinical = 33.33
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var dto = await _instructorService.GetInstructorAsync(1, 202410);
+        var dto = await _instructorService.GetInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(dto);
@@ -811,7 +811,7 @@ public sealed class InstructorServiceTests : IDisposable
             LastEmailed = null,
             LastEmailedBy = null
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Add instructor's ViperPerson (for MailId resolution via .Include(p => p.ViperPerson))
         _context.ViperPersons.Add(new ViperPerson
@@ -835,11 +835,11 @@ public sealed class InstructorServiceTests : IDisposable
             FirstName = "Admin",
             LastName = "User"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var instructor1 = await _instructorService.GetInstructorAsync(1, 202410);
-        var instructor2 = await _instructorService.GetInstructorAsync(2, 202410);
+        var instructor1 = await _instructorService.GetInstructorAsync(1, 202410, TestContext.Current.CancellationToken);
+        var instructor2 = await _instructorService.GetInstructorAsync(2, 202410, TestContext.Current.CancellationToken);
 
         // Assert - instructor with email history and ViperPerson (MailId resolved)
         Assert.NotNull(instructor1);
@@ -863,7 +863,7 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // The test setup uses empty connection strings, so the method should return empty list
         // This tests the graceful fallback behavior when the database is not available
-        var titleCodes = await _instructorService.GetTitleCodesAsync();
+        var titleCodes = await _instructorService.GetTitleCodesAsync(TestContext.Current.CancellationToken);
 
         Assert.Empty(titleCodes);
     }
@@ -877,7 +877,7 @@ public sealed class InstructorServiceTests : IDisposable
     {
         // The test setup uses empty connection strings, so the method should return empty list
         // This tests the graceful fallback behavior when the database is not available
-        var jobGroups = await _instructorService.GetJobGroupsAsync();
+        var jobGroups = await _instructorService.GetJobGroupsAsync(ct: TestContext.Current.CancellationToken);
 
         Assert.Empty(jobGroups);
     }
@@ -904,10 +904,10 @@ public sealed class InstructorServiceTests : IDisposable
                 JobGroupId = unconditionalGroups[i]
             });
         }
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert — all unconditional groups included
         Assert.Equal(unconditionalGroups.Length, result.Count);
@@ -927,10 +927,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "001898",
             JobGroupId = "124"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -951,10 +951,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "005555",
             JobGroupId = "124"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -974,10 +974,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "001067",
             JobGroupId = "S56"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -998,10 +998,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "002222",
             JobGroupId = "S56"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -1031,10 +1031,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "1234",
             JobGroupId = null
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -1054,10 +1054,10 @@ public sealed class InstructorServiceTests : IDisposable
             EffortTitleCode = "1898",
             JobGroupId = "124"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true);
+        var result = await _instructorService.GetInstructorsAsync(202410, meritOnly: true, ct: TestContext.Current.CancellationToken);
 
         // Assert — "1898" padded to "001898" matches
         Assert.Single(result);
@@ -1071,7 +1071,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task BatchResolveDepartmentsAsync_ReturnsEmptyDictionary_WhenNoMothraIds()
     {
         // Act
-        var result = await _instructorService.BatchResolveDepartmentsAsync([], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync([], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -1103,10 +1103,10 @@ public sealed class InstructorServiceTests : IDisposable
             EmpCbuc = "99",
             EmpStatus = "A"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.BatchResolveDepartmentsAsync([overrideMothraId], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync([overrideMothraId], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -1216,10 +1216,10 @@ public sealed class InstructorServiceTests : IDisposable
             JobBargainingUnit = "99",
             JobSchoolDivision = "VM"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.BatchResolveDepartmentsAsync(["11111111"], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync(["11111111"], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -1249,10 +1249,10 @@ public sealed class InstructorServiceTests : IDisposable
             EmpCbuc = "99",
             EmpStatus = "A"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _instructorService.BatchResolveDepartmentsAsync(["22222222"], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync(["22222222"], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -1263,7 +1263,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task BatchResolveDepartmentsAsync_ReturnsUNK_WhenNoAaudData()
     {
         // Act - no AAUD data seeded for this MothraId
-        var result = await _instructorService.BatchResolveDepartmentsAsync(["99999999"], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync(["99999999"], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -1326,11 +1326,11 @@ public sealed class InstructorServiceTests : IDisposable
             EmpStatus = "A"
         });
 
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _instructorService.BatchResolveDepartmentsAsync(
-            ["AAA11111", "BBB22222", "CCC33333"], 202410);
+            ["AAA11111", "BBB22222", "CCC33333"], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, result.Count);
@@ -1343,7 +1343,7 @@ public sealed class InstructorServiceTests : IDisposable
     public async Task BatchResolveDepartmentsAsync_SkipsNullAndEmptyMothraIds()
     {
         // Act
-        var result = await _instructorService.BatchResolveDepartmentsAsync(["", null!], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync(["", null!], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -1372,10 +1372,10 @@ public sealed class InstructorServiceTests : IDisposable
             EmpCbuc = "99",
             EmpStatus = "A"
         });
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act - query with different case
-        var result = await _instructorService.BatchResolveDepartmentsAsync(["case1234"], 202410);
+        var result = await _instructorService.BatchResolveDepartmentsAsync(["case1234"], 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);

--- a/test/Effort/InstructorsControllerTests.cs
+++ b/test/Effort/InstructorsControllerTests.cs
@@ -64,7 +64,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorsAsync(202410, null, false, Arg.Any<CancellationToken>()).Returns(instructors);
 
         // Act
-        var result = await _controller.GetInstructors(202410);
+        var result = await _controller.GetInstructors(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -85,7 +85,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorsAsync(202410, "VME", false, Arg.Any<CancellationToken>()).Returns(instructors);
 
         // Act
-        var result = await _controller.GetInstructors(202410, "VME");
+        var result = await _controller.GetInstructors(202410, "VME", ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -100,7 +100,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("SECRET", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetInstructors(202410, "SECRET");
+        var result = await _controller.GetInstructors(202410, "SECRET", ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -121,7 +121,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetInstructor(1, 202410);
+        var result = await _controller.GetInstructor(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -136,7 +136,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetInstructor(999, 202410);
+        var result = await _controller.GetInstructor(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -151,7 +151,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("SECRET", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetInstructor(1, 202410);
+        var result = await _controller.GetInstructor(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -178,7 +178,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.CreateInstructorAsync(request, Arg.Any<CancellationToken>()).Returns(createdInstructor);
 
         // Act
-        var result = await _controller.CreateInstructor(request);
+        var result = await _controller.CreateInstructor(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -200,7 +200,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.InstructorExistsAsync(1, 202410, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.CreateInstructor(request);
+        var result = await _controller.CreateInstructor(request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -224,7 +224,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.CreateInstructorAsync(request, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Person not found in AAUD"));
 
         // Act
-        var result = await _controller.CreateInstructor(request);
+        var result = await _controller.CreateInstructor(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -247,7 +247,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.CreateInstructorAsync(request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("Database constraint violation"));
 
         // Act
-        var result = await _controller.CreateInstructor(request);
+        var result = await _controller.CreateInstructor(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -277,7 +277,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.UpdateInstructorAsync(1, 202410, request, Arg.Any<CancellationToken>()).Returns(updatedInstructor);
 
         // Act
-        var result = await _controller.UpdateInstructor(1, 202410, request);
+        var result = await _controller.UpdateInstructor(1, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -302,7 +302,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("SECRET", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.UpdateInstructor(1, 202410, request);
+        var result = await _controller.UpdateInstructor(1, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -322,7 +322,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.UpdateInstructor(999, 202410, request);
+        var result = await _controller.UpdateInstructor(999, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -346,7 +346,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.UpdateInstructorAsync(1, 202410, request, Arg.Any<CancellationToken>()).Throws(new ArgumentException("Invalid department: INVALID"));
 
         // Act
-        var result = await _controller.UpdateInstructor(1, 202410, request);
+        var result = await _controller.UpdateInstructor(1, 202410, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -368,7 +368,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.DeleteInstructorAsync(1, 202410, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.DeleteInstructor(1, 202410);
+        var result = await _controller.DeleteInstructor(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
@@ -381,7 +381,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.DeleteInstructor(999, 202410);
+        var result = await _controller.DeleteInstructor(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -397,7 +397,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("SECRET", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeleteInstructor(1, 202410);
+        var result = await _controller.DeleteInstructor(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -418,7 +418,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.CanDeleteInstructorAsync(1, 202410, Arg.Any<CancellationToken>()).Returns((true, 5));
 
         // Act
-        var result = await _controller.CanDeleteInstructor(1, 202410);
+        var result = await _controller.CanDeleteInstructor(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -443,7 +443,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetDepartments();
+        var result = await _controller.GetDepartments(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -466,7 +466,7 @@ public sealed class InstructorsControllerTests
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string> { "VME" });
 
         // Act
-        var result = await _controller.GetDepartments();
+        var result = await _controller.GetDepartments(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -491,7 +491,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetReportUnitsAsync(Arg.Any<CancellationToken>()).Returns(reportUnits);
 
         // Act
-        var result = await _controller.GetReportUnits();
+        var result = await _controller.GetReportUnits(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -518,7 +518,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorEffortRecordsAsync(1, 202410, Arg.Any<CancellationToken>()).Returns(effortRecords);
 
         // Act
-        var result = await _controller.GetInstructorEffortRecords(1, 202410);
+        var result = await _controller.GetInstructorEffortRecords(1, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -533,7 +533,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetInstructorEffortRecords(999, 202410);
+        var result = await _controller.GetInstructorEffortRecords(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -555,7 +555,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetTitleCodesAsync(Arg.Any<CancellationToken>()).Returns(titleCodes);
 
         // Act
-        var result = await _controller.GetTitleCodes();
+        var result = await _controller.GetTitleCodes(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -569,7 +569,7 @@ public sealed class InstructorsControllerTests
         // Arrange
         _instructorServiceMock.GetTitleCodesAsync(Arg.Any<CancellationToken>()).Returns(new List<TitleCodeDto>());
         // Act
-        var result = await _controller.GetTitleCodes();
+        var result = await _controller.GetTitleCodes(TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -593,7 +593,7 @@ public sealed class InstructorsControllerTests
         _instructorServiceMock.GetJobGroupsAsync(Arg.Any<int?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(jobGroups);
 
         // Act
-        var result = await _controller.GetJobGroups();
+        var result = await _controller.GetJobGroups(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -607,7 +607,7 @@ public sealed class InstructorsControllerTests
         // Arrange
         _instructorServiceMock.GetJobGroupsAsync(Arg.Any<int?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(new List<JobGroupDto>());
         // Act
-        var result = await _controller.GetJobGroups();
+        var result = await _controller.GetJobGroups(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/test/Effort/Integration/EffortPermissionIntegrationTests.cs
+++ b/test/Effort/Integration/EffortPermissionIntegrationTests.cs
@@ -30,7 +30,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act
-        var hasFullAccess = await _permissionService.HasFullAccessAsync();
+        var hasFullAccess = await _permissionService.HasFullAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(hasFullAccess);
@@ -43,9 +43,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
-        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment);
-        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
+        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewDvm);
@@ -60,8 +60,8 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act
-        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment);
-        var canEditVme = await _permissionService.CanEditDepartmentAsync(VmeDepartment);
+        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canEditVme = await _permissionService.CanEditDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
 
         // Assert - Full access bypasses department filtering
         Assert.True(canEditDvm);
@@ -75,7 +75,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act
-        var departments = await _permissionService.GetAuthorizedDepartmentsAsync();
+        var departments = await _permissionService.GetAuthorizedDepartmentsAsync(TestContext.Current.CancellationToken);
 
         // Assert - Empty list indicates full access (all departments)
         Assert.Empty(departments);
@@ -88,9 +88,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act - Can view any person regardless of department
-        var canViewDvmPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode);
-        var canViewVmePerson = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode);
-        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode);
+        var canViewDvmPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode, TestContext.Current.CancellationToken);
+        var canViewVmePerson = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode, TestContext.Current.CancellationToken);
+        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewDvmPerson);
@@ -109,7 +109,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync();
+        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(hasDeptAccess);
@@ -122,9 +122,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
-        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment);
-        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
+        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewDvm);
@@ -139,9 +139,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment, VmeDepartment);
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
-        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment);
-        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
+        var canViewApc = await _permissionService.CanViewDepartmentAsync(ApcDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewDvm);
@@ -156,7 +156,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment, VmeDepartment);
 
         // Act
-        var departments = await _permissionService.GetAuthorizedDepartmentsAsync();
+        var departments = await _permissionService.GetAuthorizedDepartmentsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, departments.Count);
@@ -171,9 +171,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var canViewDvmPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode);
-        var canViewVmePerson = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode);
-        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode);
+        var canViewDvmPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode, TestContext.Current.CancellationToken);
+        var canViewVmePerson = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode, TestContext.Current.CancellationToken);
+        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewDvmPerson);
@@ -192,8 +192,8 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithEditEffortPermission(DvmDepartment);
 
         // Act
-        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment);
-        var canEditVme = await _permissionService.CanEditDepartmentAsync(VmeDepartment);
+        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canEditVme = await _permissionService.CanEditDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canEditDvm);
@@ -207,8 +207,8 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithEditEffortPermission(DvmDepartment);
 
         // Act
-        var canEditDvmPerson = await _permissionService.CanEditPersonEffortAsync(TestUserAaudId, TestTermCode);
-        var canEditVmePerson = await _permissionService.CanEditPersonEffortAsync(1001, TestTermCode);
+        var canEditDvmPerson = await _permissionService.CanEditPersonEffortAsync(TestUserAaudId, TestTermCode, TestContext.Current.CancellationToken);
+        var canEditVmePerson = await _permissionService.CanEditPersonEffortAsync(1001, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canEditDvmPerson);
@@ -222,7 +222,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment);
+        var canEditDvm = await _permissionService.CanEditDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
 
         // Assert - Cannot edit even their own department without EditEffort permission
         Assert.False(canEditDvm);
@@ -239,7 +239,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithSelfServiceAccess();
 
         // Act
-        var hasSelfService = await _permissionService.HasSelfServiceAccessAsync();
+        var hasSelfService = await _permissionService.HasSelfServiceAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(hasSelfService);
@@ -252,7 +252,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithSelfServiceAccess();
 
         // Act
-        var canViewOwn = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode);
+        var canViewOwn = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewOwn);
@@ -265,7 +265,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithSelfServiceAccess();
 
         // Act
-        var canViewOther = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode);
+        var canViewOther = await _permissionService.CanViewPersonEffortAsync(1001, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewOther);
@@ -308,7 +308,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithNoPermissions();
 
         // Act
-        var hasFullAccess = await _permissionService.HasFullAccessAsync();
+        var hasFullAccess = await _permissionService.HasFullAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasFullAccess);
@@ -321,7 +321,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithNoPermissions();
 
         // Act
-        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync();
+        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasDeptAccess);
@@ -334,8 +334,8 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithNoPermissions();
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
-        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
+        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewDvm);
@@ -349,7 +349,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithNoPermissions();
 
         // Act
-        var canViewPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode);
+        var canViewPerson = await _permissionService.CanViewPersonEffortAsync(TestUserAaudId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewPerson);
@@ -362,7 +362,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupNullUser();
 
         // Act
-        var hasFullAccess = await _permissionService.HasFullAccessAsync();
+        var hasFullAccess = await _permissionService.HasFullAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasFullAccess);
@@ -375,7 +375,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupNullUser();
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewDvm);
@@ -405,7 +405,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithBasePermissionOnly();
 
         // Act
-        var hasFullAccess = await _permissionService.HasFullAccessAsync();
+        var hasFullAccess = await _permissionService.HasFullAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasFullAccess);
@@ -418,7 +418,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithBasePermissionOnly();
 
         // Act
-        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync();
+        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasDeptAccess);
@@ -431,7 +431,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithBasePermissionOnly();
 
         // Act
-        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment);
+        var canViewDvm = await _permissionService.CanViewDepartmentAsync(DvmDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewDvm);
@@ -448,8 +448,8 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithFullAccess();
 
         // Act - Should have access to all departments regardless of UserAccess entries
-        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync();
-        var canViewAllDepts = await _permissionService.CanViewDepartmentAsync(ApcDepartment);
+        var hasDeptAccess = await _permissionService.HasDepartmentLevelAccessAsync(TestContext.Current.CancellationToken);
+        var canViewAllDepts = await _permissionService.CanViewDepartmentAsync(ApcDepartment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(hasDeptAccess); // ViewDept is not set
@@ -463,9 +463,9 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act - Test case insensitivity
-        var canViewUppercase = await _permissionService.CanViewDepartmentAsync("DVM");
-        var canViewLowercase = await _permissionService.CanViewDepartmentAsync("dvm");
-        var canViewMixed = await _permissionService.CanViewDepartmentAsync("Dvm");
+        var canViewUppercase = await _permissionService.CanViewDepartmentAsync("DVM", TestContext.Current.CancellationToken);
+        var canViewLowercase = await _permissionService.CanViewDepartmentAsync("dvm", TestContext.Current.CancellationToken);
+        var canViewMixed = await _permissionService.CanViewDepartmentAsync("Dvm", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canViewUppercase);
@@ -486,10 +486,10 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
             DepartmentCode = VmeDepartment,
             IsActive = false // Inactive!
         });
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment);
+        var canViewVme = await _permissionService.CanViewDepartmentAsync(VmeDepartment, TestContext.Current.CancellationToken);
 
         // Assert - Inactive access should be ignored
         Assert.False(canViewVme);
@@ -513,12 +513,12 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
             ReportUnit = DvmDepartment  // But ReportUnit matches
         };
         EffortContext.Persons.Add(personWithReportUnit);
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var canViewPerson = await _permissionService.CanViewPersonEffortAsync(2000, TestTermCode);
+        var canViewPerson = await _permissionService.CanViewPersonEffortAsync(2000, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert - Should be able to view via ReportUnit match
         Assert.True(canViewPerson);
@@ -531,7 +531,7 @@ public class EffortPermissionIntegrationTests : EffortIntegrationTestBase
         SetupUserWithDepartmentViewAccess(DvmDepartment);
 
         // Act
-        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode);
+        var canViewApcPerson = await _permissionService.CanViewPersonEffortAsync(1002, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canViewApcPerson);

--- a/test/Effort/PercentAssignTypeServiceTests.cs
+++ b/test/Effort/PercentAssignTypeServiceTests.cs
@@ -99,7 +99,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentAssignTypeAsync("Admin", "Associate Dean");
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(4, types.Count);
@@ -121,7 +121,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentAssignTypeAsync("Teaching", "Inactive Type", isActive: false);
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync(activeOnly: true);
+        var types = await _service.GetPercentAssignTypesAsync(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(types);
@@ -137,7 +137,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentAssignTypeAsync("Teaching", "Inactive Type", isActive: false);
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync(activeOnly: false);
+        var types = await _service.GetPercentAssignTypesAsync(activeOnly: false, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, types.Count);
@@ -147,7 +147,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
     public async Task GetPercentAssignTypesAsync_ReturnsEmptyList_WhenNoTypesExist()
     {
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(types);
@@ -164,7 +164,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(2, type.Id, "2024-2025");
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(types);
@@ -181,7 +181,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025");
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(types);
@@ -198,7 +198,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025", 0.2);
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(types);
@@ -212,7 +212,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentAssignTypeAsync("Teaching", "Unused Type");
 
         // Act
-        var types = await _service.GetPercentAssignTypesAsync();
+        var types = await _service.GetPercentAssignTypesAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(types);
@@ -230,7 +230,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         var type = await CreatePercentAssignTypeAsync("Teaching", "Lecture");
 
         // Act
-        var result = await _service.GetPercentAssignTypeAsync(type.Id);
+        var result = await _service.GetPercentAssignTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -244,7 +244,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
     public async Task GetPercentAssignTypeAsync_ReturnsNull_WhenNotFound()
     {
         // Act
-        var result = await _service.GetPercentAssignTypeAsync(999);
+        var result = await _service.GetPercentAssignTypeAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -257,7 +257,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         var type = await CreatePercentAssignTypeAsync("Teaching", "Lecture", showOnTemplate: false);
 
         // Act
-        var result = await _service.GetPercentAssignTypeAsync(type.Id);
+        var result = await _service.GetPercentAssignTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -278,7 +278,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentAssignTypeAsync("Research", "Grant");
 
         // Act
-        var classes = await _service.GetPercentAssignTypeClassesAsync();
+        var classes = await _service.GetPercentAssignTypeClassesAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, classes.Count);
@@ -291,7 +291,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
     public async Task GetPercentAssignTypeClassesAsync_ReturnsEmptyList_WhenNoTypes()
     {
         // Act
-        var classes = await _service.GetPercentAssignTypeClassesAsync();
+        var classes = await _service.GetPercentAssignTypeClassesAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(classes);
@@ -305,7 +305,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
     public async Task GetInstructorsByTypeAsync_ReturnsNull_WhenTypeNotFound()
     {
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(999);
+        var result = await _service.GetInstructorsByTypeAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -318,7 +318,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         var type = await CreatePercentAssignTypeAsync("Teaching", "Lecture");
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -337,7 +337,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025");
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -360,7 +360,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025");
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -382,7 +382,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(3, type.Id, "2024-2025");
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -407,7 +407,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025");
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -426,7 +426,7 @@ public sealed class PercentAssignTypeServiceTests : IDisposable
         await CreatePercentageAsync(1, type.Id, "2024-2025", 0.2);
 
         // Act
-        var result = await _service.GetInstructorsByTypeAsync(type.Id);
+        var result = await _service.GetInstructorsByTypeAsync(type.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/test/Effort/PercentAssignTypesControllerIntegrationTests.cs
+++ b/test/Effort/PercentAssignTypesControllerIntegrationTests.cs
@@ -59,7 +59,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         SetupUserWithFullAccess();
 
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -85,7 +85,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         SetupUserWithFullAccess();
 
         // Act
-        var result = await _controller.GetPercentAssignTypes(activeOnly: true);
+        var result = await _controller.GetPercentAssignTypes(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -105,10 +105,10 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         // Add percentage assignments for type 1 (Lecture)
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
         EffortContext.Percentages.Add(CreateTestPercentage(1001, 1, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -127,10 +127,10 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         // Same person, different years = counts as 2
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2023-24"));
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -151,10 +151,10 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         var secondPercentage = CreateTestPercentage(TestUserAaudId, 1, "2024-25");
         secondPercentage.PercentageValue = 0.25;
         EffortContext.Percentages.Add(secondPercentage);
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -270,7 +270,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         SetupUserWithFullAccess();
 
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.GetInstructorsByType(1, CancellationToken.None);
@@ -296,7 +296,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
 
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2023-24"));
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.GetInstructorsByType(1, CancellationToken.None);
@@ -320,7 +320,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
         EffortContext.Percentages.Add(CreateTestPercentage(1001, 1, "2023-24"));
         EffortContext.Percentages.Add(CreateTestPercentage(1002, 1, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.GetInstructorsByType(1, CancellationToken.None);
@@ -351,7 +351,7 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         var secondPercentage = CreateTestPercentage(TestUserAaudId, 1, "2024-25");
         secondPercentage.PercentageValue = 0.25;
         EffortContext.Percentages.Add(secondPercentage);
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
         var result = await _controller.GetInstructorsByType(1, CancellationToken.None);
@@ -377,10 +377,10 @@ public class PercentAssignTypesControllerIntegrationTests : EffortIntegrationTes
         EffortContext.Percentages.Add(CreateTestPercentage(TestUserAaudId, 1, "2024-25"));
         EffortContext.Percentages.Add(CreateTestPercentage(1001, 1, "2024-25"));
         EffortContext.Percentages.Add(CreateTestPercentage(1002, 2, "2024-25"));
-        await EffortContext.SaveChangesAsync();
+        await EffortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Get all types
-        var typesResult = await _controller.GetPercentAssignTypes(activeOnly: true);
+        var typesResult = await _controller.GetPercentAssignTypes(activeOnly: true, TestContext.Current.CancellationToken);
         var typesOk = Assert.IsType<OkObjectResult>(typesResult.Result);
         var types = Assert.IsAssignableFrom<IEnumerable<PercentAssignTypeDto>>(typesOk.Value).ToList();
         Assert.Equal(3, types.Count);

--- a/test/Effort/PercentAssignTypesControllerTests.cs
+++ b/test/Effort/PercentAssignTypesControllerTests.cs
@@ -57,7 +57,7 @@ public sealed class PercentAssignTypesControllerTests
         _typeServiceMock.GetPercentAssignTypesAsync(false, Arg.Any<CancellationToken>()).Returns(types);
 
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -76,7 +76,7 @@ public sealed class PercentAssignTypesControllerTests
         _typeServiceMock.GetPercentAssignTypesAsync(true, Arg.Any<CancellationToken>()).Returns(types);
 
         // Act
-        var result = await _controller.GetPercentAssignTypes(activeOnly: true);
+        var result = await _controller.GetPercentAssignTypes(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -91,7 +91,7 @@ public sealed class PercentAssignTypesControllerTests
         // Arrange
         _typeServiceMock.GetPercentAssignTypesAsync(false, Arg.Any<CancellationToken>()).Returns(new List<PercentAssignTypeDto>());
         // Act
-        var result = await _controller.GetPercentAssignTypes();
+        var result = await _controller.GetPercentAssignTypes(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/test/Effort/PercentRolloverServiceTests.cs
+++ b/test/Effort/PercentRolloverServiceTests.cs
@@ -159,7 +159,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsRolloverApplicable);
@@ -195,7 +195,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.IsRolloverApplicable);
@@ -217,7 +217,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2025, result.SourceAcademicYear);
@@ -272,7 +272,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             compensated: true);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert - Should exclude already-rolled assignment (idempotency)
         Assert.False(result.IsRolloverApplicable);
@@ -297,14 +297,14 @@ public sealed class PercentRolloverServiceTests : IDisposable
             new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Local),
             unit.Id);
 
-        var initialCount = await _effortContext.Percentages.CountAsync();
+        var initialCount = await _effortContext.Percentages.CountAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, created);
-        var finalCount = await _effortContext.Percentages.CountAsync();
+        var finalCount = await _effortContext.Percentages.CountAsync(TestContext.Current.CancellationToken);
         Assert.Equal(initialCount + 1, finalCount);
     }
 
@@ -326,14 +326,14 @@ public sealed class PercentRolloverServiceTests : IDisposable
             comment: "Test comment");
 
         // Act
-        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, created);
 
         var newRecords = await _effortContext.Percentages
             .Where(p => p.StartDate == new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Local))
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         var newRecord = Assert.Single(newRecords);
         Assert.Equal(100, newRecord.PersonId);
@@ -365,7 +365,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, created);
@@ -388,10 +388,10 @@ public sealed class PercentRolloverServiceTests : IDisposable
             compensated: true);
 
         // Act - First rollover
-        var firstRun = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var firstRun = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Act - Second rollover (should be idempotent)
-        var secondRun = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var secondRun = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, firstRun);
@@ -399,7 +399,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
 
         var targetYearCount = await _effortContext.Percentages
             .Where(p => p.StartDate == new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Local))
-            .CountAsync();
+            .CountAsync(TestContext.Current.CancellationToken);
         Assert.Equal(1, targetYearCount);  // Only one record created, not two
     }
 
@@ -436,14 +436,14 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit1.Id);
 
         // Act
-        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, created);
 
         var newRecords = await _effortContext.Percentages
             .Where(p => p.StartDate == new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Local))
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(3, newRecords.Count);
         Assert.Contains(newRecords, r => r.PersonId == 100 && Math.Abs(r.PercentageValue - 0.5) < 0.0001);
@@ -474,7 +474,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             compensated: false);
 
         // Act
-        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        var created = await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, created);
@@ -482,7 +482,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
         var newRecords = await _effortContext.Percentages
             .Where(p => p.StartDate == new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Local))
             .OrderBy(p => p.Modifier)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, newRecords.Count);
         Assert.Equal("Primary", newRecords[0].Modifier);
@@ -507,7 +507,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert
         var assignment = Assert.Single(result.Assignments);
@@ -539,10 +539,10 @@ public sealed class PercentRolloverServiceTests : IDisposable
             ModifiedBy = TestUserId
         };
         _effortContext.Percentages.Add(percentage);
-        await _effortContext.SaveChangesAsync();
+        await _effortContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _rolloverService.GetRolloverPreviewAsync(2025);
+        var result = await _rolloverService.GetRolloverPreviewAsync(2025, TestContext.Current.CancellationToken);
 
         // Assert - ViperPerson nav property is null, so PersonName falls back to "Unknown"
         var assignment = Assert.Single(result.Assignments);
@@ -564,7 +564,7 @@ public sealed class PercentRolloverServiceTests : IDisposable
             unit.Id);
 
         // Act
-        await _rolloverService.ExecuteRolloverAsync(2025, TestUserId);
+        await _rolloverService.ExecuteRolloverAsync(2025, TestUserId, TestContext.Current.CancellationToken);
 
         // Assert - rollover audit is not tied to a term
         _auditServiceMock.Received(1).AddImportAudit(

--- a/test/Effort/PercentageServiceTests.cs
+++ b/test/Effort/PercentageServiceTests.cs
@@ -121,7 +121,7 @@ public sealed class PercentageServiceTests : IDisposable
         await CreatePercentageAsync(200, type.Id, 25, new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Local));
 
         // Act
-        var results = await _percentageService.GetPercentagesForPersonAsync(100);
+        var results = await _percentageService.GetPercentagesForPersonAsync(100, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, results.Count);
@@ -134,7 +134,7 @@ public sealed class PercentageServiceTests : IDisposable
     public async Task GetPercentagesForPersonAsync_ReturnsEmptyList_WhenNoPercentagesExist()
     {
         // Act
-        var results = await _percentageService.GetPercentagesForPersonAsync(999);
+        var results = await _percentageService.GetPercentagesForPersonAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(results);
@@ -149,7 +149,7 @@ public sealed class PercentageServiceTests : IDisposable
         await CreatePercentageAsync(100, type.Id, 75, new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local), null, unit.Id);
 
         // Act
-        var results = await _percentageService.GetPercentagesForPersonAsync(100);
+        var results = await _percentageService.GetPercentagesForPersonAsync(100, TestContext.Current.CancellationToken);
 
         // Assert
         var dto = Assert.Single(results);
@@ -179,12 +179,12 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.CreatePercentageAsync(request);
+        var result = await _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(100, result.PercentageValue);
 
-        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id);
+        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id, TestContext.Current.CancellationToken);
         Assert.Equal(1.0, stored.PercentageValue);
     }
 
@@ -205,12 +205,12 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.CreatePercentageAsync(request);
+        var result = await _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(50, result.PercentageValue);
 
-        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id);
+        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id, TestContext.Current.CancellationToken);
         Assert.Equal(0.5, stored.PercentageValue);
     }
 
@@ -231,7 +231,7 @@ public sealed class PercentageServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _percentageService.CreatePercentageAsync(request));
+            () => _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("Invalid percent assignment type", ex.Message);
     }
 
@@ -253,7 +253,7 @@ public sealed class PercentageServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _percentageService.CreatePercentageAsync(request));
+            () => _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("inactive", ex.Message);
     }
 
@@ -275,7 +275,7 @@ public sealed class PercentageServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _percentageService.CreatePercentageAsync(request));
+            () => _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("between 0 and 100", ex.Message);
     }
 
@@ -297,7 +297,7 @@ public sealed class PercentageServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _percentageService.CreatePercentageAsync(request));
+            () => _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("between 0 and 100", ex.Message);
     }
 
@@ -320,7 +320,7 @@ public sealed class PercentageServiceTests : IDisposable
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _percentageService.CreatePercentageAsync(request));
+            () => _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("End date cannot be before start date", ex.Message);
     }
 
@@ -341,10 +341,10 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.CreatePercentageAsync(request);
+        var result = await _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id);
+        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id, TestContext.Current.CancellationToken);
         Assert.Equal("2024-2025", stored.AcademicYear);
     }
 
@@ -365,10 +365,10 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.CreatePercentageAsync(request);
+        var result = await _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id);
+        var stored = await _context.Percentages.FirstAsync(p => p.Id == result.Id, TestContext.Current.CancellationToken);
         Assert.Equal("2023-2024", stored.AcademicYear);
     }
 
@@ -389,7 +389,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        await _percentageService.CreatePercentageAsync(request);
+        await _percentageService.CreatePercentageAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         await _auditServiceMock.Received(1).LogPercentageChangeAsync(
@@ -423,7 +423,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.UpdatePercentageAsync(existing.Id, request);
+        var result = await _percentageService.UpdatePercentageAsync(existing.Id, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -446,7 +446,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.UpdatePercentageAsync(999, request);
+        var result = await _percentageService.UpdatePercentageAsync(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -470,7 +470,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        await _percentageService.UpdatePercentageAsync(existing.Id, request);
+        await _percentageService.UpdatePercentageAsync(existing.Id, request, TestContext.Current.CancellationToken);
 
         // Assert
         await _auditServiceMock.Received(1).LogPercentageChangeAsync(
@@ -494,11 +494,11 @@ public sealed class PercentageServiceTests : IDisposable
         var existing = await CreatePercentageAsync(100, type.Id, 50, new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local));
 
         // Act
-        var result = await _percentageService.DeletePercentageAsync(existing.Id);
+        var result = await _percentageService.DeletePercentageAsync(existing.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        var deleted = await _context.Percentages.FindAsync(existing.Id);
+        var deleted = await _context.Percentages.FindAsync(new object?[] { existing.Id }, TestContext.Current.CancellationToken);
         Assert.Null(deleted);
     }
 
@@ -506,7 +506,7 @@ public sealed class PercentageServiceTests : IDisposable
     public async Task DeletePercentageAsync_ReturnsFalse_WhenNotFound()
     {
         // Act
-        var result = await _percentageService.DeletePercentageAsync(999);
+        var result = await _percentageService.DeletePercentageAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -520,7 +520,7 @@ public sealed class PercentageServiceTests : IDisposable
         var existing = await CreatePercentageAsync(100, type.Id, 50, new DateTime(2024, 7, 1, 0, 0, 0, DateTimeKind.Local));
 
         // Act
-        await _percentageService.DeletePercentageAsync(existing.Id);
+        await _percentageService.DeletePercentageAsync(existing.Id, TestContext.Current.CancellationToken);
 
         // Assert
         await _auditServiceMock.Received(1).LogPercentageChangeAsync(
@@ -556,7 +556,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -584,7 +584,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -611,7 +611,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -640,7 +640,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -667,7 +667,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -690,7 +690,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.IsValid);
@@ -715,7 +715,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request);
+        var result = await _percentageService.ValidatePercentageAsync(request, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.IsValid);
@@ -741,7 +741,7 @@ public sealed class PercentageServiceTests : IDisposable
         };
 
         // Act
-        var result = await _percentageService.ValidatePercentageAsync(request, excludeId: existing.Id);
+        var result = await _percentageService.ValidatePercentageAsync(request, excludeId: existing.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsValid);
@@ -760,7 +760,7 @@ public sealed class PercentageServiceTests : IDisposable
         var percentage = await CreatePercentageAsync(100, type.Id, 50, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local));
 
         // Act
-        var result = await _percentageService.GetPercentageAsync(percentage.Id);
+        var result = await _percentageService.GetPercentageAsync(percentage.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -775,7 +775,7 @@ public sealed class PercentageServiceTests : IDisposable
         var percentage = await CreatePercentageAsync(100, type.Id, 50, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local), DateTime.Today.AddYears(1));
 
         // Act
-        var result = await _percentageService.GetPercentageAsync(percentage.Id);
+        var result = await _percentageService.GetPercentageAsync(percentage.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -790,7 +790,7 @@ public sealed class PercentageServiceTests : IDisposable
         var percentage = await CreatePercentageAsync(100, type.Id, 50, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local), DateTime.Today.AddDays(-1));
 
         // Act
-        var result = await _percentageService.GetPercentageAsync(percentage.Id);
+        var result = await _percentageService.GetPercentageAsync(percentage.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/test/Effort/PercentagesControllerTests.cs
+++ b/test/Effort/PercentagesControllerTests.cs
@@ -107,7 +107,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.GetPercentagesForPersonAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(percentages);
 
         // Act
-        var result = await _controller.GetPercentagesForPerson(TestPersonId);
+        var result = await _controller.GetPercentagesForPerson(TestPersonId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -123,7 +123,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanViewPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetPercentagesForPerson(TestPersonId);
+        var result = await _controller.GetPercentagesForPerson(TestPersonId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -142,7 +142,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanViewPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.GetPercentage(TestPercentageId);
+        var result = await _controller.GetPercentage(TestPercentageId, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -157,7 +157,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetPercentage(999);
+        var result = await _controller.GetPercentage(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -172,7 +172,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanViewPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetPercentage(TestPercentageId);
+        var result = await _controller.GetPercentage(TestPercentageId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -200,7 +200,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.CreatePercentageAsync(request, Arg.Any<CancellationToken>()).Returns(percentage);
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -216,7 +216,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanEditPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -238,7 +238,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.ValidatePercentageAsync(request, null, Arg.Any<CancellationToken>()).Returns(validationResult);
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -262,7 +262,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.CreatePercentageAsync(request, Arg.Any<CancellationToken>()).Returns(percentage);
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -286,7 +286,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.CreatePercentageAsync(request, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Duplicate percentage assignment"));
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -310,7 +310,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.CreatePercentageAsync(request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("DB error"));
 
         // Act
-        var result = await _controller.CreatePercentage(request);
+        var result = await _controller.CreatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -337,7 +337,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.ValidatePercentageAsync(request, null, Arg.Any<CancellationToken>()).Returns(validationResult);
 
         // Act
-        var result = await _controller.ValidatePercentage(request);
+        var result = await _controller.ValidatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -354,7 +354,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanEditPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.ValidatePercentage(request);
+        var result = await _controller.ValidatePercentage(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -387,7 +387,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.UpdatePercentageAsync(TestPercentageId, request, Arg.Any<CancellationToken>()).Returns(updatedPercentage);
 
         // Act
-        var result = await _controller.UpdatePercentage(TestPercentageId, request);
+        var result = await _controller.UpdatePercentage(TestPercentageId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -402,7 +402,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.UpdatePercentage(999, request);
+        var result = await _controller.UpdatePercentage(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -419,7 +419,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanEditPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.UpdatePercentage(TestPercentageId, request);
+        var result = await _controller.UpdatePercentage(TestPercentageId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -443,7 +443,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.ValidatePercentageAsync(Arg.Any<CreatePercentageRequest>(), TestPercentageId, Arg.Any<CancellationToken>()).Returns(validationResult);
 
         // Act
-        var result = await _controller.UpdatePercentage(TestPercentageId, request);
+        var result = await _controller.UpdatePercentage(TestPercentageId, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -468,7 +468,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.UpdatePercentageAsync(TestPercentageId, request, Arg.Any<CancellationToken>()).Throws(new InvalidOperationException("Some other error"));
 
         // Act
-        var result = await _controller.UpdatePercentage(TestPercentageId, request);
+        var result = await _controller.UpdatePercentage(TestPercentageId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -494,7 +494,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.UpdatePercentageAsync(TestPercentageId, request, Arg.Any<CancellationToken>()).Throws(new DbUpdateException("DB error"));
 
         // Act
-        var result = await _controller.UpdatePercentage(TestPercentageId, request);
+        var result = await _controller.UpdatePercentage(TestPercentageId, request, TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -516,7 +516,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.DeletePercentageAsync(TestPercentageId, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.DeletePercentage(TestPercentageId);
+        var result = await _controller.DeletePercentage(TestPercentageId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
@@ -529,7 +529,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.GetPercentageAsync(999, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.DeletePercentage(999);
+        var result = await _controller.DeletePercentage(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -545,7 +545,7 @@ public sealed class PercentagesControllerTests
         _permissionServiceMock.CanEditPersonPercentagesAsync(TestPersonId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeletePercentage(TestPercentageId);
+        var result = await _controller.DeletePercentage(TestPercentageId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);
@@ -562,7 +562,7 @@ public sealed class PercentagesControllerTests
         _percentageServiceMock.DeletePercentageAsync(TestPercentageId, Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.DeletePercentage(TestPercentageId);
+        var result = await _controller.DeletePercentage(TestPercentageId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result);

--- a/test/Effort/RCourseServiceTests.cs
+++ b/test/Effort/RCourseServiceTests.cs
@@ -78,7 +78,7 @@ public sealed class RCourseServiceTests : IDisposable
     public async Task GetOrCreateGenericRCourseAsync_CreatesNewCourse_WhenNotExists()
     {
         // Act
-        var course = await _service.GetOrCreateGenericRCourseAsync(TestTermCode);
+        var course = await _service.GetOrCreateGenericRCourseAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -91,7 +91,7 @@ public sealed class RCourseServiceTests : IDisposable
         Assert.Equal(0, course.Enrollment);
 
         // Verify course was persisted
-        var persisted = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "RESID" && c.TermCode == TestTermCode);
+        var persisted = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "RESID" && c.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.NotNull(persisted);
         Assert.Equal(course.Id, persisted.Id);
 
@@ -120,10 +120,10 @@ public sealed class RCourseServiceTests : IDisposable
             CustDept = "VME"
         };
         _context.Courses.Add(existingCourse);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var course = await _service.GetOrCreateGenericRCourseAsync(TestTermCode);
+        var course = await _service.GetOrCreateGenericRCourseAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course);
@@ -145,11 +145,11 @@ public sealed class RCourseServiceTests : IDisposable
         var termCode1 = 202410;
         var termCode2 = 202420;
         _context.Terms.Add(new EffortTerm { TermCode = termCode2 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var course1 = await _service.GetOrCreateGenericRCourseAsync(termCode1);
-        var course2 = await _service.GetOrCreateGenericRCourseAsync(termCode2);
+        var course1 = await _service.GetOrCreateGenericRCourseAsync(termCode1, TestContext.Current.CancellationToken);
+        var course2 = await _service.GetOrCreateGenericRCourseAsync(termCode2, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(course1);
@@ -167,12 +167,12 @@ public sealed class RCourseServiceTests : IDisposable
     public async Task CreateRCourseEffortRecordAsync_CreatesRecord_WhenNotExists()
     {
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert - Verify effort record was created
         var record = await _context.Records
             .Include(r => r.Course)
-            .FirstOrDefaultAsync(r => r.PersonId == TestPersonId && r.Course.Crn == "RESID");
+            .FirstOrDefaultAsync(r => r.PersonId == TestPersonId && r.Course.Crn == "RESID", TestContext.Current.CancellationToken);
 
         Assert.NotNull(record);
         Assert.Equal(TestPersonId, record.PersonId);
@@ -202,7 +202,7 @@ public sealed class RCourseServiceTests : IDisposable
             CustDept = "VME"
         };
         _context.Courses.Add(genericRCourse);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var existingRecord = new EffortRecord
         {
@@ -216,19 +216,19 @@ public sealed class RCourseServiceTests : IDisposable
             Crn = "RESID"
         };
         _context.Records.Add(existingRecord);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var countBefore = await _context.Records.CountAsync();
+        var countBefore = await _context.Records.CountAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.OnDemand);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.OnDemand, TestContext.Current.CancellationToken);
 
         // Assert - No new record created
-        var countAfter = await _context.Records.CountAsync();
+        var countAfter = await _context.Records.CountAsync(TestContext.Current.CancellationToken);
         Assert.Equal(countBefore, countAfter);
 
         // Original record unchanged
-        var record = await _context.Records.FirstAsync(r => r.Id == existingRecord.Id);
+        var record = await _context.Records.FirstAsync(r => r.Id == existingRecord.Id, TestContext.Current.CancellationToken);
         Assert.Equal(5, record.Hours);
         Assert.Null(record.Weeks);
     }
@@ -237,22 +237,22 @@ public sealed class RCourseServiceTests : IDisposable
     public async Task CreateRCourseEffortRecordAsync_DoesNotCreateRecord_WhenNoEligibleEffortType()
     {
         // Arrange - Remove all R-course allowed effort types
-        var allowedTypes = await _context.EffortTypes.Where(t => t.AllowedOnRCourses).ToListAsync();
+        var allowedTypes = await _context.EffortTypes.Where(t => t.AllowedOnRCourses).ToListAsync(TestContext.Current.CancellationToken);
         _context.EffortTypes.RemoveRange(allowedTypes);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert - No effort record created
         var record = await _context.Records
             .Include(r => r.Course)
-            .FirstOrDefaultAsync(r => r.PersonId == TestPersonId && r.Course.Crn == "RESID");
+            .FirstOrDefaultAsync(r => r.PersonId == TestPersonId && r.Course.Crn == "RESID", TestContext.Current.CancellationToken);
 
         Assert.Null(record);
 
         // Course may still be created, but no effort record
-        var course = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "RESID");
+        var course = await _context.Courses.FirstOrDefaultAsync(c => c.Crn == "RESID", TestContext.Current.CancellationToken);
         Assert.NotNull(course); // Course is created first, then effort type check happens
     }
 
@@ -263,10 +263,10 @@ public sealed class RCourseServiceTests : IDisposable
         // CLI comes first alphabetically
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert
-        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId);
+        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(record);
         Assert.Equal("CLI", record.EffortTypeId);
     }
@@ -277,15 +277,15 @@ public sealed class RCourseServiceTests : IDisposable
         // Arrange - Remove week-based types so LEC (UsesWeeks=false) is selected
         var weekBasedTypes = await _context.EffortTypes
             .Where(t => t.AllowedOnRCourses && t.UsesWeeks)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         _context.EffortTypes.RemoveRange(weekBasedTypes);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert - Hours set, Weeks null (XOR constraint: CK_Records_HoursOrWeeks)
-        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId);
+        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(record);
         Assert.Equal(0, record.Hours);
         Assert.Null(record.Weeks);
@@ -298,15 +298,15 @@ public sealed class RCourseServiceTests : IDisposable
         // Arrange - Remove hour-based types so CLI (UsesWeeks=true) is selected
         var hourBasedTypes = await _context.EffortTypes
             .Where(t => t.AllowedOnRCourses && !t.UsesWeeks)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         _context.EffortTypes.RemoveRange(hourBasedTypes);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert - Weeks set to 1 (min valid value), Hours null (XOR constraint: CK_Records_HoursOrWeeks)
-        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId);
+        var record = await _context.Records.FirstOrDefaultAsync(r => r.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(record);
         Assert.Null(record.Hours);
         Assert.Equal(1, record.Weeks); // Weeks must be > 0 per CK_Records_Weeks constraint
@@ -317,11 +317,11 @@ public sealed class RCourseServiceTests : IDisposable
     public async Task CreateRCourseEffortRecordAsync_CreatesAuditEntry_WithHarvestContext()
     {
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert - Verify audit entry was created (checking via context, not mock)
         var auditEntry = await _context.Audits
-            .FirstOrDefaultAsync(a => a.Action == EffortAuditActions.RCourseAutoCreated);
+            .FirstOrDefaultAsync(a => a.Action == EffortAuditActions.RCourseAutoCreated, TestContext.Current.CancellationToken);
 
         Assert.NotNull(auditEntry);
         Assert.Equal(EffortAuditTables.Records, auditEntry.TableName);
@@ -334,11 +334,11 @@ public sealed class RCourseServiceTests : IDisposable
     public async Task CreateRCourseEffortRecordAsync_CreatesAuditEntry_WithOnDemandContext()
     {
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.OnDemand);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.OnDemand, TestContext.Current.CancellationToken);
 
         // Assert - Verify audit entry was created with correct context
         var auditEntry = await _context.Audits
-            .FirstOrDefaultAsync(a => a.Action == EffortAuditActions.RCourseAutoCreated);
+            .FirstOrDefaultAsync(a => a.Action == EffortAuditActions.RCourseAutoCreated, TestContext.Current.CancellationToken);
 
         Assert.NotNull(auditEntry);
         Assert.Contains("when first non-R-course added", auditEntry.Changes);
@@ -357,17 +357,17 @@ public sealed class RCourseServiceTests : IDisposable
             LastName = "Instructor",
             EffortDept = "VME"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
-        await _service.CreateRCourseEffortRecordAsync(personId2, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest);
+        await _service.CreateRCourseEffortRecordAsync(TestPersonId, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
+        await _service.CreateRCourseEffortRecordAsync(personId2, TestTermCode, TestModifiedBy, RCourseCreationContext.Harvest, TestContext.Current.CancellationToken);
 
         // Assert
         var records = await _context.Records
             .Include(r => r.Course)
             .Where(r => r.Course.Crn == "RESID" && r.TermCode == TestTermCode)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, records.Count);
         Assert.Contains(records, r => r.PersonId == TestPersonId);

--- a/test/Effort/ReportsControllerTests.cs
+++ b/test/Effort/ReportsControllerTests.cs
@@ -137,7 +137,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenTermCodeIsNegative()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(-1);
+        var result = await _controller.GetTeachingActivityGrouped(-1, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -147,7 +147,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(academicYear: "2024-2099");
+        var result = await _controller.GetTeachingActivityGrouped(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -158,7 +158,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenDepartmentTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "TOOLONG7");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -168,7 +168,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenPersonIdIsZero()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, personId: 0);
+        var result = await _controller.GetTeachingActivityGrouped(202410, personId: 0, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -178,7 +178,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenPersonIdIsNegative()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, personId: -5);
+        var result = await _controller.GetTeachingActivityGrouped(202410, personId: -5, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -188,7 +188,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenRoleTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, role: "IF");
+        var result = await _controller.GetTeachingActivityGrouped(202410, role: "IF", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -198,7 +198,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityGrouped_ReturnsBadRequest_WhenTitleTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, title: "LONG");
+        var result = await _controller.GetTeachingActivityGrouped(202410, title: "LONG", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -218,7 +218,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityIndividual_ReturnsBadRequest_WhenDepartmentTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityIndividual(202410, department: "TOOLONG7");
+        var result = await _controller.GetTeachingActivityIndividual(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -228,7 +228,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityIndividual_ReturnsBadRequest_WhenRoleTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityIndividual(202410, role: "IF");
+        var result = await _controller.GetTeachingActivityIndividual(202410, role: "IF", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -238,7 +238,7 @@ public sealed class ReportsControllerTests
     public async Task GetTeachingActivityIndividual_ReturnsBadRequest_WhenTitleTooLong()
     {
         // Act
-        var result = await _controller.GetTeachingActivityIndividual(202410, title: "LONG");
+        var result = await _controller.GetTeachingActivityIndividual(202410, title: "LONG", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -258,7 +258,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -279,7 +279,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME", ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -297,7 +297,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, "I", "REG", Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME", personId: 123, role: "I", title: "REG");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME", personId: 123, role: "I", title: "REG", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -314,7 +314,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityIndividual(202410);
+        var result = await _controller.GetTeachingActivityIndividual(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -335,7 +335,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "APC")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "APC");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "APC", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -353,7 +353,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act - no department filter requested
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert - should auto-select the single authorized dept
         Assert.IsType<OkObjectResult>(result.Result);
@@ -371,7 +371,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME", "APC")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act - no department filter requested
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert - should pass all authorized departments so SP filters per-dept
         Assert.IsType<OkObjectResult>(result.Result);
@@ -389,7 +389,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "VME", ct: TestContext.Current.CancellationToken);
 
         // Assert - authorized dept is allowed through
         Assert.IsType<OkObjectResult>(result.Result);
@@ -413,7 +413,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => d != null && d.Count == 0), null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         // Act - requests "PHR" but only authorized for "VME"
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "PHR");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "PHR", ct: TestContext.Current.CancellationToken);
 
         // Assert - returns empty report instead of substituting a different department
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -428,7 +428,7 @@ public sealed class ReportsControllerTests
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert - should return Forbid, not leak data
         Assert.IsType<ForbidResult>(result.Result);
@@ -456,7 +456,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME", "APC")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert - PMI should be filtered out
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -485,7 +485,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410);
+        var result = await _controller.GetTeachingActivityGrouped(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -661,7 +661,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "ABCDEF")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, department: "ABCDEF");
+        var result = await _controller.GetTeachingActivityGrouped(202410, department: "ABCDEF", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -677,7 +677,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, null, "I", null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, role: "I");
+        var result = await _controller.GetTeachingActivityGrouped(202410, role: "I", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -693,7 +693,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, null, null, "REG", Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, title: "REG");
+        var result = await _controller.GetTeachingActivityGrouped(202410, title: "REG", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -709,7 +709,7 @@ public sealed class ReportsControllerTests
             .GetTeachingActivityReportAsync(202410, null, 1, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
         // Act
-        var result = await _controller.GetTeachingActivityGrouped(202410, personId: 1);
+        var result = await _controller.GetTeachingActivityGrouped(202410, personId: 1, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<OkObjectResult>(result.Result);
@@ -733,14 +733,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetDeptSummary_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetDeptSummary(academicYear: "2024");
+        var result = await _controller.GetDeptSummary(academicYear: "2024", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetDeptSummary_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetDeptSummary(academicYear: "2024-2099");
+        var result = await _controller.GetDeptSummary(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -748,14 +748,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetDeptSummary_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetDeptSummary(202410, department: "TOOLONG7");
+        var result = await _controller.GetDeptSummary(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetDeptSummary_ReturnsBadRequest_WhenTitleTooLong()
     {
-        var result = await _controller.GetDeptSummary(202410, title: "LONG");
+        var result = await _controller.GetDeptSummary(202410, title: "LONG", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -767,7 +767,7 @@ public sealed class ReportsControllerTests
         _deptSummaryServiceMock
             .GetDeptSummaryReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetDeptSummary(202410);
+        var result = await _controller.GetDeptSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<DeptSummaryReport>(okResult.Value);
@@ -783,7 +783,7 @@ public sealed class ReportsControllerTests
         _deptSummaryServiceMock
             .GetDeptSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, "REG", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetDeptSummary(202410, department: "VME", title: "REG");
+        var result = await _controller.GetDeptSummary(202410, department: "VME", title: "REG", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _deptSummaryServiceMock.Received(1).GetDeptSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, "REG", Arg.Any<CancellationToken>());
@@ -798,7 +798,7 @@ public sealed class ReportsControllerTests
         _deptSummaryServiceMock
             .GetDeptSummaryReportByYearAsync("2024-2025", null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetDeptSummary(academicYear: "2024-2025");
+        var result = await _controller.GetDeptSummary(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<DeptSummaryReport>(okResult.Value);
@@ -810,7 +810,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetDeptSummary(202410);
+        var result = await _controller.GetDeptSummary(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -831,7 +831,7 @@ public sealed class ReportsControllerTests
         _deptSummaryServiceMock
             .GetDeptSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetDeptSummary(202410);
+        var result = await _controller.GetDeptSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<DeptSummaryReport>(okResult.Value);
@@ -853,7 +853,7 @@ public sealed class ReportsControllerTests
         _deptSummaryServiceMock
             .GetDeptSummaryReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetDeptSummary(202410);
+        var result = await _controller.GetDeptSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<DeptSummaryReport>(okResult.Value);
@@ -874,14 +874,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetSchoolSummary_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetSchoolSummary(academicYear: "2024");
+        var result = await _controller.GetSchoolSummary(academicYear: "2024", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetSchoolSummary_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetSchoolSummary(academicYear: "2024-2099");
+        var result = await _controller.GetSchoolSummary(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -894,7 +894,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetSchoolSummary(202410);
+        var result = await _controller.GetSchoolSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<SchoolSummaryReport>(okResult.Value);
@@ -911,7 +911,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportByYearAsync("2024-2025", null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetSchoolSummary(academicYear: "2024-2025");
+        var result = await _controller.GetSchoolSummary(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<SchoolSummaryReport>(okResult.Value);
@@ -927,7 +927,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetSchoolSummary(202410);
+        var result = await _controller.GetSchoolSummary(202410, ct: TestContext.Current.CancellationToken);
 
         // Assert - all departments returned, no filtering applied
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -945,7 +945,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetSchoolSummary(202410);
+        var result = await _controller.GetSchoolSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<SchoolSummaryReport>(okResult.Value);
@@ -961,7 +961,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, "1", "REG", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetSchoolSummary(202410, department: "VME", personId: 123, role: "1", title: "REG");
+        var result = await _controller.GetSchoolSummary(202410, department: "VME", personId: 123, role: "1", title: "REG", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _schoolSummaryServiceMock.Received(1).GetSchoolSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, "1", "REG", Arg.Any<CancellationToken>());
@@ -986,7 +986,7 @@ public sealed class ReportsControllerTests
         _schoolSummaryServiceMock
             .GetSchoolSummaryReportAsync(202410, null, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetSchoolSummary(202410);
+        var result = await _controller.GetSchoolSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<SchoolSummaryReport>(okResult.Value);
@@ -1007,7 +1007,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritDetail_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetMeritDetail(academicYear: "2024-2099");
+        var result = await _controller.GetMeritDetail(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -1015,28 +1015,28 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritDetail_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetMeritDetail(202410, department: "TOOLONG7");
+        var result = await _controller.GetMeritDetail(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritDetail_ReturnsBadRequest_WhenPersonIdIsZero()
     {
-        var result = await _controller.GetMeritDetail(202410, personId: 0);
+        var result = await _controller.GetMeritDetail(202410, personId: 0, ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritDetail_ReturnsBadRequest_WhenPersonIdIsNegative()
     {
-        var result = await _controller.GetMeritDetail(202410, personId: -5);
+        var result = await _controller.GetMeritDetail(202410, personId: -5, ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritDetail_ReturnsBadRequest_WhenRoleTooLong()
     {
-        var result = await _controller.GetMeritDetail(202410, role: "IF");
+        var result = await _controller.GetMeritDetail(202410, role: "IF", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -1048,7 +1048,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritDetail(202410, personId: null);
+        var result = await _controller.GetMeritDetail(202410, personId: null, ct: TestContext.Current.CancellationToken);
         Assert.IsType<OkObjectResult>(result.Result);
     }
 
@@ -1060,7 +1060,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportAsync(202410, null, 100, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritDetail(202410, personId: 100);
+        var result = await _controller.GetMeritDetail(202410, personId: 100, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritDetailReport>(okResult.Value);
@@ -1076,7 +1076,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, "I", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritDetail(202410, department: "VME", personId: 123, role: "I");
+        var result = await _controller.GetMeritDetail(202410, department: "VME", personId: 123, role: "I", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _meritReportServiceMock.Received(1).GetMeritDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, "I", Arg.Any<CancellationToken>());
@@ -1091,7 +1091,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportByYearAsync("2024-2025", null, 100, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritDetail(academicYear: "2024-2025", personId: 100);
+        var result = await _controller.GetMeritDetail(academicYear: "2024-2025", personId: 100, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritDetailReport>(okResult.Value);
@@ -1103,7 +1103,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetMeritDetail(202410, personId: 100);
+        var result = await _controller.GetMeritDetail(202410, personId: 100, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1123,7 +1123,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 100, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritDetail(202410, personId: 100);
+        var result = await _controller.GetMeritDetail(202410, personId: 100, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritDetailReport>(okResult.Value);
@@ -1145,7 +1145,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritDetailReportAsync(202410, null, 100, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetMeritDetail(202410, personId: 100);
+        var result = await _controller.GetMeritDetail(202410, personId: 100, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritDetailReport>(okResult.Value);
@@ -1166,7 +1166,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritAverage_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetMeritAverage(academicYear: "2024-2099");
+        var result = await _controller.GetMeritAverage(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -1174,21 +1174,21 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritAverage_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetMeritAverage(202410, department: "TOOLONG7");
+        var result = await _controller.GetMeritAverage(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritAverage_ReturnsBadRequest_WhenPersonIdIsZero()
     {
-        var result = await _controller.GetMeritAverage(202410, personId: 0);
+        var result = await _controller.GetMeritAverage(202410, personId: 0, ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritAverage_ReturnsBadRequest_WhenPersonIdIsNegative()
     {
-        var result = await _controller.GetMeritAverage(202410, personId: -5);
+        var result = await _controller.GetMeritAverage(202410, personId: -5, ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -1200,7 +1200,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportAsync(202410, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritAverage(202410);
+        var result = await _controller.GetMeritAverage(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritAverageReport>(okResult.Value);
@@ -1216,7 +1216,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritAverage(202410, department: "VME", personId: 123);
+        var result = await _controller.GetMeritAverage(202410, department: "VME", personId: 123, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _meritReportServiceMock.Received(1).GetMeritAverageReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), 123, Arg.Any<CancellationToken>());
@@ -1231,7 +1231,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportByYearAsync("2024-2025", null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritAverage(academicYear: "2024-2025");
+        var result = await _controller.GetMeritAverage(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritAverageReport>(okResult.Value);
@@ -1243,7 +1243,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetMeritAverage(202410);
+        var result = await _controller.GetMeritAverage(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1267,7 +1267,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritAverage(202410);
+        var result = await _controller.GetMeritAverage(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritAverageReport>(okResult.Value);
@@ -1302,7 +1302,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritAverage(202410);
+        var result = await _controller.GetMeritAverage(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritAverageReport>(okResult.Value);
@@ -1325,7 +1325,7 @@ public sealed class ReportsControllerTests
         _meritReportServiceMock
             .GetMeritAverageReportAsync(202410, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetMeritAverage(202410);
+        var result = await _controller.GetMeritAverage(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritAverageReport>(okResult.Value);
@@ -1444,14 +1444,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritSummary_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetMeritSummary(academicYear: "2024");
+        var result = await _controller.GetMeritSummary(academicYear: "2024", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetMeritSummary_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetMeritSummary(academicYear: "2024-2099");
+        var result = await _controller.GetMeritSummary(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -1459,7 +1459,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritSummary_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetMeritSummary(202410, department: "TOOLONG7");
+        var result = await _controller.GetMeritSummary(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -1471,7 +1471,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportAsync(202410, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritSummary(202410);
+        var result = await _controller.GetMeritSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritSummaryReport>(okResult.Value);
@@ -1487,7 +1487,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritSummary(202410, department: "VME");
+        var result = await _controller.GetMeritSummary(202410, department: "VME", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _meritSummaryServiceMock.Received(1).GetMeritSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), Arg.Any<CancellationToken>());
@@ -1502,7 +1502,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportByYearAsync("2024-2025", null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritSummary(academicYear: "2024-2025");
+        var result = await _controller.GetMeritSummary(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritSummaryReport>(okResult.Value);
@@ -1514,7 +1514,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetMeritSummary(202410);
+        var result = await _controller.GetMeritSummary(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1536,7 +1536,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritSummary(202410);
+        var result = await _controller.GetMeritSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritSummaryReport>(okResult.Value);
@@ -1569,7 +1569,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritSummary(202410);
+        var result = await _controller.GetMeritSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritSummaryReport>(okResult.Value);
@@ -1591,7 +1591,7 @@ public sealed class ReportsControllerTests
         _meritSummaryServiceMock
             .GetMeritSummaryReportAsync(202410, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetMeritSummary(202410);
+        var result = await _controller.GetMeritSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MeritSummaryReport>(okResult.Value);
@@ -1605,21 +1605,21 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetClinicalEffort_ReturnsBadRequest_WhenAcademicYearMissing()
     {
-        var result = await _controller.GetClinicalEffort(academicYear: null, clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: null, clinicalType: 1, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetClinicalEffort_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetClinicalEffort(academicYear: "2024", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024", clinicalType: 1, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetClinicalEffort_ReturnsBadRequest_WhenClinicalTypeInvalid()
     {
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 99);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 99, TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("clinicalType", badRequest.Value?.ToString());
     }
@@ -1632,7 +1632,7 @@ public sealed class ReportsControllerTests
         _clinicalEffortServiceMock
             .GetClinicalEffortReportAsync("2024-2025", 1, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ClinicalEffortReport>(okResult.Value);
@@ -1649,7 +1649,7 @@ public sealed class ReportsControllerTests
         _clinicalEffortServiceMock
             .GetClinicalEffortReportAsync("2024-2025", 25, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 25);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 25, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ClinicalEffortReport>(okResult.Value);
@@ -1661,7 +1661,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1, TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1684,7 +1684,7 @@ public sealed class ReportsControllerTests
         _clinicalEffortServiceMock
             .GetClinicalEffortReportAsync("2024-2025", 1, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ClinicalEffortReport>(okResult.Value);
@@ -1718,7 +1718,7 @@ public sealed class ReportsControllerTests
         _clinicalEffortServiceMock
             .GetClinicalEffortReportAsync("2024-2025", 1, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ClinicalEffortReport>(okResult.Value);
@@ -1742,7 +1742,7 @@ public sealed class ReportsControllerTests
         _clinicalEffortServiceMock
             .GetClinicalEffortReportAsync("2024-2025", 1, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1);
+        var result = await _controller.GetClinicalEffort(academicYear: "2024-2025", clinicalType: 1, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ClinicalEffortReport>(okResult.Value);
@@ -1763,14 +1763,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetScheduledCliWeeks_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024");
+        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetScheduledCliWeeks_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024-2099");
+        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -1780,7 +1780,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var result = await _controller.GetScheduledCliWeeks(202410);
+        var result = await _controller.GetScheduledCliWeeks(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -1793,7 +1793,7 @@ public sealed class ReportsControllerTests
         _clinicalScheduleServiceMock
             .GetScheduledCliWeeksReportAsync(202410, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetScheduledCliWeeks(202410);
+        var result = await _controller.GetScheduledCliWeeks(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ScheduledCliWeeksReport>(okResult.Value);
@@ -1810,7 +1810,7 @@ public sealed class ReportsControllerTests
         _clinicalScheduleServiceMock
             .GetScheduledCliWeeksReportByYearAsync("2024-2025", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024-2025");
+        var result = await _controller.GetScheduledCliWeeks(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ScheduledCliWeeksReport>(okResult.Value);
@@ -1831,7 +1831,7 @@ public sealed class ReportsControllerTests
         _clinicalScheduleServiceMock
             .GetScheduledCliWeeksReportAsync(202410, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetScheduledCliWeeks(202410);
+        var result = await _controller.GetScheduledCliWeeks(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<ScheduledCliWeeksReport>(okResult.Value);
@@ -1846,7 +1846,7 @@ public sealed class ReportsControllerTests
     public async Task ExportMeritSummaryPdf_ReturnsBadRequest_WhenNoTermOrYear()
     {
         var request = new ReportPdfRequest(TermCode: 0);
-        var result = await _controller.ExportMeritSummaryPdf(request);
+        var result = await _controller.ExportMeritSummaryPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -1865,7 +1865,7 @@ public sealed class ReportsControllerTests
             .GetMeritSummaryReportAsync(202410, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportMeritSummaryPdf(request);
+        var result = await _controller.ExportMeritSummaryPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -1882,7 +1882,7 @@ public sealed class ReportsControllerTests
             .GenerateReportPdfAsync(report).Returns(pdfBytes);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportMeritSummaryPdf(request);
+        var result = await _controller.ExportMeritSummaryPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -1893,7 +1893,7 @@ public sealed class ReportsControllerTests
     public async Task ExportClinicalEffortPdf_ReturnsBadRequest_WhenAcademicYearMissing()
     {
         var request = new ClinicalEffortPdfRequest(AcademicYear: null, ClinicalType: 1);
-        var result = await _controller.ExportClinicalEffortPdf(request);
+        var result = await _controller.ExportClinicalEffortPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -1901,7 +1901,7 @@ public sealed class ReportsControllerTests
     public async Task ExportClinicalEffortPdf_ReturnsBadRequest_WhenClinicalTypeInvalid()
     {
         var request = new ClinicalEffortPdfRequest(AcademicYear: "2024-2025", ClinicalType: 99);
-        var result = await _controller.ExportClinicalEffortPdf(request);
+        var result = await _controller.ExportClinicalEffortPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -1922,7 +1922,7 @@ public sealed class ReportsControllerTests
             .GetClinicalEffortReportAsync("2024-2025", 1, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new ClinicalEffortPdfRequest(AcademicYear: "2024-2025", ClinicalType: 1);
-        var result = await _controller.ExportClinicalEffortPdf(request);
+        var result = await _controller.ExportClinicalEffortPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -1939,7 +1939,7 @@ public sealed class ReportsControllerTests
             .GenerateReportPdfAsync(report).Returns(pdfBytes);
 
         var request = new ClinicalEffortPdfRequest(AcademicYear: "2024-2025", ClinicalType: 1);
-        var result = await _controller.ExportClinicalEffortPdf(request);
+        var result = await _controller.ExportClinicalEffortPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -1949,7 +1949,7 @@ public sealed class ReportsControllerTests
     public async Task ExportScheduledCliWeeksPdf_ReturnsBadRequest_WhenNoTermOrYear()
     {
         var request = new ReportPdfRequest(TermCode: 0);
-        var result = await _controller.ExportScheduledCliWeeksPdf(request);
+        var result = await _controller.ExportScheduledCliWeeksPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -1959,7 +1959,7 @@ public sealed class ReportsControllerTests
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportScheduledCliWeeksPdf(request);
+        var result = await _controller.ExportScheduledCliWeeksPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result);
     }
@@ -1979,7 +1979,7 @@ public sealed class ReportsControllerTests
             .GetScheduledCliWeeksReportAsync(202410, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportScheduledCliWeeksPdf(request);
+        var result = await _controller.ExportScheduledCliWeeksPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -1996,7 +1996,7 @@ public sealed class ReportsControllerTests
             .GenerateReportPdfAsync(report).Returns(pdfBytes);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportScheduledCliWeeksPdf(request);
+        var result = await _controller.ExportScheduledCliWeeksPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -2094,14 +2094,14 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetEvalSummary_ReturnsBadRequest_WhenAcademicYearBadFormat()
     {
-        var result = await _controller.GetEvalSummary(academicYear: "2024");
+        var result = await _controller.GetEvalSummary(academicYear: "2024", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
     [Fact]
     public async Task GetEvalSummary_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetEvalSummary(academicYear: "2024-2099");
+        var result = await _controller.GetEvalSummary(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -2109,7 +2109,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetEvalSummary_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetEvalSummary(202410, department: "TOOLONG7");
+        var result = await _controller.GetEvalSummary(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -2121,7 +2121,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(202410);
+        var result = await _controller.GetEvalSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalSummaryReport>(okResult.Value);
@@ -2137,7 +2137,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(202410, department: "VME");
+        var result = await _controller.GetEvalSummary(202410, department: "VME", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>());
@@ -2152,7 +2152,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportByYearAsync("2024-2025", null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(academicYear: "2024-2025");
+        var result = await _controller.GetEvalSummary(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalSummaryReport>(okResult.Value);
@@ -2164,7 +2164,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetEvalSummary(202410);
+        var result = await _controller.GetEvalSummary(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -2185,7 +2185,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(202410);
+        var result = await _controller.GetEvalSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalSummaryReport>(okResult.Value);
@@ -2206,7 +2206,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetEvalSummary(202410);
+        var result = await _controller.GetEvalSummary(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalSummaryReport>(okResult.Value);
@@ -2221,7 +2221,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, null, 42, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(202410, personId: 42);
+        var result = await _controller.GetEvalSummary(202410, personId: 42, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalSummaryReportAsync(202410, null, 42, null, Arg.Any<CancellationToken>());
@@ -2235,7 +2235,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalSummaryReportAsync(202410, null, null, "1", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalSummary(202410, role: "1");
+        var result = await _controller.GetEvalSummary(202410, role: "1", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalSummaryReportAsync(202410, null, null, "1", Arg.Any<CancellationToken>());
@@ -2255,7 +2255,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetEvalDetail_ReturnsBadRequest_WhenAcademicYearNotConsecutive()
     {
-        var result = await _controller.GetEvalDetail(academicYear: "2024-2099");
+        var result = await _controller.GetEvalDetail(academicYear: "2024-2099", ct: TestContext.Current.CancellationToken);
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("consecutive", badRequest.Value?.ToString());
     }
@@ -2263,7 +2263,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetEvalDetail_ReturnsBadRequest_WhenDepartmentTooLong()
     {
-        var result = await _controller.GetEvalDetail(202410, department: "TOOLONG7");
+        var result = await _controller.GetEvalDetail(202410, department: "TOOLONG7", ct: TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
 
@@ -2275,7 +2275,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(202410);
+        var result = await _controller.GetEvalDetail(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalDetailReport>(okResult.Value);
@@ -2291,7 +2291,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(202410, department: "VME");
+        var result = await _controller.GetEvalDetail(202410, department: "VME", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>());
@@ -2306,7 +2306,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportByYearAsync("2024-2025", null, null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(academicYear: "2024-2025");
+        var result = await _controller.GetEvalDetail(academicYear: "2024-2025", ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalDetailReport>(okResult.Value);
@@ -2318,7 +2318,7 @@ public sealed class ReportsControllerTests
     {
         _permissionServiceMock.HasFullAccessAsync(Arg.Any<CancellationToken>()).Returns(false);
         _permissionServiceMock.GetAuthorizedDepartmentsAsync(Arg.Any<CancellationToken>()).Returns(new List<string>());
-        var result = await _controller.GetEvalDetail(202410);
+        var result = await _controller.GetEvalDetail(202410, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -2338,7 +2338,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, Arg.Is<IReadOnlyList<string>?>(d => IsDepts(d, "VME")), null, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(202410);
+        var result = await _controller.GetEvalDetail(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalDetailReport>(okResult.Value);
@@ -2359,7 +2359,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
-        var result = await _controller.GetEvalDetail(202410);
+        var result = await _controller.GetEvalDetail(202410, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<EvalDetailReport>(okResult.Value);
@@ -2374,7 +2374,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, null, 42, null, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(202410, personId: 42);
+        var result = await _controller.GetEvalDetail(202410, personId: 42, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalDetailReportAsync(202410, null, 42, null, Arg.Any<CancellationToken>());
@@ -2388,7 +2388,7 @@ public sealed class ReportsControllerTests
         _evaluationReportServiceMock
             .GetEvalDetailReportAsync(202410, null, null, "2", Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetEvalDetail(202410, role: "2");
+        var result = await _controller.GetEvalDetail(202410, role: "2", ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
         await _evaluationReportServiceMock.Received(1).GetEvalDetailReportAsync(202410, null, null, "2", Arg.Any<CancellationToken>());
@@ -2402,7 +2402,7 @@ public sealed class ReportsControllerTests
     public async Task ExportEvalSummaryPdf_ReturnsBadRequest_WhenNoTermOrYear()
     {
         var request = new ReportPdfRequest(TermCode: 0);
-        var result = await _controller.ExportEvalSummaryPdf(request);
+        var result = await _controller.ExportEvalSummaryPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -2420,7 +2420,7 @@ public sealed class ReportsControllerTests
             .GetEvalSummaryReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportEvalSummaryPdf(request);
+        var result = await _controller.ExportEvalSummaryPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -2437,7 +2437,7 @@ public sealed class ReportsControllerTests
             .GenerateSummaryPdfAsync(report).Returns(pdfBytes);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportEvalSummaryPdf(request);
+        var result = await _controller.ExportEvalSummaryPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -2448,7 +2448,7 @@ public sealed class ReportsControllerTests
     public async Task ExportEvalDetailPdf_ReturnsBadRequest_WhenNoTermOrYear()
     {
         var request = new ReportPdfRequest(TermCode: 0);
-        var result = await _controller.ExportEvalDetailPdf(request);
+        var result = await _controller.ExportEvalDetailPdf(request, TestContext.Current.CancellationToken);
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
@@ -2466,7 +2466,7 @@ public sealed class ReportsControllerTests
             .GetEvalDetailReportAsync(202410, null, null, null, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportEvalDetailPdf(request);
+        var result = await _controller.ExportEvalDetailPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -2483,7 +2483,7 @@ public sealed class ReportsControllerTests
             .GenerateDetailPdfAsync(report).Returns(pdfBytes);
 
         var request = new ReportPdfRequest(TermCode: 202410);
-        var result = await _controller.ExportEvalDetailPdf(request);
+        var result = await _controller.ExportEvalDetailPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -2566,7 +2566,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritMultiYear_ReturnsBadRequest_WhenPersonIdIsZero()
     {
-        var result = await _controller.GetMeritMultiYear(personId: 0, startYear: 2020, endYear: 2024);
+        var result = await _controller.GetMeritMultiYear(personId: 0, startYear: 2020, endYear: 2024, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -2574,7 +2574,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritMultiYear_ReturnsBadRequest_WhenPersonIdIsNegative()
     {
-        var result = await _controller.GetMeritMultiYear(personId: -1, startYear: 2020, endYear: 2024);
+        var result = await _controller.GetMeritMultiYear(personId: -1, startYear: 2020, endYear: 2024, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -2582,7 +2582,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritMultiYear_ReturnsBadRequest_WhenYearsAreMissing()
     {
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 0, endYear: 0);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 0, endYear: 0, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -2590,7 +2590,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritMultiYear_ReturnsBadRequest_WhenYearRangeExceeds10()
     {
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2010, endYear: 2025);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2010, endYear: 2025, ct: TestContext.Current.CancellationToken);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("10 years", badRequest.Value?.ToString());
@@ -2599,7 +2599,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetMeritMultiYear_ReturnsBadRequest_WhenEndYearBeforeStartYear()
     {
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2024, endYear: 2020);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2024, endYear: 2020, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -2612,7 +2612,7 @@ public sealed class ReportsControllerTests
         _meritMultiYearServiceMock
             .GetMultiYearReportAsync(123, 2020, 2024, null, null, true, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024, useAcademicYear: true);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024, useAcademicYear: true, ct: TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedReport = Assert.IsType<MultiYearReport>(okResult.Value);
@@ -2631,7 +2631,7 @@ public sealed class ReportsControllerTests
         _meritMultiYearServiceMock
             .GetMultiYearReportAsync(123, 2020, 2024, null, null, false, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -2645,7 +2645,7 @@ public sealed class ReportsControllerTests
         _meritMultiYearServiceMock
             .GetMultiYearReportAsync(123, 2020, 2024, null, null, false, Arg.Any<CancellationToken>()).Returns(report);
 
-        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024);
+        var result = await _controller.GetMeritMultiYear(personId: 123, startYear: 2020, endYear: 2024, ct: TestContext.Current.CancellationToken);
 
         Assert.IsType<ForbidResult>(result.Result);
     }
@@ -2654,7 +2654,7 @@ public sealed class ReportsControllerTests
     public async Task ExportMeritMultiYearPdf_ReturnsBadRequest_WhenPersonIdIsZero()
     {
         var request = new MultiYearPdfRequest(PersonId: 0, StartYear: 2020, EndYear: 2024);
-        var result = await _controller.ExportMeritMultiYearPdf(request);
+        var result = await _controller.ExportMeritMultiYearPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -2677,7 +2677,7 @@ public sealed class ReportsControllerTests
             .GetMultiYearReportAsync(123, 2020, 2024, null, null, false, Arg.Any<CancellationToken>()).Returns(emptyReport);
 
         var request = new MultiYearPdfRequest(PersonId: 123, StartYear: 2020, EndYear: 2024);
-        var result = await _controller.ExportMeritMultiYearPdf(request);
+        var result = await _controller.ExportMeritMultiYearPdf(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -2694,7 +2694,7 @@ public sealed class ReportsControllerTests
             .GenerateReportPdfAsync(report).Returns(pdfBytes);
 
         var request = new MultiYearPdfRequest(PersonId: 123, StartYear: 2020, EndYear: 2024);
-        var result = await _controller.ExportMeritMultiYearPdf(request);
+        var result = await _controller.ExportMeritMultiYearPdf(request, TestContext.Current.CancellationToken);
 
         var fileResult = Assert.IsType<FileContentResult>(result);
         Assert.Equal("application/pdf", fileResult.ContentType);
@@ -2719,7 +2719,7 @@ public sealed class ReportsControllerTests
         _sabbaticalServiceMock
             .GetByPersonIdAsync(123, Arg.Any<CancellationToken>()).Returns(dto);
 
-        var result = await _controller.GetSabbatical(123);
+        var result = await _controller.GetSabbatical(123, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedDto = Assert.IsType<SabbaticalDto>(okResult.Value);
@@ -2734,7 +2734,7 @@ public sealed class ReportsControllerTests
         _sabbaticalServiceMock
             .GetByPersonIdAsync(456, Arg.Any<CancellationToken>()).ReturnsNull();
 
-        var result = await _controller.GetSabbatical(456);
+        var result = await _controller.GetSabbatical(456, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedDto = Assert.IsType<SabbaticalDto>(okResult.Value);
@@ -2745,7 +2745,7 @@ public sealed class ReportsControllerTests
     [Fact]
     public async Task GetSabbatical_InvalidPersonId_ReturnsBadRequest()
     {
-        var result = await _controller.GetSabbatical(0);
+        var result = await _controller.GetSabbatical(0, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -2765,7 +2765,7 @@ public sealed class ReportsControllerTests
             .SaveAsync(123, "202409", null, 999, Arg.Any<CancellationToken>()).Returns(savedDto);
 
         var request = new SaveSabbaticalRequest("202409");
-        var result = await _controller.SaveSabbatical(123, request);
+        var result = await _controller.SaveSabbatical(123, request, TestContext.Current.CancellationToken);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnedDto = Assert.IsType<SabbaticalDto>(okResult.Value);
@@ -2777,7 +2777,7 @@ public sealed class ReportsControllerTests
     public async Task SaveSabbatical_InvalidPersonId_ReturnsBadRequest()
     {
         var request = new SaveSabbaticalRequest("202409");
-        var result = await _controller.SaveSabbatical(-1, request);
+        var result = await _controller.SaveSabbatical(-1, request, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }

--- a/test/Effort/SabbaticalServiceTests.cs
+++ b/test/Effort/SabbaticalServiceTests.cs
@@ -83,7 +83,7 @@ public sealed class SabbaticalServiceTests : IDisposable
     [Fact]
     public async Task GetByPersonIdAsync_ReturnsNull_WhenNotFound()
     {
-        var result = await _service.GetByPersonIdAsync(999);
+        var result = await _service.GetByPersonIdAsync(999, TestContext.Current.CancellationToken);
 
         Assert.Null(result);
     }
@@ -94,7 +94,7 @@ public sealed class SabbaticalServiceTests : IDisposable
         var modifier = await CreateViperPersonAsync(10, "Admin", "User");
         await CreateSabbaticalAsync(42, modifier.PersonId);
 
-        var result = await _service.GetByPersonIdAsync(42);
+        var result = await _service.GetByPersonIdAsync(42, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(42, result.PersonId);
@@ -108,7 +108,7 @@ public sealed class SabbaticalServiceTests : IDisposable
     {
         await CreateSabbaticalAsync(42, modifiedBy: 999);
 
-        var result = await _service.GetByPersonIdAsync(42);
+        var result = await _service.GetByPersonIdAsync(42, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Null(result.ModifiedBy);
@@ -123,7 +123,7 @@ public sealed class SabbaticalServiceTests : IDisposable
     {
         var modifier = await CreateViperPersonAsync(10, "Admin", "User");
 
-        var result = await _service.SaveAsync(42, "202301", "202302", modifier.PersonId);
+        var result = await _service.SaveAsync(42, "202301", "202302", modifier.PersonId, TestContext.Current.CancellationToken);
 
         Assert.Equal(42, result.PersonId);
         Assert.Equal("202301", result.ExcludeClinicalTerms);
@@ -131,7 +131,7 @@ public sealed class SabbaticalServiceTests : IDisposable
         Assert.Equal("Admin User", result.ModifiedBy);
         Assert.NotNull(result.ModifiedDate);
 
-        var entity = await _context.Sabbaticals.FirstOrDefaultAsync(s => s.PersonId == 42);
+        var entity = await _context.Sabbaticals.FirstOrDefaultAsync(s => s.PersonId == 42, TestContext.Current.CancellationToken);
         Assert.NotNull(entity);
     }
 
@@ -140,7 +140,7 @@ public sealed class SabbaticalServiceTests : IDisposable
     {
         var modifier = await CreateViperPersonAsync(10, "Admin", "User");
 
-        var result = await _service.SaveAsync(42, null, null, modifier.PersonId);
+        var result = await _service.SaveAsync(42, null, null, modifier.PersonId, TestContext.Current.CancellationToken);
 
         Assert.Null(result.ExcludeClinicalTerms);
         Assert.Null(result.ExcludeDidacticTerms);
@@ -157,12 +157,12 @@ public sealed class SabbaticalServiceTests : IDisposable
         await CreateSabbaticalAsync(42, modifier.PersonId,
             excludeClinical: "202301", excludeDidactic: "202302");
 
-        var result = await _service.SaveAsync(42, "202401,202402", "202403", modifier.PersonId);
+        var result = await _service.SaveAsync(42, "202401,202402", "202403", modifier.PersonId, TestContext.Current.CancellationToken);
 
         Assert.Equal("202401,202402", result.ExcludeClinicalTerms);
         Assert.Equal("202403", result.ExcludeDidacticTerms);
 
-        var count = await _context.Sabbaticals.CountAsync(s => s.PersonId == 42);
+        var count = await _context.Sabbaticals.CountAsync(s => s.PersonId == 42, TestContext.Current.CancellationToken);
         Assert.Equal(1, count);
     }
 
@@ -173,9 +173,9 @@ public sealed class SabbaticalServiceTests : IDisposable
         var original = await CreateSabbaticalAsync(42, modifier.PersonId);
         var originalDate = original.ModifiedDate;
 
-        await _service.SaveAsync(42, "new", "new", modifier.PersonId);
+        await _service.SaveAsync(42, "new", "new", modifier.PersonId, TestContext.Current.CancellationToken);
 
-        var entity = await _context.Sabbaticals.FirstAsync(s => s.PersonId == 42);
+        var entity = await _context.Sabbaticals.FirstAsync(s => s.PersonId == 42, TestContext.Current.CancellationToken);
         Assert.True(entity.ModifiedDate > originalDate);
     }
 
@@ -186,7 +186,7 @@ public sealed class SabbaticalServiceTests : IDisposable
     [Fact]
     public async Task GetPersonDepartmentAsync_ReturnsNull_WhenNoPerson()
     {
-        var result = await _service.GetPersonDepartmentAsync(999);
+        var result = await _service.GetPersonDepartmentAsync(999, TestContext.Current.CancellationToken);
 
         Assert.Null(result);
     }
@@ -197,7 +197,7 @@ public sealed class SabbaticalServiceTests : IDisposable
         await CreateEffortPersonAsync(42, 202301, "VME");
         await CreateEffortPersonAsync(42, 202401, "PMI");
 
-        var result = await _service.GetPersonDepartmentAsync(42);
+        var result = await _service.GetPersonDepartmentAsync(42, TestContext.Current.CancellationToken);
 
         Assert.Equal("PMI", result);
     }

--- a/test/Effort/TermServiceTests.cs
+++ b/test/Effort/TermServiceTests.cs
@@ -65,10 +65,10 @@ public sealed class TermServiceTests : IDisposable
             new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) },
             new EffortTerm { TermCode = 202510 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var terms = await _termService.GetTermsAsync();
+        var terms = await _termService.GetTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, terms.Count);
@@ -81,7 +81,7 @@ public sealed class TermServiceTests : IDisposable
     public async Task GetTermsAsync_ReturnsEmptyList_WhenNoTermsExist()
     {
         // Act
-        var terms = await _termService.GetTermsAsync();
+        var terms = await _termService.GetTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(terms);
@@ -96,10 +96,10 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - OpenedDate makes status "Opened"
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.GetTermAsync(202410);
+        var term = await _termService.GetTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -111,7 +111,7 @@ public sealed class TermServiceTests : IDisposable
     public async Task GetTermAsync_ReturnsNull_WhenTermDoesNotExist()
     {
         // Act
-        var term = await _termService.GetTermAsync(999999);
+        var term = await _termService.GetTermAsync(999999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(term);
@@ -130,10 +130,10 @@ public sealed class TermServiceTests : IDisposable
             new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) },
             new EffortTerm { TermCode = 202510 }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.GetCurrentTermAsync();
+        var term = await _termService.GetCurrentTermAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -145,10 +145,10 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - ClosedDate makes status "Closed"
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-30), ClosedDate = DateTime.Now.AddDays(-1) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.GetCurrentTermAsync();
+        var term = await _termService.GetCurrentTermAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(term);
@@ -162,14 +162,14 @@ public sealed class TermServiceTests : IDisposable
     public async Task CreateTermAsync_CreatesNewTerm_WithCreatedStatus()
     {
         // Act
-        var term = await _termService.CreateTermAsync(202510);
+        var term = await _termService.CreateTermAsync(202510, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Equal(202510, term.TermCode);
         Assert.Equal("Created", term.Status);
 
-        var savedTerm = await _context.Terms.FindAsync(202510);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202510 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
     }
 
@@ -178,11 +178,11 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.CreateTermAsync(202410)
+            () => _termService.CreateTermAsync(202410, ct: TestContext.Current.CancellationToken)
         );
     }
 
@@ -193,14 +193,14 @@ public sealed class TermServiceTests : IDisposable
         var expectedDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local);
 
         // Act
-        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: expectedDate);
+        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: expectedDate, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Equal(202510, term.TermCode);
         Assert.Equal(expectedDate, term.ExpectedCloseDate);
 
-        var savedTerm = await _context.Terms.FindAsync(202510);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202510 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
         Assert.Equal(expectedDate, savedTerm.ExpectedCloseDate);
     }
@@ -209,13 +209,13 @@ public sealed class TermServiceTests : IDisposable
     public async Task CreateTermAsync_LeavesExpectedCloseDateNull_WhenNotProvided()
     {
         // Act
-        var term = await _termService.CreateTermAsync(202510);
+        var term = await _termService.CreateTermAsync(202510, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Null(term.ExpectedCloseDate);
 
-        var savedTerm = await _context.Terms.FindAsync(202510);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202510 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
         Assert.Null(savedTerm.ExpectedCloseDate);
     }
@@ -229,18 +229,18 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - OpenedDate makes status "Opened"
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var newDate = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Local);
 
         // Act
-        var term = await _termService.UpdateExpectedCloseDateAsync(202410, newDate);
+        var term = await _termService.UpdateExpectedCloseDateAsync(202410, newDate, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Equal(newDate, term.ExpectedCloseDate);
 
-        var savedTerm = await _context.Terms.FindAsync(202410);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
         Assert.Equal(newDate, savedTerm.ExpectedCloseDate);
     }
@@ -255,11 +255,11 @@ public sealed class TermServiceTests : IDisposable
             OpenedDate = DateTime.Now.AddDays(-30),
             ClosedDate = DateTime.Now.AddDays(-1)
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -272,16 +272,16 @@ public sealed class TermServiceTests : IDisposable
             OpenedDate = DateTime.Now.AddDays(-7),
             ExpectedCloseDate = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Local)
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.UpdateExpectedCloseDateAsync(202410, null);
+        var term = await _termService.UpdateExpectedCloseDateAsync(202410, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Null(term.ExpectedCloseDate);
 
-        var savedTerm = await _context.Terms.FindAsync(202410);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
         Assert.Null(savedTerm.ExpectedCloseDate);
     }
@@ -290,7 +290,7 @@ public sealed class TermServiceTests : IDisposable
     public async Task UpdateExpectedCloseDateAsync_ReturnsNull_WhenTermNotFound()
     {
         // Act
-        var term = await _termService.UpdateExpectedCloseDateAsync(999999, new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local));
+        var term = await _termService.UpdateExpectedCloseDateAsync(999999, new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(term);
@@ -312,11 +312,11 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("after the term end date", ex.Message);
     }
 
@@ -332,11 +332,11 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("after the term end date", ex.Message);
     }
 
@@ -352,11 +352,11 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2026, 6, 16, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2026, 6, 16, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("more than 1 year", ex.Message);
     }
 
@@ -372,10 +372,10 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 16, 0, 0, 0, DateTimeKind.Local));
+        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2025, 6, 16, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -394,10 +394,10 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Local));
+        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -409,7 +409,7 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
         _viperContext.Terms.Add(new Term
         {
             TermCode = 202410,
@@ -418,11 +418,11 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2024, 12, 13, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("after the term end date", ex.Message);
     }
 
@@ -431,7 +431,7 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
         _viperContext.Terms.Add(new Term
         {
             TermCode = 202410,
@@ -440,11 +440,11 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2024, 12, 13, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 12, 14, 0, 0, 0, DateTimeKind.Local)));
+            () => _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 12, 14, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken));
         Assert.Contains("more than 1 year", ex.Message);
     }
 
@@ -453,7 +453,7 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
         _viperContext.Terms.Add(new Term
         {
             TermCode = 202410,
@@ -462,10 +462,10 @@ public sealed class TermServiceTests : IDisposable
             EndDate = new DateTime(2024, 12, 13, 0, 0, 0, DateTimeKind.Local),
             TermType = "Q"
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Local));
+        var term = await _termService.UpdateExpectedCloseDateAsync(202410, new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -482,10 +482,10 @@ public sealed class TermServiceTests : IDisposable
             OpenedDate = DateTime.Now.AddDays(-7),
             ExpectedCloseDate = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Local)
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.UpdateExpectedCloseDateAsync(202410, null);
+        var term = await _termService.UpdateExpectedCloseDateAsync(202410, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -499,7 +499,7 @@ public sealed class TermServiceTests : IDisposable
         // Validation should be skipped, not throw
 
         // Act
-        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local));
+        var term = await _termService.CreateTermAsync(202510, expectedCloseDate: new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local), TestContext.Current.CancellationToken);
 
         // Assert - Accepts any date when term not found in vwTerms
         Assert.NotNull(term);
@@ -515,17 +515,17 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - HarvestedDate makes status "Harvested"
         _context.Terms.Add(new EffortTerm { TermCode = 202410, HarvestedDate = DateTime.Now.AddDays(-1) });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.OpenTermAsync(202410);
+        var term = await _termService.OpenTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
         Assert.Equal("Opened", term.Status);
         Assert.NotNull(term.OpenedDate);
 
-        var savedTerm = await _context.Terms.FindAsync(202410);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
     }
 
@@ -533,7 +533,7 @@ public sealed class TermServiceTests : IDisposable
     public async Task OpenTermAsync_ReturnsNull_WhenTermDoesNotExist()
     {
         // Act
-        var term = await _termService.OpenTermAsync(999999);
+        var term = await _termService.OpenTermAsync(999999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(term);
@@ -549,16 +549,16 @@ public sealed class TermServiceTests : IDisposable
         // Arrange - OpenedDate makes status "Opened"
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Enrollment = 10, Crn = "12345" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (success, errorMessage) = await _termService.CloseTermAsync(202410);
+        var (success, errorMessage) = await _termService.CloseTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(success);
         Assert.Null(errorMessage);
 
-        var savedTerm = await _context.Terms.FindAsync(202410);
+        var savedTerm = await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken);
         Assert.NotNull(savedTerm);
         Assert.Equal("Closed", savedTerm.Status);
         Assert.NotNull(savedTerm.ClosedDate);
@@ -571,10 +571,10 @@ public sealed class TermServiceTests : IDisposable
         _context.Terms.Add(new EffortTerm { TermCode = 202410, OpenedDate = DateTime.Now.AddDays(-7) });
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Enrollment = 0, Crn = "12345" });
         _context.Courses.Add(new EffortCourse { Id = 2, TermCode = 202410, Enrollment = 0, Crn = "12346" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (success, errorMessage) = await _termService.CloseTermAsync(202410);
+        var (success, errorMessage) = await _termService.CloseTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(success);
@@ -585,7 +585,7 @@ public sealed class TermServiceTests : IDisposable
     public async Task CloseTermAsync_Fails_WhenTermNotFound()
     {
         // Act
-        var (success, errorMessage) = await _termService.CloseTermAsync(999999);
+        var (success, errorMessage) = await _termService.CloseTermAsync(999999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(success);
@@ -606,10 +606,10 @@ public sealed class TermServiceTests : IDisposable
             OpenedDate = DateTime.Now.AddDays(-30),
             ClosedDate = DateTime.Now.AddDays(-1)
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.ReopenTermAsync(202410);
+        var term = await _termService.ReopenTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -631,10 +631,10 @@ public sealed class TermServiceTests : IDisposable
             HarvestedDate = DateTime.Now.AddDays(-5),
             OpenedDate = DateTime.Now
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.UnopenTermAsync(202410);
+        var term = await _termService.UnopenTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -651,10 +651,10 @@ public sealed class TermServiceTests : IDisposable
             TermCode = 202410,
             OpenedDate = DateTime.Now
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var term = await _termService.UnopenTermAsync(202410);
+        var term = await _termService.UnopenTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(term);
@@ -671,14 +671,14 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _termService.DeleteTermAsync(202410);
+        var result = await _termService.DeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        Assert.Null(await _context.Terms.FindAsync(202410));
+        Assert.Null(await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -687,14 +687,14 @@ public sealed class TermServiceTests : IDisposable
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _termService.DeleteTermAsync(202410);
+        var result = await _termService.DeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        Assert.NotNull(await _context.Terms.FindAsync(202410));
+        Assert.NotNull(await _context.Terms.FindAsync(new object?[] { 202410 }, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -703,10 +703,10 @@ public sealed class TermServiceTests : IDisposable
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
         _context.Persons.Add(new EffortPerson { PersonId = 1, TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _termService.DeleteTermAsync(202410);
+        var result = await _termService.DeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -718,10 +718,10 @@ public sealed class TermServiceTests : IDisposable
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
         _context.Records.Add(new EffortRecord { Id = 1, TermCode = 202410, PersonId = 1, CourseId = 1 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _termService.DeleteTermAsync(202410);
+        var result = await _termService.DeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -736,10 +736,10 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canDelete = await _termService.CanDeleteTermAsync(202410);
+        var canDelete = await _termService.CanDeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -751,10 +751,10 @@ public sealed class TermServiceTests : IDisposable
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Crn = "12345" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canDelete = await _termService.CanDeleteTermAsync(202410);
+        var canDelete = await _termService.CanDeleteTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canDelete);
@@ -770,10 +770,10 @@ public sealed class TermServiceTests : IDisposable
         // Arrange
         _context.Terms.Add(new EffortTerm { TermCode = 202410 });
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Enrollment = 10, Crn = "12345" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canClose, zeroEnrollmentCount) = await _termService.CanCloseTermAsync(202410);
+        var (canClose, zeroEnrollmentCount) = await _termService.CanCloseTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canClose);
@@ -788,10 +788,10 @@ public sealed class TermServiceTests : IDisposable
         _context.Courses.Add(new EffortCourse { Id = 1, TermCode = 202410, Enrollment = 0, Crn = "12345" });
         _context.Courses.Add(new EffortCourse { Id = 2, TermCode = 202410, Enrollment = 0, Crn = "12346" });
         _context.Courses.Add(new EffortCourse { Id = 3, TermCode = 202410, Enrollment = 5, Crn = "12347" });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var (canClose, zeroEnrollmentCount) = await _termService.CanCloseTermAsync(202410);
+        var (canClose, zeroEnrollmentCount) = await _termService.CanCloseTermAsync(202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canClose);
@@ -807,7 +807,7 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - Add existing effort term
         _context.Terms.Add(new EffortTerm { TermCode = 202510 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Add terms to VIPER context (simulating vwTerms)
         _viperContext.Terms.AddRange(
@@ -815,10 +815,10 @@ public sealed class TermServiceTests : IDisposable
             new Term { TermCode = 202520, Description = "Winter 2026", StartDate = DateTime.Today.AddMonths(6), TermType = "Q" },
             new Term { TermCode = 202530, Description = "Spring 2026", StartDate = DateTime.Today.AddMonths(9), TermType = "Q" }
         );
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _termService.GetAvailableTermsAsync();
+        var available = await _termService.GetAvailableTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert - Should exclude 202510 (already in Effort)
         Assert.Equal(2, available.Count);
@@ -835,10 +835,10 @@ public sealed class TermServiceTests : IDisposable
             new Term { TermCode = 202520, Description = "Winter 2026", StartDate = DateTime.Today.AddMonths(6), TermType = "Q" },
             new Term { TermCode = Term.FacilityScheduleTermCode, Description = "(DO NOT USE) Facility Schedule", StartDate = DateTime.Today.AddMonths(12), TermType = "Q" }
         );
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _termService.GetAvailableTermsAsync();
+        var available = await _termService.GetAvailableTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert - Should exclude facility schedule term
         Assert.Single(available);
@@ -853,10 +853,10 @@ public sealed class TermServiceTests : IDisposable
             new Term { TermCode = 202310, Description = "Fall 2023", StartDate = DateTime.Today.AddMonths(-12), TermType = "Q" },
             new Term { TermCode = 202520, Description = "Winter 2026", StartDate = DateTime.Today.AddMonths(6), TermType = "Q" }
         );
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _termService.GetAvailableTermsAsync();
+        var available = await _termService.GetAvailableTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert - Should exclude past term
         Assert.Single(available);
@@ -869,13 +869,13 @@ public sealed class TermServiceTests : IDisposable
     {
         // Arrange - Add all future terms to Effort
         _context.Terms.Add(new EffortTerm { TermCode = 202520 });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.Terms.Add(new Term { TermCode = 202520, Description = "Winter 2026", StartDate = DateTime.Today.AddMonths(6), TermType = "Q" });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var available = await _termService.GetAvailableTermsAsync();
+        var available = await _termService.GetAvailableTermsAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(available);

--- a/test/Effort/UnitServiceTests.cs
+++ b/test/Effort/UnitServiceTests.cs
@@ -89,10 +89,10 @@ public sealed class UnitServiceTests : IDisposable
             new Unit { Id = 2, Name = "Alpha Unit", IsActive = true },
             new Unit { Id = 3, Name = "Middle Unit", IsActive = false }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var units = await _unitService.GetUnitsAsync();
+        var units = await _unitService.GetUnitsAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, units.Count);
@@ -109,10 +109,10 @@ public sealed class UnitServiceTests : IDisposable
             new Unit { Id = 1, Name = "Active Unit", IsActive = true },
             new Unit { Id = 2, Name = "Inactive Unit", IsActive = false }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var units = await _unitService.GetUnitsAsync(activeOnly: true);
+        var units = await _unitService.GetUnitsAsync(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(units);
@@ -124,7 +124,7 @@ public sealed class UnitServiceTests : IDisposable
     public async Task GetUnitsAsync_ReturnsEmptyList_WhenNoUnitsExist()
     {
         // Act
-        var units = await _unitService.GetUnitsAsync();
+        var units = await _unitService.GetUnitsAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(units);
@@ -137,7 +137,7 @@ public sealed class UnitServiceTests : IDisposable
         await CreateUnitWithPercentagesAsync("Test Unit", percentageCount: 2);
 
         // Act
-        var units = await _unitService.GetUnitsAsync();
+        var units = await _unitService.GetUnitsAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(units);
@@ -150,10 +150,10 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Unused Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var units = await _unitService.GetUnitsAsync();
+        var units = await _unitService.GetUnitsAsync(ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(units);
@@ -170,10 +170,10 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Test Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var unit = await _unitService.GetUnitAsync(1);
+        var unit = await _unitService.GetUnitAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(unit);
@@ -186,7 +186,7 @@ public sealed class UnitServiceTests : IDisposable
     public async Task GetUnitAsync_ReturnsNull_WhenNotFound()
     {
         // Act
-        var unit = await _unitService.GetUnitAsync(999);
+        var unit = await _unitService.GetUnitAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(unit);
@@ -199,7 +199,7 @@ public sealed class UnitServiceTests : IDisposable
         var unit = await CreateUnitWithPercentagesAsync("Test Unit");
 
         // Act
-        var result = await _unitService.GetUnitAsync(unit.Id);
+        var result = await _unitService.GetUnitAsync(unit.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -218,7 +218,7 @@ public sealed class UnitServiceTests : IDisposable
         var request = new CreateUnitRequest { Name = "New Unit" };
 
         // Act
-        var result = await _unitService.CreateUnitAsync(request);
+        var result = await _unitService.CreateUnitAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -228,7 +228,7 @@ public sealed class UnitServiceTests : IDisposable
         Assert.True(result.CanDelete);
 
         // Verify persisted
-        var savedUnit = await _context.Units.FirstOrDefaultAsync(u => u.Name == "New Unit");
+        var savedUnit = await _context.Units.FirstOrDefaultAsync(u => u.Name == "New Unit", TestContext.Current.CancellationToken);
         Assert.NotNull(savedUnit);
     }
 
@@ -237,13 +237,13 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Existing Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new CreateUnitRequest { Name = "Existing Unit" };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _unitService.CreateUnitAsync(request));
+            () => _unitService.CreateUnitAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", exception.Message);
     }
 
@@ -254,7 +254,7 @@ public sealed class UnitServiceTests : IDisposable
         var request = new CreateUnitRequest { Name = "Audited Unit" };
 
         // Act
-        await _unitService.CreateUnitAsync(request);
+        await _unitService.CreateUnitAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddUnitChangeAudit(
@@ -271,11 +271,11 @@ public sealed class UnitServiceTests : IDisposable
         var request = new CreateUnitRequest { Name = "  Padded Unit  " };
 
         // Act
-        var result = await _unitService.CreateUnitAsync(request);
+        var result = await _unitService.CreateUnitAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("Padded Unit", result.Name);
-        var savedUnit = await _context.Units.FirstOrDefaultAsync(u => u.Name == "Padded Unit");
+        var savedUnit = await _context.Units.FirstOrDefaultAsync(u => u.Name == "Padded Unit", TestContext.Current.CancellationToken);
         Assert.NotNull(savedUnit);
     }
 
@@ -287,7 +287,7 @@ public sealed class UnitServiceTests : IDisposable
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _unitService.CreateUnitAsync(request));
+            () => _unitService.CreateUnitAsync(request, TestContext.Current.CancellationToken));
         Assert.Contains("required", exception.Message);
     }
 
@@ -300,12 +300,12 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Original Name", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "Updated Name", IsActive = false };
 
         // Act
-        var result = await _unitService.UpdateUnitAsync(1, request);
+        var result = await _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -320,7 +320,7 @@ public sealed class UnitServiceTests : IDisposable
         var request = new UpdateUnitRequest { Name = "New Name", IsActive = true };
 
         // Act
-        var result = await _unitService.UpdateUnitAsync(999, request);
+        var result = await _unitService.UpdateUnitAsync(999, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -334,13 +334,13 @@ public sealed class UnitServiceTests : IDisposable
             new Unit { Id = 1, Name = "Unit One", IsActive = true },
             new Unit { Id = 2, Name = "Unit Two", IsActive = true }
         );
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "Unit Two", IsActive = true };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _unitService.UpdateUnitAsync(1, request));
+            () => _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("already exists", exception.Message);
     }
 
@@ -349,12 +349,12 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Same Name", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "Same Name", IsActive = false };
 
         // Act
-        var result = await _unitService.UpdateUnitAsync(1, request);
+        var result = await _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -367,12 +367,12 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "Updated", IsActive = false };
 
         // Act
-        await _unitService.UpdateUnitAsync(1, request);
+        await _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddUnitChangeAudit(
@@ -387,12 +387,12 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "  Updated Name  ", IsActive = true };
 
         // Act
-        var result = await _unitService.UpdateUnitAsync(1, request);
+        var result = await _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -404,13 +404,13 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Original", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var request = new UpdateUnitRequest { Name = "   ", IsActive = true };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _unitService.UpdateUnitAsync(1, request));
+            () => _unitService.UpdateUnitAsync(1, request, TestContext.Current.CancellationToken));
         Assert.Contains("required", exception.Message);
     }
 
@@ -423,14 +423,14 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Deletable Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _unitService.DeleteUnitAsync(1);
+        var result = await _unitService.DeleteUnitAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        var deletedUnit = await _context.Units.FindAsync(1);
+        var deletedUnit = await _context.Units.FindAsync(new object?[] { 1 }, TestContext.Current.CancellationToken);
         Assert.Null(deletedUnit);
     }
 
@@ -441,11 +441,11 @@ public sealed class UnitServiceTests : IDisposable
         var unit = await CreateUnitWithPercentagesAsync("Referenced Unit");
 
         // Act
-        var result = await _unitService.DeleteUnitAsync(unit.Id);
+        var result = await _unitService.DeleteUnitAsync(unit.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        var stillExists = await _context.Units.FindAsync(unit.Id);
+        var stillExists = await _context.Units.FindAsync(new object?[] { unit.Id }, TestContext.Current.CancellationToken);
         Assert.NotNull(stillExists);
     }
 
@@ -453,7 +453,7 @@ public sealed class UnitServiceTests : IDisposable
     public async Task DeleteUnitAsync_ReturnsFalse_WhenNotFound()
     {
         // Act
-        var result = await _unitService.DeleteUnitAsync(999);
+        var result = await _unitService.DeleteUnitAsync(999, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
@@ -464,10 +464,10 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "To Delete", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _unitService.DeleteUnitAsync(1);
+        await _unitService.DeleteUnitAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         _auditServiceMock.Received(1).AddUnitChangeAudit(
@@ -486,10 +486,10 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Unused Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var canDelete = await _unitService.CanDeleteUnitAsync(1);
+        var canDelete = await _unitService.CanDeleteUnitAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(canDelete);
@@ -502,7 +502,7 @@ public sealed class UnitServiceTests : IDisposable
         var unit = await CreateUnitWithPercentagesAsync("Used Unit");
 
         // Act
-        var canDelete = await _unitService.CanDeleteUnitAsync(unit.Id);
+        var canDelete = await _unitService.CanDeleteUnitAsync(unit.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(canDelete);
@@ -517,10 +517,10 @@ public sealed class UnitServiceTests : IDisposable
     {
         // Arrange
         _context.Units.Add(new Unit { Id = 1, Name = "Unused Unit", IsActive = true });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var count = await _unitService.GetUsageCountAsync(1);
+        var count = await _unitService.GetUsageCountAsync(1, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, count);
@@ -533,7 +533,7 @@ public sealed class UnitServiceTests : IDisposable
         var unit = await CreateUnitWithPercentagesAsync("Used Unit", percentageCount: 3);
 
         // Act
-        var count = await _unitService.GetUsageCountAsync(unit.Id);
+        var count = await _unitService.GetUsageCountAsync(unit.Id, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, count);

--- a/test/Effort/UnitsControllerTests.cs
+++ b/test/Effort/UnitsControllerTests.cs
@@ -60,7 +60,7 @@ public sealed class UnitsControllerTests
         _unitServiceMock.GetUnitsAsync(false, Arg.Any<CancellationToken>()).Returns(units);
 
         // Act
-        var result = await _controller.GetUnits();
+        var result = await _controller.GetUnits(ct: TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -79,7 +79,7 @@ public sealed class UnitsControllerTests
         _unitServiceMock.GetUnitsAsync(true, Arg.Any<CancellationToken>()).Returns(units);
 
         // Act
-        var result = await _controller.GetUnits(activeOnly: true);
+        var result = await _controller.GetUnits(activeOnly: true, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/test/Effort/VerificationControllerTests.cs
+++ b/test/Effort/VerificationControllerTests.cs
@@ -78,7 +78,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.GetMyEffortAsync(202410, Arg.Any<CancellationToken>()).Returns(myEffort);
 
         // Act
-        var result = await _controller.GetMyEffort(202410);
+        var result = await _controller.GetMyEffort(202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -94,7 +94,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.GetMyEffortAsync(202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetMyEffort(202410);
+        var result = await _controller.GetMyEffort(202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -116,7 +116,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.VerifyEffortAsync(202410, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.VerifyEffort(202410);
+        var actionResult = await _controller.VerifyEffort(202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -132,7 +132,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.VerifyEffortAsync(202410, Arg.Any<CancellationToken>()).Returns(result);
 
         // Act
-        var actionResult = await _controller.VerifyEffort(202410);
+        var actionResult = await _controller.VerifyEffort(202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
@@ -158,7 +158,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.SendVerificationEmailAsync(123, 202410, Arg.Any<CancellationToken>()).Returns(emailResult);
 
         // Act
-        var result = await _controller.SendVerificationEmail(request);
+        var result = await _controller.SendVerificationEmail(request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -175,7 +175,7 @@ public sealed class VerificationControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.SendVerificationEmail(request);
+        var result = await _controller.SendVerificationEmail(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -192,7 +192,7 @@ public sealed class VerificationControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.SendVerificationEmail(request);
+        var result = await _controller.SendVerificationEmail(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<ForbidResult>(result.Result);
@@ -209,7 +209,7 @@ public sealed class VerificationControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("DVM", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        var result = await _controller.SendVerificationEmail(request);
+        var result = await _controller.SendVerificationEmail(request, TestContext.Current.CancellationToken);
 
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
@@ -231,7 +231,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.SendBulkVerificationEmailsAsync("DVM", 202410, false, Arg.Any<CancellationToken>()).Returns(bulkResult);
 
         // Act
-        var result = await _controller.SendBulkVerificationEmails(request);
+        var result = await _controller.SendBulkVerificationEmails(request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -249,7 +249,7 @@ public sealed class VerificationControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.SendBulkVerificationEmails(request);
+        var result = await _controller.SendBulkVerificationEmails(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<ForbidResult>(result.Result);
@@ -275,7 +275,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.GetEmailHistoryAsync(123, 202410, Arg.Any<CancellationToken>()).Returns(history);
 
         // Act
-        var result = await _controller.GetEmailHistory(123, 202410);
+        var result = await _controller.GetEmailHistory(123, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -290,7 +290,7 @@ public sealed class VerificationControllerTests
         _instructorServiceMock.GetInstructorAsync(999, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.GetEmailHistory(999, 202410);
+        var result = await _controller.GetEmailHistory(999, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -306,7 +306,7 @@ public sealed class VerificationControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.GetEmailHistory(123, 202410);
+        var result = await _controller.GetEmailHistory(123, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<ForbidResult>(result.Result);
@@ -326,7 +326,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.CanVerifyAsync(123, 202410, Arg.Any<CancellationToken>()).Returns(canVerifyResult);
 
         // Act
-        var result = await _controller.CanVerify(123, 202410);
+        var result = await _controller.CanVerify(123, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -347,7 +347,7 @@ public sealed class VerificationControllerTests
         _verificationServiceMock.CanVerifyAsync(456, 202410, Arg.Any<CancellationToken>()).Returns(canVerifyResult);
 
         // Act
-        var result = await _controller.CanVerify(456, 202410);
+        var result = await _controller.CanVerify(456, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -364,7 +364,7 @@ public sealed class VerificationControllerTests
         _instructorServiceMock.GetInstructorAsync(456, 202410, Arg.Any<CancellationToken>()).ReturnsNull();
 
         // Act
-        var result = await _controller.CanVerify(456, 202410);
+        var result = await _controller.CanVerify(456, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<NotFoundObjectResult>(result.Result);
@@ -381,7 +381,7 @@ public sealed class VerificationControllerTests
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _controller.CanVerify(456, 202410);
+        var result = await _controller.CanVerify(456, 202410, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.IsType<ForbidResult>(result.Result);

--- a/test/Effort/VerificationServiceTests.cs
+++ b/test/Effort/VerificationServiceTests.cs
@@ -173,7 +173,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentPersonId().Returns(0);
 
         // Act
-        var result = await _service.GetMyEffortAsync(TestTermCode);
+        var result = await _service.GetMyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -186,7 +186,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentPersonId().Returns(9999);
 
         // Act
-        var result = await _service.GetMyEffortAsync(TestTermCode);
+        var result = await _service.GetMyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(result);
@@ -205,7 +205,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.GetMyEffortAsync(TestTermCode);
+        var result = await _service.GetMyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -228,7 +228,7 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 0
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
         _permissionServiceMock.HasSelfServiceAccessAsync(Arg.Any<CancellationToken>()).Returns(true);
@@ -239,7 +239,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.GetMyEffortAsync(TestTermCode);
+        var result = await _service.GetMyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -259,7 +259,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentPersonId().Returns(0);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -273,7 +273,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentPersonId().Returns(9999);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -284,14 +284,14 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task VerifyEffortAsync_ReturnsError_WhenAlreadyVerified()
     {
         // Arrange
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         person.EffortVerified = DateTime.Now.AddDays(-1);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -313,12 +313,12 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 0
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -334,13 +334,13 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
         Assert.NotNull(result.VerifiedDate);
 
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(person.EffortVerified);
 
         await _auditServiceMock.Received(1).LogPersonChangeAsync(
@@ -362,18 +362,18 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 40
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
         Assert.NotNull(result.VerifiedDate);
 
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(person.EffortVerified);
 
         await _auditServiceMock.Received(1).LogPersonChangeAsync(
@@ -399,7 +399,7 @@ public sealed class VerificationServiceTests : IDisposable
         };
         _context.Courses.Add(genericRCourse);
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Add generic R-course effort record with 0 hours and 0 weeks
         var genericRRecord = new EffortRecord
@@ -429,34 +429,34 @@ public sealed class VerificationServiceTests : IDisposable
         };
         _context.Records.Add(regularRecord);
 
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentPersonId().Returns(TestPersonId);
 
         // Verify initial state - generic R-course record exists
         var recordCountBefore = await _context.Records
-            .CountAsync(r => r.PersonId == TestPersonId && r.TermCode == TestTermCode);
+            .CountAsync(r => r.PersonId == TestPersonId && r.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.Equal(2, recordCountBefore);
 
         // Act
-        var result = await _service.VerifyEffortAsync(TestTermCode);
+        var result = await _service.VerifyEffortAsync(TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert: Verification succeeds
         Assert.True(result.Success);
         Assert.NotNull(result.VerifiedDate);
 
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(person.EffortVerified);
 
         // Assert: Generic R-course record is deleted
         var recordCountAfter = await _context.Records
-            .CountAsync(r => r.PersonId == TestPersonId && r.TermCode == TestTermCode);
+            .CountAsync(r => r.PersonId == TestPersonId && r.TermCode == TestTermCode, TestContext.Current.CancellationToken);
         Assert.Equal(1, recordCountAfter);
 
         var remainingRecord = await _context.Records
             .Include(r => r.Course)
             .Where(r => r.PersonId == TestPersonId && r.TermCode == TestTermCode)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         Assert.Single(remainingRecord);
         Assert.Equal(TestCourseId, remainingRecord[0].CourseId);
 
@@ -482,7 +482,7 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task CanVerifyAsync_ReturnsTrue_WhenNoRecords()
     {
         // Act - Instructors with no records can verify "no effort" for the term
-        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode);
+        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.CanVerify);
@@ -503,10 +503,10 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 0
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode);
+        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.CanVerify);
@@ -528,10 +528,10 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 40
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode);
+        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.CanVerify);
@@ -554,10 +554,10 @@ public sealed class VerificationServiceTests : IDisposable
             Hours = 40,
             Weeks = 0
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode);
+        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert: Should be zero effort because Weeks=0 for CLI after 201604
         Assert.False(result.CanVerify);
@@ -581,7 +581,7 @@ public sealed class VerificationServiceTests : IDisposable
             CustDept = "VME"
         };
         _context.Courses.Add(genericRCourse);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -593,13 +593,13 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 0
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Clear the change tracker so Include() must resolve from the database
         _context.ChangeTracker.Clear();
 
         // Act
-        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode);
+        var result = await _service.CanVerifyAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert: Generic R-course with zero hours should NOT prevent verification
         Assert.True(result.CanVerify);
@@ -618,7 +618,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(9999, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(9999, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -632,7 +632,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentUserEmail().ReturnsNull();
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -645,12 +645,12 @@ public sealed class VerificationServiceTests : IDisposable
         // Arrange: Current user has email, but recipient doesn't
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
-        var person = await _viperContext.People.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _viperContext.People.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         person.MailId = null;
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -691,7 +691,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
         // Act
-        var result = await serviceWithBadConfig.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await serviceWithBadConfig.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.Success);
@@ -719,7 +719,7 @@ public sealed class VerificationServiceTests : IDisposable
             RoleId = 1,
             Hours = 40
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
@@ -731,7 +731,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -765,18 +765,18 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Verify initial state - no LastEmailed data
-        var personBefore = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var personBefore = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.Null(personBefore.LastEmailed);
         Assert.Null(personBefore.LastEmailedBy);
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
 
         // Reload entity to verify database was updated
-        await _context.Entry(personBefore).ReloadAsync();
+        await _context.Entry(personBefore).ReloadAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(personBefore.LastEmailed);
         Assert.Equal(senderPersonId, personBefore.LastEmailedBy);
     }
@@ -796,12 +796,12 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
 
-        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId);
+        var person = await _context.Persons.FirstAsync(p => p.PersonId == TestPersonId, TestContext.Current.CancellationToken);
         Assert.NotNull(person.LastEmailed);
         Assert.Null(person.LastEmailedBy); // Should be null, not 0, to avoid FK violation
     }
@@ -833,7 +833,7 @@ public sealed class VerificationServiceTests : IDisposable
             });
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -850,9 +850,9 @@ public sealed class VerificationServiceTests : IDisposable
     {
         // Arrange: Term with ExpectedCloseDate in the future
         var expectedCloseDate = DateTime.Now.AddDays(30);
-        var effortTerm = await _context.Terms.FindAsync(TestTermCode);
+        var effortTerm = await _context.Terms.FindAsync(new object?[] { TestTermCode }, TestContext.Current.CancellationToken);
         effortTerm!.ExpectedCloseDate = expectedCloseDate;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
@@ -877,7 +877,7 @@ public sealed class VerificationServiceTests : IDisposable
             });
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -895,9 +895,9 @@ public sealed class VerificationServiceTests : IDisposable
         // Arrange: Term with ExpectedCloseDate in the past so due date is past
         // ExpectedCloseDate = 3 days ago => due date = 10 days ago (3 + 7), which is past
         var expectedCloseDate = DateTime.Now.AddDays(-3);
-        var effortTerm = await _context.Terms.FindAsync(TestTermCode);
+        var effortTerm = await _context.Terms.FindAsync(new object?[] { TestTermCode }, TestContext.Current.CancellationToken);
         effortTerm!.ExpectedCloseDate = expectedCloseDate;
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
 
@@ -922,7 +922,7 @@ public sealed class VerificationServiceTests : IDisposable
             });
 
         // Act
-        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode);
+        var result = await _service.SendVerificationEmailAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.Success);
@@ -945,7 +945,7 @@ public sealed class VerificationServiceTests : IDisposable
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(false);
 
         // Act
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, result.TotalInstructors);
@@ -980,7 +980,7 @@ public sealed class VerificationServiceTests : IDisposable
             EffortVerified = DateTime.Now
         };
         _context.Persons.Add(verifiedPerson);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _viperContext.People.Add(new Person
         {
@@ -993,7 +993,7 @@ public sealed class VerificationServiceTests : IDisposable
             ClientId = "SVM",
             Current = 1
         });
-        await _viperContext.SaveChangesAsync();
+        await _viperContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1006,7 +1006,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert: Should only send to TestPersonId (unverified), not to person 200 (verified)
         Assert.Equal(1, result.TotalInstructors);
@@ -1021,14 +1021,14 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_ExcludesRecentlyEmailed_WhenFlagIsFalse()
     {
         // Arrange: Set LastEmailed to recent date (within 7-day reply period)
-        var person = await _context.Persons.FindAsync(TestPersonId, TestTermCode);
+        var person = await _context.Persons.FindAsync(new object?[] { TestPersonId, TestTermCode }, TestContext.Current.CancellationToken);
         person!.LastEmailed = DateTime.Now.AddDays(-3); // 3 days ago, within 7-day window
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act: Call without includeRecentlyEmailed (defaults to false)
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert: Should not include recently emailed instructor
         Assert.Equal(0, result.TotalInstructors);
@@ -1039,9 +1039,9 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_IncludesRecentlyEmailed_WhenFlagIsTrue()
     {
         // Arrange: Set LastEmailed to recent date (within 7-day reply period)
-        var person = await _context.Persons.FindAsync(TestPersonId, TestTermCode);
+        var person = await _context.Persons.FindAsync(new object?[] { TestPersonId, TestTermCode }, TestContext.Current.CancellationToken);
         person!.LastEmailed = DateTime.Now.AddDays(-3); // 3 days ago, within 7-day window
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1054,7 +1054,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act: Call with includeRecentlyEmailed = true
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, includeRecentlyEmailed: true);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, includeRecentlyEmailed: true, TestContext.Current.CancellationToken);
 
         // Assert: Should include the recently emailed instructor
         Assert.Equal(1, result.TotalInstructors);
@@ -1065,9 +1065,9 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_IncludesOldEmailed_WhenFlagIsFalse()
     {
         // Arrange: Set LastEmailed to old date (outside 7-day reply period)
-        var person = await _context.Persons.FindAsync(TestPersonId, TestTermCode);
+        var person = await _context.Persons.FindAsync(new object?[] { TestPersonId, TestTermCode }, TestContext.Current.CancellationToken);
         person!.LastEmailed = DateTime.Now.AddDays(-10); // 10 days ago, outside 7-day window
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1080,7 +1080,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act: Call without includeRecentlyEmailed (defaults to false)
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert: Should include instructors emailed outside the reply window
         Assert.Equal(1, result.TotalInstructors);
@@ -1102,7 +1102,7 @@ public sealed class VerificationServiceTests : IDisposable
             Hours = 10,
             Crn = "12345"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1111,7 +1111,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.EmailedPersonIds);
@@ -1122,16 +1122,16 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_UseDueDateLogic_ExcludesEmailedBeforeDeadline()
     {
         // Arrange: Term has ExpectedCloseDate far in the future, instructor was emailed recently
-        var effortTerm = await _context.Terms.FindAsync(TestTermCode);
+        var effortTerm = await _context.Terms.FindAsync(new object?[] { TestTermCode }, TestContext.Current.CancellationToken);
         effortTerm!.ExpectedCloseDate = DateTime.Now.AddDays(30);
-        var person = await _context.Persons.FindAsync(TestPersonId, TestTermCode);
+        var person = await _context.Persons.FindAsync(new object?[] { TestPersonId, TestTermCode }, TestContext.Current.CancellationToken);
         person!.LastEmailed = DateTime.Now.AddDays(-3);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act: Before deadline → all emailed instructors are "recently emailed"
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert: Should exclude the emailed instructor
         Assert.Equal(0, result.TotalInstructors);
@@ -1142,11 +1142,11 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_UseDueDateLogic_IncludesEmailedPastDeadline()
     {
         // Arrange: Term has ExpectedCloseDate in the past, instructor was emailed recently
-        var effortTerm = await _context.Terms.FindAsync(TestTermCode);
+        var effortTerm = await _context.Terms.FindAsync(new object?[] { TestTermCode }, TestContext.Current.CancellationToken);
         effortTerm!.ExpectedCloseDate = DateTime.Now.AddDays(-1);
-        var person = await _context.Persons.FindAsync(TestPersonId, TestTermCode);
+        var person = await _context.Persons.FindAsync(new object?[] { TestPersonId, TestTermCode }, TestContext.Current.CancellationToken);
         person!.LastEmailed = DateTime.Now.AddDays(-3);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -1159,7 +1159,7 @@ public sealed class VerificationServiceTests : IDisposable
             Hours = 10,
             Crn = "12345"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1168,7 +1168,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act: Past deadline → all instructors eligible for resend
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert: Should include the recently emailed instructor
         Assert.Equal(1, result.TotalInstructors);
@@ -1179,9 +1179,9 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task SendBulkVerificationEmailsAsync_UseDueDateLogic_IncludesNeverEmailed()
     {
         // Arrange: Term has ExpectedCloseDate far in the future, instructor was NEVER emailed
-        var effortTerm = await _context.Terms.FindAsync(TestTermCode);
+        var effortTerm = await _context.Terms.FindAsync(new object?[] { TestTermCode }, TestContext.Current.CancellationToken);
         effortTerm!.ExpectedCloseDate = DateTime.Now.AddDays(30);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _context.Records.Add(new EffortRecord
         {
@@ -1194,7 +1194,7 @@ public sealed class VerificationServiceTests : IDisposable
             Hours = 10,
             Crn = "12345"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _permissionServiceMock.CanViewDepartmentAsync("VME", Arg.Any<CancellationToken>()).Returns(true);
         _permissionServiceMock.GetCurrentUserEmail().Returns("sender@ucdavis.edu");
@@ -1203,7 +1203,7 @@ public sealed class VerificationServiceTests : IDisposable
         _termServiceMock.GetTermName(TestTermCode).Returns("Fall 2024");
 
         // Act: Before deadline but never emailed → should still be included
-        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode);
+        var result = await _service.SendBulkVerificationEmailsAsync("VME", TestTermCode, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, result.TotalInstructors);
@@ -1218,7 +1218,7 @@ public sealed class VerificationServiceTests : IDisposable
     public async Task GetEmailHistoryAsync_ReturnsEmptyList_WhenNoHistory()
     {
         // Act
-        var result = await _service.GetEmailHistoryAsync(TestPersonId, TestTermCode);
+        var result = await _service.GetEmailHistoryAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -1239,10 +1239,10 @@ public sealed class VerificationServiceTests : IDisposable
             ChangedDate = DateTime.Now,
             Changes = "{\"RecipientEmail\":{\"OldValue\":null,\"NewValue\":\"test@ucdavis.edu\"},\"RecipientName\":{\"OldValue\":null,\"NewValue\":\"Test User\"}}"
         });
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var result = await _service.GetEmailHistoryAsync(TestPersonId, TestTermCode);
+        var result = await _service.GetEmailHistoryAsync(TestPersonId, TestTermCode, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);

--- a/test/RAPS/RolesTests.cs
+++ b/test/RAPS/RolesTests.cs
@@ -140,10 +140,10 @@ namespace Viper.test.RAPS
         [Fact]
         public async Task FindRole_WithValidId()
         {
-            await _sqlLiteConnection.OpenAsync();
+            await _sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
             using var context = new RAPSContext(_sqlLiteContextOptions);
 
-            if (await context.Database.EnsureCreatedAsync())
+            if (await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken))
             {
                 // arrange
                 var mockAudit = Substitute.For<IRAPSAuditServiceWrapper>();
@@ -197,10 +197,10 @@ namespace Viper.test.RAPS
         [Fact]
         public async Task EditRole_WhenValid()
         {
-            await _sqlLiteConnection.OpenAsync();
+            await _sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
             using var context = new RAPSContext(_sqlLiteContextOptions);
 
-            if (await context.Database.EnsureCreatedAsync())
+            if (await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken))
             {
                 // arrange
                 var mockAudit = Substitute.For<IRAPSAuditServiceWrapper>();
@@ -267,10 +267,10 @@ namespace Viper.test.RAPS
         [Fact]
         public async Task AddRole_WhenValid()
         {
-            await _sqlLiteConnection.OpenAsync();
+            await _sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
             using var context = new RAPSContext(_sqlLiteContextOptions);
 
-            if (await context.Database.EnsureCreatedAsync())
+            if (await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken))
             {
                 // arrange
                 var mockAudit = Substitute.For<IRAPSAuditServiceWrapper>();
@@ -303,10 +303,10 @@ namespace Viper.test.RAPS
         [Fact]
         public async Task RejectAddRole_WhenDuplicateRoleId()
         {
-            await _sqlLiteConnection.OpenAsync();
+            await _sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
             using var context = new RAPSContext(_sqlLiteContextOptions);
 
-            if (await context.Database.EnsureCreatedAsync())
+            if (await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken))
             {
                 // arrange
                 var mockAudit = Substitute.For<IRAPSAuditServiceWrapper>();
@@ -342,10 +342,10 @@ namespace Viper.test.RAPS
         [Fact]
         public async Task DeleteRole_WhenValid()
         {
-            await _sqlLiteConnection.OpenAsync();
+            await _sqlLiteConnection.OpenAsync(TestContext.Current.CancellationToken);
             using var context = new RAPSContext(_sqlLiteContextOptions);
 
-            if (await context.Database.EnsureCreatedAsync())
+            if (await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken))
             {
                 // arrange
                 int RoleId = 1;

--- a/test/Students/EmergencyContactServiceTests.cs
+++ b/test/Students/EmergencyContactServiceTests.cs
@@ -380,7 +380,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var result = await service.IsAppOpenAsync();
@@ -396,7 +396,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 0
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var result = await service.IsAppOpenAsync();
@@ -417,7 +417,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         Assert.True(result);
         var rp = await _rapsContext.TblRolePermissions.SingleAsync(rp =>
             rp.RoleId == _seededRoleId
-            && rp.PermissionId == _seededPermissionId);
+            && rp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken);
         Assert.Equal(1, rp.Access);
     }
 
@@ -430,7 +430,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var result = await service.ToggleAppAccessAsync();
@@ -439,7 +439,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         // Row is deleted on close so a role-level Deny cannot shadow individual grants.
         var rp = await _rapsContext.TblRolePermissions.FirstOrDefaultAsync(rp =>
             rp.RoleId == _seededRoleId
-            && rp.PermissionId == _seededPermissionId);
+            && rp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken);
         Assert.Null(rp);
     }
 
@@ -459,7 +459,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         await service.ToggleAppAccessAsync(); // close
@@ -467,12 +467,12 @@ public sealed class EmergencyContactServiceTests : IDisposable
         // No role-permission row should remain — a row with Access=0 would Deny
         // all members, overriding the individual grant's Access=1 (RAPS semantics).
         var rolePerm = await _rapsContext.TblRolePermissions.FirstOrDefaultAsync(rp =>
-            rp.RoleId == _seededRoleId && rp.PermissionId == _seededPermissionId);
+            rp.RoleId == _seededRoleId && rp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken);
         Assert.Null(rolePerm);
 
         // Individual grant is preserved
         var grant = await _rapsContext.TblMemberPermissions.SingleAsync(mp =>
-            mp.MemberId == "granted-student" && mp.PermissionId == _seededPermissionId);
+            mp.MemberId == "granted-student" && mp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken);
         Assert.Equal(1, grant.Access);
     }
 
@@ -485,7 +485,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 0
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var result = await service.ToggleAppAccessAsync();
@@ -493,7 +493,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         Assert.True(result);
         var rp = await _rapsContext.TblRolePermissions.SingleAsync(rp =>
             rp.RoleId == _seededRoleId
-            && rp.PermissionId == _seededPermissionId);
+            && rp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken);
         Assert.Equal(1, rp.Access);
     }
 
@@ -516,14 +516,14 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M100", 100, "Student", "Test", "V1", "12100", "student1@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.ToggleIndividualAccessAsync(100);
 
             Assert.True(result);
             Assert.True(await _rapsContext.TblMemberPermissions.AnyAsync(mp =>
                 mp.MemberId == "M100"
-                && mp.PermissionId == _seededPermissionId));
+                && mp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken));
         }
     }
 
@@ -534,7 +534,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M101", 101, "Student2", "Test", "V1", "12101", "student2@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
             {
@@ -542,14 +542,14 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 PermissionId = _seededPermissionId,
                 Access = 1
             });
-            await _rapsContext.SaveChangesAsync();
+            await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.ToggleIndividualAccessAsync(101);
 
             Assert.False(result);
             Assert.False(await _rapsContext.TblMemberPermissions.AnyAsync(mp =>
                 mp.MemberId == "M101"
-                && mp.PermissionId == _seededPermissionId));
+                && mp.PermissionId == _seededPermissionId, TestContext.Current.CancellationToken));
         }
     }
 
@@ -586,7 +586,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         var service = CreateServiceWithPermissions(EmergencyContactPermissions.Admin);
         _aaudContext.AaudUsers.Add(CreateTestUser(200, "admin200"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(999, "admin200");
         Assert.True(result);
@@ -597,7 +597,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         var service = CreateServiceWithPermissions(EmergencyContactPermissions.SISAllStudents);
         _aaudContext.AaudUsers.Add(CreateTestUser(201, "sis201"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(201, "sis201");
         Assert.False(result);
@@ -608,7 +608,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(CreateTestUser(202, "stu202"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Open the app
         _rapsContext.TblRolePermissions.Add(new TblRolePermission
@@ -617,7 +617,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(202, "stu202");
         Assert.True(result);
@@ -629,7 +629,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         var user = CreateTestUser(203, "stu203");
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(user);
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // App closed, but individual grant exists
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
@@ -638,7 +638,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(203, "stu203");
         Assert.True(result);
@@ -649,7 +649,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(CreateTestUser(204, "stu204"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(204, "stu204");
         Assert.False(result);
@@ -660,7 +660,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(CreateTestUser(205, "stu205"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Open the app — but student tries to edit someone else's record
         _rapsContext.TblRolePermissions.Add(new TblRolePermission
@@ -669,7 +669,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(999, "stu205");
         Assert.False(result);
@@ -681,7 +681,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         var user = CreateTestUser(206, "stu206");
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(user);
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // App closed, grant exists but ended yesterday
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
@@ -691,7 +691,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             Access = 1,
             EndDate = DateTime.Now.AddDays(-1)
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(206, "stu206");
         Assert.False(result);
@@ -703,7 +703,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         var user = CreateTestUser(207, "stu207");
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(user);
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Grant doesn't start until tomorrow
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
@@ -713,7 +713,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             Access = 1,
             StartDate = DateTime.Now.AddDays(1)
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(207, "stu207");
         Assert.False(result);
@@ -725,7 +725,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         var user = CreateTestUser(208, "stu208");
         var service = CreateServiceWithPermissions();
         _aaudContext.AaudUsers.Add(user);
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Member row with Access=0 should not count as a grant
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
@@ -734,7 +734,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 0
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await service.CanEditAsync(208, "stu208");
         Assert.False(result);
@@ -753,7 +753,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var status = await service.GetAccessStatusAsync();
@@ -774,7 +774,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     public async Task GetAccessStatusAsync_WithIndividualGrants_ReturnsGrantedStudents()
     {
         _aaudContext.AaudUsers.Add(CreateTestUser(300, "stu300"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
         {
@@ -782,7 +782,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var status = await service.GetAccessStatusAsync();
@@ -795,7 +795,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     public async Task GetAccessStatusAsync_ExpiredGrant_Excluded()
     {
         _aaudContext.AaudUsers.Add(CreateTestUser(301, "stu301"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
         {
@@ -804,7 +804,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             Access = 1,
             EndDate = DateTime.Now.AddDays(-1)
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var status = await service.GetAccessStatusAsync();
@@ -826,7 +826,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
     {
         // Grant survives both app open and app closed
         _aaudContext.AaudUsers.Add(CreateTestUser(302, "stu302"));
-        await _aaudContext.SaveChangesAsync();
+        await _aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         _rapsContext.TblMemberPermissions.Add(new TblMemberPermission
         {
             MemberId = "M302",
@@ -839,7 +839,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 1
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         var statusOpen = await service.GetAccessStatusAsync();
@@ -848,7 +848,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
         // Close app (removes role-permission row); grant unchanged
         _rapsContext.TblRolePermissions.RemoveRange(_rapsContext.TblRolePermissions);
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var statusClosed = await service.GetAccessStatusAsync();
         Assert.False(statusClosed.AppOpen);
@@ -869,7 +869,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M400", 400, "First", "Student", "V1", "12400", "s400@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // 1. Open app
             Assert.True(await service.ToggleAppAccessAsync());
@@ -902,7 +902,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             PermissionId = _seededPermissionId,
             Access = 0
         });
-        await _rapsContext.SaveChangesAsync();
+        await _rapsContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var service = CreateService();
         Assert.True(await service.ToggleAppAccessAsync());
@@ -910,7 +910,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
         var rows = await _rapsContext.TblRolePermissions
             .Where(rp => rp.RoleId == _seededRoleId && rp.PermissionId == _seededPermissionId)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         Assert.Single(rows);
         Assert.Equal(1, rows[0].Access);
     }
@@ -923,7 +923,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M401", 401, "Second", "Student", "V1", "12401", "s401@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             Assert.True(await service.ToggleIndividualAccessAsync(401));   // grant
             Assert.False(await service.ToggleIndividualAccessAsync(401));  // revoke
@@ -933,7 +933,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             // Final state: no grant for this student
             var grants = await _rapsContext.TblMemberPermissions
                 .Where(mp => mp.MemberId == "M401" && mp.PermissionId == _seededPermissionId)
-                .ToListAsync();
+                .ToListAsync(TestContext.Current.CancellationToken);
             Assert.Empty(grants);
         }
     }
@@ -946,7 +946,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         {
             // User exists in AAUD but is not seeded as a current DVM student
             aaudContext.AaudUsers.Add(CreateTestUser(403, "stu403"));
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => service.ToggleIndividualAccessAsync(403));
@@ -973,7 +973,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M200", 200, "Student", "New", "V1", "12345", "student3@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var request = new UpdateStudentContactRequest
             {
@@ -1006,7 +1006,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
             var savedContact = await _sisContext.StudentContacts
                 .Include(c => c.EmergencyContacts)
-                .FirstOrDefaultAsync(c => c.Pidm == 12345);
+                .FirstOrDefaultAsync(c => c.Pidm == 12345, TestContext.Current.CancellationToken);
 
             Assert.NotNull(savedContact);
             Assert.Equal("One Shields Avenue", savedContact.Address);
@@ -1038,7 +1038,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M201", 201, "Student", "Existing", "V1", "12346", "student4@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Create existing contact record
             var existingContact = new StudentContact
@@ -1049,7 +1049,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 Zip = "00000"
             };
             _sisContext.StudentContacts.Add(existingContact);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var localEc = new StudentEmergencyContact
             {
@@ -1058,7 +1058,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 Name = "Old Name"
             };
             _sisContext.StudentEmergencyContacts.Add(localEc);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var request = new UpdateStudentContactRequest
             {
@@ -1082,7 +1082,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
             var savedContact = await _sisContext.StudentContacts
                 .Include(c => c.EmergencyContacts)
-                .FirstOrDefaultAsync(c => c.Pidm == 12346);
+                .FirstOrDefaultAsync(c => c.Pidm == 12346, TestContext.Current.CancellationToken);
 
             Assert.NotNull(savedContact);
             Assert.Equal("New Address", savedContact.Address);
@@ -1102,7 +1102,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M300", 300, "Test", "Phone", "V1", "12399", "student5@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var request = new UpdateStudentContactRequest
             {
@@ -1125,7 +1125,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
             // Verify nothing was persisted
             var saved = await _sisContext.StudentContacts
-                .FirstOrDefaultAsync(c => c.Pidm == 12399);
+                .FirstOrDefaultAsync(c => c.Pidm == 12399, TestContext.Current.CancellationToken);
             Assert.Null(saved);
         }
     }
@@ -1162,7 +1162,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 LastName = "Divergent",
                 FirstName = "Student"
             });
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var request = new UpdateStudentContactRequest
             {
@@ -1182,12 +1182,12 @@ public sealed class EmergencyContactServiceTests : IDisposable
 
             // Should save using the VIEW pidm (12700), not the stale AaudUser pidm (99999)
             var correctContact = await _sisContext.StudentContacts
-                .FirstOrDefaultAsync(c => c.Pidm == 12700);
+                .FirstOrDefaultAsync(c => c.Pidm == 12700, TestContext.Current.CancellationToken);
             Assert.NotNull(correctContact);
             Assert.Equal("Test Address", correctContact.Address);
 
             var staleContact = await _sisContext.StudentContacts
-                .FirstOrDefaultAsync(c => c.Pidm == 99999);
+                .FirstOrDefaultAsync(c => c.Pidm == 99999, TestContext.Current.CancellationToken);
             Assert.Null(staleContact);
         }
     }
@@ -1204,7 +1204,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         {
             SeedDvmStudent(aaudContext, "M500", 500, "LastA", "StudentA", "V1", "12500", "studenta@ucdavis.edu");
             SeedDvmStudent(aaudContext, "M501", 501, "LastB", "StudentB", "V2", "12501", "studentb@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactListAsync();
 
@@ -1226,7 +1226,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M502", 502, "LastC", "StudentC", "V3", "12502", "studentc@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactListAsync();
 
@@ -1242,7 +1242,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M503", 503, "Doe", "Jane", "V1", "12503", "jdoe@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactListAsync();
 
@@ -1258,7 +1258,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M504", 504, "Doe", "John", "V2", "12504", "jdoe2@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Seed contact data
             var contact = new StudentContact
@@ -1270,7 +1270,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 CellPhone = "5305551234"
             };
             _sisContext.StudentContacts.Add(contact);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var localEc = new StudentEmergencyContact
             {
@@ -1282,7 +1282,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 Email = "jdoe@example.com"
             };
             _sisContext.StudentEmergencyContacts.Add(localEc);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactListAsync();
 
@@ -1311,7 +1311,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 IdsMailid = "nobody@ucdavis.edu",
                 StudentsTermCode = "202610"
             });
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactListAsync();
 
@@ -1334,7 +1334,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M600", 600, "Doe", "Jane", "V1", "12600", "jdoe3@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactReportAsync();
 
@@ -1352,7 +1352,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
         using (aaudContext)
         {
             SeedDvmStudent(aaudContext, "M601", 601, "Doe", "John", "V2", "12601", "jdoe4@ucdavis.edu");
-            await aaudContext.SaveChangesAsync();
+            await aaudContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var contact = new StudentContact
             {
@@ -1365,7 +1365,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 ContactPermanent = true
             };
             _sisContext.StudentContacts.Add(contact);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var emergencyEc = new StudentEmergencyContact
             {
@@ -1377,7 +1377,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
                 Email = "jdoe@example.com"
             };
             _sisContext.StudentEmergencyContacts.Add(emergencyEc);
-            await _sisContext.SaveChangesAsync();
+            await _sisContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             var result = await service.GetStudentContactReportAsync();
 

--- a/test/Students/PhotoServiceTest.cs
+++ b/test/Students/PhotoServiceTest.cs
@@ -115,7 +115,7 @@ namespace Viper.test.Students
             var validMailId = "test-user.name123";
             var photoPath = Path.Join(_testPhotoDirectory, $"{validMailId}.jpg");
             var testPhotoBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10 };
-            await File.WriteAllBytesAsync(photoPath, testPhotoBytes);
+            await File.WriteAllBytesAsync(photoPath, testPhotoBytes, TestContext.Current.CancellationToken);
 
             // Act
             var result = await _photoService.GetStudentPhotoAsync(validMailId);
@@ -136,7 +136,7 @@ namespace Viper.test.Students
             var mailId = "testuser";
             var photoPath = Path.Join(_testPhotoDirectory, $"{mailId}.jpg");
             var testPhotoBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46 };
-            await File.WriteAllBytesAsync(photoPath, testPhotoBytes);
+            await File.WriteAllBytesAsync(photoPath, testPhotoBytes, TestContext.Current.CancellationToken);
 
             // Act
             var result = await _photoService.GetStudentPhotoAsync(mailId);
@@ -200,13 +200,13 @@ namespace Viper.test.Students
             var mailId = "cachetest";
             var photoPath = Path.Join(_testPhotoDirectory, $"{mailId}.jpg");
             var testPhotoBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x01, 0x02 };
-            await File.WriteAllBytesAsync(photoPath, testPhotoBytes);
+            await File.WriteAllBytesAsync(photoPath, testPhotoBytes, TestContext.Current.CancellationToken);
 
             // Act - First call
             var result1 = await _photoService.GetStudentPhotoAsync(mailId);
 
             // Modify file on disk (to verify cache is used)
-            await File.WriteAllBytesAsync(photoPath, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            await File.WriteAllBytesAsync(photoPath, new byte[] { 0x00, 0x00, 0x00, 0x00 }, TestContext.Current.CancellationToken);
 
             // Act - Second call
             var result2 = await _photoService.GetStudentPhotoAsync(mailId);
@@ -248,7 +248,7 @@ namespace Viper.test.Students
             // Arrange
             var mailId = "urltest";
             var photoPath = Path.Join(_testPhotoDirectory, $"{mailId}.jpg");
-            await File.WriteAllBytesAsync(photoPath, new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 });
+            await File.WriteAllBytesAsync(photoPath, new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }, TestContext.Current.CancellationToken);
 
             // Act
             var result = await _photoService.GetStudentPhotoUrlAsync(mailId);
@@ -286,7 +286,7 @@ namespace Viper.test.Students
             // Arrange
             var mailId = "existstest";
             var photoPath = Path.Join(_testPhotoDirectory, $"{mailId}.jpg");
-            await File.WriteAllBytesAsync(photoPath, new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 });
+            await File.WriteAllBytesAsync(photoPath, new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }, TestContext.Current.CancellationToken);
 
             // Act
             var result = await _photoService.StudentPhotoExistsAsync(mailId);


### PR DESCRIPTION
## Summary

Phase 1.5 of the .NET warnings cleanup. Clears all **1511 xUnit1051** warnings, taking the build from **1535 warnings to 24**. Test-only: no production code is touched.

Stacked on #261, which has to land first.

## Why fix rather than suppress

xUnit v3 signals `TestContext.Current.CancellationToken` when a run is cancelled or a test exceeds its timeout. A call that accepts a token but never receives one keeps running past cancellation, so a hung test cannot be cut off and CI burns to the job timeout instead of failing the test.

That payoff is real but rare. The everyday one is signal: these were 98% of the build's warnings and buried the 24 that actually matter.

## How, given `dotnet format` cannot do it

The obvious route does not work. xUnit ships a fixer but declares no Fix All provider:

```
Unable to fix xUnit1051. Code fix UseCancellationTokenFixer doesn't support Fix All in Solution.
```

It completes with an empty diff. So the edit was driven off the compiler's own diagnostic positions rather than regex over source, which matters because the flagged calls span 228 distinct method names, multi-line argument lists, and calls nested inside `Assert.ThrowsAsync` lambdas.

Three shapes came out of it, the last two discovered by compiling and reading the errors rather than assumed up front:

| Shape | Count | Why |
|---|---|---|
| Positional | 1321 | the token is the only trailing optional parameter |
| Named | 190 | an optional parameter sits *before* the token, so appending positionally put a `CancellationToken` into a `bool` or `string?` slot; or the call already used named arguments, which an unnamed one cannot follow |
| `FindAsync` array overload | 37 | supplying a token forces it: `FindAsync(id)` becomes `FindAsync(new object?[] { id }, token)` |

The parameter name is not uniform in this repo (**722 `ct`** vs **132 `cancellationToken`**), so each named argument was resolved from its target method's own declaration rather than guessed.

## No regression guard

`xUnit1051` stays at its default `warning`. All 1511 sites are fixed, but nothing stops new ones appearing.

Promoting it to `error` is not viable while `main` and `Development` have diverged. Severity applies repo-wide, but a branch's view of the repo does not: a branch based on `main` cannot see the test files that exist only on `Development`, so those become hard build errors the moment the merge lands, and Development deploys to TEST. Any in-flight branch carrying test files `main` has not seen would hit the same wall.

Verified the current behaviour by probe: reintroducing an untokened call produces `warning xUnit1051` and the build still exits 0.

Worth revisiting once the two branches converge, or replacing with a CI check on the count, which runs against the merge result rather than one branch's view and so sidesteps the problem entirely.

## Verification

- `verify:build` clean: 0 errors, 0 xUnit1051, 1535 warnings down to 24
- Backend suite **2672 passing, unchanged from before the sweep**
- 0 production files touched; 43 files changed, all under `test/` plus `.editorconfig`

The unchanged test count is the check that matters here. A rewrite landing on a different overload would drop or break tests rather than fail the build, so "still compiles" would not have been sufficient evidence on its own.
