### PR TITLE
chore(analyzer): clear the warnings from the SonarAnalyzer 10.31 bump

### DIFF
--- a/test/Areas/Directory/VMACSServiceTest.cs
+++ b/test/Areas/Directory/VMACSServiceTest.cs
@@ -61,7 +61,7 @@ namespace Viper.test.Areas.Directory
 
             Assert.NotNull(query);
             Assert.NotNull(query.item);
-            Assert.Equal("Doe, John", query.item!.Name?.Single());
+            Assert.Equal("Doe, John", query.item.Name?.Single());
         }
 
         [Fact]

--- a/test/CMS/CMSContentControllerTests.cs
+++ b/test/CMS/CMSContentControllerTests.cs
@@ -150,7 +150,7 @@ public sealed class CMSContentControllerTests : IDisposable
         var result = await _controller.GetContentBlock(5, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(5, result.Value!.ContentBlockId);
+        Assert.Equal(5, result.Value.ContentBlockId);
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public sealed class CMSContentControllerTests : IDisposable
         var result = await _controller.CreateContentBlock(request, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(7, result.Value!.ContentBlockId);
+        Assert.Equal(7, result.Value.ContentBlockId);
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public sealed class CMSContentControllerTests : IDisposable
         var result = await _controller.CreateContentBlock(request, TestContext.Current.CancellationToken);
 
         Assert.IsType<ObjectResult>(result.Result);
-        var problem = (ObjectResult)result.Result!;
+        var problem = (ObjectResult)result.Result;
         Assert.IsType<ValidationProblemDetails>(problem.Value);
     }
 
@@ -313,7 +313,7 @@ public sealed class CMSContentControllerTests : IDisposable
         var result = await _controller.UpdateContentBlock(3, request, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(3, result.Value!.ContentBlockId);
+        Assert.Equal(3, result.Value.ContentBlockId);
     }
 
     [Fact]

--- a/test/CMS/CMSFilesControllerTests.cs
+++ b/test/CMS/CMSFilesControllerTests.cs
@@ -160,7 +160,7 @@ public sealed class CMSFilesControllerTests : IDisposable
         var result = await _controller.GetFile(guid, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(guid, result.Value!.FileGuid);
+        Assert.Equal(guid, result.Value.FileGuid);
     }
 
     [Fact]

--- a/test/CMS/CMSLeftNavControllerTests.cs
+++ b/test/CMS/CMSLeftNavControllerTests.cs
@@ -56,7 +56,7 @@ public sealed class CMSLeftNavControllerTests
         var result = await _controller.GetMenu(5, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(5, result.Value!.LeftNavMenuId);
+        Assert.Equal(5, result.Value.LeftNavMenuId);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public sealed class CMSLeftNavControllerTests
         var result = await _controller.UpdateMenu(5, request, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Equal(5, result.Value!.LeftNavMenuId);
+        Assert.Equal(5, result.Value.LeftNavMenuId);
     }
 
     [Fact]

--- a/test/CMS/CMSOptionsControllerTests.cs
+++ b/test/CMS/CMSOptionsControllerTests.cs
@@ -70,7 +70,7 @@ public sealed class CMSOptionsControllerTests : IDisposable
         var result = await _controller.SearchPeople(search!, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result.Value);
-        Assert.Empty(result.Value!);
+        Assert.Empty(result.Value);
     }
 
     [Fact]

--- a/test/ClinicalScheduler/PermissionsControllerTest.cs
+++ b/test/ClinicalScheduler/PermissionsControllerTest.cs
@@ -128,10 +128,10 @@ namespace Viper.test.ClinicalScheduler
             var okResult = Assert.IsType<OkObjectResult>(result.Result);
             dynamic? response = okResult.Value;
             Assert.Equal(TestUserMothraId, response!.user.mothraId);
-            Assert.Equal(TestUserDisplayName, response!.user.displayName);
-            Assert.False(response!.permissions.hasManagePermission);
-            Assert.Equal(1, response!.permissions.editableServiceCount);
-            Assert.Single(response!.editableServices);
+            Assert.Equal(TestUserDisplayName, response.user.displayName);
+            Assert.False(response.permissions.hasManagePermission);
+            Assert.Equal(1, response.permissions.editableServiceCount);
+            Assert.Single(response.editableServices);
         }
 
         [Fact]

--- a/test/Effort/HarvestTimeParserTests.cs
+++ b/test/Effort/HarvestTimeParserTests.cs
@@ -37,8 +37,7 @@ public sealed class HarvestTimeParserTests
     {
         var result = HarvestTimeParser.ParseTimeString(input);
 
-        Assert.NotNull(result);
-        var value = result!.Value;
+        var value = Assert.IsType<TimeSpan>(result);
         Assert.Equal(expectedHour, value.Hours);
         Assert.Equal(expectedMinute, value.Minutes);
     }

--- a/test/HealthChecks/HealthCheckCollectorTokenHandlerTests.cs
+++ b/test/HealthChecks/HealthCheckCollectorTokenHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Viper.test.HealthChecks
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(recorder.LastRequest);
-            var values = recorder.LastRequest!.Headers.GetValues(HealthCheckCollectorAuth.HeaderName).ToList();
+            var values = recorder.LastRequest.Headers.GetValues(HealthCheckCollectorAuth.HeaderName).ToList();
             Assert.Single(values);
             Assert.Equal(HealthCheckCollectorAuth.Token, values[0]);
         }

--- a/test/Scheduler/ScheduledJobRunnerTests.cs
+++ b/test/Scheduler/ScheduledJobRunnerTests.cs
@@ -48,7 +48,7 @@ namespace Viper.test.Scheduler
 
             Assert.True(capturing.Ran);
             Assert.NotNull(capturing.CapturedContext);
-            Assert.Equal(ScheduledJobContext.SchedulerActor, capturing.CapturedContext!.ModBy);
+            Assert.Equal(ScheduledJobContext.SchedulerActor, capturing.CapturedContext.ModBy);
         }
 
         [Fact]

--- a/test/Students/EmergencyContactControllerTests.cs
+++ b/test/Students/EmergencyContactControllerTests.cs
@@ -214,7 +214,7 @@ public class EmergencyContactControllerTests
         var result = await _controller.GetStudentContactDetail(999);
 
         Assert.IsType<ObjectResult>(result.Result);
-        var objectResult = (ObjectResult)result.Result!;
+        var objectResult = (ObjectResult)result.Result;
         Assert.Equal(403, objectResult.StatusCode);
     }
 
@@ -662,7 +662,7 @@ public class EmergencyContactControllerTests
         var method = typeof(EmergencyContactController).GetMethod(nameof(EmergencyContactController.GetStudentContactDetail));
         Assert.NotNull(method);
 
-        var permissionAttrs = method!.GetCustomAttributes(typeof(PermissionAttribute), false);
+        var permissionAttrs = method.GetCustomAttributes(typeof(PermissionAttribute), false);
         Assert.Empty(permissionAttrs);
 
         var authorizeAttrs = method.GetCustomAttributes(typeof(AuthorizeAttribute), false);
@@ -676,7 +676,7 @@ public class EmergencyContactControllerTests
         var method = typeof(EmergencyContactController).GetMethod(nameof(EmergencyContactController.CanEdit));
         Assert.NotNull(method);
 
-        var permissionAttrs = method!.GetCustomAttributes(typeof(PermissionAttribute), false);
+        var permissionAttrs = method.GetCustomAttributes(typeof(PermissionAttribute), false);
         Assert.Empty(permissionAttrs);
 
         var authorizeAttrs = method.GetCustomAttributes(typeof(AuthorizeAttribute), false);

--- a/test/Students/EmergencyContactServiceTests.cs
+++ b/test/Students/EmergencyContactServiceTests.cs
@@ -1387,7 +1387,7 @@ public sealed class EmergencyContactServiceTests : IDisposable
             Assert.Equal("95616", student.Zip);
             Assert.True(student.ContactPermanent);
             Assert.NotNull(student.EmergencyContact);
-            Assert.Equal("Jane Doe", student.EmergencyContact!.Name);
+            Assert.Equal("Jane Doe", student.EmergencyContact.Name);
         }
     }
 

--- a/web/Areas/CMS/Services/CmsFilePathSafety.cs
+++ b/web/Areas/CMS/Services/CmsFilePathSafety.cs
@@ -30,7 +30,9 @@ namespace Viper.Areas.CMS.Services
             "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
         };
 
-        private static readonly Regex DisallowedFileNameChars = new(@"[^a-zA-Z0-9._\- ]", RegexOptions.Compiled);
+        // Bounds matching so a pathological filename cannot pin a request thread.
+        private static readonly Regex DisallowedFileNameChars =
+            new(@"[^a-zA-Z0-9._\- ]", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         /// <summary>
         /// Returns a filename safe to use in a Content-Disposition response header.
@@ -46,7 +48,17 @@ namespace Viper.Areas.CMS.Services
             }
 
             var fileNamePart = StripPathComponents(userInput);
-            var filtered = DisallowedFileNameChars.Replace(fileNamePart, string.Empty).Trim();
+
+            string filtered;
+            try
+            {
+                filtered = DisallowedFileNameChars.Replace(fileNamePart, string.Empty).Trim();
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Fail safe: an unfiltered name must never reach the response header.
+                return DefaultDownloadName;
+            }
 
             // Reject names that collapse to only dots/spaces: ".", ".." etc. would
             // become "..zip" after the suffix step, which is traversal-shaped.

--- a/web/Areas/CTS/Controllers/BundleCompetencyController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyController.cs
@@ -22,12 +22,12 @@ namespace Viper.Areas.CTS.Controllers
 
         private bool BundleExists(int bundleId)
         {
-            return context.Bundles.Any(b => b.BundleId == bundleId);
+            return context.Bundles.AsNoTracking().Any(b => b.BundleId == bundleId);
         }
 
         private bool CompetencyExists(int competencyId)
         {
-            return context.Competencies.Any(b => b.CompetencyId == competencyId);
+            return context.Competencies.AsNoTracking().Any(b => b.CompetencyId == competencyId);
         }
 
         [HttpGet]

--- a/web/Areas/CTS/Controllers/BundleCompetencyController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyController.cs
@@ -22,12 +22,12 @@ namespace Viper.Areas.CTS.Controllers
 
         private bool BundleExists(int bundleId)
         {
-            return context.Bundles.Where(b => b.BundleId == bundleId).Any();
+            return context.Bundles.Any(b => b.BundleId == bundleId);
         }
 
         private bool CompetencyExists(int competencyId)
         {
-            return context.Competencies.Where(b => b.CompetencyId == competencyId).Any();
+            return context.Competencies.Any(b => b.CompetencyId == competencyId);
         }
 
         [HttpGet]

--- a/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
@@ -22,12 +22,13 @@ namespace Viper.Areas.CTS.Controllers
 
         private bool BundleExists(int bundleId)
         {
-            return context.Bundles.Any(b => b.BundleId == bundleId);
+            return context.Bundles.AsNoTracking().Any(b => b.BundleId == bundleId);
         }
 
         private bool SameNameExists(int bundleId, string name, int? bundleCompetencyGroupId = null)
         {
             return context.BundleCompetencyGroups
+                .AsNoTracking()
                 .Any(g => g.BundleId == bundleId
                     && g.Name == name
                     && (bundleCompetencyGroupId == null || bundleCompetencyGroupId != g.BundleCompetencyGroupId));

--- a/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
+++ b/web/Areas/CTS/Controllers/BundleCompetencyGroupController.cs
@@ -22,16 +22,15 @@ namespace Viper.Areas.CTS.Controllers
 
         private bool BundleExists(int bundleId)
         {
-            return context.Bundles.Where(b => b.BundleId == bundleId).Any();
+            return context.Bundles.Any(b => b.BundleId == bundleId);
         }
 
         private bool SameNameExists(int bundleId, string name, int? bundleCompetencyGroupId = null)
         {
             return context.BundleCompetencyGroups
-                .Where(g => g.BundleId == bundleId
+                .Any(g => g.BundleId == bundleId
                     && g.Name == name
-                    && (bundleCompetencyGroupId == null || bundleCompetencyGroupId != g.BundleCompetencyGroupId))
-                .Any();
+                    && (bundleCompetencyGroupId == null || bundleCompetencyGroupId != g.BundleCompetencyGroupId));
         }
 
         [HttpGet]

--- a/web/Areas/CTS/Models/CompetencyBundleAssociationDto.cs
+++ b/web/Areas/CTS/Models/CompetencyBundleAssociationDto.cs
@@ -49,7 +49,7 @@ namespace Viper.Areas.CTS.Models
                     .Where(bc => bc.Bundle != null)
                     .Select(bc => new BundleInfoDto
                     {
-                        BundleId = bc.Bundle!.BundleId,
+                        BundleId = bc.Bundle.BundleId,
                         Name = bc.Bundle.Name,
                         Clinical = bc.Bundle.Clinical,
                         Assessment = bc.Bundle.Assessment,

--- a/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/CliniciansController.cs
@@ -289,7 +289,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                                 isPrimaryEvaluator = schedule.Evaluator
                             };
                         })
-                          .OrderBy(r => r!.name) // Sort rotations alphabetically
+                          .OrderBy(r => r.name) // Sort rotations alphabetically
                           .Cast<dynamic>()
                           .ToArray()
                         : Array.Empty<dynamic>();

--- a/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
+++ b/web/Areas/ClinicalScheduler/Controllers/InstructorScheduleController.cs
@@ -76,24 +76,36 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                         correlationId));
                 }
 
+                // ValidateRequestAsync above already guarantees both are present. Capturing them
+                // as non-null locals makes every later use provable rather than asserted.
+                if (request.RotationId is not { } rotationId || request.GradYear is not { } gradYear)
+                {
+                    return BadRequest(new ErrorResponse(
+                        ErrorCodes.ValidationError,
+                        "Please check your input and try again.",
+                        correlationId));
+                }
+
                 // Step 2: Check permissions - include own schedule check
-                if (!await CheckPermissionsForAddAsync(request.RotationId!.Value, request.MothraId!, correlationId, cancellationToken))
+                if (!await CheckPermissionsForAddAsync(rotationId, request.MothraId, correlationId, cancellationToken))
                 {
                     return Forbid();
                 }
 
                 // Step 3: Check for conflicts and build warning message
                 var warningMessage = await BuildConflictWarningAsync(
-                    request.MothraId!,
+                    request.MothraId,
                     request.WeekIds,
-                    request.GradYear!.Value,
-                    request.RotationId!.Value,
+                    gradYear,
+                    rotationId,
                     correlationId,
                     cancellationToken);
 
                 // Step 4: Add instructor through service layer
                 var response = await ProcessAddInstructorAsync(
                     request,
+                    rotationId,
+                    gradYear,
                     warningMessage,
                     correlationId,
                     cancellationToken);
@@ -176,16 +188,18 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
 
         private async Task<AddInstructorResponse> ProcessAddInstructorAsync(
             AddInstructorRequest request,
+            int rotationId,
+            int gradYear,
             string? warningMessage,
             string correlationId,
             CancellationToken cancellationToken)
         {
             // Add instructor to schedule
             var createdSchedules = await _scheduleEditService.AddInstructorAsync(
-                request.MothraId!,
-                request.RotationId!.Value,
+                request.MothraId,
+                rotationId,
                 request.WeekIds,
-                request.GradYear!.Value,
+                gradYear,
                 request.IsPrimaryEvaluator,
                 cancellationToken);
 
@@ -198,7 +212,7 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
             }
 
             _logger.LogInformation("Successfully added instructor to rotation {RotationId} for {WeekCount} weeks (CorrelationId: {CorrelationId})",
-                request.RotationId!.Value, request.WeekIds.Length, correlationId);
+                rotationId, request.WeekIds.Length, correlationId);
 
             return new AddInstructorResponse
             {
@@ -388,8 +402,18 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                         correlationId));
                 }
 
+                // [Required] plus the ModelState check above already guarantee this. Capturing it
+                // as a non-null local makes every later use provable rather than asserted.
+                if (request.IsPrimary is not { } isPrimary)
+                {
+                    return BadRequest(new ErrorResponse(
+                        ErrorCodes.ValidationError,
+                        "Please check your input and try again.",
+                        correlationId));
+                }
+
                 var (success, previousPrimaryName) = await _scheduleEditService.SetPrimaryEvaluatorAsync(
-                    instructorScheduleId, request.IsPrimary!.Value, cancellationToken, request.RequiresPrimaryEvaluator);
+                    instructorScheduleId, isPrimary, cancellationToken, request.RequiresPrimaryEvaluator);
 
                 if (!success)
                 {
@@ -399,14 +423,14 @@ namespace Viper.Areas.ClinicalScheduler.Controllers
                         correlationId));
                 }
 
-                var action = request.IsPrimary!.Value ? "set as" : "removed as";
+                var action = isPrimary ? "set as" : "removed as";
                 _logger.LogInformation("Successfully {Action} primary evaluator for instructor schedule {ScheduleId} (CorrelationId: {CorrelationId})",
                     action, instructorScheduleId, correlationId);
 
                 return Ok(new
                 {
                     message = $"Instructor successfully {action} primary evaluator",
-                    isPrimaryEvaluator = request.IsPrimary!.Value,
+                    isPrimaryEvaluator = isPrimary,
                     previousPrimaryName
                 });
             }

--- a/web/Areas/Computing/Services/BiorenderStudentLookup.cs
+++ b/web/Areas/Computing/Services/BiorenderStudentLookup.cs
@@ -56,8 +56,10 @@ namespace Viper.Areas.Computing.Services
                 );
             }
 
+            // GetSingleStudent returns a constructed BiorenderStudent on every path, so there is
+            // nothing to filter out here.
             var taskResults = await Task.WhenAll(resultList);
-            return taskResults.Where(t => t != null).ToList()!;
+            return taskResults.ToList();
         }
 
         /// <summary>

--- a/web/Areas/Effort/Controllers/ClinicalImportController.cs
+++ b/web/Areas/Effort/Controllers/ClinicalImportController.cs
@@ -131,8 +131,10 @@ public class ClinicalImportController : BaseEffortController
         // Create a channel for progress events
         var channel = Channel.CreateUnbounded<ClinicalImportProgressEvent>();
 
-        // Start the import in a background task.
-        // Don't pass ct to Task.Run — cancellation is handled cooperatively inside the lambda.
+        // Start the import in a background task. CancellationToken.None is deliberate: a token
+        // here only stops the task ever starting, which would skip the lambda's own catch and
+        // leave the channel un-completed, hanging the SSE reader below. Cancellation is handled
+        // cooperatively via ct inside the lambda instead.
         var importTask = Task.Run(async () =>
         {
             try
@@ -160,7 +162,7 @@ public class ClinicalImportController : BaseEffortController
             {
                 channel.Writer.TryComplete();
             }
-        });
+        }, CancellationToken.None);
 
         try
         {

--- a/web/Areas/Effort/Controllers/PercentRolloverController.cs
+++ b/web/Areas/Effort/Controllers/PercentRolloverController.cs
@@ -91,8 +91,10 @@ public class PercentRolloverController : BaseEffortController
         // Create a channel for progress events
         var channel = Channel.CreateUnbounded<RolloverProgressEvent>();
 
-        // Start the rollover in a background task.
-        // Don't pass ct to Task.Run — cancellation is handled cooperatively inside the lambda.
+        // Start the rollover in a background task. CancellationToken.None is deliberate: a token
+        // here only stops the task ever starting, which would skip the lambda's own catch and
+        // leave the channel un-completed, hanging the SSE reader below. Cancellation is handled
+        // cooperatively via ct inside the lambda instead.
         var rolloverTask = Task.Run(async () =>
         {
             try
@@ -120,7 +122,7 @@ public class PercentRolloverController : BaseEffortController
             {
                 channel.Writer.TryComplete();
             }
-        });
+        }, CancellationToken.None);
 
         try
         {

--- a/web/Areas/Effort/Services/ClinicalImportService.cs
+++ b/web/Areas/Effort/Services/ClinicalImportService.cs
@@ -128,8 +128,8 @@ public class ClinicalImportService : IClinicalImportService
         // (emeritus/recall appointments are excluded from harvest).
         var titleCodeByMothraId = aaudImportInfo
             .Where(a => !string.IsNullOrEmpty(a.TitleCode?.Trim())
-                && _titleLookup.ContainsKey(a.TitleCode!.Trim())
-                && !excludedTitleCodes.Contains(a.TitleCode!.Trim()))
+                && _titleLookup.ContainsKey(a.TitleCode.Trim())
+                && !excludedTitleCodes.Contains(a.TitleCode.Trim()))
             .GroupBy(a => a.MothraId, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First().TitleCode!.Trim(), StringComparer.OrdinalIgnoreCase);
 
@@ -265,9 +265,11 @@ public class ClinicalImportService : IClinicalImportService
 
         await _context.SaveChangesAsync(ct);
 
-        if (ownsTransaction)
+        // Null-check the transaction rather than ownsTransaction: identical by construction
+        // above, but this is the form the compiler can actually prove.
+        if (transaction != null)
         {
-            await transaction!.CommitAsync(ct);
+            await transaction.CommitAsync(ct);
         }
 
         return result;
@@ -341,9 +343,11 @@ public class ClinicalImportService : IClinicalImportService
 
             await _context.SaveChangesAsync(ct);
 
-            if (ownsTransaction)
+            // Null-check the transaction rather than ownsTransaction: identical by construction
+            // above, but this is the form the compiler can actually prove.
+            if (transaction != null)
             {
-                await transaction!.CommitAsync(ct);
+                await transaction.CommitAsync(ct);
             }
 
             _logger.LogInformation(

--- a/web/Areas/Effort/Services/ClinicalScheduleService.cs
+++ b/web/Areas/Effort/Services/ClinicalScheduleService.cs
@@ -150,7 +150,11 @@ public class ClinicalScheduleService : BaseReportService, IClinicalScheduleServi
             paramNames.Add(paramName);
             command.Parameters.AddWithValue(paramName, clinicalJobCodes[i]);
         }
+        // The interpolation injects only the "@jc0, @jc1, ..." placeholder names generated
+        // above; every job code value is bound through AddWithValue, never concatenated.
+#pragma warning disable S2077 // Formatting SQL queries is security-sensitive
         command.CommandText = $"SELECT DISTINCT emplid FROM pps.dbo.vw_personJobPosition WHERE jobcode IN ({string.Join(", ", paramNames)})";
+#pragma warning restore S2077
 
         await using var reader = await command.ExecuteReaderAsync(ct);
         while (await reader.ReadAsync(ct))

--- a/web/Areas/Effort/Services/Harvest/ClinicalHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/ClinicalHarvestPhase.cs
@@ -236,7 +236,7 @@ public sealed class ClinicalHarvestPhase : HarvestPhaseBase
     {
         // Only build previews for importable instructors (those with valid AAUD data + title code)
         var clinicalMothraIds = clinicalPersonData
-            .Where(c => !string.IsNullOrEmpty(c.MothraId) && importableMothraIds.Contains(c.MothraId!))
+            .Where(c => !string.IsNullOrEmpty(c.MothraId) && importableMothraIds.Contains(c.MothraId))
             .Select(c => c.MothraId!)
             .Distinct()
             .ToList();

--- a/web/Areas/Effort/Services/Harvest/CrestHarvestPhase.cs
+++ b/web/Areas/Effort/Services/Harvest/CrestHarvestPhase.cs
@@ -272,7 +272,7 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
             .Select(i => new { i.IdsMothraid, i.IdsPKey })
             .ToListAsync(ct);
 
-        var pKeys = aaudIds.Where(i => !string.IsNullOrEmpty(i.IdsPKey)).Select(i => i.IdsPKey!).Distinct().ToList();
+        var pKeys = aaudIds.Where(i => !string.IsNullOrEmpty(i.IdsPKey)).Select(i => i.IdsPKey).Distinct().ToList();
 
         var employees = await context.AaudContext.Employees
             .AsNoTracking()
@@ -311,7 +311,7 @@ public sealed class CrestHarvestPhase : HarvestPhaseBase
         var mothraIdToPKey = aaudIds
             .Where(i => !string.IsNullOrEmpty(i.IdsMothraid) && !string.IsNullOrEmpty(i.IdsPKey))
             .GroupBy(i => i.IdsMothraid!, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.Select(i => i.IdsPKey!).ToList(), StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(g => g.Key, g => g.Select(i => i.IdsPKey).ToList(), StringComparer.OrdinalIgnoreCase);
 
         // Step 4: Build instructor details
         var instructorDetails = new List<CrestInstructorDto>();

--- a/web/Areas/Effort/Services/InstructorService.cs
+++ b/web/Areas/Effort/Services/InstructorService.cs
@@ -802,7 +802,7 @@ public class InstructorService : IInstructorService
         var mothraIdToPKey = idsRecords
             .Where(i => !string.IsNullOrEmpty(i.IdsMothraid) && !string.IsNullOrEmpty(i.IdsPKey))
             .GroupBy(i => i.IdsMothraid!, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().IdsPKey!, StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(g => g.Key, g => g.First().IdsPKey, StringComparer.OrdinalIgnoreCase);
 
         var pKeys = mothraIdToPKey.Values.Distinct().ToList();
 
@@ -1357,7 +1357,7 @@ public class InstructorService : IInstructorService
                     .Where(cr => cr.ChildCourse != null)
                     .Select(cr => new ChildCourseDto
                     {
-                        Id = cr.ChildCourse!.Id,
+                        Id = cr.ChildCourse.Id,
                         SubjCode = cr.ChildCourse.SubjCode,
                         CrseNumb = cr.ChildCourse.CrseNumb,
                         SeqNumb = cr.ChildCourse.SeqNumb,

--- a/web/Areas/RAPS/Services/OuGroupService.cs
+++ b/web/Areas/RAPS/Services/OuGroupService.cs
@@ -251,7 +251,7 @@ namespace Viper.Areas.RAPS.Services
             //Create a lookup of loginids of members that should be in the group
             Dictionary<string, bool> membersInRoles = members
                 .Where(m => m.LoginId != null)
-                .Select(m => m.LoginId!)
+                .Select(m => m.LoginId)
                 .Distinct()
                 .ToDictionary(id => id, _ => true);
 

--- a/web/Areas/RAPS/Services/UinformService.cs
+++ b/web/Areas/RAPS/Services/UinformService.cs
@@ -250,9 +250,9 @@ namespace Viper.Areas.RAPS.Services
             {
                 string toSign = method.Method.ToUpper() + ":" + epochTime + ":" + publicKey;
                 // Legacy API requires HMACSHA1 - third-party system constraint
-#pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
+#pragma warning disable CA5350, S4790 // Do Not Use Weak Cryptographic Algorithms
                 using var sha1 = new HMACSHA1(Encoding.ASCII.GetBytes(privateKey));
-#pragma warning restore CA5350
+#pragma warning restore CA5350, S4790
                 byte[] hashed = sha1.ComputeHash(Encoding.ASCII.GetBytes(toSign));
                 return Convert.ToBase64String(hashed);
             }

--- a/web/Areas/Students/Services/StudentList.cs
+++ b/web/Areas/Students/Services/StudentList.cs
@@ -57,10 +57,16 @@ namespace Viper.Areas.Students.Services
             //include all class years, as long as at least one of them is the given year
             else if (classYear != null)
             {
-                //get all students that have a class year entry in this year
-                q = q.Where(q => q.Student != null && _context.StudentClassYears
-                        .Any(anyClassYear => anyClassYear.ClassYear == classYear && anyClassYear.PersonId == q.Student.PersonId)
-                    );
+                //get all students that have a class year entry in this year. Pre-loading the ids
+                //keeps this a single IN list instead of a subquery correlated to every outer row.
+                var personIdsInClassYear = await _context.StudentClassYears
+                    .AsNoTracking()
+                    .Where(cy => cy.ClassYear == classYear)
+                    .Select(cy => cy.PersonId)
+                    .Distinct()
+                    .ToListAsync();
+                q = q.Where(studentClassYear => studentClassYear.Student != null
+                    && EF.Parameter(personIdsInClassYear).Contains(studentClassYear.Student.PersonId));
             }
 
             if (personId != null)

--- a/web/Areas/Students/Services/StudentList.cs
+++ b/web/Areas/Students/Services/StudentList.cs
@@ -59,8 +59,7 @@ namespace Viper.Areas.Students.Services
             {
                 //get all students that have a class year entry in this year
                 q = q.Where(q => q.Student != null && _context.StudentClassYears
-                        .Where(anyClassYear => anyClassYear.ClassYear == classYear && anyClassYear.PersonId == q.Student.PersonId)
-                        .Any()
+                        .Any(anyClassYear => anyClassYear.ClassYear == classYear && anyClassYear.PersonId == q.Student.PersonId)
                     );
             }
 

--- a/web/Classes/SitemapMiddleware.cs
+++ b/web/Classes/SitemapMiddleware.cs
@@ -80,10 +80,17 @@ namespace Viper.Classes
                     using (var memoryStream = new MemoryStream())
                     {
                         var bytes = Encoding.UTF8.GetBytes(sitemapContent.ToString());
-                        await memoryStream.WriteAsync(bytes.AsMemory());
+                        await memoryStream.WriteAsync(bytes.AsMemory(), context.RequestAborted);
                         memoryStream.Seek(0, SeekOrigin.Begin);
-                        await memoryStream.CopyToAsync(stream, bytes.Length);
+                        await memoryStream.CopyToAsync(stream, bytes.Length, context.RequestAborted);
                     }
+                }
+                // A disconnected client is not a generation failure. The response has
+                // already started by this point, so end the request instead of running
+                // the rest of the pipeline against it.
+                catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+                {
+                    // Intentionally no fall-through to _next: the request is over.
                 }
                 // Middleware boundary: any sitemap-generation failure (DB, IO,
                 // reflection, etc.) must fall through to the pipeline rather than

--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -29,7 +29,11 @@ namespace Viper.Controllers
         private readonly AAUDContext _aAUDContext;
         private readonly RAPSContext _rapsContext;
         private readonly VIPERContext _viperContext;
+        // An XML namespace identifier, not a network endpoint. The scheme is part of the
+        // literal CAS responses are namespaced with; changing it stops the elements matching.
+#pragma warning disable S5332 // Using http protocol is insecure
         private readonly XNamespace _ns = "http://www.yale.edu/tp/cas";
+#pragma warning restore S5332
         private readonly IHttpClientFactory _clientFactory;
         private readonly CasSettings _settings;
         private readonly List<string> _casAttributesToCapture = new() { "authenticationDate", "credentialType" };
@@ -210,7 +214,12 @@ namespace Viper.Controllers
         [Route("/[action]")]
         [Route("/[action]/{statusCode:int}")]
         [AllowAnonymous]
+        // Anti-forgery is irrelevant here: the error page is anonymous, binds one int? route
+        // value, and mutates no state. Requiring a token would break the 404/500 handler,
+        // which is re-executed on requests that never carried one.
+#pragma warning disable S4502 // Disabling CSRF protections is security-sensitive
         [IgnoreAntiforgeryToken]
+#pragma warning restore S4502
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [SearchExclude]
 #pragma warning disable S6967 // Error handler uses simple route parameter, not form data requiring validation

--- a/web/ViteProxyHelpers.cs
+++ b/web/ViteProxyHelpers.cs
@@ -319,7 +319,17 @@ internal static class ViteProxyHelpers
             }
         }
 
-        await response.Content.CopyToAsync(context.Response.Body);
+        try
+        {
+            await response.Content.CopyToAsync(context.Response.Body, context.RequestAborted);
+        }
+        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        {
+            // The client disconnected mid-stream. Swallow rather than rethrow: the caller
+            // catches TaskCanceledException as "Vite dev server unavailable" and falls
+            // through to the static-file branch, which would both log the wrong cause and
+            // write to a response that has already started.
+        }
     }
 
     /// <summary>
@@ -392,7 +402,7 @@ internal static class ViteProxyHelpers
                     var contentType = GetContentType(Path.GetExtension(resolvedPhysical));
                     // Set content type if not already started
                     context.Response.ContentType = contentType ?? "application/octet-stream";
-                    await context.Response.SendFileAsync(resolvedPhysical);
+                    await context.Response.SendFileAsync(resolvedPhysical, context.RequestAborted);
                     return;
                 }
             }
@@ -403,7 +413,7 @@ internal static class ViteProxyHelpers
             }
 
             context.Response.StatusCode = 502;
-            await context.Response.WriteAsync("Vite dev server not running. Please start the frontend development server or build static files as appropriate.");
+            await context.Response.WriteAsync("Vite dev server not running. Please start the frontend development server or build static files as appropriate.", context.RequestAborted);
         }
     }
 


### PR DESCRIPTION
Closes 58 of the 59 warnings added by the SonarAnalyzer 10.31 bump. Build goes from 79 warnings to 21.

One commit per rule family; the file sets are disjoint, so any single commit can be dropped independently.

| Rule | Sites | Change |
|---|---|---|
| S8969 | 41 | Remove redundant null-forgiving operators |
| S8949 | 7 | Pass `context.RequestAborted`; explicit `CancellationToken.None` on the two SSE `Task.Run` calls |
| S2971 | 5 | Fold `Where(...).Any()` into `Any(...)` |
| S2077, S5332, S4502, S4790 | 4 | Suppress with justifications: parameter placeholders bound via `AddWithValue`, XML namespace literal, anonymous error page, legacy uInform HMACSHA1 |
| S6444 | 1 | Bound the CMS download-name regex to 1s, treating a timeout as an unsafe name |

Behavioural changes, worth a closer look:

- `ViteProxyHelpers` and `SitemapMiddleware` now catch `OperationCanceledException when (context.RequestAborted.IsCancellationRequested)`. Without it a client disconnect read as a Vite outage or a sitemap failure, and fell through to further middleware on an already-started response.
- The two clinical-import commit guards move from `if (ownsTransaction)` to `if (transaction != null)`: equivalent by construction, but provable to the compiler.
- `AddInstructor` and `SetPrimaryEvaluator` capture their `[Required]` nullable fields into non-null locals behind an explicit guard, clearing the CodeQL nullable-dereference findings on those lines.

Not fixed: S1313, the hardcoded F5 internal IP in `ForwardedHeadersExtensions`. Moving it to config beside the Cloudflare CIDRs is proxy-trust surface and belongs with the `Program.cs` work.

Verified: clean-cache `npm run verify:build` 79 to 21 warnings, zero CS diagnostics; `npm run test:backend` 2708 passed.
