### PR TITLE
refactor(cms): map zip GUIDs to files with Select

### DIFF
--- a/web/Areas/CMS/Data/CMS.cs
+++ b/web/Areas/CMS/Data/CMS.cs
@@ -421,10 +421,8 @@ namespace Viper.Areas.CMS.Data
                 LogSuspiciousDownloadName(controller, fileName, safeDownloadName, currentUser);
             }
 
-            foreach (var guid in guids)
+            foreach (CMSFile? file in guids.Select(guid => GetFile(guid, null, null, null, null)))
             {
-                CMSFile? file = GetFile(guid, null, null, null, null);
-
                 if (file == null)
                 {
                     continue;


### PR DESCRIPTION
Resolves CodeQL alert [#760](https://github.com/ucdavis/VIPER/security/code-scanning/760) (`cs/linq/missed-select`) in `DownloadZip`.

The `foreach` bound its iteration variable solely to pass it to `GetFile`, so the mapping is now expressed with `.Select(...)`. `Select` is lazily evaluated, so `GetFile` is still invoked once per GUID in the original order and the per-file trash, existence, permission, and audit logic is unchanged.

Verified: `npm run verify:build` clean, `DownloadZipSecurityTests` (68) and `CmsTrashDownloadTests` (12) pass.