### PR TITLE
fix(lint): surface stylelint results and clear the backlog they hid

### DIFF
--- a/VueApp/src/CMS/pages/ManageLinkCollections.vue
+++ b/VueApp/src/CMS/pages/ManageLinkCollections.vue
@@ -826,7 +826,6 @@ loadCollections()
 
 .link-url {
     white-space: normal;
-    word-break: break-word;
     overflow-wrap: anywhere;
 }
 
@@ -854,7 +853,7 @@ loadCollections()
 }
 
 .link-field {
-    word-break: break-word;
+    overflow-wrap: break-word;
     min-width: 0;
 }
 

--- a/VueApp/src/CTS/components/LevelSelect.vue
+++ b/VueApp/src/CTS/components/LevelSelect.vue
@@ -160,23 +160,27 @@ div.levelSelection button.selectedLevel {
 }
 
 div.levelSelection button.selectedLevel.selectedLevel--1 {
-    background-color: rgba(62, 127, 238, 0.3);
+    background-color: rgb(62 127 238 / 30%);
     color: #212529;
 }
+
 div.levelSelection button.selectedLevel.selectedLevel--2 {
-    background-color: rgba(62, 127, 238, 0.7);
+    background-color: rgb(62 127 238 / 70%);
     color: #212529;
 }
+
 div.levelSelection button.selectedLevel.selectedLevel--3 {
-    background-color: rgba(62, 127, 238, 1);
+    background-color: rgb(62 127 238 / 100%);
     color: #000;
 }
+
 div.levelSelection button.selectedLevel.selectedLevel--4 {
-    background-color: rgba(0, 44, 175, 0.8);
+    background-color: rgb(0 44 175 / 80%);
     color: #fff;
 }
+
 div.levelSelection button.selectedLevel.selectedLevel--5 {
-    background-color: rgba(11, 3, 139, 1);
+    background-color: rgb(11 3 139 / 100%);
     color: #fff;
 }
 

--- a/VueApp/src/CTS/pages/CompetenciesBundleReport.vue
+++ b/VueApp/src/CTS/pages/CompetenciesBundleReport.vue
@@ -381,7 +381,7 @@ onMounted(() => {
 .col-competency-name {
     display: block;
     white-space: normal;
-    word-break: break-word;
+    overflow-wrap: break-word;
     line-height: 1.4;
     max-width: 100%;
 }
@@ -389,13 +389,13 @@ onMounted(() => {
 /* Apply wrapping to competency name column cells */
 .competency-name-column {
     white-space: normal;
-    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 /* Ensure name column respects its width and allows wrapping */
 :deep(.q-table td:nth-child(2)) {
     white-space: normal;
-    word-break: break-word;
+    overflow-wrap: break-word;
     vertical-align: top;
     max-width: 0; /* This forces the cell to respect table-layout: fixed */
 }
@@ -404,7 +404,7 @@ onMounted(() => {
 :deep(.q-table td:nth-child(3)),
 :deep(.q-table td:nth-child(4)) {
     white-space: normal;
-    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 /* Bundle chips wrapper */

--- a/VueApp/src/ClinicalScheduler/components/ScheduleView.vue
+++ b/VueApp/src/ClinicalScheduler/components/ScheduleView.vue
@@ -391,7 +391,7 @@ defineExpose({
 }
 
 /* Mobile single column: q-gutter-md adds only a left margin, which left-pins the card */
-@media (max-width: 599.98px) {
+@media (width <= 599.98px) {
     .schedule-week-grid,
     .schedule-week-grid > * {
         margin-left: 0;

--- a/VueApp/src/ClinicalScheduler/components/WeekCell.vue
+++ b/VueApp/src/ClinicalScheduler/components/WeekCell.vue
@@ -437,10 +437,10 @@ const cardClasses = computed(() => {
     background-color: var(--ucdavis-gold-20);
     border-radius: 4px;
     padding: 2px 4px;
-    animation: fadeToBackground var(--highlight-duration) ease-out forwards; /* Duration from ANIMATIONS.HIGHLIGHT_DURATION_MS */
+    animation: fade-to-background var(--highlight-duration) ease-out forwards; /* Duration from ANIMATIONS.HIGHLIGHT_DURATION_MS */
 }
 
-@keyframes fadeToBackground {
+@keyframes fade-to-background {
     0% {
         background-color: var(--ucdavis-gold-30);
     }

--- a/VueApp/src/ClinicalScheduler/components/WeekHistoryContent.vue
+++ b/VueApp/src/ClinicalScheduler/components/WeekHistoryContent.vue
@@ -304,6 +304,7 @@ watch(
     max-height: 55vh;
 
     /* Height comes from the measured content (script); animate size changes between weeks */
+    /* stylelint-disable-next-line declaration-property-value-no-unknown -- Vue SFC v-bind() is resolved at compile time */
     height: v-bind("bodyHeight");
     transition: height 0.24s cubic-bezier(0.22, 1, 0.36, 1);
     will-change: height;

--- a/VueApp/src/Effort/pages/AuditList.vue
+++ b/VueApp/src/Effort/pages/AuditList.vue
@@ -884,6 +884,6 @@ onMounted(() => initPage())
 <style scoped>
 .changes-cell {
     white-space: normal !important;
-    word-break: break-word;
+    overflow-wrap: break-word;
 }
 </style>

--- a/VueApp/src/Effort/pages/StaffDashboard.vue
+++ b/VueApp/src/Effort/pages/StaffDashboard.vue
@@ -1258,7 +1258,17 @@ watch(
 .dept-row--clickable:hover,
 .dept-row--clickable:focus {
     background-color: #e0e0e0;
-    outline: none;
+}
+
+/* A background tint alone is too weak a focus indicator for keyboard users
+   (WCAG 2.4.7), so carry the system focus ring. The transparent outline is
+   invisible normally but becomes the indicator under Windows forced-colors,
+   where box-shadow is dropped. */
+.dept-row--clickable:focus-visible {
+    outline: 2px solid transparent;
+    box-shadow:
+        0 0 0 0.1rem white,
+        0 0 0 0.25rem var(--focus-ring-color);
 }
 
 .dept-row--no-dept {
@@ -1318,7 +1328,15 @@ watch(
 .clickable-badge:hover,
 .clickable-badge:focus {
     filter: brightness(0.95);
-    outline: none;
+}
+
+/* A 5% brightness shift is not a visible focus indicator (WCAG 2.4.7), so carry
+   the system focus ring. See the note on .dept-row--clickable above. */
+.clickable-badge:focus-visible {
+    outline: 2px solid transparent;
+    box-shadow:
+        0 0 0 0.1rem white,
+        0 0 0 0.25rem var(--focus-ring-color);
 }
 
 #no-instructors-alerts {

--- a/VueApp/src/assets/base.css
+++ b/VueApp/src/assets/base.css
@@ -4,21 +4,13 @@
     --vt-c-white-soft: #f8f8f8;
     --vt-c-white-mute: #f2f2f2;
 
-    --vt-c-black: #181818;
-    --vt-c-black-soft: #222222;
-    --vt-c-black-mute: #282828;
-
     --vt-c-indigo: #2c3e50;
 
     --vt-c-divider-light-1: rgba(60, 60, 60, 0.29);
     --vt-c-divider-light-2: rgba(60, 60, 60, 0.12);
-    --vt-c-divider-dark-1: rgba(84, 84, 84, 0.65);
-    --vt-c-divider-dark-2: rgba(84, 84, 84, 0.48);
 
     --vt-c-text-light-1: var(--vt-c-indigo);
     --vt-c-text-light-2: rgba(60, 60, 60, 0.66);
-    --vt-c-text-dark-1: var(--vt-c-white);
-    --vt-c-text-dark-2: rgba(235, 235, 235, 0.64);
 }
 
 /* semantic color variables for this project */
@@ -34,20 +26,6 @@
     --color-text: var(--vt-c-text-light-1);
 
     --section-gap: 160px;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --color-background: var(--vt-c-black);
-        --color-background-soft: var(--vt-c-black-soft);
-        --color-background-mute: var(--vt-c-black-mute);
-
-        --color-border: var(--vt-c-divider-dark-2);
-        --color-border-hover: var(--vt-c-divider-dark-1);
-
-        --color-heading: var(--vt-c-text-dark-1);
-        --color-text: var(--vt-c-text-dark-2);
-    }
 }
 
 *,

--- a/VueApp/src/components/SortableList.vue
+++ b/VueApp/src/components/SortableList.vue
@@ -297,8 +297,8 @@ function onMoveDown(index: number) {
 }
 
 /* "Just moved" cue: a brand-blue tint and ring that fade out. It is a colour/shadow
-   fade (no movement), so it also plays under reduced motion — where the slide is
-   skipped — keeping a clear signal that something changed. */
+   fade with no movement, but reduced motion still turns it off (see the media query
+   below); the row's new position remains the signal that something changed. */
 @keyframes sortable-row-flash {
     0% {
         background-color: var(--ucdavis-blue-10);
@@ -313,6 +313,13 @@ function onMoveDown(index: number) {
 
 .sortable-row--moved {
     animation: sortable-row-flash 1s ease-out;
+}
+
+/* Must follow the rule above: equal specificity, so the later declaration wins. */
+@media screen and (prefers-reduced-motion: reduce) {
+    .sortable-row--moved {
+        animation: none;
+    }
 }
 
 /* On phones the row becomes a stacked card: handle + controls share a top bar,

--- a/scripts/lib/lint-staged-common.js
+++ b/scripts/lib/lint-staged-common.js
@@ -228,8 +228,10 @@ function parseArguments() {
 function parseJsonOutput(stdout, stderr, toolName, textFallbackParser) {
     const logger = createLogger(toolName)
 
-    // Parse JSON output (should be in stdout with --format json)
-    const jsonOutput = stdout.trim()
+    // ESLint writes its JSON report to stdout, but Stylelint writes to stderr, so
+    // fall back to stderr when stdout is empty. Without this the report is dropped
+    // and the tool silently reports no issues.
+    const jsonOutput = stdout.trim() || stderr.trim()
 
     try {
         if (jsonOutput) {

--- a/scripts/lint-staged-css.js
+++ b/scripts/lint-staged-css.js
@@ -90,47 +90,73 @@ function parseTextOutput(output) {
     return issues
 }
 
+/**
+ * Block the commit, dumping whatever Stylelint emitted so the failure is diagnosable
+ * @param {string} reason - What went wrong
+ * @param {string} blockedMessage - Short summary for the COMMIT BLOCKED line
+ * @param {string} stdout - Stylelint stdout
+ * @param {string} stderr - Stylelint stderr, deprecation warnings already filtered
+ * @returns {never}
+ */
+function blockCommit(reason, blockedMessage, stdout, stderr) {
+    logger.error(reason)
+    if (stdout) {
+        logger.error(stdout)
+    }
+    if (stderr) {
+        logger.error(stderr)
+    }
+    logger.error(`🛑 COMMIT BLOCKED - ${blockedMessage}`)
+    process.exit(1)
+}
+
+// Stylelint receives each path as an argument and Windows caps a command line at
+// ~8191 chars, so a whole-tree run (200+ files) has to be split into batches.
+const MAX_BATCH_SIZE = 50
+
 try {
-    // Run Stylelint using shared command runner
-    const stylelintArgs = [...(fixFlag ? ["--fix"] : []), "--formatter", "json", "--allow-empty-input", ...files]
-
     logger.info(`Running Stylelint accessibility and style checks on ${files.length} CSS/Vue files...`)
-    const stylelintResult = runCommand("stylelint", stylelintArgs, "Stylelint", projectRoot)
 
-    // Check for fatal errors
-    if (stylelintResult.status !== 0 && stylelintResult.status !== 2) {
-        logger.error("Stylelint command failed:")
-        if (stylelintResult.stdout) {
-            logger.error(stylelintResult.stdout)
+    const issues = []
+
+    for (let index = 0; index < files.length; index += MAX_BATCH_SIZE) {
+        const batch = files.slice(index, index + MAX_BATCH_SIZE)
+        const stylelintArgs = [...(fixFlag ? ["--fix"] : []), "--formatter", "json", "--allow-empty-input", ...batch]
+
+        const stylelintResult = runCommand("stylelint", stylelintArgs, "Stylelint", projectRoot)
+
+        // Filter out deprecation warnings before parsing: stylelint writes its JSON
+        // report to stderr, so a leading DeprecationWarning line would make the whole
+        // report unparseable.
+        const cleanStderr = stylelintResult.stderr
+            ? stylelintResult.stderr
+                  .split("\n")
+                  .filter((line) => !line.includes("DeprecationWarning"))
+                  .join("\n")
+                  .trim()
+            : ""
+
+        // Check for fatal errors
+        if (stylelintResult.status !== 0 && stylelintResult.status !== 2) {
+            blockCommit("Stylelint command failed:", "Stylelint execution failed", stylelintResult.stdout, cleanStderr)
         }
-        if (stylelintResult.stderr) {
-            logger.error(stylelintResult.stderr)
+
+        // Parse and accumulate this batch's Stylelint output
+        const batchIssues = parseStylelintOutput(stylelintResult.stdout, cleanStderr)
+        issues.push(...batchIssues)
+
+        // Status 2 means "violations found", so an empty batch means the report was lost in
+        // parsing. Fail closed: passing silently here is the blind-stylelint bug this script
+        // exists to prevent.
+        if (stylelintResult.status === 2 && batchIssues.length === 0) {
+            blockCommit(
+                "Stylelint reported violations but none could be parsed:",
+                "Stylelint output could not be read",
+                stylelintResult.stdout,
+                cleanStderr,
+            )
         }
-        logger.error("🛑 COMMIT BLOCKED - Stylelint execution failed")
-        process.exit(1)
     }
-
-    // Status 2 means "violations found" - only warn if no violations were parsed
-    if (stylelintResult.status === 2) {
-        const jsonToCheck = stylelintResult.stdout.trim() || stylelintResult.stderr.trim()
-        const hasValidJson = jsonToCheck && jsonToCheck.startsWith("[")
-        if (!hasValidJson) {
-            logger.warning("STYLELINT CONFIGURATION WARNING: Status 2 with no parseable violations")
-            logger.warning("📋 Consider reviewing stylelint.config.mjs if unexpected behavior occurs")
-        }
-    }
-
-    // Filter out deprecation warnings
-    const cleanStderr = stylelintResult.stderr
-        ? stylelintResult.stderr
-              .split("\n")
-              .filter((line) => !line.includes("DeprecationWarning"))
-              .join("\n")
-              .trim()
-        : ""
-
-    // Parse and categorize Stylelint output
-    const issues = parseStylelintOutput(stylelintResult.stdout, cleanStderr)
 
     // For CSS, we need special handling of accessibility categories
     const criticalAccessibilityIssues = []

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,13 @@
 // oxlint-disable-next-line import/no-default-export, import/no-anonymous-default-export -- Stylelint config requires default export
 export default {
-    extends: ["stylelint-config-standard", "@double-great/stylelint-a11y/strict"],
+    // The a11y plugin's own "recommended" tier is what we enforce. Its "strict" tier
+    // turns on nine further rules which between them produced 132 findings here and
+    // no real defects: dark-theme demands (we ship a single light theme whose
+    // contrast pairings are verified against WCAG AA, see DESIGN.md), baseline-grid
+    // line heights, and display:none inside print and responsive blocks. Every
+    // genuine WCAG failure found so far came from a recommended rule. Revisit strict,
+    // media-prefers-color-scheme in particular, if we implement dark mode.
+    extends: ["stylelint-config-standard", "@double-great/stylelint-a11y/recommended"],
     customSyntax: "postcss-html",
     ignoreFiles: [
         "**/bin/**", // .NET build output directories


### PR DESCRIPTION
## Summary

Started as a Windows-only "command line is too long" failure in the CSS lint step. Fixing that revealed the real problem: **stylelint has been reporting nothing at all, repo-wide.**

Takes `VueApp/src` from 164 stylelint findings to 0.

## Two bugs in the tooling

**1. Every stylelint result was being discarded.** `parseJsonOutput` in `scripts/lib/lint-staged-common.js` read only `stdout`, but stylelint writes its JSON report to `stderr`. With `stdout` empty the function returned `[]` and the CSS check reported success no matter what it found. The text fallback did not catch it either, since that only fires on a JSON parse error rather than on empty output.

ESLint writes to `stdout`, so the vue and cshtml checks were unaffected and still report identically.

**2. Stylelint received every path as an argument.** A whole-tree run passed 207 paths on one command line and blew past the Windows ~8191 character limit. Now batched in groups of 50, matching what `runOxfmtCheck` already did.

Fixing only the second bug would have left stylelint just as blind, minus the crash. This was caught by injecting a deliberate `#FFFFFF` violation after the batching fix and finding it still went unreported.

## Remediation: 164 to 0

| Change | Count |
|---|---|
| Modern color notation, media range syntax, blank lines (`stylelint --fix`) | 21 |
| `word-break: break-word` to `overflow-wrap` (one dropped as redundant) | 7 |
| Keyframe renamed to kebab-case | 1 |
| Vue `v-bind()` false positive suppressed | 1 |
| **Keyboard focus rings restored** | **2** |
| Resolved by moving from the a11y `strict` tier to `recommended` | 132 |

### The focus ring fix is a real accessibility bug

Two `:focus` states in `StaffDashboard.vue` set `outline: none` and offered only a background tint or a 5% brightness shift in its place, leaving keyboard users with no visible focus indicator (WCAG 2.4.7). Both now carry the system focus ring on `:focus-visible`, matching the pattern in `styles/base.css` including the transparent outline that keeps the indicator visible under Windows forced-colors.

### One autofix was wrong and was corrected

`stylelint --fix` generated a `@media (prefers-reduced-motion: reduce)` block **before** the rule it overrides. At equal specificity the later declaration wins, so the animation always won and the reduced-motion override never applied. It was also emitted at column 0. Moved after the rule, with a comment recording why order matters. Worth knowing that `--fix` output needs review rather than being assumed safe; it also wrote three bare-LF lines that had to be normalized back to CRLF.

## strict to recommended

The a11y plugin ships two tiers. `recommended` enables 3 rules, `strict` adds 9 more.

Lining that up against what was actually found here: **both genuine WCAG failures came from `recommended` rules** (`no-outline-none`, `media-prefers-reduced-motion`). Every one of the 132 findings from `strict`-only rules turned out to be a design decision or a false positive:

- `media-prefers-color-scheme` (95) asks every colour rule for a dark counterpart. The app ships a single light theme whose pairings are verified against WCAG AA (see DESIGN.md), and Quasar themes via a `body--dark` class rather than this media query, so even a proper dark mode likely would not satisfy it.
- `no-display-none` (13) flags `display: none` inside `@media print` and responsive blocks, where it is correct.
- `line-height-is-vertical-rhythmed` (12) enforces a baseline grid. This is not WCAG 1.4.12, which requires text to stay readable when a *user* sets 1.5, not that authors ship it.
- `font-size-is-readable` (9) flags 13px on dense UI chrome, a DESIGN.md typography question.

Switching tiers replaces a growing list of one-off rule disables with a single decision, and follows the maintainer's own tiering. The reasoning is recorded in a comment on the `extends` line.

Verified the plugin is still enforcing rather than silently unloaded: an injected `outline: none` inside a `<style>` block is still caught by `a11y/no-outline-none`.

## Dead code

`assets/base.css` carried a `@media (prefers-color-scheme: dark)` block from the Vue starter template, flipping `--color-*` to dark values and implying dark-mode support the app does not have. Removed, along with the seven `--vt-c-*-dark` declarations it orphaned.

Note for a possible follow-up: that file is reached only by the scaffold `main.ts` entry, whose `App.vue` still renders the Vue logo placeholder. None of the seven area SPAs import it, and nothing in `web/Views` references the main bundle, so the whole `index.html` -> `main.ts` -> `App.vue` -> `main.css` -> `base.css` chain looks unused. Removing it would also drop a Vite build target, so it is left out of this PR.

## Verification

- Stylelint: `VueApp/src` and the Razor CSS both at 0 findings
- Frontend: 88 files / 1,120 tests pass
- Backend: 2,708 tests pass
- Line endings: CRLF preserved throughout, including files `stylelint --fix` had rewritten

## Reviewer note

`chore(lint): disable a11y/media-prefers-color-scheme` is superseded by the later tier swap, which removed that one-off disable. Kept for history; happy to squash the two if preferred.
