### PR TITLE
feat(session): move the SPA session poll off the legacy CFM

### DIFF
--- a/VueApp/src/components/SessionTimeout.vue
+++ b/VueApp/src/components/SessionTimeout.vue
@@ -2,83 +2,84 @@
 import { ref } from "vue"
 import { useUserStore } from "@/store/UserStore"
 import { getLoginUrl } from "@/composables/RequireLogin"
+import StatusBanner from "@/components/StatusBanner.vue"
 
 const userStore = useUserStore()
-//https://" + HttpHelper.HttpContext?.Request.Host.Value
-const onDev = import.meta.env.VITE_ENVIRONMENT === "DEVELOPMENT"
 const viperHome = import.meta.env.VITE_VIPER_HOME
+const sessionTimeoutUrl = `${import.meta.env.VITE_API_URL}sessionTimeout`
 const loginHref = getLoginUrl()
-const sessionRefreshUrl =
-    (onDev ? "http://localhost/" : "/") +
-    "public/timeout/seconds_until_timeout_v2.cfm?id=" +
-    userStore.userInfo.loginId +
-    "&service=" +
-    (onDev ? "Viper2-dev" : "Viper2")
 const showSessionTimeoutWarning = ref(false)
 const sessionExpireTime = ref("")
 const sessionExpired = ref(false)
 let sessionTimeoutCheckEventId = 0
 const sessionReloaded = ref(false)
+const sessionExtendFailed = ref(false)
 
+// Hour 0 is 12 AM, not 0 AM.
+function formatExpireTime(sessionTimeoutDateTime: string) {
+    const d = new Date(sessionTimeoutDateTime)
+    return (d.getHours() % 12 || 12) + ":" + ("0" + d.getMinutes()).slice(-2) + (d.getHours() >= 12 ? " PM" : " AM")
+}
+
+// Plain fetch rather than useFetch, deliberately: these are session lifecycle calls. useFetch
+// pushes every failure into the global error store, which would raise a banner on each blip of a
+// silent five minute poll, and would fire the auth handler at exactly the moment our own dialog
+// is offering the user a log in.
 async function checkSessionTimeout() {
-    if (
-        userStore.userInfo.loginId === undefined ||
-        userStore.userInfo.loginId === null ||
-        userStore.userInfo.loginId.length === 0
-    ) {
+    if (!userStore.userInfo.loginId) {
         return //don't check the session if the user is not logged in
     }
-    //try to get the session timeout from an external application
-    try {
-        fetch(sessionRefreshUrl)
-            .then((r) => (r.status === 200 ? r.json() : r))
-            .then((r) => {
-                let nextCheck = 300
-                //show timeout warning if the session will time out in 5 minutes or less
-                if (r.secondsUntilTimeout !== undefined && r.secondsUntilTimeout < 300) {
-                    showSessionTimeoutWarning.value = true
-                    sessionExpired.value = r.secondsUntilTimeout < 15 //consider session timing out in 15 seconds to be timed out already
-                    var d = new Date(r.sessionTimeoutDateTime)
-                    sessionExpireTime.value =
-                        (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) +
-                        ":" +
-                        ("0" + d.getMinutes()).slice(-2) +
-                        (d.getHours() >= 12 ? " PM" : " AM")
-                    nextCheck = sessionExpired.value ? 0 : Math.max(r.secondsUntilTimeout - 15, 5)
-                }
-                if (nextCheck > 0) {
-                    sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, nextCheck * 1000)
-                }
-            })
-    } catch (e) {
-        void e
-    }
-}
-async function extendSession() {
-    fetch(viperHome + "RefreshSession")
-        .then((r) => (r.status === 200 ? r.json() : r))
+    // Timeout so a request that hangs rather than fails still reaches the catch below.
+    fetch(sessionTimeoutUrl, { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error("Session check returned " + r.status))))
         .then((r) => {
-            try {
-                clearTimeout(sessionTimeoutCheckEventId)
-            } catch (e) {
-                void e
+            let nextCheck = 300
+            //show timeout warning if the session will time out in 5 minutes or less
+            // "<=" so an exact 300 still warns: otherwise the next poll lands at expiry.
+            if (r.secondsUntilTimeout !== undefined && r.secondsUntilTimeout <= 300) {
+                showSessionTimeoutWarning.value = true
+                sessionExpired.value = r.secondsUntilTimeout < 15 //consider session timing out in 15 seconds to be timed out already
+                sessionExpireTime.value = formatExpireTime(r.sessionTimeoutDateTime)
+                nextCheck = sessionExpired.value ? 0 : Math.max(r.secondsUntilTimeout - 15, 5)
+            } else if (r.secondsUntilTimeout !== undefined) {
+                // Extended elsewhere, in another tab or by an API call, so stand the warning down.
+                hideSessionTimeoutWarning()
             }
+            if (nextCheck > 0) {
+                sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, nextCheck * 1000)
+            }
+        })
+        // Silent, but reschedule: one failed poll must not stop the checks for the life of the page.
+        // Retry quickly once the warning is up, since expiry is minutes away.
+        .catch(() => {
+            const retry = showSessionTimeoutWarning.value ? 15000 : 300000
+            sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, retry)
+        })
+}
 
-            var d = new Date(r.sessionTimeoutDateTime)
-            sessionExpireTime.value =
-                (d.getHours() > 12 ? d.getHours() - 12 : d.getHours()) +
-                ":" +
-                ("0" + d.getMinutes()).slice(-2) +
-                (d.getHours() >= 12 ? " PM" : " AM")
+async function extendSession() {
+    sessionExtendFailed.value = false
+    fetch(viperHome + "RefreshSession", { signal: AbortSignal.timeout(10000) })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error("RefreshSession returned " + r.status))))
+        .then((r) => {
+            clearTimeout(sessionTimeoutCheckEventId)
+            sessionExpireTime.value = formatExpireTime(r.sessionTimeoutDateTime)
             sessionReloaded.value = true
             sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, 5000)
 
             window.setTimeout(hideSessionTimeoutWarning, 1000)
         })
+        // Leave the dialog up so the user can retry or log in, and say so: the session was not extended.
+        .catch(() => {
+            sessionExtendFailed.value = true
+        })
 }
+
 function hideSessionTimeoutWarning() {
     showSessionTimeoutWarning.value = false
+    sessionExpired.value = false
     sessionReloaded.value = false
+    sessionExtendFailed.value = false
 }
 
 sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, 60000)
@@ -111,7 +112,7 @@ sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, 60000)
                     color="secondary"
                     class="q-px-md"
                     label="Log in"
-                    v-if="sessionExpired"
+                    v-if="sessionExpired || sessionExtendFailed"
                     :href="loginHref"
                 ></q-btn>
                 <q-btn
@@ -122,6 +123,12 @@ sessionTimeoutCheckEventId = window.setTimeout(checkSessionTimeout, 60000)
                     v-if="!sessionExpired && !sessionReloaded"
                     @click="extendSession"
                 ></q-btn>
+            </q-card-section>
+            <q-card-section
+                v-if="sessionExtendFailed && !sessionExpired"
+                class="q-pt-none"
+            >
+                <StatusBanner type="error"> Could not extend your session. Please try again. </StatusBanner>
             </q-card-section>
         </q-card>
     </q-dialog>


### PR DESCRIPTION
> **Stacked on #304, which is stacked on #302. Review this one third.** GitHub stack #305. Base is `feature/session-timeout-endpoint`, so this diff shows only the SPA work.

Migrates the Vue SPA's session timeout component off the legacy ColdFusion endpoint and onto the VIPER 2 endpoint added in #304.

## Why this one matters

#304 only moved the Razor side. `SessionTimeout.vue` is a parallel implementation of the same component and was still calling `public/timeout/seconds_until_timeout_v2.cfm?id=<loginId>`, the exact unauthenticated endpoint #304 exists to replace. So until this merges:

- the login-id-in-a-query-string read hole stays open for every SPA user, and
- **legacy VIPER 1 cannot be decommissioned**, because the SPA still depends on it at runtime.

With this merged, nothing in `web/` or `VueApp/src/` references the CFM. Retiring `seconds_until_timeout_v2.cfm` becomes a separate, coordinated change in the legacy repo. Note that `seconds_until_timeout.cfm` (v1) must stay, since VIPER 1 uses it for its own timeout.

## Deliberate deviation: plain `fetch`, not `useFetch()`

`CLAUDE.md` says use the service layer plus `useFetch()`. I am not doing that here, and it is worth a reviewer's attention.

It is **not** the envelope. `fetchWrapper` only unwraps when `r.success !== undefined` (`ViperFetch.ts:137-141`), so the envelope-less payload from the new endpoint passes through fine. `useFetch()` would work.

The reason is error handling. `useFetch()` routes every failure through `errorHandler.handleError`, which writes to the **global error store** (`ErrorHandler.ts:13`). For this component that is wrong twice over:

- The poll is a silent background check every five minutes. A transient network blip would raise a global error banner at the user, who neither asked for nor can act on it.
- On 401/403 it fires `handleAuthError`, which would kick in at exactly the moment our own dialog is trying to tell the user their session expired and offer them a Log in button. The two would fight.

The file already used plain `fetch`, so this is not a regression, but it is a conscious exception rather than an oversight. Happy to revisit if you would rather add a non-reporting variant to the service layer.

## Also carried over

This file had the same defects #302 fixed on the Razor side, so the same fixes apply:

- Non-OK responses are rejected instead of being passed into the success handler.
- A failed extend renders a `StatusBanner type="error"` inside the dialog, and leaves the dialog up so the user can retry. `StatusBanner` is the SPA equivalent of the Razor `q-banner` per `DESIGN.md`, and `type="error"` is assertive (`role="alert"`) by default.
- The poll's dead `try/catch`, which could not catch an async rejection, is replaced with a real `.catch` that reschedules. Previously a rejected poll scheduled no follow-up, so session checking stopped for the life of the page.
- The warning stands down by itself when the session is extended elsewhere, instead of leaving a stale "your session will expire at ..." on screen forever.
- Midnight renders as "12:05 AM" rather than "0:05 AM", and the formatter is now one function instead of being duplicated in both handlers.

`extendSession`'s target is unchanged on purpose. It uses `VITE_VIPER_HOME`, which is already `/2/` in `.env.test` and `.env.production`, so it was never affected by the PathBase bug in #302.

## Verification

| Command | Result |
| --- | --- |
| `npm run lint -- --fix VueApp/src/components/SessionTimeout.vue` | No issues; TypeScript, fallow and jscpd all clean |
| `npm run verify:build` | Build succeeded, 0 errors |
| `npm run test:frontend` | **1121 passed** (88 files), 0 failed |
| `npm run test:backend` | **2710 passed**, 0 failed |

**Not verified locally.** There is no existing test for this component and I did not add one; it is DOM-and-timer heavy and the valuable assertions need the real endpoint. The end-to-end path (SPA polling `/2/api/sessionTimeout` under the real PathBase, against a real database) needs a TEST deploy. Local dev has no PathBase, so the `/2` prefix cannot be exercised here.
