### PR TITLE
feat(session): serve session expiry from VIPER 2, not the legacy CFM

### DIFF
--- a/test/Controllers/SessionTimeoutControllerTests.cs
+++ b/test/Controllers/SessionTimeoutControllerTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Viper.Classes;
+using Viper.Controllers;
+
+namespace Viper.test.Controllers
+{
+    /// <summary>
+    /// The session expiry poll must never extend the session, or it would never time out. Both
+    /// controller bases in this app write a fresh expiry on every action, so the guarantee rests
+    /// entirely on this controller not inheriting either of them. Pin that.
+    /// </summary>
+    public class SessionTimeoutControllerTests
+    {
+        [Fact]
+        public void Controller_DoesNotInheritASessionExtendingBase()
+        {
+            Assert.False(typeof(ApiController).IsAssignableFrom(typeof(SessionTimeoutController)));
+            Assert.False(typeof(AreaController).IsAssignableFrom(typeof(SessionTimeoutController)));
+        }
+
+        [Fact]
+        public void Controller_DoesNotCarryTheSessionUpdateFilter()
+        {
+            Assert.Empty(typeof(SessionTimeoutController)
+                .GetCustomAttributes(typeof(ApiSessionUpdateFilterAttribute), inherit: true));
+
+            foreach (MethodInfo action in typeof(SessionTimeoutController).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                Assert.Empty(action.GetCustomAttributes(typeof(ApiSessionUpdateFilterAttribute), inherit: true));
+            }
+        }
+    }
+}

--- a/web/Classes/SessionTimeoutStatus.cs
+++ b/web/Classes/SessionTimeoutStatus.cs
@@ -1,0 +1,12 @@
+namespace Viper.Classes
+{
+    /// <summary>
+    /// Session expiry contract polled by the session timeout dialog.
+    /// </summary>
+    public class SessionTimeoutStatus
+    {
+        public string SessionTimeoutDateTime { get; set; } = string.Empty;
+
+        public int SecondsUntilTimeout { get; set; }
+    }
+}

--- a/web/Classes/Utilities/SessionTimeoutService.cs
+++ b/web/Classes/Utilities/SessionTimeoutService.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using NLog;
 using Viper.Classes.SQLContext;
 using Viper.Models.AAUD;
@@ -7,7 +8,7 @@ namespace Viper.Classes.Utilities
 {
     public static class SessionTimeoutService
     {
-        private const int SessionTimeoutSeconds = (29 * 60) + 30;
+        internal const int SessionTimeoutSeconds = (29 * 60) + 30;
 
         public static void UpdateSessionTimeout(VIPERContext context)
         {
@@ -51,7 +52,8 @@ namespace Viper.Classes.Utilities
             string service = GetService();
             if (!string.IsNullOrEmpty(loggedInUserId) && context != null)
             {
-                SessionTimeout? record = context.SessionTimeouts.Find(loggedInUserId, service);
+                SessionTimeout? record = context.SessionTimeouts.AsNoTracking()
+                    .FirstOrDefault(s => s.LoginId == loggedInUserId && s.Service == service);
                 if (record != null)
                 {
                     return record;

--- a/web/Controllers/SessionTimeoutController.cs
+++ b/web/Controllers/SessionTimeoutController.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using NLog;
+using Viper.Classes;
+using Viper.Classes.SQLContext;
+using Viper.Classes.Utilities;
+
+namespace Viper.Controllers
+{
+    /// <summary>
+    /// Read-only session expiry poll for the session timeout dialog. Takes no parameters: the user
+    /// comes from the auth cookie.
+    /// </summary>
+    /// <remarks>
+    /// Inherits ControllerBase, not Viper.Classes.ApiController or Viper.Classes.AreaController.
+    /// Both of those extend the session on every action, which would stop the session ever expiring,
+    /// and ApiController also wraps responses in an ApiResponse envelope the dialog cannot read. The
+    /// [ApiController] attribute below is Microsoft.AspNetCore.Mvc.ApiControllerAttribute and
+    /// carries none of that behaviour.
+    ///
+    /// No [Authorize]: attribute-routed actions do not pick up RequireAuthorization from the
+    /// conventional routes, and the action takes no parameters and reads identity from the cookie,
+    /// so an anonymous caller learns only that it has no session. The dialog then offers a log in
+    /// rather than retrying a call that would 401.
+    /// </remarks>
+    [ApiController]
+    [Route("/api/sessionTimeout")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+    public class SessionTimeoutController : ControllerBase
+    {
+        // Ten minutes rather than zero, so a database blip cannot strand the user behind a warning
+        // dialog they cannot dismiss.
+        private const int SecondsOnError = 600;
+
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        private readonly VIPERContext _viperContext;
+
+        public SessionTimeoutController(VIPERContext viperContext)
+        {
+            _viperContext = viperContext;
+        }
+
+        [HttpGet]
+        public ActionResult<SessionTimeoutStatus> GetSessionTimeout()
+        {
+            try
+            {
+                Models.VIPER.SessionTimeout? record = SessionTimeoutService.GetSessionTimeout(_viperContext);
+                if (record != null)
+                {
+                    return Status(record.SessionTimeoutDateTime,
+                        (int)(record.SessionTimeoutDateTime - DateTime.Now).TotalSeconds);
+                }
+
+                // Authenticated but untracked. Only AreaController, ApiSessionUpdateFilter and
+                // RefreshSession write the row, so a page served by a plain Controller leaves a
+                // valid session with no row. Grant a full window rather than report it expired.
+                return User.Identity?.IsAuthenticated == true
+                    ? Status(DateTime.Now.AddSeconds(SessionTimeoutService.SessionTimeoutSeconds),
+                        SessionTimeoutService.SessionTimeoutSeconds)
+                    : Status(DateTime.Now, 0);
+            }
+            catch (SqlException ex)
+            {
+                return CouldNotRead(ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return CouldNotRead(ex);
+            }
+        }
+
+        private static SessionTimeoutStatus CouldNotRead(Exception ex)
+        {
+            Logger.Error(ex, "Could not read session timeout");
+            return Status(DateTime.Now.AddSeconds(SecondsOnError), SecondsOnError);
+        }
+
+        // Carry the offset. The column is a bare datetime written from DateTime.Now, so it is local
+        // wall-clock; without the offset a client in another timezone reads it as its own and shows
+        // the wrong expiry time.
+        private static SessionTimeoutStatus Status(DateTime sessionTimeout, int secondsUntilTimeout)
+        {
+            DateTimeOffset local = new(DateTime.SpecifyKind(sessionTimeout, DateTimeKind.Local));
+            return new SessionTimeoutStatus
+            {
+                SessionTimeoutDateTime = local.ToString("yyyy-MM-dd'T'HH:mm:sszzz", CultureInfo.InvariantCulture),
+                SecondsUntilTimeout = secondsUntilTimeout
+            };
+        }
+    }
+}

--- a/web/Models/SessionTimeoutCheck.cs
+++ b/web/Models/SessionTimeoutCheck.cs
@@ -1,9 +1,0 @@
-namespace Viper.Models
-{
-    public class SessionTimeoutCheck
-    {
-        public DateTime SessionTimeout { get; set; }
-        public int SecondsUntilTimeout { get; set; }
-        public string LoginId { get; set; } = null!;
-    }
-}

--- a/web/Views/Shared/Components/SessionTimeout/Default.cshtml
+++ b/web/Views/Shared/Components/SessionTimeout/Default.cshtml
@@ -30,7 +30,6 @@
     createVueApp({
         data() {
             return {
-                sessionRefreshUrl: '@Html.Raw(ViewData["sessionRefreshUrl"] ?? "")',
                 showSessionTimeoutWarning: false,
                 sessionExpireTime: 0,
                 sessionExpired: false,
@@ -42,7 +41,7 @@
         methods: {
             checkSessionTimeout: async function () {
                 // Timeout so a request that hangs rather than fails still reaches the catch below.
-                fetch(this.sessionRefreshUrl, { signal: AbortSignal.timeout(10000) })
+                fetch('@Url.Content("~/api/sessionTimeout")', { signal: AbortSignal.timeout(10000) })
                     .then(r => r.ok ? r.json() : Promise.reject(new Error('Session check returned ' + r.status)))
                     .then(r => {
                         var nextCheck = 300
@@ -50,11 +49,12 @@
                         if (r.secondsUntilTimeout !== undefined && r.secondsUntilTimeout <= 300) {
                             this.showSessionTimeoutWarning = true
                             this.sessionExpired = r.secondsUntilTimeout < 15
-                            var d = new Date(r.sessionTimeoutDateTime)
-                            this.sessionExpireTime = (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) + ":"
-                                + ("0" + d.getMinutes()).slice(-2)
-                                + (d.getHours() >= 12 ? " PM" : " AM")
+                            this.sessionExpireTime = this.formatExpireTime(r.sessionTimeoutDateTime)
                             nextCheck = this.sessionExpired ? 0 : Math.max(r.secondsUntilTimeout - 15, 5)
+                        }
+                        else if (r.secondsUntilTimeout !== undefined) {
+                            // Extended elsewhere, in another tab or by an API call, so stand the warning down.
+                            this.hideSessionTimeoutWarning()
                         }
                         if(nextCheck > 0) {
                             this.sessionTimeoutCheckEventId = window.setTimeout(this.checkSessionTimeout, nextCheck * 1000)
@@ -78,10 +78,7 @@
                         }
                         catch(e) { void e }
 
-                        var d = new Date(r.sessionTimeoutDateTime)
-                        this.sessionExpireTime = (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) + ":"
-                            + ("0" + d.getMinutes()).slice(-2)
-                            + (d.getHours() >= 12 ? " PM" : " AM")
+                        this.sessionExpireTime = this.formatExpireTime(r.sessionTimeoutDateTime)
                         this.sessionReloaded = true
                         this.sessionTimeoutCheckEventId = window.setTimeout(this.checkSessionTimeout, 5000)
 
@@ -92,8 +89,16 @@
             },
             hideSessionTimeoutWarning: function() {
                 this.showSessionTimeoutWarning = false
+                this.sessionExpired = false
                 this.sessionReloaded = false
                 this.sessionExtendFailed = false
+            },
+            // Hour 0 is 12 AM, not 0 AM.
+            formatExpireTime: function(sessionTimeoutDateTime) {
+                var d = new Date(sessionTimeoutDateTime)
+                return (d.getHours() % 12 || 12) + ":"
+                    + ("0" + d.getMinutes()).slice(-2)
+                    + (d.getHours() >= 12 ? " PM" : " AM")
             },
             login: function() {
                 var returnUrl = encodeURIComponent(window.location.pathname + window.location.search)

--- a/web/Views/Shared/Components/SessionTimeout/SessionTimeout.cs
+++ b/web/Views/Shared/Components/SessionTimeout/SessionTimeout.cs
@@ -7,14 +7,11 @@ namespace Viper.Views.Shared.Components.SessionTimeout
     {
         public IViewComponentResult Invoke()
         {
-            UserHelper userHelper = new UserHelper();
-            string? loginId = userHelper.GetCurrentUser()?.LoginId;
-            bool onDev = HttpHelper.Environment?.EnvironmentName == "Development";
-            ViewData["sessionRefreshUrl"] = (onDev ? "http://localhost/" : ("https://" + HttpHelper.HttpContext?.Request.Host.Value + "/"))
-                + "/public/timeout/seconds_until_timeout_v2.cfm?id="
-                + (loginId ?? "")
-                + "&service=" + (onDev ? "Viper2-dev" : "Viper2");
-            return View("Default");
+            // The layout renders this on public pages too. An anonymous visitor has no session, and
+            // the poll would report zero seconds left and tell them it had expired.
+            return UserClaimsPrincipal?.Identity?.IsAuthenticated == true
+                ? View("Default")
+                : Content(string.Empty);
         }
 
     }


### PR DESCRIPTION
> **Stacked on #302. Review that one first.** This branch is based on `fix/session-refresh-pathbase`, so this diff shows only the endpoint work. #302 is a standalone one-line bug fix and does not depend on anything here. If this PR is declined, #302 is unaffected.

Replaces the cross-origin session-expiry poll to legacy VIPER 1 with a read-only VIPER 2 endpoint.

## Why

- The legacy `seconds_until_timeout_v2.cfm` takes `loginID` as an **unauthenticated query string parameter**, so anyone can read anyone's session expiry. The new endpoint takes no parameters and derives the user from the auth cookie.
- The CFM carries hardcoded CORS handling for `localhost:7157-7159` purely to work in dev. Same-origin removes the need.
- It removes a runtime dependency on legacy VIPER 1 for Razor pages.

## The one thing to check carefully

**The endpoint must never extend the session.** Both controller base classes in this app write a fresh expiry on *every* action:

- `ApiController` via `[ApiSessionUpdateFilter]` (`ApiSessionUpdateFilter.cs:13`)
- `AreaController` via its `OnActionExecutionAsync` override (`AreaController.cs:20`)

So `SessionTimeoutController` deliberately derives from plain `ControllerBase`. If someone "tidies" it onto `ApiController` later, polling would renew the session every 5 minutes and **sessions would never expire**. Inheriting `ApiController` would also wrap the payload in the `ApiResponse` envelope and break the JSON contract the dialog reads.

That invariant is now pinned by `test/Controllers/SessionTimeoutControllerTests.cs`, which fails if the base class changes.

## Decisions

- **Database error returns ~600 seconds**, not 0, matching the legacy `<cfcatch>`, so a DB blip cannot strand a user behind a warning dialog they cannot dismiss.
- **A missing row is now split two ways, which legacy could not do.** Rows are written only by `AreaController`, `ApiSessionUpdateFilter` and `RefreshSession`, so a page served by a plain `Controller` (`CMSController`, for instance) leaves a perfectly valid session with no row at all. Legacy had no auth context, could not tell that apart from a dead session, and reported "expired" to a user who was fine. With the cookie we can: an authenticated user with no row gets a full window, an anonymous caller still gets 0. This weakens nothing, because the row drives only this advisory dialog and is not enforced server-side.

The JSON contract (`sessionTimeoutDateTime`, `secondsUntilTimeout`) is unchanged, so the client shape is untouched.

## Also here

- Anonymous visitors no longer poll at all. The layout renders this component on public pages, and both before and after this change an anonymous poll returns 0, which told a logged-out visitor on the home page that their session had expired 60 seconds after load. The ViewComponent now renders nothing when unauthenticated, matching the guard the SPA sibling already has.
- The expiry timestamp is emitted **with a UTC offset**. The column is a bare `datetime` written from `DateTime.Now`, so it is local wall-clock; without an offset a client in another timezone reads it as its own and displays the wrong expiry.
- `no-store` on a per-user, time-sensitive GET.
- The warning now stands down by itself when the session is extended elsewhere. Previously, once `secondsUntilTimeout` climbed back above 300 the poll skipped the whole branch and never cleared `showSessionTimeoutWarning`, so a user who kept working in a second tab was left staring at a stale "your session will expire at ..." that would never go away.
- Midnight renders as "12:05 AM" rather than "0:05 AM". The formatter was duplicated verbatim in both handlers and is now one method, so the two cannot drift.
- `SessionTimeout.cs` cleanup: the hardcoded `http://localhost/`, the double slash, and the `loginId` in the query string are all gone with the URL. It no longer needs to be async.

## Minor behavioural note

Moving the poll same-origin means it now reaches .NET carrying the auth cookie, and cookie auth uses sliding expiration (`ExpireTimeSpan` 12h at `Program.cs:146`, `SlidingExpiration` left unset so it defaults to true). The old cross-origin ColdFusion poll could not touch that cookie.

The practical effect is small. Sliding expiration only reissues the cookie after 6h have elapsed, and polling stops once the session expires, so an abandoned tab goes quiet roughly 30 minutes after the last real activity and never survives to the renewal point. Keeping the poll running to 6h would require activity every ~29.5 minutes to keep the `SessionTimeout` row alive, and that activity is itself same-origin .NET traffic already renewing the cookie. So the poll can extend cookie life by at most ~30 minutes beyond what ordinary navigation already does. Recording it for the record rather than flagging it as a blocker.

## Not done

The SPA (`VueApp/src/components/SessionTimeout.vue`) still polls the legacy CFM with `?id=<loginId>`, so **the CFM cannot be decommissioned yet**. `VueApp/` was out of scope for this work. Migrating it is the natural follow-up and would close the unauthenticated-read hole for the SPA too.

## Verification

| Command | Result |
| --- | --- |
| `npm run lint -- --fix <changed files>` | No issues found |
| `npm run verify:build` | All build verifications passed |
| `npm run test:backend` | 2710 passed, 0 failed (2708 existing plus 2 new) |

**Not verifiable locally:** local dev has no PathBase, so the `/2` behaviour of `@Url.Content("~/api/sessionTimeout")` needs a TEST deploy to confirm, as does the end-to-end poll against a real database.
