### PR TITLE
fix(session): use ~/ so Refresh Session keeps the /2 PathBase

### DIFF
--- a/web/Views/Shared/Components/SessionTimeout/Default.cshtml
+++ b/web/Views/Shared/Components/SessionTimeout/Default.cshtml
@@ -14,14 +14,19 @@
                 Your session has been extended to {{sessionExpireTime}}.
             </div>
             <q-space></q-space>
-            <q-btn dense color="secondary" class="q-px-md" label="Log in" v-if="sessionExpired" @@click="login"></q-btn>
+            <q-btn dense color="secondary" class="q-px-md" label="Log in" v-if="sessionExpired || sessionExtendFailed" @@click="login"></q-btn>
             <q-btn dense color="secondary" class="q-px-md" label="Refresh Session" v-if="!sessionExpired && !sessionReloaded" @@click="extendSession"></q-btn>
+        </q-card-section>
+        <q-card-section v-if="sessionExtendFailed && !sessionExpired" class="q-pt-none">
+            <q-banner dense rounded role="alert" class="error-surface">
+                Could not extend your session. Please try again.
+            </q-banner>
         </q-card-section>
     </q-card>
 </q-dialog>
 
 <script asp-add-nonce="true">
-    /* global clearTimeout */
+    /* global clearTimeout, AbortSignal */
     createVueApp({
         data() {
             return {
@@ -30,35 +35,43 @@
                 sessionExpireTime: 0,
                 sessionExpired: false,
                 sessionTimeoutCheckEventId: 0,
-                sessionReloaded: false
+                sessionReloaded: false,
+                sessionExtendFailed: false
             }
         },
         methods: {
             checkSessionTimeout: async function () {
-                try {
-                    fetch(this.sessionRefreshUrl)
-                        .then(r => r.status === 200 ? r.json() : r)
-                        .then(r => {
-                            var nextCheck = 300
-                            if (r.secondsUntilTimeout !== undefined && r.secondsUntilTimeout < 300) {
-                                this.showSessionTimeoutWarning = true
-                                this.sessionExpired = r.secondsUntilTimeout < 15
-                                var d = new Date(r.sessionTimeoutDateTime)
-                                this.sessionExpireTime = (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) + ":"
-                                    + ("0" + d.getMinutes()).slice(-2)
-                                    + (d.getHours() >= 12 ? " PM" : " AM")
-                                nextCheck = this.sessionExpired ? 0 : Math.max(r.secondsUntilTimeout - 15, 5)
-                            }
-                            if(nextCheck > 0) {
-                                this.sessionTimeoutCheckEventId = window.setTimeout(this.checkSessionTimeout, nextCheck * 1000)
-                            }
-                        })
-                }
-                catch (e) { void e }
+                // Timeout so a request that hangs rather than fails still reaches the catch below.
+                fetch(this.sessionRefreshUrl, { signal: AbortSignal.timeout(10000) })
+                    .then(r => r.ok ? r.json() : Promise.reject(new Error('Session check returned ' + r.status)))
+                    .then(r => {
+                        var nextCheck = 300
+                        // "<=" so an exact 300 still warns: otherwise the next poll lands at expiry.
+                        if (r.secondsUntilTimeout !== undefined && r.secondsUntilTimeout <= 300) {
+                            this.showSessionTimeoutWarning = true
+                            this.sessionExpired = r.secondsUntilTimeout < 15
+                            var d = new Date(r.sessionTimeoutDateTime)
+                            this.sessionExpireTime = (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) + ":"
+                                + ("0" + d.getMinutes()).slice(-2)
+                                + (d.getHours() >= 12 ? " PM" : " AM")
+                            nextCheck = this.sessionExpired ? 0 : Math.max(r.secondsUntilTimeout - 15, 5)
+                        }
+                        if(nextCheck > 0) {
+                            this.sessionTimeoutCheckEventId = window.setTimeout(this.checkSessionTimeout, nextCheck * 1000)
+                        }
+                    })
+                    // Silent, but reschedule: one failed poll must not stop the checks for the life of
+                    // the page. Retry quickly once the warning is up, since expiry is minutes away.
+                    .catch(() => {
+                        var retry = this.showSessionTimeoutWarning ? 15000 : 300000
+                        this.sessionTimeoutCheckEventId = window.setTimeout(this.checkSessionTimeout, retry)
+                    })
             },
             extendSession: async function() {
-                fetch("/RefreshSession")
-                    .then(r => r.status === 200 ? r.json() : r)
+                this.sessionExtendFailed = false
+                // "~/" keeps the app's PathBase. A bare "/" resolves to the domain root, outside this app.
+                fetch('@Url.Content("~/RefreshSession")', { signal: AbortSignal.timeout(10000) })
+                    .then(r => r.ok ? r.json() : Promise.reject(new Error('RefreshSession returned ' + r.status)))
                     .then(r => {
                         try {
                             clearTimeout(this.sessionTimeoutCheckEventId)
@@ -74,10 +87,13 @@
 
                         window.setTimeout(this.hideSessionTimeoutWarning, 1000)
                     })
+                    // Leave the dialog up so the user can retry or log in, and say so: the session was not extended.
+                    .catch(() => { this.sessionExtendFailed = true })
             },
             hideSessionTimeoutWarning: function() {
                 this.showSessionTimeoutWarning = false
                 this.sessionReloaded = false
+                this.sessionExtendFailed = false
             },
             login: function() {
                 var returnUrl = encodeURIComponent(window.location.pathname + window.location.search)


### PR DESCRIPTION
## The bug

On TEST and PROD, the session timeout warning appears ("Your session will expire at 10:30 AM. Click Refresh Session to continue working.") and clicking **Refresh Session** does nothing. The console shows:

```
Uncaught (in promise) SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

## Root cause

`extendSession` fetched a bare root-relative `"/RefreshSession"`. TEST and PROD run VIPER 2 as an IIS sub-application under a `/2` PathBase, with legacy VIPER 1 at `/`. So the call landed on legacy VIPER 1, which returned an HTML page. `r.json()` threw, and with no `.catch` on the chain it surfaced as an unhandled rejection, so the button looked dead.

This is pre-existing on `main`, `Development`, and every feature branch. It is not a regression. It does not reproduce locally because local development has no PathBase, so the bare path happens to resolve correctly.

## Changes

- `extendSession` now uses `@Url.Content("~/RefreshSession")`, which includes the PathBase. This matches the `login` method at the bottom of the same file.
- A non-OK response is rejected rather than passed into the success handler. Previously a non-200 fed the `Response` object straight through, rendering "Your session has been extended to Invalid Date" while the session was never extended.
- A failed extend now renders a `role="alert"` `q-banner` inside the dialog using the shared `.error-surface` treatment, and leaves the warning dialog on screen so the user can retry. Per DESIGN.md, Razor pages use `q-banner` with accessible classes rather than a toast, and an actionable error belongs next to the control that failed rather than in something transient. The banner is suppressed once the session actually expires, so the expired message and a stale failure message cannot show together.
- The poll's `try { ... } catch (e) { void e }` was dead code: a synchronous `catch` cannot catch an async rejection. It is replaced with a real `.catch` that reschedules the next check. Beyond making the failure non-silent, this fixes a second bug: a rejected poll previously scheduled no follow-up, so session checking stopped for the remaining life of the page.

`checkSessionTimeout`'s target is deliberately unchanged. It reads the shared `Viper.dbo.SessionTimeout` row through the legacy VIPER 1 CFM endpoint at the domain root, so its root-relative URL is correct.

## Verification

Run locally, one at a time:

| Command | Result |
| --- | --- |
| `npm run lint -- --fix web/Views/Shared/Components/SessionTimeout/Default.cshtml` | No issues found |
| `npm run verify:build` | All build verifications passed |
| `npm run test:backend` | 2708 passed, 0 failed |

**What is not verified locally.** Local development has no PathBase. There is no `UsePathBase` call in `Program.cs`; the `/2` prefix comes only from IIS sub-application hosting (see the comment at `web/Classes/Scheduler/HangfireExtensions.cs:111`). Locally, `"/RefreshSession"` and `@Url.Content("~/RefreshSession")` therefore render to the identical string, so a local run cannot demonstrate the fix. The fix rests on the documented behaviour of `Url.Content("~/...")`, which prepends `Request.PathBase`. **Confirming the TEST symptom is resolved requires a TEST deploy**: check that the rendered markup contains `/2/RefreshSession` and that the button extends the session.
